### PR TITLE
Update OpenVPN image

### DIFF
--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.4.8-r1'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.5.0-r1'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -71,7 +71,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.4.8-r1'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.5.0-r1'
         command:
         - bash
         - -ec

--- a/hack/images/openvpn/Dockerfile
+++ b/hack/images/openvpn/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
-ARG OPENVPN_VERSION
+FROM alpine:3.13
+ARG OPENVPN_VERSION=2.5.0-r1
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -U \

--- a/hack/images/openvpn/release.sh
+++ b/hack/images/openvpn/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/openvpn
-VERSION=2.4.8-r1
+VERSION=2.5.0-r1
 
 docker build --build-arg OPENVPN_VERSION=${VERSION} --no-cache --pull -t "${REPOSITORY}:v${VERSION}" .
 docker push "${REPOSITORY}:v${VERSION}"

--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -148,7 +148,7 @@ func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeplo
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:    "iptables-init",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.5.0-r1",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
@@ -204,7 +204,7 @@ iptables -A INPUT -i tun0 -j DROP
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.5.0-r1",
 					Command: []string{"/usr/sbin/openvpn"},
 					Args:    vpnArgs,
 					Ports: []corev1.ContainerPort{
@@ -257,7 +257,7 @@ iptables -A INPUT -i tun0 -j DROP
 				},
 				{
 					Name:    "ip-fixup",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.5.0-r1",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c",

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -110,7 +110,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
@@ -88,7 +88,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -137,7 +137,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: ip-fixup
         resources:
           limits:
@@ -191,7 +191,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: iptables-init
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -82,7 +82,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        image: quay.io/kubermatic/openvpn:v2.5.0-r1
         name: openvpn-client
         resources:
           limits:

--- a/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/pkg/resources/vpnsidecar/openvpnClient.go
@@ -50,7 +50,7 @@ type openvpnData interface {
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:    name,
-		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
+		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.5.0-r1",
 		Command: []string{"/usr/sbin/openvpn"},
 		Args: []string{
 			"--client",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the OpenVPN image used in KKP, the old one is impacted by a high-level vulnerability.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

https://quay.io/repository/kubermatic/openvpn/manifest/sha256:9d90f6d8d83f38f0fa7a8d949864fb62395ec5b22c4933d1e40ad8d9bef11723?tab=vulnerabilities

The vulnerability impacts `jq`. I'm not sure it is required and I don't see how it could be exploited, but it is still better to update at least to reassure KKP users.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update OpenVPN image to version v2.5.0-r1.
```
