### PR TITLE
[release/v2.16] Fix operator failing to reconcile admission configs (#6639)

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/admission.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/admission.go
@@ -67,7 +67,8 @@ func ClusterAdmissionWebhookCreator(cfg *operatorv1alpha1.KubermaticConfiguratio
 							Port:      pointer.Int32Ptr(443),
 						},
 					},
-					ObjectSelector: &metav1.LabelSelector{},
+					ObjectSelector:    &metav1.LabelSelector{},
+					NamespaceSelector: &metav1.LabelSelector{},
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a reconcile loop in 2.16.

**Does this PR introduce a user-facing change?**:
```release-note
Fix the operator failing to reconcile the ValidatingWebhookConfiguration object for the cluster validation webhook
```
