### PR TITLE
update Velero to 1.5.3

### DIFF
--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: velero
-version: 1.4.7
-appVersion: v1.5.2
+version: 1.4.8
+appVersion: v1.5.3
 description: A Helm chart for Heptio Velero
 keywords:
 - kubermatic

--- a/charts/backup/velero/crd/backups.yaml
+++ b/charts/backup/velero/crd/backups.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/backupstoragelocations.yaml
+++ b/charts/backup/velero/crd/backupstoragelocations.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/deletebackuprequests.yaml
+++ b/charts/backup/velero/crd/deletebackuprequests.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/downloadrequests.yaml
+++ b/charts/backup/velero/crd/downloadrequests.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/podvolumebackups.yaml
+++ b/charts/backup/velero/crd/podvolumebackups.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/podvolumerestores.yaml
+++ b/charts/backup/velero/crd/podvolumerestores.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/resticrepositories.yaml
+++ b/charts/backup/velero/crd/resticrepositories.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/restores.yaml
+++ b/charts/backup/velero/crd/restores.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/schedules.yaml
+++ b/charts/backup/velero/crd/schedules.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/serverstatusrequests.yaml
+++ b/charts/backup/velero/crd/serverstatusrequests.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/volumesnapshotlocations.yaml
+++ b/charts/backup/velero/crd/volumesnapshotlocations.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.5.2. Do not edit.
+# This file has been generated with Velero v1.5.3. Do not edit.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -58,7 +58,6 @@ velero:
         cpu: 100m
         memory: 30Mi
       limits:
-        cpu: 300m
         # during backups memory usage can spike, see https://github.com/restic/restic/issues/979
         memory: 1Gi
 
@@ -127,8 +126,7 @@ velero:
       cpu: 100m
       memory: 50Mi
     limits:
-      cpu: 200m
-      memory: 100Mi
+      memory: 512Mi
 
   affinity:
     # Backups are potentially long-running tasks and rescheduling Velero

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -18,7 +18,7 @@ velero:
   # that also contains the restic binary
   image:
     repository: docker.io/velero/velero
-    tag: v1.5.2
+    tag: v1.5.3
     pullPolicy: IfNotPresent
 
   # CLI flags to pass to velero server; note that the two flags

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -23,7 +23,7 @@ containerize ./hack/update-velero-crds.sh
 
 velero=velero
 if ! [ -x "$(command -v $velero)" ]; then
-  version=v1.5.2
+  version=v1.5.3
   url="https://github.com/vmware-tanzu/velero/releases/download/$version/velero-$version-linux-amd64.tar.gz"
   velero=/tmp/velero
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Velero 1.5.2 had a severe bug where backupstorage locations were never validated (i.e. used). This PR also increases the limits for Velero a bit: No more CPU limit as that's usually stupid anyway, and higher memory limit because my own testing Velero was consuming 180MiB with 0 backups in the cluster.

**Does this PR introduce a user-facing change?**:
```release-note
Update Velero to 1.5.3.
```
