### PR TITLE
Implement Project-Sync Controller

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -24,17 +24,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	externalcluster "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster"
-	masterconstrainttemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/master-constraint-template-controller"
 	projectlabelsynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-label-synchronizer"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
-	seedproxy "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-proxy"
-	seedsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-sync"
-	serviceaccount "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/service-account"
-	userprojectbinding "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/user-project-binding"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/usersshkeyssynchronizer"
 	seedcontrollerlifecycle "k8c.io/kubermatic/v2/pkg/controller/shared/seed-controller-lifecycle"
-	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,48 +37,48 @@ import (
 )
 
 func createAllControllers(ctrlCtx *controllerContext) error {
-	rbacControllerFactory := rbacControllerFactoryCreator(
-		ctrlCtx.mgr.GetConfig(),
-		ctrlCtx.seedsGetter,
-		ctrlCtx.seedKubeconfigGetter,
-		ctrlCtx.workerCount,
-		ctrlCtx.labelSelectorFunc,
-		ctrlCtx.workerNamePredicate,
-	)
-	projectLabelSynchronizerFactory := projectLabelSynchronizerFactoryCreator(ctrlCtx)
-	userSSHKeysSynchronizerFactory := userSSHKeysSynchronizerFactoryCreator(ctrlCtx)
-
-	if err := seedcontrollerlifecycle.Add(ctrlCtx.ctx,
-		kubermaticlog.Logger,
-		ctrlCtx.mgr,
-		ctrlCtx.namespace,
-		ctrlCtx.seedsGetter,
-		ctrlCtx.seedKubeconfigGetter,
-		rbacControllerFactory,
-		projectLabelSynchronizerFactory,
-		userSSHKeysSynchronizerFactory); err != nil {
-		//TODO: Find a better name
-		return fmt.Errorf("failed to create seedcontrollerlifecycle: %v", err)
-	}
-	if err := userprojectbinding.Add(ctrlCtx.mgr); err != nil {
-		return fmt.Errorf("failed to create userprojectbinding controller: %v", err)
-	}
-	if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
-		return fmt.Errorf("failed to create serviceaccount controller: %v", err)
-	}
-	if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
-		return fmt.Errorf("failed to create seedsync controller: %v", err)
-	}
-	if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
-		return fmt.Errorf("failed to create seedproxy controller: %v", err)
-	}
-	if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
-		return fmt.Errorf("failed to create external cluster controller: %v", err)
-	}
-	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
-		return fmt.Errorf("failed to create master constraint template controller: %v", err)
-	}
-	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.workerName, ctrlCtx.seedKubeconfigGetter); err != nil {
+	//rbacControllerFactory := rbacControllerFactoryCreator(
+	//	ctrlCtx.mgr.GetConfig(),
+	//	ctrlCtx.seedsGetter,
+	//	ctrlCtx.seedKubeconfigGetter,
+	//	ctrlCtx.workerCount,
+	//	ctrlCtx.labelSelectorFunc,
+	//	ctrlCtx.workerNamePredicate,
+	//)
+	//projectLabelSynchronizerFactory := projectLabelSynchronizerFactoryCreator(ctrlCtx)
+	//userSSHKeysSynchronizerFactory := userSSHKeysSynchronizerFactoryCreator(ctrlCtx)
+	//
+	//if err := seedcontrollerlifecycle.Add(ctrlCtx.ctx,
+	//	kubermaticlog.Logger,
+	//	ctrlCtx.mgr,
+	//	ctrlCtx.namespace,
+	//	ctrlCtx.seedsGetter,
+	//	ctrlCtx.seedKubeconfigGetter,
+	//	rbacControllerFactory,
+	//	projectLabelSynchronizerFactory,
+	//	userSSHKeysSynchronizerFactory); err != nil {
+	//	//TODO: Find a better name
+	//	return fmt.Errorf("failed to create seedcontrollerlifecycle: %v", err)
+	//}
+	//if err := userprojectbinding.Add(ctrlCtx.mgr); err != nil {
+	//	return fmt.Errorf("failed to create userprojectbinding controller: %v", err)
+	//}
+	//if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
+	//	return fmt.Errorf("failed to create serviceaccount controller: %v", err)
+	//}
+	//if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
+	//	return fmt.Errorf("failed to create seedsync controller: %v", err)
+	//}
+	//if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
+	//	return fmt.Errorf("failed to create seedproxy controller: %v", err)
+	//}
+	//if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
+	//	return fmt.Errorf("failed to create external cluster controller: %v", err)
+	//}
+	//if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
+	//	return fmt.Errorf("failed to create master constraint template controller: %v", err)
+	//}
+	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create projectsync controller: %v", err)
 	}
 

--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	projectsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	externalcluster "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster"
@@ -82,6 +84,9 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	}
 	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create master constraint template controller: %v", err)
+	}
+	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.workerName, ctrlCtx.seedKubeconfigGetter); err != nil {
+		return fmt.Errorf("failed to create projectsync controller: %v", err)
 	}
 
 	return nil

--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -20,14 +20,20 @@ import (
 	"context"
 	"fmt"
 
-	projectsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 
+	externalcluster "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster"
+	masterconstrainttemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/master-constraint-template-controller"
 	projectlabelsynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-label-synchronizer"
+	projectsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-sync"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
+	seedproxy "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-proxy"
+	seedsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-sync"
+	serviceaccount "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/service-account"
+	userprojectbinding "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/user-project-binding"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/usersshkeyssynchronizer"
 	seedcontrollerlifecycle "k8c.io/kubermatic/v2/pkg/controller/shared/seed-controller-lifecycle"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,47 +43,47 @@ import (
 )
 
 func createAllControllers(ctrlCtx *controllerContext) error {
-	//rbacControllerFactory := rbacControllerFactoryCreator(
-	//	ctrlCtx.mgr.GetConfig(),
-	//	ctrlCtx.seedsGetter,
-	//	ctrlCtx.seedKubeconfigGetter,
-	//	ctrlCtx.workerCount,
-	//	ctrlCtx.labelSelectorFunc,
-	//	ctrlCtx.workerNamePredicate,
-	//)
-	//projectLabelSynchronizerFactory := projectLabelSynchronizerFactoryCreator(ctrlCtx)
-	//userSSHKeysSynchronizerFactory := userSSHKeysSynchronizerFactoryCreator(ctrlCtx)
-	//
-	//if err := seedcontrollerlifecycle.Add(ctrlCtx.ctx,
-	//	kubermaticlog.Logger,
-	//	ctrlCtx.mgr,
-	//	ctrlCtx.namespace,
-	//	ctrlCtx.seedsGetter,
-	//	ctrlCtx.seedKubeconfigGetter,
-	//	rbacControllerFactory,
-	//	projectLabelSynchronizerFactory,
-	//	userSSHKeysSynchronizerFactory); err != nil {
-	//	//TODO: Find a better name
-	//	return fmt.Errorf("failed to create seedcontrollerlifecycle: %v", err)
-	//}
-	//if err := userprojectbinding.Add(ctrlCtx.mgr); err != nil {
-	//	return fmt.Errorf("failed to create userprojectbinding controller: %v", err)
-	//}
-	//if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
-	//	return fmt.Errorf("failed to create serviceaccount controller: %v", err)
-	//}
-	//if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
-	//	return fmt.Errorf("failed to create seedsync controller: %v", err)
-	//}
-	//if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
-	//	return fmt.Errorf("failed to create seedproxy controller: %v", err)
-	//}
-	//if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
-	//	return fmt.Errorf("failed to create external cluster controller: %v", err)
-	//}
-	//if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
-	//	return fmt.Errorf("failed to create master constraint template controller: %v", err)
-	//}
+	rbacControllerFactory := rbacControllerFactoryCreator(
+		ctrlCtx.mgr.GetConfig(),
+		ctrlCtx.seedsGetter,
+		ctrlCtx.seedKubeconfigGetter,
+		ctrlCtx.workerCount,
+		ctrlCtx.labelSelectorFunc,
+		ctrlCtx.workerNamePredicate,
+	)
+	projectLabelSynchronizerFactory := projectLabelSynchronizerFactoryCreator(ctrlCtx)
+	userSSHKeysSynchronizerFactory := userSSHKeysSynchronizerFactoryCreator(ctrlCtx)
+
+	if err := seedcontrollerlifecycle.Add(ctrlCtx.ctx,
+		kubermaticlog.Logger,
+		ctrlCtx.mgr,
+		ctrlCtx.namespace,
+		ctrlCtx.seedsGetter,
+		ctrlCtx.seedKubeconfigGetter,
+		rbacControllerFactory,
+		projectLabelSynchronizerFactory,
+		userSSHKeysSynchronizerFactory); err != nil {
+		//TODO: Find a better name
+		return fmt.Errorf("failed to create seedcontrollerlifecycle: %v", err)
+	}
+	if err := userprojectbinding.Add(ctrlCtx.mgr); err != nil {
+		return fmt.Errorf("failed to create userprojectbinding controller: %v", err)
+	}
+	if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
+		return fmt.Errorf("failed to create serviceaccount controller: %v", err)
+	}
+	if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
+		return fmt.Errorf("failed to create seedsync controller: %v", err)
+	}
+	if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
+		return fmt.Errorf("failed to create seedproxy controller: %v", err)
+	}
+	if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
+		return fmt.Errorf("failed to create external cluster controller: %v", err)
+	}
+	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
+		return fmt.Errorf("failed to create master constraint template controller: %v", err)
+	}
 	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create projectsync controller: %v", err)
 	}

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"k8c.io/kubermatic/v2/pkg/features"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"k8c.io/kubermatic/v2/pkg/features"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -166,6 +166,11 @@ func main() {
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",
 			},
+			{
+				ResourceName:     "Project",
+				ImportAlias:      "kubermaticv1",
+				APIVersionPrefix: "KubermaticV1",
+			},
 		},
 	}
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2119,6 +2119,8 @@ const (
 	GatekeeperConstraintCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-constraints"
 	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup
 	KubermaticConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-constraints"
+	// SeedProjectCleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup
+	SeedProjectCleanupFinalizer = "kubermatic.io/cleanup-seed-projects"
 )
 
 func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType {

--- a/pkg/controller/master-controller-manager/project-sync/OWNERS
+++ b/pkg/controller/master-controller-manager/project-sync/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig-app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/master-controller-manager/project-sync/controller.go
+++ b/pkg/controller/master-controller-manager/project-sync/controller.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectsync
+
+import (
+	"context"
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	"go.uber.org/zap"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "project-sync-controller"
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	recorder                record.EventRecorder
+	masterClient            ctrlruntimeclient.Client
+	seedClientGetter        provider.SeedClientGetter
+	workerNameLabelSelector labels.Selector
+}
+
+func Add(mgr manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+	workerName string,
+	seedKubeconfigGetter provider.SeedKubeconfigGetter) error {
+
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %v", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		masterClient:            mgr.GetClient(),
+		seedClientGetter:        provider.SeedClientGetterFactory(seedKubeconfigGetter),
+		workerNameLabelSelector: workerSelector,
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Project{}},
+		&handler.EnqueueRequestForObject{},
+	); err != nil {
+		return fmt.Errorf("failed to create watch for Projects: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Seed{}},
+		enqueueAllProjects(reconciler.masterClient, reconciler.log),
+	); err != nil {
+		return fmt.Errorf("failed to create seed watcher: %v", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles Kubermatic Project objects on the master cluster to all seed clusters
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+
+	project := &kubermaticv1.Project{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, project); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if !project.DeletionTimestamp.IsZero() {
+		if err := r.handleDeletion(ctx, log, project); err != nil {
+			return reconcile.Result{}, fmt.Errorf("handling deletion: %v", err)
+		}
+	}
+
+	kuberneteshelper.AddFinalizer(project, kubermaticapiv1.SeedProjectCleanupFinalizer)
+	if err := r.masterClient.Update(ctx, project); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to add Project finalizer %s: %v", project.Name, err)
+	}
+
+	projectCreatorGetter := []reconciling.NamedKubermaticV1ProjectCreatorGetter{
+		projectCreatorGetter(project),
+	}
+
+	err := r.syncAllSeeds(ctx, log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
+		workerNameLabelSelectorRequirements, _ := r.workerNameLabelSelector.Requirements()
+		projectLabelRequirement, err := labels.NewRequirement(kubermaticv1.ProjectIDLabelKey, selection.Equals, []string{project.Name})
+		if err != nil {
+			return fmt.Errorf("failed to construct label requirement for project: %v", err)
+		}
+
+		listOpts := &ctrlruntimeclient.ListOptions{
+			LabelSelector: labels.NewSelector().Add(append(workerNameLabelSelectorRequirements, *projectLabelRequirement)...),
+		}
+		clusterList := &kubermaticv1.ClusterList{}
+		if err := seedClusterClient.List(ctx, clusterList, listOpts); err != nil {
+			return fmt.Errorf("failed to list Cluster objects: %v", err)
+		}
+		if len(clusterList.Items) == 0 {
+			// No cluster within this Project is found in this Seed, so in this case, we don't sync this Project to Seed.
+			return nil
+		}
+		return reconciling.ReconcileKubermaticV1Projects(ctx, projectCreatorGetter, "", seedClusterClient)
+	})
+
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("reconciled Project: %s: %v", project.Name, err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, project *kubermaticv1.Project) error {
+	err := r.syncAllSeeds(ctx, log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
+		if err := seedClusterClient.Delete(ctx, project); err != nil {
+			return ctrlruntimeclient.IgnoreNotFound(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	kuberneteshelper.RemoveFinalizer(project, kubermaticapiv1.SeedProjectCleanupFinalizer)
+	if err := r.masterClient.Update(ctx, project); err != nil {
+		return fmt.Errorf("failed to remove Project finalizer %s: %v", project.Name, err)
+	}
+	return nil
+}
+
+func (r *reconciler) syncAllSeeds(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	project *kubermaticv1.Project,
+	action func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error) error {
+
+	seedList := &kubermaticv1.SeedList{}
+	if err := r.masterClient.List(ctx, seedList); err != nil {
+		return fmt.Errorf("failed listing seeds: %w", err)
+	}
+
+	for _, seed := range seedList.Items {
+		seedClient, err := r.seedClientGetter(&seed)
+		if err != nil {
+			return fmt.Errorf("failed getting seed client for Seed %s: %w", seed.Name, err)
+		}
+
+		err = action(seedClient, project)
+		if err != nil {
+			return fmt.Errorf("failed syncing Project for Seed %s: %w", seed.Name, err)
+		}
+		log.Debugw("Reconciled Project with Seed", "seed", seed.Name)
+	}
+	return nil
+}
+
+func projectCreatorGetter(project *kubermaticv1.Project) reconciling.NamedKubermaticV1ProjectCreatorGetter {
+	return func() (string, reconciling.KubermaticV1ProjectCreator) {
+		return project.Name, func(p *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+			p.Name = project.Name
+			p.Spec = project.Spec
+			return p, nil
+		}
+	}
+}
+
+func enqueueAllProjects(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		projectList := &kubermaticv1.ProjectList{}
+		if err := client.List(context.Background(), projectList); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list Projects: %v", err))
+		}
+		for _, project := range projectList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: project.Name,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/controller/master-controller-manager/project-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-sync/controller_test.go
@@ -15,3 +15,128 @@ limitations under the License.
 */
 
 package projectsync
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const projectName = "project-test"
+
+func TestReconcile(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		requestName     string
+		expectedProject *kubermaticv1.Project
+		masterClient    ctrlruntimeclient.Client
+		seedClient      ctrlruntimeclient.Client
+	}{
+		{
+			name:            "scenario 1: sync project from master cluster to seed cluster",
+			requestName:     projectName,
+			expectedProject: generateProject(projectName, false),
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, false), test.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				Build(),
+		},
+		{
+			name:            "scenario 2: cleanup project on the seed cluster when master project is being terminated",
+			requestName:     projectName,
+			expectedProject: nil,
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, true), test.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, false), test.GenTestSeed()).
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: tc.masterClient,
+				seedClientGetter: func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
+					return tc.seedClient, nil
+				},
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			seedProject := &kubermaticv1.Project{}
+			err := tc.seedClient.Get(ctx, request.NamespacedName, seedProject)
+			if tc.expectedProject == nil {
+				if err == nil {
+					t.Fatal("failed clean up project on the seed cluster")
+				} else if !errors.IsNotFound(err) {
+					t.Fatalf("failed to get project: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("failed to get project: %v", err)
+				}
+				if !reflect.DeepEqual(seedProject.Spec, tc.expectedProject.Spec) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedProject, tc.expectedProject))
+				}
+				if !reflect.DeepEqual(seedProject.Name, tc.expectedProject.Name) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedProject, tc.expectedProject))
+				}
+			}
+		})
+	}
+}
+
+func generateProject(name string, deleted bool) *kubermaticv1.Project {
+	project := &kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: projectName,
+		},
+		Spec: kubermaticv1.ProjectSpec{
+			Name: fmt.Sprintf("project-%s", name),
+		},
+		Status: kubermaticv1.ProjectStatus{
+			Phase: kubermaticv1.ProjectActive,
+		},
+	}
+	if deleted {
+		deleteTime := metav1.NewTime(time.Now())
+		project.DeletionTimestamp = &deleteTime
+		project.Finalizers = append(project.Finalizers, v1.SeedProjectCleanupFinalizer)
+	}
+	return project
+}

--- a/pkg/controller/master-controller-manager/project-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-sync/controller_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectsync

--- a/pkg/controller/master-controller-manager/project-sync/doc.go
+++ b/pkg/controller/master-controller-manager/project-sync/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package proejctsync contains a controller that is responsible for ensuring that the
+kubermatic Project objects are synced from master to the seed clusters.
+*/
+package projectsync

--- a/pkg/controller/master-controller-manager/project-sync/resources.go
+++ b/pkg/controller/master-controller-manager/project-sync/resources.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectsync
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+func projectCreatorGetter(project *kubermaticv1.Project) reconciling.NamedKubermaticV1ProjectCreatorGetter {
+	return func() (string, reconciling.KubermaticV1ProjectCreator) {
+		return project.Name, func(p *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+			p.Name = project.Name
+			p.Spec = project.Spec
+			p.Status = project.Status
+			return p, nil
+		}
+	}
+}

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -951,3 +951,40 @@ func ReconcileKubermaticV1ConstraintTemplates(ctx context.Context, namedGetters 
 
 	return nil
 }
+
+// KubermaticV1ProjectCreator defines an interface to create/update Projects
+type KubermaticV1ProjectCreator = func(existing *kubermaticv1.Project) (*kubermaticv1.Project, error)
+
+// NamedKubermaticV1ProjectCreatorGetter returns the name of the resource and the corresponding creator function
+type NamedKubermaticV1ProjectCreatorGetter = func() (name string, create KubermaticV1ProjectCreator)
+
+// KubermaticV1ProjectObjectWrapper adds a wrapper so the KubermaticV1ProjectCreator matches ObjectCreator.
+// This is needed as Go does not support function interface matching.
+func KubermaticV1ProjectObjectWrapper(create KubermaticV1ProjectCreator) ObjectCreator {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return create(existing.(*kubermaticv1.Project))
+		}
+		return create(&kubermaticv1.Project{})
+	}
+}
+
+// ReconcileKubermaticV1Projects will create and update the KubermaticV1Projects coming from the passed KubermaticV1ProjectCreator slice
+func ReconcileKubermaticV1Projects(ctx context.Context, namedGetters []NamedKubermaticV1ProjectCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
+	for _, get := range namedGetters {
+		name, create := get()
+		createObject := KubermaticV1ProjectObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			createObject = objectModifier(createObject)
+		}
+
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.Project{}, false); err != nil {
+			return fmt.Errorf("failed to ensure Project %s/%s: %v", namespace, name, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a sync controller in the master controller manager to propagate Project objects from Master Cluster to Seed Cluster.
This is needed for MLA (Monitoring, Logging, Alerting) of user clusters. MLA controller in seed controller manager will need to create dedicated Grafana Organization for every KKP Project, and map KKP users to Grafana users in the Organization.
However, Project and User information is not available in the Seed Cluster. This PR is the first step, it adds a controller to sync projects from Master cluster to Seed cluster. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6688 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
