### PR TITLE
decreased default opa webhook timeout from 10 to 3 sec

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -109,7 +109,7 @@ func main() {
 	flag.StringVar(&runOp.updateWindowStart, "update-window-start", "", "The start time of the update window, e.g. 02:00")
 	flag.StringVar(&runOp.updateWindowLength, "update-window-length", "", "The length of the update window, e.g. 1h")
 	flag.BoolVar(&runOp.opaIntegration, "opa-integration", false, "Enable OPA integration in user cluster")
-	flag.IntVar(&runOp.opaWebhookTimeout, "opa-webhook-timeout", 10, "Timeout for OPA Integration validating webhook, in seconds")
+	flag.IntVar(&runOp.opaWebhookTimeout, "opa-webhook-timeout", 3, "Timeout for OPA Integration validating webhook, in seconds")
 	flag.BoolVar(&runOp.useSSHKeyAgent, "enable-ssh-key-agent", false, "Enable UserSSHKeyAgent integration in user cluster")
 	flag.StringVar(&runOp.caBundleFile, "ca-bundle", "", "The path to the cluster's CA bundle (PEM-encoded).")
 	flag.Parse()


### PR DESCRIPTION
**What this PR does / why we need it**:
Long timeouts can cause leader election problems if gatekeeper is down. (https://github.com/open-policy-agent/gatekeeper/pull/871) so putting it to 3 secs.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Changed default gatekeeper webhook timeout to 3 sec
```
