### PR TITLE
WIP: Fix operating system decoding on empty operating system spec

### DIFF
--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -49,6 +49,10 @@ func GetAPIV1OperatingSystemSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv
 		return nil, fmt.Errorf("failed to get machine providerConfig: %v", err)
 	}
 
+	if decodedProviderSpec.OperatingSystemSpec.Raw == nil {
+		return &apiv1.OperatingSystemSpec{}, nil
+	}
+
 	operatingSystemSpec := &apiv1.OperatingSystemSpec{}
 
 	switch decodedProviderSpec.OperatingSystem {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
When machine deployments are created manually(without using the api) and the OperatingSystemSpec is left empty, KKP api will fail to decode the MachineDeployment spec. This PR returns an empty OperatingSystemSpec in case of dropping that field in the manually created MD.

Fixes #6637 

**Does this PR introduce a user-facing change?**:
No
```release-note
None
```
