### PR TITLE
Fix CA bundle handling in S3 uploader

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.32
+version: 1.1.33
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/cleanup-container.yaml
+++ b/charts/kubermatic/static/cleanup-container.yaml
@@ -1,7 +1,7 @@
 # This file has been generated using hack/update-kubermatic-chart.sh, do not edit.
 
 name: cleanup-container
-image: quay.io/kubermatic/s3-storer:v0.1.4
+image: quay.io/kubermatic/s3-storer:v0.1.5
 command:
 - /bin/sh
 - -c

--- a/charts/kubermatic/static/store-container.yaml
+++ b/charts/kubermatic/static/store-container.yaml
@@ -1,7 +1,7 @@
 # This file has been generated using hack/update-kubermatic-chart.sh, do not edit.
 
 name: store-container
-image: quay.io/kubermatic/s3-storer:v0.1.4
+image: quay.io/kubermatic/s3-storer:v0.1.5
 command:
 - /bin/sh
 - -c

--- a/charts/s3-exporter/Chart.yaml
+++ b/charts/s3-exporter/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: s3-exporter
-version: 1.1.4
-appVersion: v0.4
+version: 1.1.5
+appVersion: v0.5
 keywords:
 - kubermatic
 - prometheus

--- a/charts/s3-exporter/templates/deployment.yaml
+++ b/charts/s3-exporter/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           - -access-key-id=$(ACCESS_KEY_ID)
           - -secret-access-key=$(SECRET_ACCESS_KEY)
           - -bucket={{ .Values.s3Exporter.bucket }}
+{{- if .Values.s3Exporter.caBundleConfigMap }}
+          - -ca-bundle=/etc/cabundle/cabundle.pem
+{{- end }}
           env:
           - name: ACCESS_KEY_ID
             valueFrom:
@@ -56,6 +59,16 @@ spec:
                 key: SECRET_ACCESS_KEY
           resources:
 {{ toYaml .Values.s3Exporter.resources | indent 12 }}
+{{- with .Values.s3Exporter.caBundleConfigMap }}
+          volumeMounts:
+            - name: cabundle
+              mountPath: /etc/cabundle
+              readOnly: true
+      volumes:
+        - name: cabundle
+          configMap:
+            name: '{{ . }}'
+{{- end }}
       nodeSelector:
 {{ toYaml .Values.s3Exporter.nodeSelector | indent 8 }}
       affinity:

--- a/charts/s3-exporter/values.yaml
+++ b/charts/s3-exporter/values.yaml
@@ -15,16 +15,17 @@
 s3Exporter:
   image:
     repository: quay.io/kubermatic/s3-exporter
-    tag: v0.4
+    tag: v0.5
   endpoint: http://minio.minio.svc.cluster.local:9000
   bucket: kubermatic-etcd-backups
+  # uncomment this and create a ConfigMap with a "cabundle.pem" in it,
+  # then update the name here; this will configure the exporter to use
+  # your CA bundle when communicating with S3.
+  # caBundleConfigMap: name-of-the-configmap
   resources:
     requests:
       cpu: 50m
       memory: 24Mi
-    limits:
-      cpu: 150m
-      memory: 32Mi
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/cmd/s3-exporter/Dockerfile
+++ b/cmd/s3-exporter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add --no-cache ca-certificates

--- a/cmd/s3-exporter/README.md
+++ b/cmd/s3-exporter/README.md
@@ -14,6 +14,8 @@ Usage of ./s3-exporter:
         The port to listen on (default ":9340")
   -bucket string
         The bucket to monitor (default "kubermatic-etcd-backups")
+  -ca-bundle string
+        Filename of the CA bundle to use (if not given, default system certificates are used)
   -endpoint string
         The s3 endpoint, e.G. https://my-s3.com:9000
   -kubeconfig string

--- a/cmd/s3-storeuploader/Dockerfile
+++ b/cmd/s3-storeuploader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add --no-cache ca-certificates

--- a/cmd/s3-storeuploader/README.md
+++ b/cmd/s3-storeuploader/README.md
@@ -29,6 +29,6 @@ GLOBAL OPTIONS:
 
 ```bash
 CGO_ENABLED=0 go build -ldflags '-w -extldflags "-static"' -o s3-storeuploader k8c.io/kubermatic/v2/cmd/s3-storeuploader
-sudo docker build -t quay.io/kubermatic/s3-storer:v0.1.4 .
-sudo docker push quay.io/kubermatic/s3-storer:v0.1.4
+docker build -t quay.io/kubermatic/s3-storer:v0.1.5 .
+docker push quay.io/kubermatic/s3-storer:v0.1.5
 ```

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -143,7 +143,7 @@ spec:
     # BackupCleanupContainer is the container used for removing expired backups from the storage location.
     backupCleanupContainer: |-
       name: cleanup-container
-      image: quay.io/kubermatic/s3-storer:v0.1.4
+      image: quay.io/kubermatic/s3-storer:v0.1.5
       command:
       - /bin/sh
       - -c
@@ -191,7 +191,7 @@ spec:
     # BackupStoreContainer is the container used for shipping etcd snapshots to a backup location.
     backupStoreContainer: |-
       name: store-container
-      image: quay.io/kubermatic/s3-storer:v0.1.4
+      image: quay.io/kubermatic/s3-storer:v0.1.5
       command:
       - /bin/sh
       - -c

--- a/hack/publish-s3-exporter.sh
+++ b/hack/publish-s3-exporter.sh
@@ -21,13 +21,13 @@ set -euo pipefail
 
 cd $(dirname $0)/..
 
-export REGISTRY=quay.io/kubermatic/s3-exporter
-export TAG=v0.4
+REPOSITORY=quay.io/kubermatic/s3-exporter
+TAG=v0.5
 
 GOOS=linux GOARCH=amd64 make s3-exporter
 
 mv _build/s3-exporter cmd/s3-exporter/
 cd cmd/s3-exporter/
 
-docker build -t $REGISTRY:$TAG .
-docker push $REGISTRY:$TAG
+docker build -t "$REPOSITORY:$TAG" .
+docker push "$REPOSITORY:$TAG"

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -637,7 +637,7 @@ func defaultVersioning(settings *operatorv1alpha1.KubermaticVersioningConfigurat
 
 const DefaultBackupStoreContainer = `
 name: store-container
-image: quay.io/kubermatic/s3-storer:v0.1.4
+image: quay.io/kubermatic/s3-storer:v0.1.5
 command:
 - /bin/sh
 - -c
@@ -770,7 +770,7 @@ env:
 
 const DefaultBackupCleanupContainer = `
 name: cleanup-container
-image: quay.io/kubermatic/s3-storer:v0.1.4
+image: quay.io/kubermatic/s3-storer:v0.1.5
 command:
 - /bin/sh
 - -c


### PR DESCRIPTION
**What this PR does / why we need it**:
The S3 uploader is not built automatically for each release, so the old version 0.1.4 doesn't know the `-ca-bundle` flag yet. This PR fixes that and improves the Helm chart.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
