### PR TITLE
Implement UserProjectBinding-Sync Controller

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -31,6 +31,7 @@ import (
 	seedsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-sync"
 	serviceaccount "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/service-account"
 	userprojectbinding "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/user-project-binding"
+	userprojectbindingsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/user-project-binding-sync"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/usersshkeyssynchronizer"
 	seedcontrollerlifecycle "k8c.io/kubermatic/v2/pkg/controller/shared/seed-controller-lifecycle"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -86,6 +87,9 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	}
 	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create projectsync controller: %v", err)
+	}
+	if err := userprojectbindingsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
+		return fmt.Errorf("failed to create userprojectbindingsync controller: %v", err)
 	}
 
 	return nil

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -171,6 +171,11 @@ func main() {
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",
 			},
+			{
+				ResourceName:     "UserProjectBinding",
+				ImportAlias:      "kubermaticv1",
+				APIVersionPrefix: "KubermaticV1",
+			},
 		},
 	}
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2121,6 +2121,8 @@ const (
 	KubermaticConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-constraints"
 	// SeedProjectCleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup
 	SeedProjectCleanupFinalizer = "kubermatic.io/cleanup-seed-projects"
+	// SeedUserProjectBindingCleanupFinalizer indicates that Kubermatic UserProjectBindings on the seed clusters need cleanup
+	SeedUserProjectBindingCleanupFinalizer = "kubermatic.io/cleanup-seed-user-project-bindings"
 )
 
 func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType {

--- a/pkg/controller/master-controller-manager/project-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-sync/controller_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/OWNERS
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig-app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/controller.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userprojectbindingsync
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "user-project-binding-sync-controller"
+)
+
+type reconciler struct {
+	log              *zap.SugaredLogger
+	recorder         record.EventRecorder
+	masterClient     ctrlruntimeclient.Client
+	seedClientGetter provider.SeedClientGetter
+}
+
+func Add(mgr manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+	seedKubeconfigGetter provider.SeedKubeconfigGetter) error {
+
+	reconciler := &reconciler{
+		log:              log.Named(ControllerName),
+		recorder:         mgr.GetEventRecorderFor(ControllerName),
+		masterClient:     mgr.GetClient(),
+		seedClientGetter: provider.SeedClientGetterFactory(seedKubeconfigGetter),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.UserProjectBinding{}},
+		&handler.EnqueueRequestForObject{},
+	); err != nil {
+		return fmt.Errorf("failed to create watch for userprojectbindings: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Seed{}},
+		enqueueAllUserProjectBindings(reconciler.masterClient, reconciler.log),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for seeds: %v", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles Kubermatic UserProjectBinding objects on the master cluster to all seed clusters
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+
+	userProjectBinding := &kubermaticv1.UserProjectBinding{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, userProjectBinding); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if !userProjectBinding.DeletionTimestamp.IsZero() {
+		if err := r.handleDeletion(ctx, log, userProjectBinding); err != nil {
+			return reconcile.Result{}, fmt.Errorf("handling deletion: %v", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !kuberneteshelper.HasFinalizer(userProjectBinding, kubermaticapiv1.SeedUserProjectBindingCleanupFinalizer) {
+		kuberneteshelper.AddFinalizer(userProjectBinding, kubermaticapiv1.SeedUserProjectBindingCleanupFinalizer)
+		if err := r.masterClient.Update(ctx, userProjectBinding); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to add userProjectBinding finalizer %s: %v", userProjectBinding.Name, err)
+		}
+	}
+
+	userProjectBindingCreatorGetters := []reconciling.NamedKubermaticV1UserProjectBindingCreatorGetter{
+		userProjectBindingCreatorGetter(userProjectBinding),
+	}
+
+	err := r.syncAllSeeds(ctx, log, userProjectBinding, func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error {
+		return reconciling.ReconcileKubermaticV1UserProjectBindings(ctx, userProjectBindingCreatorGetters, "", seedClusterClient)
+	})
+
+	if err != nil {
+		r.recorder.Eventf(userProjectBinding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		return reconcile.Result{}, fmt.Errorf("reconciled userprojectbinding: %s: %v", userProjectBinding.Name, err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, userProjectBinding *kubermaticv1.UserProjectBinding) error {
+	err := r.syncAllSeeds(ctx, log, userProjectBinding, func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error {
+		if err := seedClusterClient.Delete(ctx, userProjectBinding); err != nil {
+			return ctrlruntimeclient.IgnoreNotFound(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if kuberneteshelper.HasFinalizer(userProjectBinding, kubermaticapiv1.SeedUserProjectBindingCleanupFinalizer) {
+		kuberneteshelper.RemoveFinalizer(userProjectBinding, kubermaticapiv1.SeedUserProjectBindingCleanupFinalizer)
+		if err := r.masterClient.Update(ctx, userProjectBinding); err != nil {
+			return fmt.Errorf("failed to remove userprojectbinding finalizer %s: %v", userProjectBinding.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) syncAllSeeds(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	userProjectBinding *kubermaticv1.UserProjectBinding,
+	action func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error) error {
+
+	seedList := &kubermaticv1.SeedList{}
+	if err := r.masterClient.List(ctx, seedList); err != nil {
+		return fmt.Errorf("failed listing seeds: %w", err)
+	}
+
+	for _, seed := range seedList.Items {
+		seedClient, err := r.seedClientGetter(&seed)
+		if err != nil {
+			return fmt.Errorf("failed getting seed client for seed %s: %w", seed.Name, err)
+		}
+
+		err = action(seedClient, userProjectBinding)
+		if err != nil {
+			return fmt.Errorf("failed syncing userprojectbinding for seed %s: %w", seed.Name, err)
+		}
+		log.Debugw("Reconciled userprojectbinding with seed", "seed", seed.Name)
+	}
+	return nil
+}
+
+func enqueueAllUserProjectBindings(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		userProjectBindingList := &kubermaticv1.UserProjectBindingList{}
+		if err := client.List(context.Background(), userProjectBindingList); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list userprojectbindings: %v", err))
+		}
+		for _, userProjectBinding := range userProjectBindingList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: userProjectBinding.Name,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/controller_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/controller_test.go
@@ -22,11 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/controller_test.go
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package projectsync
+package userprojectbindingsync
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -39,25 +40,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const projectName = "project-test"
+const userProjectBindingName = "user-project-binding-test"
 
 func TestReconcile(t *testing.T) {
 
 	testCases := []struct {
-		name            string
-		requestName     string
-		expectedProject *kubermaticv1.Project
-		masterClient    ctrlruntimeclient.Client
-		seedClient      ctrlruntimeclient.Client
+		name                       string
+		requestName                string
+		expectedUserProjectBinding *kubermaticv1.UserProjectBinding
+		masterClient               ctrlruntimeclient.Client
+		seedClient                 ctrlruntimeclient.Client
 	}{
 		{
-			name:            "scenario 1: sync project from master cluster to seed cluster",
-			requestName:     projectName,
-			expectedProject: generateProject(projectName, false),
+			name:                       "scenario 1: sync userProjectBinding from master cluster to seed cluster",
+			requestName:                userProjectBindingName,
+			expectedUserProjectBinding: generateUserProjectBinding(userProjectBindingName, false),
 			masterClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
-				WithObjects(generateProject(projectName, false), test.GenTestSeed()).
+				WithObjects(generateUserProjectBinding(userProjectBindingName, false), test.GenTestSeed()).
 				Build(),
 			seedClient: fakectrlruntimeclient.
 				NewClientBuilder().
@@ -65,18 +66,18 @@ func TestReconcile(t *testing.T) {
 				Build(),
 		},
 		{
-			name:            "scenario 2: cleanup project on the seed cluster when master project is being terminated",
-			requestName:     projectName,
-			expectedProject: nil,
+			name:                       "scenario 2: cleanup userProjectBinding on the seed cluster when master userProjectBinding is being terminated",
+			requestName:                userProjectBindingName,
+			expectedUserProjectBinding: nil,
 			masterClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
-				WithObjects(generateProject(projectName, true), test.GenTestSeed()).
+				WithObjects(generateUserProjectBinding(userProjectBindingName, true), test.GenTestSeed()).
 				Build(),
 			seedClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
-				WithObjects(generateProject(projectName, false), test.GenTestSeed()).
+				WithObjects(generateUserProjectBinding(userProjectBindingName, false), test.GenTestSeed()).
 				Build(),
 		},
 	}
@@ -98,45 +99,44 @@ func TestReconcile(t *testing.T) {
 				t.Fatalf("reconciling failed: %v", err)
 			}
 
-			seedProject := &kubermaticv1.Project{}
-			err := tc.seedClient.Get(ctx, request.NamespacedName, seedProject)
-			if tc.expectedProject == nil {
+			seedUserProjectBinding := &kubermaticv1.UserProjectBinding{}
+			err := tc.seedClient.Get(ctx, request.NamespacedName, seedUserProjectBinding)
+			if tc.expectedUserProjectBinding == nil {
 				if err == nil {
-					t.Fatal("failed clean up project on the seed cluster")
+					t.Fatal("failed clean up userProjectBinding on the seed cluster")
 				} else if !errors.IsNotFound(err) {
-					t.Fatalf("failed to get project: %v", err)
+					t.Fatalf("failed to get userProjectBinding: %v", err)
 				}
 			} else {
 				if err != nil {
-					t.Fatalf("failed to get project: %v", err)
+					t.Fatalf("failed to get userProjectBinding: %v", err)
 				}
-				if !reflect.DeepEqual(seedProject.Spec, tc.expectedProject.Spec) {
-					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedProject, tc.expectedProject))
+				if !reflect.DeepEqual(seedUserProjectBinding.Spec, tc.expectedUserProjectBinding.Spec) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedUserProjectBinding, tc.expectedUserProjectBinding))
 				}
-				if !reflect.DeepEqual(seedProject.Name, tc.expectedProject.Name) {
-					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedProject, tc.expectedProject))
+				if !reflect.DeepEqual(seedUserProjectBinding.Name, tc.expectedUserProjectBinding.Name) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedUserProjectBinding, tc.expectedUserProjectBinding))
 				}
 			}
 		})
 	}
 }
 
-func generateProject(name string, deleted bool) *kubermaticv1.Project {
-	project := &kubermaticv1.Project{
+func generateUserProjectBinding(name string, deleted bool) *kubermaticv1.UserProjectBinding {
+	userProjectBinding := &kubermaticv1.UserProjectBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: kubermaticv1.ProjectSpec{
-			Name: fmt.Sprintf("project-%s", name),
-		},
-		Status: kubermaticv1.ProjectStatus{
-			Phase: kubermaticv1.ProjectActive,
+		Spec: kubermaticv1.UserProjectBindingSpec{
+			ProjectID: "test-project",
+			Group:     rbac.EditorGroupNamePrefix + "test-project",
+			UserEmail: "test@test.com",
 		},
 	}
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
-		project.DeletionTimestamp = &deleteTime
-		project.Finalizers = append(project.Finalizers, v1.SeedProjectCleanupFinalizer)
+		userProjectBinding.DeletionTimestamp = &deleteTime
+		userProjectBinding.Finalizers = append(userProjectBinding.Finalizers, v1.SeedUserProjectBindingCleanupFinalizer)
 	}
-	return project
+	return userProjectBinding
 }

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/doc.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/doc.go
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 /*
-Package projectsync contains a controller that is responsible for ensuring that the
-Kubermatic Project objects are synced from master to the seed clusters.
+Package userproejctbindingsync contains a controller that is responsible for ensuring that the
+kubermatic UserProjectBinding objects are synced from master to the seed clusters.
 */
-package projectsync
+
+package userprojectbindingsync

--- a/pkg/controller/master-controller-manager/user-project-binding-sync/resources.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-sync/resources.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userprojectbindingsync
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+func userProjectBindingCreatorGetter(userProjectBinding *kubermaticv1.UserProjectBinding) reconciling.NamedKubermaticV1UserProjectBindingCreatorGetter {
+	return func() (string, reconciling.KubermaticV1UserProjectBindingCreator) {
+		return userProjectBinding.Name, func(p *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error) {
+			p.Name = userProjectBinding.Name
+			p.Labels = userProjectBinding.Labels
+			p.Spec = userProjectBinding.Spec
+			return p, nil
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a sync controller in the master controller manager to propagate `UserProjectBinding` objects from Master Cluster to Seed Cluster.
This is needed for MLA (Monitoring, Logging, Alerting) of user clusters. MLA controller in seed controller manager will map KKP User-Project to Grafana User-Organization.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6707 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
