### PR TITLE
Fix broken s3 storeuploader and broken cluster creation

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.34
+version: 1.1.35
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/cleanup-container.yaml
+++ b/charts/kubermatic/static/cleanup-container.yaml
@@ -1,7 +1,7 @@
 # This file has been generated using hack/update-kubermatic-chart.sh, do not edit.
 
 name: cleanup-container
-image: quay.io/kubermatic/s3-storer:v0.1.5
+image: quay.io/kubermatic/s3-storer:v0.1.6
 command:
 - /bin/sh
 - -c

--- a/charts/kubermatic/static/store-container.yaml
+++ b/charts/kubermatic/static/store-container.yaml
@@ -1,7 +1,7 @@
 # This file has been generated using hack/update-kubermatic-chart.sh, do not edit.
 
 name: store-container
-image: quay.io/kubermatic/s3-storer:v0.1.5
+image: quay.io/kubermatic/s3-storer:v0.1.6
 command:
 - /bin/sh
 - -c

--- a/cmd/s3-storeuploader/README.md
+++ b/cmd/s3-storeuploader/README.md
@@ -29,6 +29,6 @@ GLOBAL OPTIONS:
 
 ```bash
 CGO_ENABLED=0 go build -ldflags '-w -extldflags "-static"' -o s3-storeuploader k8c.io/kubermatic/v2/cmd/s3-storeuploader
-docker build -t quay.io/kubermatic/s3-storer:v0.1.5 .
-docker push quay.io/kubermatic/s3-storer:v0.1.5
+docker build -t quay.io/kubermatic/s3-storer:v0.1.6 .
+docker push quay.io/kubermatic/s3-storer:v0.1.6
 ```

--- a/cmd/s3-storeuploader/main.go
+++ b/cmd/s3-storeuploader/main.go
@@ -35,7 +35,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "S3 storer"
 	app.Usage = ""
-	app.Version = "v1.0.0"
+	app.Version = "v0.1.6"
 	app.Description = "Helper tool to backup files to S3 and maintain a given number of revisions"
 
 	endpointFlag := cli.StringFlag{
@@ -74,7 +74,7 @@ func main() {
 		Name:  "secure",
 		Usage: "Enable tls validation",
 	}
-	caBundleFlag := cli.BoolFlag{
+	caBundleFlag := cli.StringFlag{
 		Name:  "ca-bundle",
 		Usage: "Filename of the CA bundle to use (if not given, default system certificates are used)",
 	}

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -143,7 +143,7 @@ spec:
     # BackupCleanupContainer is the container used for removing expired backups from the storage location.
     backupCleanupContainer: |-
       name: cleanup-container
-      image: quay.io/kubermatic/s3-storer:v0.1.5
+      image: quay.io/kubermatic/s3-storer:v0.1.6
       command:
       - /bin/sh
       - -c
@@ -191,7 +191,7 @@ spec:
     # BackupStoreContainer is the container used for shipping etcd snapshots to a backup location.
     backupStoreContainer: |-
       name: store-container
-      image: quay.io/kubermatic/s3-storer:v0.1.5
+      image: quay.io/kubermatic/s3-storer:v0.1.6
       command:
       - /bin/sh
       - -c

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -638,7 +638,7 @@ func defaultVersioning(settings *operatorv1alpha1.KubermaticVersioningConfigurat
 
 const DefaultBackupStoreContainer = `
 name: store-container
-image: quay.io/kubermatic/s3-storer:v0.1.5
+image: quay.io/kubermatic/s3-storer:v0.1.6
 command:
 - /bin/sh
 - -c
@@ -771,7 +771,7 @@ env:
 
 const DefaultBackupCleanupContainer = `
 name: cleanup-container
-image: quay.io/kubermatic/s3-storer:v0.1.5
+image: quay.io/kubermatic/s3-storer:v0.1.6
 command:
 - /bin/sh
 - -c


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster Creation was broken in new weekly release `weekly-2021-11`.

Error `kubermatic-seed-controller-manager`
```
2021-03-21 19:11:54 | E0321 18:11:54.651126       1 reflector.go:127] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:156: Failed to watch *v1.EtcdBackupConfig: failed to list *v1.EtcdBackupConfig: Get "https://10.96.0.1:443/apis/kubermatic.k8s.io/v1/etcdbackupconfigs?limit=500&resourceVersion=0": stream error: stream ID 21905; INTERNAL_ERROR
```

S3 storeuploader had wrong CLI flag type and caused the error:
```
k logs --all-containers etcd-backup-fbcp67x9v6-1616350652-jqhxs
Creating backup
{"level":"info","ts":1616350657.240245,"caller":"snapshot/v3_snapshot.go:110","msg":"created temporary db file","path":"/backup/snapshot.db.part"}
{"level":"warn","ts":"2021-03-21T18:17:37.407Z","caller":"clientv3/retry_interceptor.go:116","msg":"retry stream intercept"}
{"level":"info","ts":1616350657.4080198,"caller":"snapshot/v3_snapshot.go:121","msg":"fetching snapshot","endpoint":"https://etcd-0.etcd.cluster-fbcp67x9v6.svc.cluster.local.:2379"}
{"level":"info","ts":1616350657.98365,"caller":"snapshot/v3_snapshot.go:134","msg":"fetched snapshot","endpoint":"https://etcd-0.etcd.cluster-fbcp67x9v6.svc.cluster.local.:2379","took":0.743333633}
{"level":"info","ts":1616350657.98382,"caller":"snapshot/v3_snapshot.go:143","msg":"saved","path":"/backup/snapshot.db"}
Snapshot saved at /backup/snapshot.db
Successfully created backup, exiting
Incorrect Usage: invalid boolean value "/etc/ca-bundle/ca-bundle.pem" for -ca-bundle: parse error

NAME:
   s3-storeuploader store - Stores the given file on S3

USAGE:
   s3-storeuploader store [command options] [arguments...]

OPTIONS:
   --endpoint value, -e value  S3 endpoint
   --secure                    Enable tls validation
   --ca-bundle                 Filename of the CA bundle to use (if not given, default system certificates are used)
   --access-key-id value       S3 AccessKeyID [$ACCESS_KEY_ID]
   --secret-access-key value   S3 SecretAccessKey [$SECRET_ACCESS_KEY]
   --bucket value, -b value    S3 bucket in which to store the snapshots (default: "kubermatic-backups")
   --prefix value, -p value    Prefix to use for all objects stored in S3
   --file value, -f value      Path to the file to store in S3 (default: "/backup/snapshot.db")
   --create-bucket             creates the bucket if it does not exist yet
   
{"level":"fatal","time":"2021-03-21T18:17:38.395Z","caller":"s3-storeuploader/main.go:179","msg":"Failed to run command","error":"invalid boolean value \"/etc/ca-bundle/ca-bundle.pem\" for -ca-bundle: parse error"}
```
Temporary fix is to use new builded docker image `quay.io/kubermatic/s3-storer:v0.1.6` via the `KubermaticConfiguration`:
```
  seedController:
    # BackupCleanupContainer is the container used for removing expired backups from the storage location.
    backupCleanupContainer: |-
      name: cleanup-container
      image: quay.io/kubermatic/s3-storer:v0.1.6
      command:
       #..... continue with default
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Why didn't a e2e test fail?
At the run environment no cluster couldn't get created anymore.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
fix S3 storage uploader CA bundle option flag
```
