### PR TITLE
[release/v2.16] fix cert-manager validating webhook

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: cert-manager
-version: 1.4.1
+version: 1.4.2
 appVersion: v0.16.1
 description: A Helm chart for cert-manager
 keywords:

--- a/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -51,4 +51,4 @@ webhooks:
       service:
         name: cert-manager-webhook
         namespace: {{ .Release.Namespace | quote }}
-        path: /mutate
+        path: /validate


### PR DESCRIPTION
**What this PR does / why we need it**:
When setting up the Helm chart, I accidentally copypasted the wrong path here. This can lead to errors like

> Error from server (InternalError): error when creating "charts/cert-manager/test/certificate.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": validating webhook may not return response.patch

In the master branch, #6739 takes care of updating and fixing cert-manager.

**Does this PR introduce a user-facing change?**:
```release-note
Fix cert-manager validating webhook
```
