### PR TITLE
[release/v2.14] fix cert-manager validating webhook

### DIFF
--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: cert-manager
-version: 1.1.8
+version: 1.1.9
 appVersion: v0.13.0
 description: A Helm chart for cert-manager
 keywords:

--- a/config/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/config/cert-manager/templates/webhook-validating-webhook.yaml
@@ -51,4 +51,4 @@ webhooks:
       service:
         name: webhook
         namespace: {{ .Release.Namespace | quote }}
-        path: /mutate
+        path: /validate


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports #6741 and is a manual PR because of the changes to the repo structure.

**Does this PR introduce a user-facing change?**:
```release-note
Fix cert-manager validating webhook
```
