### PR TITLE
[release/v2.16] Implement Project-Sync Controller

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -25,6 +25,7 @@ import (
 	externalcluster "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster"
 	masterconstrainttemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/master-constraint-template-controller"
 	projectlabelsynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-label-synchronizer"
+	projectsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/project-sync"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	seedproxy "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-proxy"
 	seedsync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/seed-sync"
@@ -82,6 +83,9 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	}
 	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create master constraint template controller: %v", err)
+	}
+	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
+		return fmt.Errorf("failed to create projectsync controller: %v", err)
 	}
 
 	return nil

--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -84,7 +84,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create master constraint template controller: %v", err)
 	}
-	if err := projectsync.Add(ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
+	if err := projectsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create projectsync controller: %v", err)
 	}
 

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -161,6 +161,11 @@ func main() {
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",
 			},
+			{
+				ResourceName:     "Project",
+				ImportAlias:      "kubermaticv1",
+				APIVersionPrefix: "KubermaticV1",
+			},
 		},
 	}
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2124,6 +2124,8 @@ const (
 	GatekeeperConstraintCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-constraints"
 	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup
 	KubermaticConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-constraints"
+	// SeedProjectCleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup
+	SeedProjectCleanupFinalizer = "kubermatic.io/cleanup-seed-projects"
 )
 
 func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType {

--- a/pkg/controller/master-controller-manager/project-sync/OWNERS
+++ b/pkg/controller/master-controller-manager/project-sync/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig-app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/master-controller-manager/project-sync/controller.go
+++ b/pkg/controller/master-controller-manager/project-sync/controller.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectsync
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "project-sync-controller"
+)
+
+type reconciler struct {
+	log              *zap.SugaredLogger
+	recorder         record.EventRecorder
+	masterClient     ctrlruntimeclient.Client
+	seedClientGetter provider.SeedClientGetter
+}
+
+func Add(mgr manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+	seedKubeconfigGetter provider.SeedKubeconfigGetter) error {
+
+	reconciler := &reconciler{
+		log:              log.Named(ControllerName),
+		recorder:         mgr.GetEventRecorderFor(ControllerName),
+		masterClient:     mgr.GetClient(),
+		seedClientGetter: provider.SeedClientGetterFactory(seedKubeconfigGetter),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Project{}},
+		&handler.EnqueueRequestForObject{},
+	); err != nil {
+		return fmt.Errorf("failed to create watch for projects: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Seed{}},
+		enqueueAllProjects(reconciler.masterClient, reconciler.log),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for seeds: %v", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles Kubermatic Project objects on the master cluster to all seed clusters
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+
+	project := &kubermaticv1.Project{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, project); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if !project.DeletionTimestamp.IsZero() {
+		if err := r.handleDeletion(ctx, log, project); err != nil {
+			return reconcile.Result{}, fmt.Errorf("handling deletion: %v", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !kuberneteshelper.HasFinalizer(project, kubermaticapiv1.SeedProjectCleanupFinalizer) {
+		kuberneteshelper.AddFinalizer(project, kubermaticapiv1.SeedProjectCleanupFinalizer)
+		if err := r.masterClient.Update(ctx, project); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to add project finalizer %s: %v", project.Name, err)
+		}
+	}
+
+	projectCreatorGetters := []reconciling.NamedKubermaticV1ProjectCreatorGetter{
+		projectCreatorGetter(project),
+	}
+
+	err := r.syncAllSeeds(ctx, log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
+		return reconciling.ReconcileKubermaticV1Projects(ctx, projectCreatorGetters, "", seedClusterClient)
+	})
+
+	if err != nil {
+		r.recorder.Eventf(project, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		return reconcile.Result{}, fmt.Errorf("reconciled project: %s: %v", project.Name, err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, project *kubermaticv1.Project) error {
+	err := r.syncAllSeeds(ctx, log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
+		if err := seedClusterClient.Delete(ctx, project); err != nil {
+			return ctrlruntimeclient.IgnoreNotFound(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if kuberneteshelper.HasFinalizer(project, kubermaticapiv1.SeedProjectCleanupFinalizer) {
+		kuberneteshelper.RemoveFinalizer(project, kubermaticapiv1.SeedProjectCleanupFinalizer)
+		if err := r.masterClient.Update(ctx, project); err != nil {
+			return fmt.Errorf("failed to remove project finalizer %s: %v", project.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) syncAllSeeds(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	project *kubermaticv1.Project,
+	action func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error) error {
+
+	seedList := &kubermaticv1.SeedList{}
+	if err := r.masterClient.List(ctx, seedList); err != nil {
+		return fmt.Errorf("failed listing seeds: %w", err)
+	}
+
+	for _, seed := range seedList.Items {
+		seedClient, err := r.seedClientGetter(&seed)
+		if err != nil {
+			return fmt.Errorf("failed getting seed client for seed %s: %w", seed.Name, err)
+		}
+
+		err = action(seedClient, project)
+		if err != nil {
+			return fmt.Errorf("failed syncing project for seed %s: %w", seed.Name, err)
+		}
+		log.Debugw("Reconciled project with seed", "seed", seed.Name)
+	}
+	return nil
+}
+
+func enqueueAllProjects(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		projectList := &kubermaticv1.ProjectList{}
+		if err := client.List(context.Background(), projectList); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list projects: %v", err))
+		}
+		for _, project := range projectList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: project.Name,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/controller/master-controller-manager/project-sync/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-sync/controller_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectsync
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const projectName = "project-test"
+
+func TestReconcile(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		requestName     string
+		expectedProject *kubermaticv1.Project
+		masterClient    ctrlruntimeclient.Client
+		seedClient      ctrlruntimeclient.Client
+	}{
+		{
+			name:            "scenario 1: sync project from master cluster to seed cluster",
+			requestName:     projectName,
+			expectedProject: generateProject(projectName, false),
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, false), test.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				Build(),
+		},
+		{
+			name:            "scenario 2: cleanup project on the seed cluster when master project is being terminated",
+			requestName:     projectName,
+			expectedProject: nil,
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, true), test.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, false), test.GenTestSeed()).
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: tc.masterClient,
+				seedClientGetter: func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
+					return tc.seedClient, nil
+				},
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			seedProject := &kubermaticv1.Project{}
+			err := tc.seedClient.Get(ctx, request.NamespacedName, seedProject)
+			if tc.expectedProject == nil {
+				if err == nil {
+					t.Fatal("failed clean up project on the seed cluster")
+				} else if !errors.IsNotFound(err) {
+					t.Fatalf("failed to get project: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("failed to get project: %v", err)
+				}
+				if !reflect.DeepEqual(seedProject.Spec, tc.expectedProject.Spec) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedProject, tc.expectedProject))
+				}
+				if !reflect.DeepEqual(seedProject.Name, tc.expectedProject.Name) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedProject, tc.expectedProject))
+				}
+			}
+		})
+	}
+}
+
+func generateProject(name string, deleted bool) *kubermaticv1.Project {
+	project := &kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: projectName,
+		},
+		Spec: kubermaticv1.ProjectSpec{
+			Name: fmt.Sprintf("project-%s", name),
+		},
+		Status: kubermaticv1.ProjectStatus{
+			Phase: kubermaticv1.ProjectActive,
+		},
+	}
+	if deleted {
+		deleteTime := metav1.NewTime(time.Now())
+		project.DeletionTimestamp = &deleteTime
+		project.Finalizers = append(project.Finalizers, v1.SeedProjectCleanupFinalizer)
+	}
+	return project
+}

--- a/pkg/controller/master-controller-manager/project-sync/doc.go
+++ b/pkg/controller/master-controller-manager/project-sync/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package proejctsync contains a controller that is responsible for ensuring that the
+kubermatic Project objects are synced from master to the seed clusters.
+*/
+package projectsync

--- a/pkg/controller/master-controller-manager/project-sync/resources.go
+++ b/pkg/controller/master-controller-manager/project-sync/resources.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectsync
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+func projectCreatorGetter(project *kubermaticv1.Project) reconciling.NamedKubermaticV1ProjectCreatorGetter {
+	return func() (string, reconciling.KubermaticV1ProjectCreator) {
+		return project.Name, func(p *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+			p.Name = project.Name
+			p.Spec = project.Spec
+			p.Status = project.Status
+			return p, nil
+		}
+	}
+}

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -925,7 +925,7 @@ type NamedKubermaticV1ProjectCreatorGetter = func() (name string, create Kuberma
 // KubermaticV1ProjectObjectWrapper adds a wrapper so the KubermaticV1ProjectCreator matches ObjectCreator.
 // This is needed as Go does not support function interface matching.
 func KubermaticV1ProjectObjectWrapper(create KubermaticV1ProjectCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+	return func(existing runtime.Object) (runtime.Object, error) {
 		if existing != nil {
 			return create(existing.(*kubermaticv1.Project))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry pick of #6708 to release/2.16. Needed to fix #6752

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6752

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Kubermatic Projects are now synced from the Master cluster to all Seed clusters. 
Fixed issue where user clusters could not be created properly on multi seed clusters, when the seed is not also the master cluster. 
```
