### PR TITLE
Fixed clusters clusterrolebinding naming and added cleanup

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2127,6 +2127,8 @@ const (
 	SeedProjectCleanupFinalizer = "kubermatic.io/cleanup-seed-projects"
 	// SeedUserProjectBindingCleanupFinalizer indicates that Kubermatic UserProjectBindings on the seed clusters need cleanup
 	SeedUserProjectBindingCleanupFinalizer = "kubermatic.io/cleanup-seed-user-project-bindings"
+	// ClusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup
+	ClusterRoleBindingsCleanupFinalizer = "kubermatic.io/cleanup-cluster-role-bindings"
 )
 
 func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType {

--- a/pkg/clusterdeletion/clusterrolebindings.go
+++ b/pkg/clusterdeletion/clusterrolebindings.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdeletion
+
+import (
+	"context"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/usercluster"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (d *Deletion) cleanupClusterRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer) {
+		return nil
+	}
+
+	toDelete := &rbacv1.ClusterRoleBinding{}
+	toDelete.Name = usercluster.GenClusterRoleBindingName(cluster.Status.NamespaceName)
+	if err := d.seedClient.Delete(ctx, toDelete); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	oldCluster := cluster.DeepCopy()
+	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer)
+	return d.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+}

--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -77,6 +77,11 @@ func (d *Deletion) CleanupCluster(ctx context.Context, log *zap.SugaredLogger, c
 		return err
 	}
 
+	// Delete ClusterRoleBindings on for the cluster on the seed cluster
+	if err := d.cleanupClusterRoleBindings(ctx, cluster); err != nil {
+		return err
+	}
+
 	// If we still have nodes, we must not cleanup other infrastructure at the cloud provider
 	if kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
 		return nil

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -94,6 +94,15 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		}
 	}
 
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer) {
+		err := r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
+			kuberneteshelper.AddFinalizer(c, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &reconcile.Result{}, nil
 }
 

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -17,6 +17,8 @@ limitations under the License.
 package usercluster
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -120,7 +122,7 @@ func ClusterRoleCreator() (string, reconciling.ClusterRoleCreator) {
 
 func ClusterRoleBinding(namespace string) reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
-		return roleBindingName, func(rb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+		return GenClusterRoleBindingName(namespace), func(rb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     roleName,
 				Kind:     "ClusterRole",
@@ -136,4 +138,8 @@ func ClusterRoleBinding(namespace string) reconciling.NamedClusterRoleBindingCre
 			return rb, nil
 		}
 	}
+}
+
+func GenClusterRoleBindingName(targetNamespace string) string {
+	return fmt.Sprintf("%s-%s", roleBindingName, targetNamespace)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed clusters clusterrolebinding naming and added cleanup.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
