### PR TITLE
Handle apiextensions/v1 CRDs

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -39,6 +39,7 @@ import (
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -222,6 +223,10 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		}
 
 		kubeClient := mgr.GetClient()
+
+		if err := apiextensionsv1.AddToScheme(mgr.GetScheme()); err != nil {
+			return fmt.Errorf("failed to add scheme: %v", err)
+		}
 
 		if err := apiextensionsv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
 			return fmt.Errorf("failed to add scheme: %v", err)

--- a/pkg/install/util/crd.go
+++ b/pkg/install/util/crd.go
@@ -44,8 +44,10 @@ func DeployCRDs(ctx context.Context, kubeClient ctrlruntimeclient.Client, log lo
 		if err := kubeClient.Create(ctx, crd); err != nil && !kerrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to deploy CRD %s: %v", crd.GetName(), err)
 		}
+	}
 
-		// wait for CRD to be established
+	// wait for CRDs to be established
+	for _, crd := range crds {
 		if err := WaitForReadyCRD(ctx, kubeClient, crd.GetName(), 30*time.Second); err != nil {
 			return fmt.Errorf("failed to wait for CRD %s to have Established=True condition: %v", crd.GetName(), err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the code for loading CRDs from disk a bit more generic, allowing it to handle both v1beta1 and v1 CRDs. This is required for us upgrading cert-manager, for example.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
