### PR TITLE
allow to disable Minio's s3-credentials Secret

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.20
+version: 1.0.21
 appVersion: RELEASE.2021-03-04T00-53-13Z
 description: minio
 keywords:

--- a/charts/minio/templates/secret-external.yaml
+++ b/charts/minio/templates/secret-external.yaml
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ with .Values.minio.credentials.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: s3-credentials
-  namespace: kube-system
+  name: {{ .name | quote }}
+  namespace: {{ .namespace | quote }}
 type: Opaque
 data:
-  ACCESS_KEY_ID: "{{ .Values.minio.credentials.accessKey | b64enc }}"
-  SECRET_ACCESS_KEY: "{{ .Values.minio.credentials.secretKey | b64enc }}"
+  ACCESS_KEY_ID: {{ $.Values.minio.credentials.accessKey | b64enc | quote }}
+  SECRET_ACCESS_KEY: {{ $.Values.minio.credentials.secretKey | b64enc | quote }}
+{{ end }}

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -23,6 +23,16 @@ minio:
     accessKey: '' # 32 byte long
     secretKey: '' # 64 byte long
 
+    # When set to true, a Secret will be created in the given namespace.
+    # Kubermatic requires an "s3-credentials" Secret in the kube-system
+    # namespace to perform usercluster etcd snapshots, _if_ the default
+    # backup containers are used (see KubermaticConfiguration).
+    # Otherwise, this can be disabled for example by setting
+    # `--set "minio.credentials.secret=null"` when running Helm.
+    secret:
+      name: s3-credentials
+      namespace: kube-system
+
   flags:
     # Set to true to enable Minio's strict S3 compatibility mode.
     # See https://github.com/minio/minio/pull/7609 for more information.
@@ -49,14 +59,14 @@ minio:
         cpu: 100m
         memory: 32Mi
       limits:
-        cpu: 300m
+        cpu: 1
         memory: 512Mi
     backup:
       requests:
         cpu: 50m
         memory: 32Mi
       limits:
-        cpu: 500m
+        cpu: 1
         memory: 1500Mi
 
   nodeSelector: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
In some environments, the Minio chart is installed multiple times (e.g. on CI, where we have it as a general storage and a second version just as a gocache), so it would be nice if two Helm releases do not fight over the same Secet.

**Does this PR introduce a user-facing change?**:
```release-note
Allow to disable the s3-credentials Secret in the Minio chart
```
