### PR TITLE
fix test certificate for KKP installer

### DIFF
--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -24,6 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,6 +56,10 @@ func waitForCertManagerWebhook(ctx context.Context, logger *logrus.Entry, kubeCl
 		},
 		Spec: certmanagerv1alpha2.CertificateSpec{
 			SecretName: certName,
+			DNSNames:   []string{"www.example.com"},
+			IssuerRef: v1.ObjectReference{
+				Name: "dummy-issuer", // does not have to actually exist
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Suddenly the cert-manager started to reject my cert.

**Does this PR introduce a user-facing change?**:
```release-note
Fix installer trying an invalid certificate to test cert-manager
```
