### PR TITLE
Bump all Docker images to Alpine 3.13

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.4.1
+      - image: quay.io/kubermatic/util:1.5.0
         command:
         - "./hack/ci/verify-chart-versions.sh"
         resources:
@@ -145,7 +145,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.4.1
+      - image: quay.io/kubermatic/util:1.5.0
         command:
         - "./hack/verify-grafana-dashboards.sh"
         resources:
@@ -266,7 +266,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/wwhrd:0.4.0-1
+      - image: quay.io/kubermatic/wwhrd:0.4.0-2
         command:
         - ./hack/verify-licenses.sh
         resources:
@@ -298,7 +298,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.4.1
+      - image: quay.io/kubermatic/util:1.5.0
         command:
         - ./hack/verify-prometheus-rules.sh
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.12
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 ENV KUBERMATIC_CHARTS_DIRECTORY=/opt/charts/
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.19.7/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.20.5/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN wget -O- https://get.helm.sh/helm-v3.5.0-linux-amd64.tar.gz | tar xzOf - linux-amd64/helm > /usr/local/bin/helm
 
 # We need the ca-certs so they api doesn't crash because it can't verify the certificate of Dex

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 ADD ./ /addons/

--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.4.10
+version: 1.4.11
 appVersion: 7.4.3
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -28,7 +28,7 @@ grafana:
     tag: 1.4.1
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
-    tag: 1.2.0
+    tag: 1.3.0
   resources:
     requests:
       cpu: 100m

--- a/cmd/http-prober/Dockerfile
+++ b/cmd/http-prober/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/cmd/http-prober/release.sh
+++ b/cmd/http-prober/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ver=v0.3.1
+ver=v0.3.2
 
 set -euox pipefail
 

--- a/cmd/kubeletdnat-controller/Dockerfile
+++ b/cmd/kubeletdnat-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -u iptables

--- a/cmd/nodeport-proxy/Dockerfile
+++ b/cmd/nodeport-proxy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:latest
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 ADD ./_build/lb-updater /

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/hack/images/grafana-plugins/Dockerfile
+++ b/hack/images/grafana-plugins/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.12
+FROM alpine:3.13
+LABEL maintainer="support@kubermatic.com"
 
 RUN mkdir -p /plugins
 WORKDIR /plugins

--- a/hack/images/grafana-plugins/release.sh
+++ b/hack/images/grafana-plugins/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/grafana-plugins
-VERSION=1.2.0
+VERSION=1.3.0
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}" .
 docker push "${REPOSITORY}:${VERSION}"

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.12
+FROM alpine:3.13
+LABEL maintainer="support@kubermatic.com"
 
-ENV MC_VERSION=RELEASE.2020-09-03T00-08-28Z \
-    KUBECTL_VERSION=v1.18.8 \
-    HELM_VERSION=v2.16.9 \
-    VAULT_VERSION=1.5.1 \
+ENV MC_VERSION=RELEASE.2021-03-12T03-36-59Z \
+    KUBECTL_VERSION=v1.20.5 \
+    HELM_VERSION=v2.17.0 \
+    VAULT_VERSION=1.6.3 \
     YQ_VERSION=3.3.4 \
     WWHRD_VERSION=0.4.0
 

--- a/hack/images/util/release.sh
+++ b/hack/images/util/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/util
-VERSION=1.4.1
+VERSION=1.5.0
 SUFFIX=""
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}${SUFFIX}" .

--- a/hack/images/wwhrd/Dockerfile
+++ b/hack/images/wwhrd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.12 AS builder
+FROM alpine:3.13 AS builder
 
 RUN apk update
 RUN apk add curl
@@ -20,6 +20,7 @@ RUN cd tmp && curl -L --fail https://github.com/frapposelli/wwhrd/releases/downl
 RUN /tmp/wwhrd -v
 
 FROM golang:1.16.1
+LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /tmp/wwhrd /usr/local/bin/
 ENTRYPOINT ["wwhrd"]

--- a/hack/images/wwhrd/release.sh
+++ b/hack/images/wwhrd/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/wwhrd
 VERSION=0.4.0
-NUMBER=1
+NUMBER=2
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}-${NUMBER}" .
 docker push "${REPOSITORY}:${VERSION}-${NUMBER}"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -93,7 +93,7 @@ EOF
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:1.4.1}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:1.5.0}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
 
   if ! [ -f /.dockerenv ]; then

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/wwhrd:0.4.0-0 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/wwhrd:0.4.0-2 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -228,7 +228,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret) rec
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   "quay.io/kubermatic/util:1.4.1",
+					Image:   "quay.io/kubermatic/util:1.5.0",
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	tag                = "v0.3.1"
+	tag                = "v0.3.2"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
@@ -198,7 +198,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller-webhook.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
@@ -198,7 +198,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller-webhook.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
@@ -198,7 +198,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-machine-controller-webhook.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-machine-controller.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -198,7 +198,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller-webhook.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller-webhook.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-machine-controller-webhook.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-machine-controller-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller-webhook.yaml
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller-webhook.yaml
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-machine-controller-webhook.yaml
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1
+        image: quay.io/kubermatic/http-prober:v0.3.2
         name: copy-http-prober
         resources: {}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
Starring at build logs made me notice the various different Alpine versions in use. This PR cleans up and bumps all to the same version.

All images have been built and pushed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
