### PR TITLE
Handle cert-manager CRD migration in Installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -87,6 +87,10 @@ var (
 		Name:  "storageclass",
 		Usage: fmt.Sprintf("Type of StorageClass to create (one of %v)", common.SupportedStorageClassProviders().List()),
 	}
+	enableCertManagerV2MigrationFlag = cli.BoolFlag{
+		Name:  "migrate-cert-manager",
+		Usage: "enable the migration for cert-manager CRDs from v1alpha2 to v1",
+	}
 )
 
 func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) cli.Command {
@@ -104,6 +108,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) c
 			deployHelmTimeoutFlag,
 			deployHelmBinaryFlag,
 			deployStorageClassFlag,
+			enableCertManagerV2MigrationFlag,
 		},
 	}
 }
@@ -245,15 +250,16 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		}
 
 		opt := stack.DeployOptions{
-			HelmClient:                 helmClient,
-			KubeClient:                 kubeClient,
-			HelmValues:                 helmValues,
-			KubermaticConfiguration:    kubermaticConfig,
-			RawKubermaticConfiguration: rawKubermaticConfig,
-			Logger:                     subLogger,
-			StorageClassProvider:       ctx.String(deployStorageClassFlag.Name),
-			ForceHelmReleaseUpgrade:    ctx.Bool(deployForceFlag.Name),
-			ChartsDirectory:            ctx.GlobalString(chartsDirectoryFlag.Name),
+			HelmClient:                   helmClient,
+			KubeClient:                   kubeClient,
+			HelmValues:                   helmValues,
+			KubermaticConfiguration:      kubermaticConfig,
+			RawKubermaticConfiguration:   rawKubermaticConfig,
+			Logger:                       subLogger,
+			StorageClassProvider:         ctx.String(deployStorageClassFlag.Name),
+			ForceHelmReleaseUpgrade:      ctx.Bool(deployForceFlag.Name),
+			ChartsDirectory:              ctx.GlobalString(chartsDirectoryFlag.Name),
+			EnableCertManagerV2Migration: ctx.Bool(enableCertManagerV2MigrationFlag.Name),
 		}
 
 		logger.Infof("🧩 Deploying %s…", kubermaticStack.Name())

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -78,6 +78,15 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 	v2 := semver.MustParse("2.0.0")
 
 	if release != nil && release.Version.LessThan(v2) && !chart.Version.LessThan(v2) {
+		if !opt.EnableCertManagerV2Migration {
+			sublogger.Warn("cert-manager CRDs need to be migrated. This requires to temporarily remove and recreate")
+			sublogger.Warn("all related resources (like Certificates, Issuers, etc.). Rerun the installer with")
+			sublogger.Warn("--migrate-cert-manager to enable this mandatory migration.")
+			sublogger.Warn("Please refer to the KKP 2.17 upgrade notes for more information.")
+
+			return fmt.Errorf("user must acknowledge the migration using --migrate-cert-manager")
+		}
+
 		if err := migrateCertManagerV2(ctx, sublogger, kubeClient, helmClient, opt, chart, release); err != nil {
 			return fmt.Errorf("upgrade failed: %v", err)
 		}

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -188,17 +188,13 @@ func migrateCertManagerV2(
 	logger.Info("Removing Custom Resource Definitions…")
 	for _, crdGVK := range allCRDs {
 		crd := apiextensionsv1.CustomResourceDefinition{}
-		key := types.NamespacedName{Name: crdName(crdGVK)}
+		crd.Name = crdName(crdGVK)
 
-		if err := kubeClient.Get(ctx, key, &crd); err != nil {
+		if err := kubeClient.Delete(ctx, &crd); err != nil {
 			if kerrors.IsNotFound(err) {
 				continue
 			}
 
-			return fmt.Errorf("failed to retrieve CRD %s: %v", crdGVK.Kind, err)
-		}
-
-		if err := kubeClient.Delete(ctx, &crd); err != nil {
 			return fmt.Errorf("failed to delete CRD %s: %v", crdGVK.Kind, err)
 		}
 	}

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -19,19 +19,137 @@ package kubermaticmaster
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
+	"k8c.io/kubermatic/v2/pkg/install/stack"
+	"k8c.io/kubermatic/v2/pkg/install/util"
+	"k8c.io/kubermatic/v2/pkg/log"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	v1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	logger.Info("📦 Deploying cert-manager…")
+	sublogger := log.Prefix(logger, "   ")
+
+	if opt.KubermaticConfiguration.Spec.Ingress.CertificateIssuer.Name == "" {
+		sublogger.Info("No CertificateIssuer configured in KubermaticConfiguration, skipping.")
+		return nil
+	}
+
+	chartDir := filepath.Join(opt.ChartsDirectory, "cert-manager")
+
+	chart, err := helm.LoadChart(chartDir)
+	if err != nil {
+		return fmt.Errorf("failed to load Helm chart: %v", err)
+	}
+
+	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, CertManagerNamespace); err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, CertManagerNamespace, CertManagerReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to check to Helm release: %v", err)
+	}
+
+	// if a pre-2.0 version of the chart is installed, we must perform a
+	// larger migration to bring the cluster from cert-manager 0.16 to 1.x
+	// (and its CRD from v1alpha2 to v1)
+	v2 := semver.MustParse("2.0.0")
+
+	if release != nil && release.Version.LessThan(v2) && !chart.Version.LessThan(v2) {
+		if err := purgeCertManager(ctx, sublogger, kubeClient, helmClient, opt, chart, release); err != nil {
+			return fmt.Errorf("upgrade failed: %v", err)
+		}
+	}
+
+	sublogger.Info("Deploying Custom Resource Definitions…")
+	if err := util.DeployCRDs(ctx, kubeClient, sublogger, filepath.Join(chartDir, "crd")); err != nil {
+		return fmt.Errorf("failed to deploy CRDs: %v", err)
+	}
+
+	sublogger.Info("Deploying Helm chart…")
+	release, err = util.CheckHelmRelease(ctx, sublogger, helmClient, CertManagerNamespace, CertManagerReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to check to Helm release: %v", err)
+	}
+
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, CertManagerNamespace, CertManagerReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	}
+
+	if err := waitForCertManagerWebhook(ctx, sublogger, kubeClient); err != nil {
+		return fmt.Errorf("failed to verify that the webhook is functioning: %v", err)
+	}
+
+	logger.Info("✅ Success.")
+
+	return nil
+}
+
+// purgeCertManager removes all tracecs of cert-manager from the cluster,
+// so that the installer can then install it cleanly.
+func purgeCertManager(
+	ctx context.Context,
+	logger *logrus.Entry,
+	kubeClient ctrlruntimeclient.Client,
+	helmClient helm.Client,
+	opt stack.DeployOptions,
+	chart *helm.Chart,
+	release *helm.Release,
+) error {
+	logger.Infof("%s detected, performing upgrade to Helm chart %s…", release.Version.String(), chart.Version.String())
+
+	// step 1: purge the Helm release
+	logger.Info("Uninstalling cert-manager…")
+	if err := helmClient.UninstallRelease(CertManagerNamespace, CertManagerReleaseName); err != nil {
+		return fmt.Errorf("failed to uninstall release: %v", err)
+	}
+
+	// step 2: delete all cert-manager CRDs
+	logger.Info("Removing cert-manager Custom Resource Definitions…")
+	crdNames := []string{
+		"certificaterequests.cert-manager.io",
+		"certificates.cert-manager.io",
+		"challenges.acme.cert-manager.io",
+		"clusterissuers.cert-manager.io",
+		"issuers.cert-manager.io",
+		"orders.acme.cert-manager.io",
+	}
+	for _, crdName := range crdNames {
+		logger.Info("  %s", crdName)
+
+		crd := apiextensionsv1beta1.CustomResourceDefinition{}
+		key := types.NamespacedName{Name: crdName}
+
+		if err := kubeClient.Get(ctx, key, &crd); err != nil {
+			if kerrors.IsNotFound(err) {
+				continue
+			}
+
+			return fmt.Errorf("failed to retrieve CRD %s: %v", crdName, err)
+		}
+
+		if err := kubeClient.Delete(ctx, &crd); err != nil {
+			return fmt.Errorf("failed to delete CRD %s: %v", crdName, err)
+		}
+	}
+
+	return nil
+}
 
 func waitForCertManagerWebhook(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client) error {
 	logger.Debug("Waiting for webhook to become ready…")
@@ -45,7 +163,9 @@ func waitForCertManagerWebhook(ctx context.Context, logger *logrus.Entry, kubeCl
 
 	// always clean up on a best-effort basis
 	defer func() {
-		_ = deleteCertificate(ctx, kubeClient, CertManagerNamespace, certName)
+		if err := deleteCertificate(ctx, kubeClient, CertManagerNamespace, certName); err != nil {
+			logger.Warnf("Failed to cleanup: %v", err)
+		}
 	}()
 
 	// create a dummy cert to see if the webhook is alive and well

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -377,30 +377,6 @@ func removeFinalizersFromCustomResources(ctx context.Context, kubeClient ctrlrun
 	return nil
 }
 
-func waitForCRDsGone(ctx context.Context, kubeClient ctrlruntimeclient.Client, crds []schema.GroupVersionKind, finalizers []string) error {
-	for _, crdGVK := range crds {
-		items, err := util.ListResources(ctx, kubeClient, crdGVK)
-		if err != nil {
-			return fmt.Errorf("failed to list %s resources: %v", crdGVK.Kind, err)
-		}
-
-		for idx := range items {
-			item := items[idx]
-
-			if kubernetes.HasAnyFinalizer(&item, finalizers...) {
-				oldItem := item.DeepCopy()
-				kubernetes.RemoveFinalizer(&item, finalizers...)
-
-				if err := kubeClient.Patch(ctx, &item, ctrlruntimeclient.MergeFrom(oldItem)); err != nil {
-					return fmt.Errorf("failed to patch %s %s/%s: %v", crdGVK.Kind, item.GetNamespace(), item.GetName(), err)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
 func waitForCertManagerWebhook(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client) error {
 	logger.Debug("Waiting for webhook to become ready…")
 

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -18,23 +18,30 @@ package kubermaticmaster
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
+
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/log"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
-	v1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,14 +78,14 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 	v2 := semver.MustParse("2.0.0")
 
 	if release != nil && release.Version.LessThan(v2) && !chart.Version.LessThan(v2) {
-		if err := purgeCertManager(ctx, sublogger, kubeClient, helmClient, opt, chart, release); err != nil {
+		if err := migrateCertManagerV2(ctx, sublogger, kubeClient, helmClient, opt, chart, release); err != nil {
 			return fmt.Errorf("upgrade failed: %v", err)
 		}
-	}
-
-	sublogger.Info("Deploying Custom Resource Definitions…")
-	if err := util.DeployCRDs(ctx, kubeClient, sublogger, filepath.Join(chartDir, "crd")); err != nil {
-		return fmt.Errorf("failed to deploy CRDs: %v", err)
+	} else {
+		sublogger.Info("Deploying Custom Resource Definitions…")
+		if err := util.DeployCRDs(ctx, kubeClient, sublogger, filepath.Join(chartDir, "crd")); err != nil {
+			return fmt.Errorf("failed to deploy CRDs: %v", err)
+		}
 	}
 
 	sublogger.Info("Deploying Helm chart…")
@@ -100,9 +107,9 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 	return nil
 }
 
-// purgeCertManager removes all tracecs of cert-manager from the cluster,
+// migrateCertManagerV2 removes all tracecs of cert-manager from the cluster,
 // so that the installer can then install it cleanly.
-func purgeCertManager(
+func migrateCertManagerV2(
 	ctx context.Context,
 	logger *logrus.Entry,
 	kubeClient ctrlruntimeclient.Client,
@@ -111,40 +118,283 @@ func purgeCertManager(
 	chart *helm.Chart,
 	release *helm.Release,
 ) error {
-	logger.Infof("%s detected, performing upgrade to Helm chart %s…", release.Version.String(), chart.Version.String())
+	logger.Infof("%s detected, performing upgrade to %s…", release.Version.String(), chart.Version.String())
 
 	// step 1: purge the Helm release
-	logger.Info("Uninstalling cert-manager…")
+	logger.Info("Uninstalling release…")
 	if err := helmClient.UninstallRelease(CertManagerNamespace, CertManagerReleaseName); err != nil {
 		return fmt.Errorf("failed to uninstall release: %v", err)
 	}
 
-	// step 2: delete all cert-manager CRDs
-	logger.Info("Removing cert-manager Custom Resource Definitions…")
-	crdNames := []string{
-		"certificaterequests.cert-manager.io",
-		"certificates.cert-manager.io",
-		"challenges.acme.cert-manager.io",
-		"clusterissuers.cert-manager.io",
-		"issuers.cert-manager.io",
-		"orders.acme.cert-manager.io",
-	}
-	for _, crdName := range crdNames {
-		logger.Info("  %s", crdName)
+	now := time.Now().Format("2006-01-02T150405")
 
-		crd := apiextensionsv1beta1.CustomResourceDefinition{}
-		key := types.NamespacedName{Name: crdName}
+	// for these CRDs, we not only back them up as YAML, but also restore them
+	// automatically so the user doesn't have to (and we filter out resources
+	// with an ownerRef, which would indicate that some other process/object
+	// manages a given certificate, for example)
+	restorableCRDs := []schema.GroupVersionKind{
+		// restore issuers and clusterissues before certs and requests
+		{Version: "v1alpha2", Group: "cert-manager.io", Kind: "clusterissuer"},
+		{Version: "v1alpha2", Group: "cert-manager.io", Kind: "issuer"},
+		{Version: "v1alpha2", Group: "cert-manager.io", Kind: "certificaterequest"},
+		{Version: "v1alpha2", Group: "cert-manager.io", Kind: "certificate"},
+	}
+
+	allCRDs := append(
+		restorableCRDs,
+		schema.GroupVersionKind{Version: "v1alpha2", Group: "acme.cert-manager.io", Kind: "challenge"},
+		schema.GroupVersionKind{Version: "v1alpha2", Group: "acme.cert-manager.io", Kind: "order"},
+	)
+
+	// step 2: fetch restorable resources in memory
+	logger.Info("Creating backups for all Custom Resources…")
+	objectsToRestore, secrets, err := getCustomResources(ctx, logger, kubeClient, restorableCRDs)
+	if err != nil {
+		return fmt.Errorf("failed to list resources: %v", err)
+	}
+
+	// step 3: backup resources into files
+	for _, crdGVK := range allCRDs {
+		logger.Infof("  dumping %s", crdGVK.Kind)
+
+		filename := fmt.Sprintf("backup_%s_%s.yaml", now, crdGVK.Kind)
+		if err := util.BackupResources(ctx, kubeClient, crdGVK, filename); err != nil {
+			return fmt.Errorf("failed to backup %s resources: %v", crdGVK.Kind, err)
+		}
+	}
+
+	logger.Infof("  dumping secret")
+	filename := fmt.Sprintf("backup_%s_secret.yaml", now)
+	if err := util.DumpResources(ctx, filename, secrets); err != nil {
+		return fmt.Errorf("failed to backup secret resources: %v", err)
+	}
+
+	// step 4: remove finalizers from resources
+	logger.Info("Removing finalizers from Custom Resources…")
+	if err := removeFinalizersFromCustomResources(ctx, kubeClient, allCRDs, []string{"finalizer.acme.cert-manager.io"}); err != nil {
+		return fmt.Errorf("failed to remove finalizers: %v", err)
+	}
+
+	// step 5: delete all cert-manager CRDs
+	logger.Info("Removing Custom Resource Definitions…")
+	for _, crdGVK := range allCRDs {
+		crd := apiextensionsv1.CustomResourceDefinition{}
+		key := types.NamespacedName{Name: crdName(crdGVK)}
 
 		if err := kubeClient.Get(ctx, key, &crd); err != nil {
 			if kerrors.IsNotFound(err) {
 				continue
 			}
 
-			return fmt.Errorf("failed to retrieve CRD %s: %v", crdName, err)
+			return fmt.Errorf("failed to retrieve CRD %s: %v", crdGVK.Kind, err)
 		}
 
 		if err := kubeClient.Delete(ctx, &crd); err != nil {
-			return fmt.Errorf("failed to delete CRD %s: %v", crdName, err)
+			return fmt.Errorf("failed to delete CRD %s: %v", crdGVK.Kind, err)
+		}
+	}
+
+	// wait for all CRs to be gone; we do this now after deleting all
+	// CRDs so that as many CRs as possible can be cleaned up, if e.g.
+	// the first CRD already got stuck it doesn't block others from
+	// being cleaned up
+	hasErrors := false
+	for _, crdGVK := range allCRDs {
+		if err := util.WaitForCRDGone(ctx, kubeClient, crdName(crdGVK), 10*time.Second); err != nil {
+			logger.Errorf("  %s could not be deleted, please check for remaining resources and remove any finalizers", crdName(crdGVK))
+			hasErrors = true
+		}
+	}
+
+	if hasErrors {
+		logger.Warn("Remaining finalizers indicate third party controllers that due to the deleted")
+		logger.Warn("CRDs cannot properly clean up anymore and must be resolved manually.")
+		logger.Warn("After manual cleanup, ensure that all cert-manager CRDs are gone from the cluster.")
+		logger.Warn("You can then re-run the installer and it will continue the migration.")
+		return errors.New("cleanup failed")
+	}
+
+	// step 6: install new CRDs
+	logger.Info("Deploying new Custom Resource Definitions…")
+	if err := util.DeployCRDs(ctx, kubeClient, logger, filepath.Join(chart.Directory, "crd")); err != nil {
+		return fmt.Errorf("failed to deploy CRDs: %v", err)
+	}
+
+	// step 7: recreate deleted resources
+	logger.Info("Recreating deleted resources…")
+	for _, object := range objectsToRestore {
+		logger.Infof("  creating %s %s/%s", object.GroupVersionKind().Kind, object.GetNamespace(), object.GetName())
+
+		object.SetResourceVersion("")
+		object.SetUID("")
+		object.SetSelfLink("")
+
+		// only log errors, but continue, as the user can easily fix
+		// problems by using the YAML backup files
+		if err := kubeClient.Create(ctx, &object); err != nil {
+			if kerrors.IsAlreadyExists(err) {
+				logger.Warn("  already exists, please compare to backup")
+			} else {
+				logger.Errorf("  failed: %v", err)
+			}
+
+			hasErrors = true
+		}
+	}
+
+	if hasErrors {
+		logger.Warn("Use the YAML backup files to manually recreate missing resources.")
+	}
+
+	return nil
+}
+
+// crdName returns the plural name of a CRD. It assumes the given GVK
+// is in singular. This function is required because for _fetching_
+// custom resources we need the singular name, but to fetch the CRD
+// itself we need the plural name.
+func crdName(gvk schema.GroupVersionKind) string {
+	// make kind plural, the cheap and easy and brittle way
+	gvk.Kind += "s"
+
+	return gvk.GroupKind().String()
+}
+
+func getCustomResources(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, crds []schema.GroupVersionKind) ([]unstructured.Unstructured, []unstructured.Unstructured, error) {
+	resources := []unstructured.Unstructured{}
+	secrets := []unstructured.Unstructured{}
+
+	for _, crdGVK := range crds {
+		logger.Infof("  fetching %s", crdGVK.Kind)
+
+		items, err := util.ListResources(ctx, kubeClient, crdGVK)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list %s resources: %v", crdGVK.Kind, err)
+		}
+
+		for idx := range items {
+			item := items[idx]
+
+			// we want to only restore resources that have not been automatically
+			// created by cert-manager, e.g. via Ingress annotation, so we filter
+			// out anything that has an owner ref; excluded resources are still
+			// backed up as YAML
+			if len(item.GetOwnerReferences()) == 0 {
+				resources = append(resources, item)
+			}
+
+			// for certificates, we want to also dump the Secret that contains
+			// the actual certificate data
+			if crdGVK.Kind == "certificate" {
+				secret, err := getSecretForCertificate(ctx, kubeClient, item)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to get Secret for certificate %s/%s: %v", item.GetNamespace(), item.GetName(), err)
+				}
+
+				if secret != nil {
+					// as the Secret most likely has an ownerRef to the Certificate, we
+					// must restore it _after_ the Certificate has been created
+					resources = append(resources, *secret)
+
+					// dump secrets later as well
+					secrets = append(secrets, *secret)
+				}
+			}
+		}
+	}
+
+	return resources, secrets, nil
+}
+
+func getSecretForCertificate(ctx context.Context, kubeClient ctrlruntimeclient.Client, unstructuredCert unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	// convert to typed certificate
+	bytes, err := unstructuredCert.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode certificate as JSON: %v", err)
+	}
+
+	cert := &certmanagerv1alpha2.Certificate{}
+	if err := json.Unmarshal(bytes, cert); err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+
+	// invalid cert
+	if cert.Spec.SecretName == "" {
+		return nil, nil
+	}
+
+	// just because a SecretName is set, does not mean it exists;
+	// we could check the cert Status and parse the conditions, but
+	// it's easier to just try to fetch the secret and see what happens
+	secret := &v1.Secret{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{
+		Name:      cert.Spec.SecretName,
+		Namespace: cert.Namespace,
+	}, secret); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to retrieve Secret %q for certificate: %v", cert.Spec.SecretName, err)
+	}
+
+	// convert back to unstructured to make the surrounding handling
+	// code easier
+	bytes, err = json.Marshal(secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode Secret as JSON: %v", err)
+	}
+
+	result := &unstructured.Unstructured{}
+	if err := result.UnmarshalJSON(bytes); err != nil {
+		return nil, fmt.Errorf("failed to decode Secret: %v", err)
+	}
+
+	return result, nil
+}
+
+func removeFinalizersFromCustomResources(ctx context.Context, kubeClient ctrlruntimeclient.Client, crds []schema.GroupVersionKind, finalizers []string) error {
+	for _, crdGVK := range crds {
+		items, err := util.ListResources(ctx, kubeClient, crdGVK)
+		if err != nil {
+			return fmt.Errorf("failed to list %s resources: %v", crdGVK.Kind, err)
+		}
+
+		for idx := range items {
+			item := items[idx]
+
+			if kubernetes.HasAnyFinalizer(&item, finalizers...) {
+				oldItem := item.DeepCopy()
+				kubernetes.RemoveFinalizer(&item, finalizers...)
+
+				if err := kubeClient.Patch(ctx, &item, ctrlruntimeclient.MergeFrom(oldItem)); err != nil {
+					return fmt.Errorf("failed to patch %s %s/%s: %v", crdGVK.Kind, item.GetNamespace(), item.GetName(), err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func waitForCRDsGone(ctx context.Context, kubeClient ctrlruntimeclient.Client, crds []schema.GroupVersionKind, finalizers []string) error {
+	for _, crdGVK := range crds {
+		items, err := util.ListResources(ctx, kubeClient, crdGVK)
+		if err != nil {
+			return fmt.Errorf("failed to list %s resources: %v", crdGVK.Kind, err)
+		}
+
+		for idx := range items {
+			item := items[idx]
+
+			if kubernetes.HasAnyFinalizer(&item, finalizers...) {
+				oldItem := item.DeepCopy()
+				kubernetes.RemoveFinalizer(&item, finalizers...)
+
+				if err := kubeClient.Patch(ctx, &item, ctrlruntimeclient.MergeFrom(oldItem)); err != nil {
+					return fmt.Errorf("failed to patch %s %s/%s: %v", crdGVK.Kind, item.GetNamespace(), item.GetName(), err)
+				}
+			}
 		}
 	}
 
@@ -163,6 +413,9 @@ func waitForCertManagerWebhook(ctx context.Context, logger *logrus.Entry, kubeCl
 
 	// always clean up on a best-effort basis
 	defer func() {
+		// it can take a moment for the cert to appear
+		time.Sleep(3 * time.Second)
+
 		if err := deleteCertificate(ctx, kubeClient, CertManagerNamespace, certName); err != nil {
 			logger.Warnf("Failed to cleanup: %v", err)
 		}
@@ -177,7 +430,7 @@ func waitForCertManagerWebhook(ctx context.Context, logger *logrus.Entry, kubeCl
 		Spec: certmanagerv1alpha2.CertificateSpec{
 			SecretName: certName,
 			DNSNames:   []string{"www.example.com"},
-			IssuerRef: v1.ObjectReference{
+			IssuerRef: certmanagermetav1.ObjectReference{
 				Name: "dummy-issuer", // does not have to actually exist
 			},
 		},

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -30,15 +30,16 @@ import (
 )
 
 type DeployOptions struct {
-	HelmClient                 helm.Client
-	HelmValues                 *yamled.Document
-	KubeClient                 ctrlruntimeclient.Client
-	StorageClassProvider       string
-	KubermaticConfiguration    *operatorv1alpha1.KubermaticConfiguration
-	RawKubermaticConfiguration *unstructured.Unstructured
-	ForceHelmReleaseUpgrade    bool
-	ChartsDirectory            string
-	Logger                     *logrus.Entry
+	HelmClient                   helm.Client
+	HelmValues                   *yamled.Document
+	KubeClient                   ctrlruntimeclient.Client
+	StorageClassProvider         string
+	KubermaticConfiguration      *operatorv1alpha1.KubermaticConfiguration
+	RawKubermaticConfiguration   *unstructured.Unstructured
+	ForceHelmReleaseUpgrade      bool
+	ChartsDirectory              string
+	Logger                       *logrus.Entry
+	EnableCertManagerV2Migration bool
 }
 
 type Stack interface {

--- a/pkg/install/util/backup.go
+++ b/pkg/install/util/backup.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BackupResources takes a GroupVersionKind and dumps all resources
+// of that type (across all namespaces) as YAML into the given
+// filename (the file will be truncated first).
+func BackupResources(ctx context.Context, kubeClient ctrlruntimeclient.Client, gvk schema.GroupVersionKind, filename string) error {
+	items, err := ListResources(ctx, kubeClient, gvk)
+	if err != nil {
+		return fmt.Errorf("failed to list resources: %v", err)
+	}
+
+	return DumpResources(ctx, filename, items)
+}
+
+func ListResources(ctx context.Context, kubeClient ctrlruntimeclient.Client, gvk schema.GroupVersionKind) ([]unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+
+	if err := kubeClient.List(ctx, list); err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}
+
+func DumpResources(ctx context.Context, filename string, objects []unstructured.Unstructured) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %v", filename, err)
+	}
+	defer f.Close()
+
+	encoder := yaml.NewEncoder(f)
+	encoder.SetIndent(2)
+
+	f.WriteString(fmt.Sprintf("# This backup was created %s.\n", time.Now().Format(time.UnixDate)))
+
+	for _, item := range objects {
+		encoder.Encode(item.Object)
+	}
+
+	return nil
+}

--- a/pkg/install/util/backup.go
+++ b/pkg/install/util/backup.go
@@ -62,10 +62,14 @@ func DumpResources(ctx context.Context, filename string, objects []unstructured.
 	encoder := yaml.NewEncoder(f)
 	encoder.SetIndent(2)
 
-	f.WriteString(fmt.Sprintf("# This backup was created %s.\n", time.Now().Format(time.UnixDate)))
+	if _, err := f.WriteString(fmt.Sprintf("# This backup was created %s.\n", time.Now().Format(time.UnixDate))); err != nil {
+		return fmt.Errorf("failed to write date: %v", err)
+	}
 
 	for _, item := range objects {
-		encoder.Encode(item.Object)
+		if err := encoder.Encode(item.Object); err != nil {
+			return fmt.Errorf("failed to encode object as YAML: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -54,10 +54,10 @@ func HasOnlyFinalizer(o metav1.Object, name string) bool {
 	return set.Has(name) && set.Len() == 1
 }
 
-// RemoveFinalizer removes the given finalizer from the object
-func RemoveFinalizer(obj metav1.Object, toRemove string) {
+// RemoveFinalizer removes the given finalizers from the object
+func RemoveFinalizer(obj metav1.Object, toRemove ...string) {
 	set := sets.NewString(obj.GetFinalizers()...)
-	set.Delete(toRemove)
+	set.Delete(toRemove...)
 	obj.SetFinalizers(set.List())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to #6739, this PR automates the migration procedure for the new CRDs. It follows the steps outlined in the previous PR, just with a few additions. In general, this is the workflow:

1. require the user to provide `--migrate-cert-manager` to the installer, so that they confirm that they know what's going to happen next.
1. delete cert-manager chart to ensure to funny business is happening anymore
1. fetch all cert-manager resources (certs, orders, challenges, issuers, ..) and store them
   * in memory, so we can later restore them automatically
   * as YAML files as a backup for the user
   * this includes the Secrets for each Certificate, so the actual key/cert as PEM are also backed up
1. remove finalizers from cert-manager resources (in case there are active challenges, for example)
1. delete all cert-manager CRDs, wait for them to be gone (i.e. all resources are actually gone)
1. install new CRDs, wait for them to be established
1. recreate previously stored resources (certs, secrets, issuers); note that resources with an ownerRef are _not_ restored, as it is assumed whoever created them, will do so again (e.g. for an Ingress annotation)
1. install the new cert-manager chart

The migration is triggered by detecting a pre 2.0 Helm release in the cluster. It has nothing to do with Kubermatic's version.

I tested this locally using kind and by commenting out a few steps in the `pkg/installer/stack/kubermatic-master/stack.go`:

```bash
export KUBECONFIG=certmanager.kubeconfig
kind delete cluster --name certmanager
kind create cluster --name certmanager

# cert-manager-1.4.1 is simply the cert-manager chart from the latest KKP
# download on github

kubectl apply -f cert-manager-1.4.1/crd/
kubectl apply -f test-ingress.yaml
kubectl apply -f test-cert-secret.yaml
helm3 --namespace cert-manager upgrade --atomic --create-namespace --install cert-manager ./cert-manager-1.4.1/
```

`test-ingress.yaml`:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
  name: test
spec:
  backend:
    serviceName: dex
    servicePort: 5556
  rules:
  - host: dev.kubermatic.io
    http:
      paths:
      - backend:
          serviceName: dex
          servicePort: 5556
        path: /dex
      - backend:
          serviceName: dex
          servicePort: 5557
        path: /grpc
  tls:
  - hosts:
    - dev.kubermatic.io
    secretName: test-tls
```

`test-cert-secret.yaml`:

```yaml
apiVersion: v1
kind: Secret
metadata:
  annotations:
    cert-manager.io/alt-names: dev.kubermatic.io
    cert-manager.io/certificate-name: test-tls
    cert-manager.io/common-name: dev.kubermatic.io
    cert-manager.io/ip-sans: ""
    cert-manager.io/issuer-group: cert-manager.io
    cert-manager.io/issuer-kind: ClusterIssuer
    cert-manager.io/issuer-name: letsencrypt-prod
    cert-manager.io/uri-sans: ""
  name: test-tls
type: kubernetes.io/tls
data:
  tls.crt: .....put anything here....
  tls.key: .....put anything here....
```

Once the cluster is up and running, I tested via

```bash
rm -f _build/kubermatic-installer
make kubermatic-installer
_build/kubermatic-installer deploy \
  --helm-binary ~/bin/helm-3.3.1 \
  --config test-kubermaticconfig.yaml \
  --helm-values test-helmvalues.yaml \
  --migrate-cert-manager
```

The config files used in the command above do not contain anything interesting, just bare bones config files.

```
INFO[14:30:32] 🛫 Initializing installer…                     edition="Community Edition" version=1174d9171881f2e8a74d971988e5389f61c3e82a
INFO[14:30:32] 🚦 Validating the provided configuration…
WARN[14:30:32]    Helm values: kubermaticOperator.imagePullSecret is empty, setting to spec.imagePullSecret from KubermaticConfiguration
WARN[14:30:32]    Helm values: The Dex configuration does not contain a `kubermatic` client to allow logins to the Kubermatic dashboard.
WARN[14:30:32]    If you intend to use Dex, please refer to the example configuration to define a `kubermatic` client and connectors.
INFO[14:30:32] ✅ Provided configuration is valid.
INFO[14:30:32] 🧩 Deploying KKP master stack…
INFO[14:30:32]    📦 Deploying cert-manager…
INFO[14:30:32]       1.4.1 detected, performing upgrade to 2.0.0…
INFO[14:30:32]       Uninstalling release…
INFO[14:30:33]       Creating backups for all Custom Resources…
INFO[14:30:33]         fetching clusterissuer
INFO[14:30:33]         fetching issuer
INFO[14:30:33]         fetching certificaterequest
INFO[14:30:33]         fetching certificate
INFO[14:30:33]         dumping clusterissuer
INFO[14:30:33]         dumping issuer
INFO[14:30:33]         dumping certificaterequest
INFO[14:30:33]         dumping certificate
INFO[14:30:33]         dumping challenge
INFO[14:30:33]         dumping order
INFO[14:30:33]         dumping secret
INFO[14:30:33]       Removing finalizers from Custom Resources…
INFO[14:30:33]       Removing Custom Resource Definitions…
INFO[14:30:35]       Deploying new Custom Resource Definitions…
INFO[14:30:36]       Recreating deleted resources…
INFO[14:30:36]         creating Secret default/test-tls
WARN[14:30:36]         already exists, please compare to backup
WARN[14:30:36]       Use the YAML backup files to manually recreate missing resources.
INFO[14:30:36]       Deploying Helm chart…
INFO[14:31:17]    ✅ Success.
```

Without the `--migrate-cert-manager` flag:

```
INFO[15:08:39] 🛫 Initializing installer…                     edition="Community Edition" version=50beee394ada24c8c128cb489884ac9268d2559e
INFO[15:08:39] 🚦 Validating the provided configuration…
WARN[15:08:39]    Helm values: kubermaticOperator.imagePullSecret is empty, setting to spec.imagePullSecret from KubermaticConfiguration
WARN[15:08:39]    Helm values: The Dex configuration does not contain a `kubermatic` client to allow logins to the Kubermatic dashboard.
WARN[15:08:39]    If you intend to use Dex, please refer to the example configuration to define a `kubermatic` client and connectors.
INFO[15:08:39] ✅ Provided configuration is valid.
INFO[15:08:39] 🧩 Deploying KKP master stack…
INFO[15:08:39]    📦 Deploying cert-manager…
WARN[15:08:39]       cert-manager CRDs need to be migrated. This requires to temporarily remove and recreate
WARN[15:08:39]       all related resources (like Certificates, Issuers, etc.). Rerun the installer with
WARN[15:08:39]       --migrate-cert-manager to enable this mandatory migration.
WARN[15:08:39]       Please refer to the KKP 2.17 upgrade notes for more information.
ERRO[15:08:39] ❌ Operation failed: failed to deploy cert-manager: user must acknowledge the migration using --migrate-cert-manager.
```

The backup is just a bunch of YAML files in the current working directory:

```
-rw-rw-r--  1 xrstf xrstf   56 Mär 26 15:08 backup_2021-03-26T150848_certificaterequest.yaml
-rw-rw-r--  1 xrstf xrstf 1,9K Mär 26 15:08 backup_2021-03-26T150848_certificate.yaml
-rw-rw-r--  1 xrstf xrstf   56 Mär 26 15:08 backup_2021-03-26T150848_challenge.yaml
-rw-rw-r--  1 xrstf xrstf   56 Mär 26 15:08 backup_2021-03-26T150848_clusterissuer.yaml
-rw-rw-r--  1 xrstf xrstf   56 Mär 26 15:08 backup_2021-03-26T150848_issuer.yaml
-rw-rw-r--  1 xrstf xrstf   56 Mär 26 15:08 backup_2021-03-26T150848_order.yaml
-rw-rw-r--  1 xrstf xrstf  16K Mär 26 15:08 backup_2021-03-26T150848_secret.yaml
```

I have considered the following problems:

* **Customers might have not v1alpha2 CRDs, but v1beta1 already.** The installer handles this by being more careful about the actual apiextensions being used, so this should not cause a problem.
* **Resources are stuck because of unknown finalizers.** The installer only removes the cert-manager finalizer, assuming third party software might want to do its own cleanup. If resources are stuck, the user is informed that they need to manually review the finalizers and make sure to remove all cert-manager resources. Afterwards, they can simply rerun the installer, which will then see "no cert-manager, no CRDs, will install from scratch" and everything should be fine.
* **Certs might be in pending state.** In this case, there might not be a Secret yet for a cert. The installer is pretty simple and does not care about any states, it simply takes whatever Secret is referred to in the Cert. This is useful if the cert is pending, but the Secret is still valid. In this case, we will properly backup the soon-to-expire Secret.
* **Customers can opt out** by performing the cert-manager upgrade manually. As long as Helm reports a 2.0+ release of cert-manager, the installer is happy.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
