### PR TITLE
Use GetConfig instead of GetConfigOrDie in seed-controller-manager

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -91,7 +91,11 @@ func main() {
 		electionName += "-" + options.workerName
 	}
 
-	cfg := ctrlruntime.GetConfigOrDie()
+	cfg, err := ctrlruntime.GetConfig()
+	if err != nil {
+		log.Fatalw("Failed to get kubeconfig", zap.Error(err))
+	}
+
 	// Create a manager, disable metrics as we have our own handler that exposes
 	// the metrics of both the ctrltuntime registry and the default registry
 	mgr, err := manager.New(cfg, manager.Options{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the seed-controller-manager to use `GetConfig` function instead of `GetConfigOrDie`.

The reason for doing this is that if `$KUBECONFIG` is set to a non-existing kubeconfig, the seed-controller-manager would exit without showing an error.

```
2021-03-26T15:31:24.585+0100	info	cli/hello.go:36	Starting Kubermatic Seed Controller-Manager (Enterprise Edition)...	{"worker-name": "xmudrii1", "version": "06f40d16f89f6fc4e426bcdf2adbd12bbc6ae15b", "commit": "06f40d16f89f6fc4e426bcdf2adbd12bbc6ae15b"}
```

The return value would be 1, but without an error message, it's hard to find out what's causing the seed-controller-manager to exit.

[`GetConfigOrDie` function](https://github.com/kubernetes-sigs/controller-runtime/blob/fa42462a01b0f33cfb42dd7396d198435a013122/pkg/client/config/config.go#L151-L158) is just a wrapper around `GetConfig` that logs an error and exits with error code 1. I'm not sure why we don't see the error, since the function is supposed to log it, but I guess it might be related to how we initialize our logger.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf 