### PR TITLE
Use new Docker images

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.16.2
+      - image: golang:1.16.1
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.16.2
+      - image: golang:1.16.1
         command:
         - make
         args:
@@ -123,7 +123,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:1.16.2-19.03-0
+      - image: quay.io/kubermatic/build:1.16.1-19.03-0
         command:
         - "./hack/verify-kubermatic-chart.sh"
         resources:
@@ -167,7 +167,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:1.16.2-19.03-0
+      - image: quay.io/kubermatic/build:1.16.1-19.03-0
         command:
         - "./hack/verify-docs.sh"
         resources:
@@ -223,7 +223,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:1.16.2-19.03-0
+      - image: quay.io/kubermatic/build:1.16.1-19.03-0
         command:
         - make
         args:
@@ -1376,7 +1376,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:1.16.2-19.03-0
+      - image: quay.io/kubermatic/build:1.16.1-19.03-0
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -410,6 +410,13 @@ presubmits:
             cpu: 3.5
           limits:
             memory: 4Gi
+        volumeMounts:
+        - name: scratchpad
+          mountPath: /scratchpad
+      volumes:
+        - name: scratchpad
+          emptyDir:
+            medium: Memory
 
   - name: pre-kubermatic-e2e-aws-flatcar-1.18
     decorate: true

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.16.1
+      - image: golang:1.16.2
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.16.1
+      - image: golang:1.16.2
         command:
         - make
         args:
@@ -123,7 +123,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:16.1-1903-0
+      - image: quay.io/kubermatic/build:1.16.2-19.03-0
         command:
         - "./hack/verify-kubermatic-chart.sh"
         resources:
@@ -167,7 +167,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:16.1-1903-0
+      - image: quay.io/kubermatic/build:1.16.2-19.03-0
         command:
         - "./hack/verify-docs.sh"
         resources:
@@ -223,7 +223,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:16.1-1903-0
+      - image: quay.io/kubermatic/build:1.16.2-19.03-0
         command:
         - make
         args:
@@ -332,7 +332,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/kind:with-conformance-tests-v2.0
         command:
         - ./hack/ci/test-github-release.sh
         resources:
@@ -351,7 +351,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/e2e-kind:v1.0.24
+        - image: quay.io/kubermatic/kind:v2.0
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -386,7 +386,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/kind:with-conformance-tests-v2.0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -427,7 +427,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/kind:with-conformance-tests-v2.0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -468,7 +468,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -509,7 +509,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -550,7 +550,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -593,7 +593,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: "ee"
@@ -643,7 +643,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -689,7 +689,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -732,7 +732,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -780,7 +780,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -823,7 +823,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -866,7 +866,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -909,7 +909,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -954,7 +954,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -999,7 +999,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1044,7 +1044,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1088,7 +1088,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1134,7 +1134,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1184,8 +1184,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
-        imagePullPolicy: Always
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         command:
         - "./hack/ci/run-api-e2e.sh"
         env:
@@ -1226,7 +1225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
@@ -1263,15 +1262,14 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:v1.0.24
-        imagePullPolicy: Always
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
         command:
         - make
         args:
         - run-nodeport-proxy-e2e-test-in-kind
         env:
         - name: KIND_NODE_VERSION
-          value: v1.19.1
+          value: v1.20.2
         securityContext:
           privileged: true
         resources:
@@ -1299,7 +1297,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
+        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -1371,7 +1369,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:16.1-1903-0
+      - image: quay.io/kubermatic/build:1.16.2-19.03-0
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode

--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -35,8 +35,9 @@ fi
 
 apt install time -y
 
+start_docker_daemon
+
 echodate "Logging into Quay"
-docker ps > /dev/null 2>&1 || start-docker.sh
 retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
 echodate "Successfully logged into Quay"
 

--- a/hack/ci/run-offline-test.sh
+++ b/hack/ci/run-offline-test.sh
@@ -124,9 +124,7 @@ function finish {
 }
 trap finish EXIT
 
-# Start docker
-docker ps &> /dev/null || start-docker.sh
-
+start_docker_daemon
 retry 5 docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io
 
 echodate "Building and pushing Docker images"

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -23,6 +23,7 @@ fi
 
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
 export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
+export KIND_NODE_VERSION="${KIND_CLUSTER_NAME:-v1.18.2}"
 
 start_docker_daemon
 

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -37,7 +37,7 @@ echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 
 beforeKindCreate=$(nowms)
-cat <<EOF | kind create cluster --config=-
+cat << EOF | kind create cluster --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: $KIND_CLUSTER_NAME

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -194,6 +194,39 @@ appendTrap cleanup_kubermatic_clusters_in_kind EXIT
 
 TEST_NAME="Expose Dex and Kubermatic API"
 echodate "Exposing Dex and Kubermatic API to localhost..."
-kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 > /dev/null &
-kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 > /dev/null &
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex-nodeport
+  namespace: oauth
+spec:
+  type: NodePort
+  ports:
+    - name: dex
+      port: 5556
+      protocol: TCP
+      nodePort: 32000
+  selector:
+    app: dex
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubermatic-api-nodeport
+  namespace: kubermatic
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      nodePort: 32001
+  selector:
+    app.kubernetes.io/name: kubermatic-api
+EOF
+
 echodate "Finished exposing components"

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -195,7 +195,7 @@ appendTrap cleanup_kubermatic_clusters_in_kind EXIT
 TEST_NAME="Expose Dex and Kubermatic API"
 echodate "Exposing Dex and Kubermatic API to localhost..."
 
-cat <<EOF | kubectl apply -f -
+cat << EOF | kubectl apply -f -
 apiVersion: v1
 kind: Service
 metadata:
@@ -212,7 +212,7 @@ spec:
     app: dex
 EOF
 
-cat <<EOF | kubectl apply -f -
+cat << EOF | kubectl apply -f -
 apiVersion: v1
 kind: Service
 metadata:

--- a/hack/ci/setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/setup-legacy-kubermatic-in-kind.sh
@@ -207,8 +207,41 @@ appendTrap cleanup_kubermatic_clusters_in_kind EXIT
 
 TEST_NAME="Expose Dex and Kubermatic API"
 echodate "Exposing Dex and Kubermatic API to localhost..."
-kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 &
-kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 &
+
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex-nodeport
+  namespace: oauth
+spec:
+  type: NodePort
+  ports:
+    - name: dex
+      port: 5556
+      protocol: TCP
+      nodePort: 32000
+  selector:
+    app: dex
+EOF
+
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubermatic-api-nodeport
+  namespace: kubermatic
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      nodePort: 32001
+  selector:
+    app.kubernetes.io/name: kubermatic-api
+EOF
+
 echodate "Finished exposing components"
 
 echodate "Waiting for Dex to be ready"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -327,29 +327,7 @@ cleanup_kubermatic_clusters_in_kind() {
   set -e
 }
 
-docker_logs() {
-  if [[ $? -ne 0 ]]; then
-    echodate "Printing Docker logs"
-    cat /tmp/docker.log
-    echodate "Done printing Docker logs"
-  fi
-}
-
 start_docker_daemon() {
-  if docker stats --no-stream > /dev/null 2>&1; then
-    echodate "Not starting Docker again, it's already running."
-    return
-  fi
-
-  # Start Docker daemon
-  echodate "Starting Docker"
-  # Set the MTU to 1400 to avoid issues with our CI environment.
-  dockerd --mtu 1400 > /tmp/docker.log 2>&1 &
-  echodate "Started Docker successfully"
-  appendTrap docker_logs EXIT
-
-  # Wait for Docker to start
-  echodate "Waiting for Docker"
-  retry 5 docker stats --no-stream
-  echodate "Docker became ready"
+  # call the special entrypoint script we put into our Docker image
+  /usr/local/bin/start-docker.sh
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We have begun to cleanup our Docker images and this makes it so that we use the new images.

The way we start Docker has been cleaned up. All containers now should use the `start-docker.sh` provided in the Docker image. Other than that, there are no real changes in this PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
