### PR TITLE
Fix CoreDNS upgrade issue

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -56,13 +56,9 @@ func DeploymentCreator() reconciling.NamedDeploymentCreatorGetter {
 			dep.Labels = resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil)
 
 			dep.Spec.Replicas = resources.Int32(2)
-			// The Selector is immutable, so we don't change it if it's set. This happens in upgrade cases
-			// where coredns is switched from a manifest based addon to a user-cluster-controller-manager resource
-			if dep.Spec.Selector == nil {
-				dep.Spec.Selector = &metav1.LabelSelector{
-					MatchLabels: resources.BaseAppLabels(resources.CoreDNSDeploymentName,
-						map[string]string{"app.kubernetes.io/name": "kube-dns"}),
-				}
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabels(resources.CoreDNSDeploymentName,
+					map[string]string{"app.kubernetes.io/name": "kube-dns"}),
 			}
 
 			iptr := intstr.FromInt(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
CoreDNS has a special upgrade case: CoreDNS was moved into a resource instead of a manifest addon. When KKP is upgraded
 from 2.14.x to 2.15.x, the CoreDNS manifest is actually removed from the KKP container, so it's resources are not cleaned up by `r.cleanupManfests()`. When the resources are applied later in the user-cluster-controller, it fails because the old manifest deployment still exists and it's has immutable fields that can't be updated.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6428

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
