### PR TITLE
do not require port 8080 to be available to run the installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -201,7 +201,10 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			return fmt.Errorf("failed to get config: %v", err)
 		}
 
-		mgr, err := manager.New(ctrlConfig, manager.Options{})
+		mgr, err := manager.New(ctrlConfig, manager.Options{
+			MetricsBindAddress:     "0",
+			HealthProbeBindAddress: "0",
+		})
 		if err != nil {
 			return fmt.Errorf("failed to construct mgr: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This can cause some serious problems.

/cherrypick release/v2.15
/cherrypick release/v2.16

**Does this PR introduce a user-facing change?**:
```release-note
Installer does not listen on port 8080 anymore
```
