### PR TITLE
Use UDP for node-local-dns external queries

### DIFF
--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -73,9 +73,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . /etc/resolv.conf {
-                force_tcp
-        }
+        forward . /etc/resolv.conf 
         prometheus :9253
         }
 ---

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
@@ -104,9 +104,7 @@ ip6.arpa:53 {
     reload
     loop
     bind 169.254.20.10
-    forward . /etc/resolv.conf {
-            force_tcp
-    }
+    forward . /etc/resolv.conf
     prometheus :9253
     }
   `


### PR DESCRIPTION
A customer complained about the DNS latencies on external requests from
the user cluster side. Those are due to some TCP timeouts in their network.
TCP requests have been added to node-local-dns for some reasons :UDP conntrack,
reliability, etc. See [kubernetes/kubernetes#93471](https://github.com/kubernetes/kubernetes/pull/93471)

As there is no need/issue with the external request, we will follow the
Kubernetes standard and remove the force_tcp flag for all external DNS requests.

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6795

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Node-local-dns is now using UDP for external queries
```
