### PR TITLE
Revert Update to kind 0.10 (#6773)

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -332,7 +332,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         command:
         - ./hack/ci/test-github-release.sh
         resources:
@@ -386,7 +386,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -427,7 +427,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -468,7 +468,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -509,7 +509,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -550,7 +550,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -593,7 +593,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: "ee"
@@ -643,7 +643,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -689,7 +689,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -732,7 +732,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -780,7 +780,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -823,7 +823,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -866,7 +866,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -909,7 +909,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -954,7 +954,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -999,7 +999,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1044,7 +1044,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1088,7 +1088,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1134,7 +1134,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1184,7 +1184,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         imagePullPolicy: Always
         command:
         - "./hack/ci/run-api-e2e.sh"
@@ -1226,7 +1226,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
@@ -1263,7 +1263,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         imagePullPolicy: Always
         command:
         - make
@@ -1299,7 +1299,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.27
+        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -67,7 +67,7 @@ echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 
 beforeKindCreate=$(nowms)
-export KIND_NODE_VERSION=v1.20.2
+export KIND_NODE_VERSION=v1.18.2
 kind create cluster --name "$KIND_CLUSTER_NAME" --image=kindest/node:$KIND_NODE_VERSION
 pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$KIND_NODE_VERSION\""
 

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -27,7 +27,7 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.20.2}"
+KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.18.2}"
 
 type kind > /dev/null || fatal \
   "Kind is required to run this script, please refer to: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR reverts update to kind 0.10 (#6773).

The reason for doing this is that we're observing a lot of test failures (about 80-85% of tests failing) that started happening between March 26th and 27th. One of the PRs that merged in that period is #6773 which updated kind to 0.10 and Kubernetes to v1.20.2.

To roll out updating kind as a possible reason for failures, we'll revert this PR and observe the situation. It's also the PR that is easiest to revert.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```