### PR TITLE
[release/v2.14] Use UDP for node-local-dns external queries

### DIFF
--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -73,9 +73,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . /etc/resolv.conf {
-                force_tcp
-        }
+        forward . /etc/resolv.conf 
         prometheus :9253
         }
 ---


### PR DESCRIPTION
Manual cherry-pick of #6796
Node-local-dns wasn't migrated to the user cluster controller manager in 2.14, so changing only the manifests in addons.

```release-note
Node-local-dns is now using UDP for external queries
```
