### PR TITLE
Constraint Template CRD validation

### DIFF
--- a/pkg/handler/v2/constraint_template/constraint_template.go
+++ b/pkg/handler/v2/constraint_template/constraint_template.go
@@ -233,6 +233,17 @@ func validateConstraintTemplate(ct *kubermaticv1.ConstraintTemplate) error {
 		return fmt.Errorf("template's name %s is not equal to the lowercase of CRD's Kind: %s", ct.Name,
 			ct.Spec.CRD.Spec.Names.Kind)
 	}
+
+	if len(ct.Spec.Targets) >= 1 {
+		if ct.Spec.Targets[0].Rego == "" {
+			return fmt.Errorf("template's rego is empty")
+		}
+		if ct.Spec.Targets[0].Target == "" {
+			return fmt.Errorf("template's target is empty")
+		}
+	} else {
+		return fmt.Errorf("template's target list is empty")
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds validation  for Kubermatic Constraint Templates endpoints so it fits the Gatekeeper Constraint templates. With this it will be easier to avoid creating Constraint Templates which cannot be synced to the user cluster as Gatekeeper Constraint Templates because they are invalid. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6769 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added validation for Kubermatic Constraint Template API.
```
