### PR TITLE
Add cloud-init sa and its roles

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/namespace.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinitsettings
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NamespaceCreator creates the namespace for CloudInitSettingsNamespace
+func NamespaceCreator() (string, reconciling.NamespaceCreator) {
+	return resources.CloudInitSettingsNamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		return ns, nil
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/serviceaccount.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinitsettings
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	serviceAccountName = "cloud-init-getter"
+	roleName           = "cloud-init-getter"
+	roleBindingName    = "cloud-init-getter"
+)
+
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return serviceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}
+
+func RoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
+		return roleName,
+			func(r *rbacv1.Role) (*rbacv1.Role, error) {
+				r.Rules = []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"secrets"},
+						Verbs: []string{
+							"get",
+							"list",
+						},
+					},
+				}
+				return r, nil
+			}
+	}
+}
+
+func RoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
+		return roleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+			rb.RoleRef = rbacv1.RoleRef{
+				Name:     roleName,
+				Kind:     "Role",
+				APIGroup: rbacv1.GroupName,
+			}
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Name: serviceAccountName,
+					Kind: rbacv1.ServiceAccountKind,
+				},
+			}
+			return rb, nil
+		}
+	}
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -331,7 +331,9 @@ const (
 	KubermaticNamespace = "kubermatic"
 	// GatekeeperNamespace is the main gatkeeper namespace where the gatekeeper config is stored
 	GatekeeperNamespace = "gatekeeper-system"
-
+	// CloudInitSettingsNamespace are used in order to reach, authenticate and be authorized by the api server, to fetch
+	// the machine  provisioning cloud-init
+	CloudInitSettingsNamespace = "cloud-init-settings"
 	// DefaultOwnerReadOnlyMode represents file mode with read permission for owner only
 	DefaultOwnerReadOnlyMode = 0400
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a new ServiceAccount in the user cluster, to access the user cluster api server and fetch a secret that will hold the cloud-init data.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fetch the provisioning cloud-init over the api-server 
```
