### PR TITLE
Do not create initial Machine Deployments with 0 replicas

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -135,7 +135,7 @@ func CreateEndpoint(ctx context.Context, projectID string, body apiv1.CreateClus
 	// the user cluster (in case errors happen and the controller needs to re-reconcile), we ensure that the MD
 	// has a proper name instead of relying on the GenerateName.
 	partialCluster.Annotations = make(map[string]string)
-	if body.NodeDeployment != nil {
+	if body.NodeDeployment != nil && body.NodeDeployment.Spec.Replicas > 0 {
 		isBYO, err := common.IsBringYourOwnProvider(spec.Cloud)
 		if err != nil {
 			return nil, errors.NewBadRequest("cannot verify the provider due to an invalid spec: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**: In the https://github.com/kubermatic/kubermatic/pull/6064 the check for node deployment creation has changed from `if body.NodeDeployment != nil && body.NodeDeployment.Spec.Replicas > 0` to just `if body.NodeDeployment != nil`. This pull request reverts that single change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: @xrstf @zreigz @floreks What do you think? Should we restore the old behavior and perhaps add some note in the UI?

EDIT: Other solution could be adding some checkbox in the UI that disables initial machine deployment creation and then we would be sending `nil` to the API and this check would not be needed.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Initial Machine Deployments when user specified 0 replicas will not be created anymore.
```
