### PR TITLE
[release/v2.16]Allow loose RPF for calico

### DIFF
--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -438,6 +438,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
+          # FIXME: Remove FELIX_IGNORELOOSERPF from env when this is v3.12.0+
           image: docker.io/calico/node:v3.8.0
           env:
             # Use Kubernetes API as the backing datastore.
@@ -460,6 +461,9 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,canal"
+            # Run on systems with loose reverse path forwarding (RPF) (net.ipv4.conf.*.rp_filter = 2)
+            - name: FELIX_IGNORELOOSERPF
+              value: "true"
             # Period, in seconds, at which felix re-applies all iptables state
             - name: FELIX_IPTABLESREFRESHINTERVAL
               value: "60"

--- a/hack/ci/setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/setup-legacy-kubermatic-in-kind.sh
@@ -160,12 +160,13 @@ echodate "Deploying Kubermatic using Helm..."
 beforeDeployment=$(nowms)
 
 SEED_KUBECONFIG="$(cat $KUBECONFIG | sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./' | base64 -w0)"
+KUBERMATIC_DOMAIN="${KUBERMATIC_DOMAIN:-ci.kubermatic.io}"
 
 # we always override the quay repositories so we don't have to care if the
 # Helm chart is made for CE or EE
 retry 3 kubectl create ns kubermatic
 retry 3 helm3 --namespace kubermatic install --atomic --timeout 5m \
-  --set=kubermatic.domain=ci.kubermatic.io \
+  --set=kubermatic.domain="$KUBERMATIC_DOMAIN" \
   --set=kubermatic.isMaster=true \
   --set=kubermatic.imagePullSecretData="$IMAGE_PULL_SECRET_DATA" \
   --set-string=kubermatic.controller.image.repository="quay.io/kubermatic/kubermatic$REPOSUFFIX" \


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6853

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Adds `FELIX_IGNORELOOSERPF=true` to `calico-node` container env to allow running on nodes with `net.ipv4.conf.*.rp_filter = 2` set.
```
