### PR TITLE
[release/v2.16] fix imagepullsecret for user-cluster-prometheus-config-validation

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -278,8 +278,6 @@ presubmits:
         env:
         - name: KUBERMATIC_EDITION
           value: ee
-      imagePullSecrets:
-      - name: quay
 
   - name: pre-kubermatic-user-cluster-prometheus-config-validation
     run_if_changed: "pkg/resources/prometheus"
@@ -296,7 +294,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
       imagePullSecrets:
-      - name: quay
+      - name: kubermatic-quay
 
   - name: pre-kubermatic-simulate-github-release
     run_if_changed: "hack/ci/github-release.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:
Forgot to update this in #6858.

The util image is public and doesn't need a pull secret.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
