### PR TITLE
adapt regex to also capture the hetzner amd node lineup (cpx)

### DIFF
--- a/pkg/handler/common/provider/hetzner.go
+++ b/pkg/handler/common/provider/hetzner.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
-var reStandardSize = regexp.MustCompile("(^cx)")
+var reStandardSize = regexp.MustCompile("(^cx|^cpx)")
 var reDedicatedSize = regexp.MustCompile("(^ccx)")
 
 func HetznerSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, settingsProvider provider.SettingsProvider, projectID, clusterID string) (interface{}, error) {


### PR DESCRIPTION
Signed-off-by: Elias Wallat <walle@strlnd.net>

**What this PR does / why we need it**:

When creating a user cluster with Hetzner as the cloud provider, we would also like to use the new AMD Cloud Servers (CPX) as nodes.

**Which issue(s) this PR fixes**:
Fixes #6327

```release-note
Hetzner AMD Cloud Server (CPX) now selectable when creating a user cluster
```