### PR TITLE
Add prefix to ClusterRole and ClusterRoleBinding objects of MLA

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/clusterrole.go
@@ -26,7 +26,7 @@ import (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.UserClusterPrometheusClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabels(resources.UserClusterPrometheusClusterRoleName, nil)
+			cr.Labels = resources.BaseAppLabels(appName, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/clusterrolebinding.go
@@ -26,7 +26,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.UserClusterPrometheusClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabels(resources.UserClusterPrometheusClusterRoleBindingName, nil)
+			crb.Labels = resources.BaseAppLabels(appName, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.UserClusterPrometheusClusterRoleName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/configmap.go
@@ -45,7 +45,7 @@ func ConfigMapCreator(config Config) reconciling.NamedConfigMapCreatorGetter {
 				return nil, err
 			}
 			configMap.Data["prometheus.yaml"] = configBuf.String()
-			configMap.Labels = resources.BaseAppLabels(resources.UserClusterPrometheusConfigMapName, nil)
+			configMap.Labels = resources.BaseAppLabels(appName, nil)
 			return configMap, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
@@ -32,6 +32,7 @@ import (
 const (
 	imageName = "prometheus/prometheus"
 	tag       = "v2.26.0"
+	appName   = "mla-prometheus"
 
 	configVolumeName  = "config-volume"
 	configPath        = "/etc/config"
@@ -54,7 +55,7 @@ var (
 func DeploymentCreator() reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterPrometheusDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-			deployment.Labels = resources.BaseAppLabels(resources.UserClusterPrometheusDeploymentName, nil)
+			deployment.Labels = resources.BaseAppLabels(appName, nil)
 
 			deployment.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: controllerLabels,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/serviceaccount.go
@@ -26,7 +26,7 @@ import (
 func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 	return func() (string, reconciling.ServiceAccountCreator) {
 		return resources.UserClusterPrometheusServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			sa.Labels = resources.BaseAppLabels(resources.UserClusterPrometheusServiceAccountName, nil)
+			sa.Labels = resources.BaseAppLabels(appName, nil)
 			return sa, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/clusterrole.go
@@ -26,7 +26,7 @@ import (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.PromtailClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabels(resources.PromtailClusterRoleName, nil)
+			cr.Labels = resources.BaseAppLabels(appName, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/clusterrolebinding.go
@@ -26,7 +26,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.PromtailClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabels(resources.PromtailClusterRoleBindingName, nil)
+			crb.Labels = resources.BaseAppLabels(appName, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.PromtailClusterRoleName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
@@ -32,6 +32,7 @@ import (
 const (
 	imageName = "grafana/promtail"
 	tag       = "2.1.0"
+	appName   = "mla-promtail"
 
 	configVolumeName         = "config"
 	configVolumeMountPath    = "/etc/promtail"
@@ -57,7 +58,7 @@ var (
 func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.PromtailDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
-			ds.Labels = resources.BaseAppLabels(resources.PromtailDaemonSetName, nil)
+			ds.Labels = resources.BaseAppLabels(appName, nil)
 
 			ds.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: controllerLabels,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/secret.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/secret.go
@@ -45,7 +45,7 @@ func SecretCreator(config Config) reconciling.NamedSecretCreatorGetter {
 				return nil, err
 			}
 			secret.Data["promtail.yaml"] = configBuf.Bytes()
-			secret.Labels = resources.BaseAppLabels(resources.PromtailSecretName, nil)
+			secret.Labels = resources.BaseAppLabels(appName, nil)
 			return secret, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/serviceaccount.go
@@ -26,7 +26,7 @@ import (
 func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 	return func() (string, reconciling.ServiceAccountCreator) {
 		return resources.PromtailServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			sa.Labels = resources.BaseAppLabels(resources.PromtailServiceAccountName, nil)
+			sa.Labels = resources.BaseAppLabels(appName, nil)
 			return sa, nil
 		}
 	}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -577,15 +577,15 @@ const (
 const (
 	MLANamespace                   = "mla-system"
 	PromtailServiceAccountName     = "promtail"
-	PromtailClusterRoleName        = "promtail"
-	PromtailClusterRoleBindingName = "promtail"
+	PromtailClusterRoleName        = "system:kubermatic:mla:promtail"
+	PromtailClusterRoleBindingName = "system:kubermatic:mla:promtail"
 	PromtailSecretName             = "promtail"
 	PromtailDaemonSetName          = "promtail"
 
 	UserClusterPrometheusConfigMapName          = "prometheus"
 	UserClusterPrometheusServiceAccountName     = "prometheus"
-	UserClusterPrometheusClusterRoleName        = "prometheus"
-	UserClusterPrometheusClusterRoleBindingName = "prometheus"
+	UserClusterPrometheusClusterRoleName        = "system:kubermatic:mla:prometheus"
+	UserClusterPrometheusClusterRoleBindingName = "system:kubermatic:mla:prometheus"
 	UserClusterPrometheusDeploymentName         = "prometheus"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `system:kubermatic:mla` prefix to ClusterRole and ClusterRoleBinding objects of MLA resource package, to indicate that those resources are system-related.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6813 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
