### PR TITLE
Fix for envoy daemonset reconcile failing

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -85,10 +85,14 @@ func getAgentPodSpec(agentIP net.IP, versions kubermatic.Versions) corev1.PodSpe
 		InitContainers: getInitContainers(agentIP, versions),
 		Containers:     getContainers(versions),
 		//TODO(youssefazrak) needed?
-		PriorityClassName: "system-cluster-critical",
-		DNSPolicy:         corev1.DNSClusterFirst,
-		HostNetwork:       true,
-		Volumes:           getVolumes(),
+		PriorityClassName:             "system-cluster-critical",
+		DNSPolicy:                     corev1.DNSClusterFirst,
+		HostNetwork:                   true,
+		Volumes:                       getVolumes(),
+		RestartPolicy:                 corev1.RestartPolicyAlways,
+		TerminationGracePeriodSeconds: utilpointer.Int64Ptr(30),
+		SecurityContext:               &corev1.PodSecurityContext{},
+		SchedulerName:                 corev1.DefaultSchedulerName,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The user cluster controller reconcile keeps failing:
`{"level":"error","time":"2021-04-14T14:39:13.022Z","caller":"resources/controller.go:226","msg":"Reconciling failed","error":"failed to reconcile the DaemonSet: failed to ensure DaemonSet kube-system/envoy-agent: failed waiting for the cache to contain our latest changes: timed out waiting for the condition"}
{"level":"error","time":"2021-04-14T14:39:26.690Z","caller":"resources/controller.go:226","msg":"Reconciling failed","error":"failed to reconcile the DaemonSet: failed to ensure DaemonSet kube-system/envoy-agent: failed waiting for the cache to contain our latest changes: timed out waiting for the condition"}
`
It looks like we are missing some default fields in the pod spec so the reconcile cant finish succesfully. 

Diff:
```
  &v1.DaemonSet{
        TypeMeta:   {Kind: "DaemonSet", APIVersion: "apps/v1"},
        ObjectMeta: {Name: "envoy-agent", Namespace: "kube-system", SelfLink: "/apis/apps/v1/namespaces/kube-system/daemonsets/envoy-agent", UID: "acefda5d-9d7e-4852-9cf7-18074e1856ec", ...},
        Spec: v1.DaemonSetSpec{
                Selector: &{MatchLabels: {"app": "envoy-agent", "app.kubernetes.io/name": "envoy-agent"}},
                Template: v1.PodTemplateSpec{
                        ObjectMeta: {Labels: {"app": "envoy-agent", "app.kubernetes.io/name": "envoy-agent"}},
                        Spec: v1.PodSpec{
                                ... // 2 identical fields
                                Containers:                    {{Name: "envoy-agent", Image: "docker.io/envoyproxy/envoy:v1.17.1", Args: {"--config-path", "etc/envoy/envoy.yaml", "--component-log-level", "upstream:trace,connection:trace,http:trace,router:trace,filter:t"...}, Resources: {Limits: {s"cpu": {i: {...}, s: "100m", Format: "DecimalSI"}, s"memory": {i: {...}, Format: "BinarySI"}}, Requests: {s"cpu": {i: {...}, s: "50m", Format: "DecimalSI"}, s"memory": {i: {...}, Format: "BinarySI"}}}, ...}},
                                EphemeralContainers:           nil,
-                               RestartPolicy:                 "Always",
+                               RestartPolicy:                 "",
-                               TerminationGracePeriodSeconds: &30,
+                               TerminationGracePeriodSeconds: nil,
                                ActiveDeadlineSeconds:         nil,
                                DNSPolicy:                     "ClusterFirst",
                                ... // 7 identical fields
                                HostIPC:               false,
                                ShareProcessNamespace: nil,
-                               SecurityContext:       s"&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[]Sysctl{},WindowsOptions:nil,FSGroupChangePolicy:nil,SeccompProfile:nil,}",
+                               SecurityContext:       nil,
                                ImagePullSecrets:      nil,
                                Hostname:              "",
                                Subdomain:             "",
                                Affinity:              nil,
-                               SchedulerName:         "default-scheduler",
+                               SchedulerName:         "",
                                Tolerations:           nil,
                                HostAliases:           nil,
                                ... // 10 identical fields
                        },
                },
                UpdateStrategy:       {Type: "RollingUpdate", RollingUpdate: &{MaxUnavailable: &{IntVal: 1}}},
                MinReadySeconds:      0,
                RevisionHistoryLimit: &10,
        },
        Status: {CurrentNumberScheduled: 1, DesiredNumberScheduled: 1, ObservedGeneration: 2, UpdatedNumberScheduled: 1, ...},
  }
```

This PR adds them so the reconcile can pass.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
