### PR TITLE
Remove support for k8s 1.17 and update versions

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -370,47 +370,6 @@ presubmits:
   # Base Kubernetes Tests (AWS, Flatcar)
   #########################################################
 
-  - name: pre-kubermatic-e2e-aws-flatcar-1.17
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.17.16"
-        - name: DISTRIBUTIONS
-          value: flatcar
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
-
   - name: pre-kubermatic-e2e-aws-flatcar-1.18
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
@@ -432,7 +391,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.14"
+          value: "v1.18.17"
         - name: DISTRIBUTIONS
           value: flatcar
         - name: SERVICE_ACCOUNT_KEY
@@ -473,7 +432,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.8"
+          value: "v1.19.9"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -514,7 +473,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.5"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -575,7 +534,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.20-ce
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.21-ce
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -598,7 +557,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -618,7 +577,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.20-legacy
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.21-legacy
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -644,7 +603,7 @@ presubmits:
         - name: USE_LEGACY_HELM_CHART
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -668,7 +627,7 @@ presubmits:
   # Extended Kubernetes Tests (various cloud providers, OS)
   #########################################################
 
-  - name: pre-kubermatic-e2e-azure-ubuntu-1.20
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.21
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -689,7 +648,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: PROVIDER
@@ -713,7 +672,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.20
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.21
     decorate: true
     always_run: false
     optional: true
@@ -735,7 +694,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -757,7 +716,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.20-psp
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.21-psp
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -778,7 +737,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -804,7 +763,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-do-centos-1.20
+  - name: pre-kubermatic-e2e-do-centos-1.21
     decorate: true
     always_run: false
     optional: true
@@ -826,7 +785,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: DISTRIBUTIONS
           value: centos
         - name: PROVIDER
@@ -848,7 +807,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-packet-ubuntu-1.20
+  - name: pre-kubermatic-e2e-packet-ubuntu-1.21
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -869,7 +828,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "packet"
         - name: DISTRIBUTIONS
@@ -891,7 +850,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-kubevirt-centos-1.20
+  - name: pre-kubermatic-e2e-kubevirt-centos-1.21
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -912,7 +871,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -934,7 +893,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.20
+  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.21
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -955,7 +914,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "hetzner"
         - name: DISTRIBUTIONS
@@ -979,7 +938,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-ubuntu-1.20
+  - name: pre-kubermatic-e2e-openstack-ubuntu-1.21
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -1000,7 +959,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "openstack"
         - name: DISTRIBUTIONS
@@ -1024,7 +983,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-centos-1.20
+  - name: pre-kubermatic-e2e-openstack-centos-1.21
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -1045,7 +1004,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -1069,7 +1028,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.20
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
     decorate: true
     run_if_changed: "pkg/provider/cloud/vsphere"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -1090,7 +1049,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1112,7 +1071,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.20-customfolder
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
     decorate: true
     optional: true
     run_if_changed: "pkg/provider/cloud/vsphere"
@@ -1134,7 +1093,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1158,7 +1117,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.20-datastore-cluster
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
     decorate: true
     optional: true
     run_if_changed: "pkg/provider/cloud/vsphere"
@@ -1180,7 +1139,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.21.0"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1272,7 +1231,7 @@ presubmits:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.20.2
+          value: v1.21.0
         - name: KUBERMATIC_EDITION
           value: ee
         - name: SERVICE_ACCOUNT_KEY
@@ -1345,7 +1304,7 @@ presubmits:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.20.2
+              value: v1.21.0
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -26,10 +26,10 @@
 {{ $version = "v1.19.0 "}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v1.20.0 "}}
+{{ $version = "v1.20.3 "}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v1.21.0 "}}
+{{ $version = "v1.20.3 "}}
 {{ end }}
 
 ---

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -26,10 +26,10 @@
 {{ $version = "v1.19.0 "}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v1.20.0 "}}
+{{ $version = "v1.20.3 "}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v1.21.0 "}}
+{{ $version = "v1.20.3 "}}
 {{ end }}
 
 ---

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.38
+version: 1.1.39
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -2,28 +2,8 @@
 
 updates:
 - automatic: true
-  from: 1.15.*
-  to: 1.16.*
-  type: kubernetes
-- from: 1.16.*
-  to: 1.16.*
-  type: kubernetes
-- automatic: true
-  from: <= 1.16.12, >= 1.16.0
-  to: 1.16.13
-  type: kubernetes
-- from: 1.16.*
-  to: 1.17.*
-  type: kubernetes
-- from: 1.17.*
-  to: 1.17.*
-  type: kubernetes
-- automatic: true
-  from: <= 1.17.8, >= 1.17.0
-  to: 1.17.9
-  type: kubernetes
-- from: 1.17.*
-  to: 1.18.*
+  from: 1.17.*
+  to: 1.18.17
   type: kubernetes
 - from: 1.18.*
   to: 1.18.*

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -2,16 +2,6 @@
 
 versions:
 - type: kubernetes
-  version: 1.17.9
-- type: kubernetes
-  version: 1.17.11
-- type: kubernetes
-  version: 1.17.12
-- type: kubernetes
-  version: 1.17.13
-- type: kubernetes
-  version: 1.17.16
-- type: kubernetes
   version: 1.18.6
 - type: kubernetes
   version: 1.18.8
@@ -20,15 +10,21 @@ versions:
 - type: kubernetes
   version: 1.18.14
 - type: kubernetes
+  version: 1.18.17
+- type: kubernetes
   version: 1.19.0
 - type: kubernetes
   version: 1.19.2
 - type: kubernetes
   version: 1.19.3
+- type: kubernetes
+  version: 1.19.8
 - default: true
   type: kubernetes
-  version: 1.19.8
+  version: 1.19.9
 - type: kubernetes
   version: 1.20.2
+- type: kubernetes
+  version: 1.20.5
 - type: kubernetes
   version: 1.21.0

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -397,7 +397,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.19.8
+      default: 1.19.9
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -415,23 +415,9 @@ spec:
           # for the worker nodes of all matching user clusters.
           automaticNodeUpdate: false
           # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-          from: 1.15.*
+          from: 1.17.*
           # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-          to: 1.16.*
-        - from: 1.16.*
-          to: 1.16.*
-        - automatic: true
-          from: <= 1.16.12, >= 1.16.0
-          to: 1.16.13
-        - from: 1.16.*
-          to: 1.17.*
-        - from: 1.17.*
-          to: 1.17.*
-        - automatic: true
-          from: <= 1.17.8, >= 1.17.0
-          to: 1.17.9
-        - from: 1.17.*
-          to: 1.18.*
+          to: 1.18.17
         - from: 1.18.*
           to: 1.18.*
         - automatic: true
@@ -451,20 +437,18 @@ spec:
           to: 1.21.*
       # Versions lists the available versions.
       versions:
-        - 1.17.9
-        - 1.17.11
-        - 1.17.12
-        - 1.17.13
-        - 1.17.16
         - 1.18.6
         - 1.18.8
         - 1.18.10
         - 1.18.14
+        - 1.18.17
         - 1.19.0
         - 1.19.2
         - 1.19.3
         - 1.19.8
+        - 1.19.9
         - 1.20.2
+        - 1.20.5
         - 1.21.0
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -191,71 +191,33 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.19.8"),
+		Default: semver.MustParse("v1.19.9"),
 		Versions: []*semver.Version{
-			// Kubernetes 1.17
-			semver.MustParse("v1.17.9"),
-			semver.MustParse("v1.17.11"),
-			semver.MustParse("v1.17.12"),
-			semver.MustParse("v1.17.13"),
-			semver.MustParse("v1.17.16"),
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.6"),
 			semver.MustParse("v1.18.8"),
 			semver.MustParse("v1.18.10"),
 			semver.MustParse("v1.18.14"),
+			semver.MustParse("v1.18.17"),
 			// Kubernetes 1.19
 			semver.MustParse("v1.19.0"),
 			semver.MustParse("v1.19.2"),
 			semver.MustParse("v1.19.3"),
 			semver.MustParse("v1.19.8"),
+			semver.MustParse("v1.19.9"),
 			// Kubernetes 1.20
 			semver.MustParse("v1.20.2"),
+			semver.MustParse("v1.20.5"),
 			// Kubernetes 1.21
 			semver.MustParse("v1.21.0"),
 		},
 		Updates: []operatorv1alpha1.Update{
-			{
-				// Auto-upgrade unsupported clusters
-				From:      "1.15.*",
-				To:        "1.16.*",
-				Automatic: pointer.BoolPtr(true),
-			},
-
-			// ======= 1.16 =======
-			{
-				// Allow to change to any patch version
-				From: "1.16.*",
-				To:   "1.16.*",
-			},
-			{
-				// CVE-2019-11253, CVE-2020-8559
-				From:      "<= 1.16.12, >= 1.16.0",
-				To:        "1.16.13",
-				Automatic: pointer.BoolPtr(true),
-			},
-			{
-				// Allow to next minor release
-				From: "1.16.*",
-				To:   "1.17.*",
-			},
-
 			// ======= 1.17 =======
 			{
-				// Allow to change to any patch version
-				From: "1.17.*",
-				To:   "1.17.*",
-			},
-			{
-				// CVE-2020-8559
-				From:      "<= 1.17.8, >= 1.17.0",
-				To:        "1.17.9",
+				// Auto-upgrade unsupported clusters
+				From:      "1.17.*",
+				To:        "1.18.17",
 				Automatic: pointer.BoolPtr(true),
-			},
-			{
-				// Allow to next minor release
-				From: "1.17.*",
-				To:   "1.18.*",
 			},
 
 			// ======= 1.18 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove 1.17 from default supported kubernetes versions and update patch versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Drop Kubernetes 1.17 support and update default versions.
```
