### PR TITLE
Fix switching to Tunneling expose strategy in existing clusters

### DIFF
--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -86,6 +86,7 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, externalURL stri
 			se.Spec.Ports[0].Port = 443
 			if exposeStrategy == kubermaticv1.ExposeStrategyTunneling {
 				se.Spec.Ports[0].TargetPort = intstr.FromInt(resources.APIServerSecurePort)
+				se.Spec.Ports[0].NodePort = 0 // allows switching from other expose strategies
 			} else {
 				// We assign the target port the same value as the NodePort port.
 				// The reason is that we need  both access the apiserver using

--- a/pkg/resources/openvpn/service.go
+++ b/pkg/resources/openvpn/service.go
@@ -66,6 +66,10 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy) reconciling.Name
 			se.Spec.Ports[0].Protocol = corev1.ProtocolTCP
 			se.Spec.Ports[0].TargetPort = intstr.FromInt(1194)
 
+			if exposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+				se.Spec.Ports[0].NodePort = 0 // allows switching from other expose strategies
+			}
+
 			return se, nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Fixes switching to Tunneling expose strategy in existing clusters with NodePort / LoadBalancer expose strategy.

Avoids this issue:
```
failed to ensure Service cluster-c472mjm7zv/apiserver-external: failed to update object *v1.Service 'cluster-c472mjm7zv/apiserver-external': Service "apiserver-external" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
