### PR TITLE
Default upgrade

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.29
+version: 1.1.30
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -3,17 +3,15 @@
 updates:
 - automatic: true
   from: 1.15.*
-  to: 1.16.*
-  type: kubernetes
-- from: 1.16.*
-  to: 1.16.*
+  to: 1.16.13
   type: kubernetes
 - automatic: true
   from: <= 1.16.12, >= 1.16.0
   to: 1.16.13
   type: kubernetes
-- from: 1.16.*
-  to: 1.17.*
+- automatic: true
+  from: 1.16.*
+  to: 1.17.16
   type: kubernetes
 - from: 1.17.*
   to: 1.17.*

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -2,14 +2,6 @@
 
 updates:
 - automatic: true
-  from: 1.15.*
-  to: 1.16.13
-  type: kubernetes
-- automatic: true
-  from: <= 1.16.12, >= 1.16.0
-  to: 1.16.13
-  type: kubernetes
-- automatic: true
   from: 1.16.*
   to: 1.17.16
   type: kubernetes

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -2,6 +2,8 @@
 
 versions:
 - type: kubernetes
+  version: 1.16.13
+- type: kubernetes
   version: 1.17.9
 - type: kubernetes
   version: 1.17.11

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -2,8 +2,6 @@
 
 versions:
 - type: kubernetes
-  version: 1.16.13
-- type: kubernetes
   version: 1.17.9
 - type: kubernetes
   version: 1.17.11

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -427,14 +427,8 @@ spec:
           # for the worker nodes of all matching user clusters.
           automaticNodeUpdate: false
           # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-          from: 1.15.*
-          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-          to: 1.16.13
-        - automatic: true
-          from: <= 1.16.12, >= 1.16.0
-          to: 1.16.13
-        - automatic: true
           from: 1.16.*
+          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
           to: 1.17.16
         - from: 1.17.*
           to: 1.17.*
@@ -458,7 +452,6 @@ spec:
           to: 1.20.*
       # Versions lists the available versions.
       versions:
-        - 1.16.13
         - 1.17.9
         - 1.17.11
         - 1.17.12

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -429,14 +429,13 @@ spec:
           # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
           from: 1.15.*
           # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-          to: 1.16.*
-        - from: 1.16.*
-          to: 1.16.*
+          to: 1.16.13
         - automatic: true
           from: <= 1.16.12, >= 1.16.0
           to: 1.16.13
-        - from: 1.16.*
-          to: 1.17.*
+        - automatic: true
+          from: 1.16.*
+          to: 1.17.16
         - from: 1.17.*
           to: 1.17.*
         - automatic: true
@@ -459,6 +458,7 @@ spec:
           to: 1.20.*
       # Versions lists the available versions.
       versions:
+        - 1.16.13
         - 1.17.9
         - 1.17.11
         - 1.17.12

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -190,6 +190,8 @@ var (
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
 		Default: semver.MustParse("v1.19.3"),
 		Versions: []*semver.Version{
+			// Kubernetes 1.16
+			semver.MustParse("v1.16.13"),
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
 			semver.MustParse("v1.17.11"),
@@ -212,16 +214,11 @@ var (
 			{
 				// Auto-upgrade unsupported clusters
 				From:      "1.15.*",
-				To:        "1.16.*",
+				To:        "1.16.13",
 				Automatic: pointer.BoolPtr(true),
 			},
 
 			// ======= 1.16 =======
-			{
-				// Allow to change to any patch version
-				From: "1.16.*",
-				To:   "1.16.*",
-			},
 			{
 				// CVE-2019-11253, CVE-2020-8559
 				From:      "<= 1.16.12, >= 1.16.0",
@@ -231,7 +228,8 @@ var (
 			{
 				// Allow to next minor release
 				From: "1.16.*",
-				To:   "1.17.*",
+				To:   "1.17.16",
+				Automatic: pointer.BoolPtr(true),
 			},
 
 			// ======= 1.17 =======

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -190,8 +190,6 @@ var (
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
 		Default: semver.MustParse("v1.19.3"),
 		Versions: []*semver.Version{
-			// Kubernetes 1.16
-			semver.MustParse("v1.16.13"),
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
 			semver.MustParse("v1.17.11"),
@@ -211,20 +209,6 @@ var (
 			semver.MustParse("v1.20.2"),
 		},
 		Updates: []operatorv1alpha1.Update{
-			{
-				// Auto-upgrade unsupported clusters
-				From:      "1.15.*",
-				To:        "1.16.13",
-				Automatic: pointer.BoolPtr(true),
-			},
-
-			// ======= 1.16 =======
-			{
-				// CVE-2019-11253, CVE-2020-8559
-				From:      "<= 1.16.12, >= 1.16.0",
-				To:        "1.16.13",
-				Automatic: pointer.BoolPtr(true),
-			},
 			{
 				// Auto-upgrade unsupported clusters
 				From:      "1.16.*",

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -226,9 +226,9 @@ var (
 				Automatic: pointer.BoolPtr(true),
 			},
 			{
-				// Allow to next minor release
-				From: "1.16.*",
-				To:   "1.17.16",
+				// Auto-upgrade unsupported clusters
+				From:      "1.16.*",
+				To:        "1.17.16",
 				Automatic: pointer.BoolPtr(true),
 			},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR fixes #6683 and allows default upgrades on startup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6683

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
https://github.com/kubermatic/kubermatic/blob/master/docs/dev-getting-started.md

**Does this PR introduce a user-facing change?**:
```release-note
Fix default version configuration to have automatic upgrade from Kubernetes 1.16 to 1.17.
```
