### PR TITLE
Expose MLA Gateway using KKP expose strategies

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -81,7 +81,7 @@ type controllerRunOptions struct {
 	opaWebhookTimeout     int
 	useSSHKeyAgent        bool
 	caBundleFile          string
-	mlaGatewayPort        int
+	mlaGatewayURL         string
 	userClusterLogging    bool
 	userClusterMonitoring bool
 }
@@ -115,7 +115,7 @@ func main() {
 	flag.IntVar(&runOp.opaWebhookTimeout, "opa-webhook-timeout", 3, "Timeout for OPA Integration validating webhook, in seconds")
 	flag.BoolVar(&runOp.useSSHKeyAgent, "enable-ssh-key-agent", false, "Enable UserSSHKeyAgent integration in user cluster")
 	flag.StringVar(&runOp.caBundleFile, "ca-bundle", "", "The path to the cluster's CA bundle (PEM-encoded).")
-	flag.IntVar(&runOp.mlaGatewayPort, "mla-gateway-port", 0, "The port of MLA(Monitoring, Logging, and Alerting) gateway.")
+	flag.StringVar(&runOp.mlaGatewayURL, "mla-gateway-url", "", "The URL of MLA (Monitoring, Logging, and Alerting) gateway endpoint.")
 	flag.BoolVar(&runOp.userClusterLogging, "user-cluster-logging", false, "Enable logging in user cluster.")
 	flag.BoolVar(&runOp.userClusterMonitoring, "user-cluster-monitoring", false, "Enable monitoring in user cluster.")
 	flag.Parse()
@@ -149,8 +149,8 @@ func main() {
 		log.Fatal("-ca-bundle must be set")
 	}
 	if runOp.userClusterLogging || runOp.userClusterMonitoring {
-		if runOp.mlaGatewayPort == 0 {
-			log.Fatal("-mla-gateway-port must be set when enabling user cluster logging or monitoring")
+		if runOp.mlaGatewayURL == "" {
+			log.Fatal("-mla-gateway-url must be set when enabling user cluster logging or monitoring")
 		}
 	}
 
@@ -239,9 +239,9 @@ func main() {
 		runOp.opaWebhookTimeout,
 		caBundle,
 		usercluster.UserClusterMLA{
-			Logging:        runOp.userClusterLogging,
-			Monitoring:     runOp.userClusterMonitoring,
-			MLAGatewayPort: runOp.mlaGatewayPort,
+			Logging:       runOp.userClusterLogging,
+			Monitoring:    runOp.userClusterMonitoring,
+			MLAGatewayURL: runOp.mlaGatewayURL,
 		},
 		log,
 	); err != nil {

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -270,7 +270,7 @@ func (r *datasourceGrafanaReconciler) ensureServices(ctx context.Context, c *kub
 	creators := []reconciling.NamedServiceCreatorGetter{
 		GatewayAlertServiceCreator(),
 		GatewayInternalServiceCreator(),
-		GatewayExternalServiceCreator(),
+		GatewayExternalServiceCreator(c),
 	}
 	return reconciling.ReconcileServices(ctx, creators, c.Status.NamespaceName, r.Client, reconciling.OwnerRefWrapper(resources.GetClusterRef(c)))
 }

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -97,6 +97,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					Spec: kubermaticv1.ClusterSpec{
 						HumanReadableName: "Super Cluster",
 						MLA:               &kubermaticv1.MLASettings{LoggingEnabled: true, MonitoringEnabled: true},
+						ExposeStrategy:    kubermaticv1.ExposeStrategyNodePort,
 					},
 					Status: kubermaticv1.ClusterStatus{NamespaceName: "cluster-clusterUID"},
 				},
@@ -152,6 +153,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					Spec: kubermaticv1.ClusterSpec{
 						HumanReadableName: "Super Cluster",
 						MLA:               &kubermaticv1.MLASettings{LoggingEnabled: true, MonitoringEnabled: true},
+						ExposeStrategy:    kubermaticv1.ExposeStrategyNodePort,
 					},
 					Status: kubermaticv1.ClusterStatus{NamespaceName: "cluster-clusterUID"},
 				},
@@ -202,6 +204,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					Spec: kubermaticv1.ClusterSpec{
 						HumanReadableName: "New Super Cluster",
 						MLA:               &kubermaticv1.MLASettings{LoggingEnabled: true, MonitoringEnabled: true},
+						ExposeStrategy:    kubermaticv1.ExposeStrategyNodePort,
 					},
 					Status: kubermaticv1.ClusterStatus{NamespaceName: "cluster-clusterUID"},
 				},
@@ -309,6 +312,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 							MonitoringEnabled: true,
 							LoggingEnabled:    false,
 						},
+						ExposeStrategy: kubermaticv1.ExposeStrategyNodePort,
 					},
 					Status: kubermaticv1.ClusterStatus{NamespaceName: "cluster-clusterUID"},
 				},
@@ -367,6 +371,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 							MonitoringEnabled: false,
 							LoggingEnabled:    true,
 						},
+						ExposeStrategy: kubermaticv1.ExposeStrategyNodePort,
 					},
 					Status: kubermaticv1.ClusterStatus{NamespaceName: "cluster-clusterUID"},
 				},

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -235,7 +235,7 @@ func GatewayExternalServiceCreator(c *kubermaticv1.Cluster) reconciling.NamedSer
 
 			switch c.Spec.ExposeStrategy {
 			case kubermaticv1.ExposeStrategyNodePort:
-				// Exposes MLA GW via ModePort.
+				// Exposes MLA GW via NodePort.
 				s.Spec.Type = corev1.ServiceTypeNodePort
 				s.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = nodeportproxy.NodePortType.String()
 				delete(s.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -267,6 +267,10 @@ func GatewayExternalServiceCreator(c *kubermaticv1.Cluster) reconciling.NamedSer
 			s.Spec.Ports[0].Port = 80
 			s.Spec.Ports[0].TargetPort = intstr.FromString(extPortName)
 
+			if c.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+				s.Spec.Ports[0].NodePort = 0 // allows switching from other expose strategies
+			}
+
 			return s, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -58,9 +58,9 @@ const (
 )
 
 type UserClusterMLA struct {
-	Logging        bool
-	Monitoring     bool
-	MLAGatewayPort int
+	Logging       bool
+	Monitoring    bool
+	MLAGatewayURL string
 }
 
 // Add creates a new user cluster controller.

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -570,7 +570,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 	if r.userClusterMLA.Monitoring {
 		creators = []reconciling.NamedConfigMapCreatorGetter{
 			userclusterprometheus.ConfigMapCreator(userclusterprometheus.Config{
-				MLAGatewayURL: fmt.Sprintf("http://%s:%d/api/v1/push", r.clusterURL.Hostname(), r.userClusterMLA.MLAGatewayPort),
+				MLAGatewayURL: r.userClusterMLA.MLAGatewayURL + "/api/v1/push",
 			}),
 		}
 		if err := reconciling.ReconcileConfigMaps(ctx, creators, resources.MLANamespace, r.Client); err != nil {
@@ -617,7 +617,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 	if r.userClusterMLA.Logging {
 		creators = []reconciling.NamedSecretCreatorGetter{
 			promtail.SecretCreator(promtail.Config{
-				MLAGatewayURL: fmt.Sprintf("http://%s:%d/loki/api/v1/push", r.clusterURL.Hostname(), r.userClusterMLA.MLAGatewayPort),
+				MLAGatewayURL: r.userClusterMLA.MLAGatewayURL + "/loki/api/v1/push",
 			}),
 		}
 		if err := reconciling.ReconcileSecrets(ctx, creators, resources.MLANamespace, r.Client); err != nil {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -587,6 +587,11 @@ const (
 	UserClusterPrometheusClusterRoleName        = "system:kubermatic:mla:prometheus"
 	UserClusterPrometheusClusterRoleBindingName = "system:kubermatic:mla:prometheus"
 	UserClusterPrometheusDeploymentName         = "prometheus"
+
+	// MLAGatewayExternalServiceName is the name for the MLA Gateway external service
+	MLAGatewayExternalServiceName = "mla-gateway-ext"
+	// MLAGatewaySNIPrefix is the URL prefix which identifies the MLA Gateway endpoint in the external URL if SNI expose strategy is used
+	MLAGatewaySNIPrefix = "mla."
 )
 
 // ECDSAKeyPair is a ECDSA x509 certificate and private key

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.17.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.18.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.19.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.20.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-version","1.21.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-user-cluster-monitoring=true","-user-cluster-logging=false","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-mla-gateway-url","http://jh8j81chn.europe-west3-c.dev.kubermatic.io:30005","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -608,6 +608,20 @@ func TestLoadFiles(t *testing.T) {
 									ClusterIP: "192.0.2.14",
 								},
 							},
+							&corev1.Service{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      resources.MLAGatewayExternalServiceName,
+									Namespace: cluster.Status.NamespaceName,
+								},
+								Spec: corev1.ServiceSpec{
+									Ports: []corev1.ServicePort{
+										{
+											NodePort: 30005,
+										},
+									},
+									ClusterIP: "192.0.2.15",
+								},
+							},
 						).
 						Build()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes the user cluster MLA (Monitoring, Logging and Alerting) Gateway to the user cluster MLA components using the currently used KKP expose strategy. HTTPS part to enable SNI will be part of a future PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6490 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
