### PR TITLE
use secret created by grafana

### DIFF
--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -167,7 +167,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.Var(&c.tunnelingAgentIP, "tunneling-agent-ip", "The address used by the tunneling agents.")
 	flag.StringVar(&c.grafanaURL, "grafana-url", "http://grafana.mla.svc.cluster.local", "The URL of Grafana instance which in running for MLA stack.")
 	flag.StringVar(&c.grafanaHeaderName, "grafana-header-name", "X-WEBAUTH-USER", "Grafana Auth Proxy HTTP Header that will contain the username or email")
-	flag.StringVar(&c.grafanaSecret, "grafana-secret-name", "mla/secret", "Grafana secret name in format namespace/secretname, that contains basic auth info")
+	flag.StringVar(&c.grafanaSecret, "grafana-secret-name", "mla/grafana", "Grafana secret name in format namespace/secretname, that contains basic auth info")
 	c.admissionWebhook.AddFlags(flag.CommandLine, true)
 	addFlags(flag.CommandLine)
 	flag.Parse()

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -38,9 +38,11 @@ import (
 )
 
 const (
-	ControllerName = "kubermatic_mla_controller"
-	mlaFinalizer   = "kubermatic.io/mla"
-	defaultOrgID   = 1
+	ControllerName     = "kubermatic_mla_controller"
+	mlaFinalizer       = "kubermatic.io/mla"
+	defaultOrgID       = 1
+	grafanaUserKey     = "admin-user"
+	grafanaPasswordKey = "admin-password"
 )
 
 var (
@@ -83,12 +85,16 @@ func Add(
 	if err := client.Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
 		return fmt.Errorf("failed to get Grafana Secret: %v", err)
 	}
-	auth, ok := secret.Data["auth"]
+	adminName, ok := secret.Data[grafanaUserKey]
 	if !ok {
-		return fmt.Errorf("Grafana Secret %q does not contain auth", grafanaSecret)
+		return fmt.Errorf("Grafana Secret %q does not contain %s key", grafanaSecret, grafanaUserKey)
+	}
+	adminPass, ok := secret.Data[grafanaPasswordKey]
+	if !ok {
+		return fmt.Errorf("Grafana Secret %q does not contain %s key", grafanaSecret, grafanaPasswordKey)
 	}
 	httpClient := &http.Client{Timeout: 15 * time.Second}
-	grafanaClient := grafanasdk.NewClient(grafanaURL, string(auth), httpClient)
+	grafanaClient := grafanasdk.NewClient(grafanaURL, fmt.Sprintf("%s:%s", adminName, adminPass), httpClient)
 	if err := newOrgGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient); err != nil {
 		return fmt.Errorf("failed to create mla project controller: %v", err)
 	}


### PR DESCRIPTION
grafana helm chart creates secret with auth info and we can use it in mla controller

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
