### PR TITLE
Update openstack cloud controller manager version

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -137,6 +137,8 @@ func getOSFlags(data *resources.TemplateData) []string {
 	return flags
 }
 
+const latestCCMVersion = "1.20.2"
+
 func getOSVersion(version semver.Semver) (string, error) {
 	if version.Minor() < 17 {
 		return "", fmt.Errorf("Kubernetes version %s is not supported", version.String())
@@ -150,11 +152,11 @@ func getOSVersion(version semver.Semver) (string, error) {
 	case 19:
 		return "1.19.2", nil
 	case 20:
-		return "1.20.2", nil
+		return latestCCMVersion, nil
 	case 21:
-		return "1.20.2", nil
+		return latestCCMVersion, nil
 	default:
-		return "1.20.2", nil
+		return latestCCMVersion, nil
 	}
 }
 

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -150,9 +150,11 @@ func getOSVersion(version semver.Semver) (string, error) {
 	case 19:
 		return "1.19.2", nil
 	case 20:
-		return "1.20.0", nil
+		return "1.20.2", nil
+	case 21:
+		return "1.20.2", nil
 	default:
-		return "1.19.2", nil
+		return "1.20.2", nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the CCM openstack version for k8s 1.20 and 1.21 as the current version (`1.20.0`) crashes with the cloud-config generated by KKP (empty `lb-provider`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6919

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix OpenStack crashing with Kubernetes 1.20 and 1.21.
```
