### PR TITLE
[release/v2.16] Update openstack cloud controller manager version

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -149,8 +149,10 @@ func getOSVersion(version semver.Semver) (string, error) {
 		return "1.18.0", nil
 	case 19:
 		return "1.19.2", nil
+	case 20:
+		return "1.20.2", nil
 	default:
-		return "1.19.2", nil
+		return "1.20.2", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.19.2
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
This is a backport of #6923

**Does this PR introduce a user-facing change?**:
```release-note
Fix OpenStack crashing with Kubernetes 1.20 and 1.21.
```