### PR TITLE
filter AWS machine types by architecture

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -6550,6 +6550,13 @@
             "type": "string",
             "name": "Region",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {
@@ -11198,6 +11205,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {
@@ -13699,6 +13713,10 @@
       "type": "object",
       "title": "AWSSize represents a object of AWS size.",
       "properties": {
+        "architecture": {
+          "type": "string",
+          "x-go-name": "Architecture"
+        },
         "gpus": {
           "type": "integer",
           "format": "int64",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -118,12 +118,13 @@ type DatacenterMeta struct {
 // AWSSize represents a object of AWS size.
 // swagger:model AWSSize
 type AWSSize struct {
-	Name       string  `json:"name"`
-	PrettyName string  `json:"pretty_name"`
-	Memory     float32 `json:"memory"`
-	VCPUs      int     `json:"vcpus"`
-	GPUs       int     `json:"gpus"`
-	Price      float64 `json:"price"`
+	Name         string  `json:"name"`
+	PrettyName   string  `json:"pretty_name"`
+	Memory       float32 `json:"memory"`
+	VCPUs        int     `json:"vcpus"`
+	GPUs         int     `json:"gpus"`
+	Price        float64 `json:"price"`
+	Architecture string  `json:"architecture"`
 }
 
 // AWSSizeList represents an array of AWS sizes.

--- a/pkg/handler/common/architecture.go
+++ b/pkg/handler/common/architecture.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const (
+	ARM64Architecture = "arm64"
+	X64Architecture   = "x64"
+)

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -274,7 +274,6 @@ func isARM64Architecture(physicalProcessor string) bool {
 }
 
 func isValidArchitecture(architecture, processorType string) bool {
-
 	if architecture == handlercommon.ARM64Architecture {
 		return isARM64Architecture(processorType)
 	}

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -95,7 +95,7 @@ func AWSSubnetNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider
 	return SetDefaultSubnet(machineDeployments, subnetList)
 }
 
-func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, settingsProvider provider.SettingsProvider, projectID, clusterID string) (interface{}, error) {
+func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, settingsProvider provider.SettingsProvider, projectID, clusterID, architecture string) (interface{}, error) {
 	cluster, err := handlercommon.GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, projectID, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 	if err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.U
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	return AWSSizes(dc.Spec.AWS.Region, settings.Spec.MachineDeploymentVMResourceQuota)
+	return AWSSizes(dc.Spec.AWS.Region, architecture, settings.Spec.MachineDeploymentVMResourceQuota)
 }
 
 func ListAWSSubnets(accessKeyID, secretAccessKey, vpcID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSSubnetList, error) {
@@ -228,7 +228,7 @@ func SetDefaultSubnet(machineDeployments *clusterv1alpha1.MachineDeploymentList,
 	return subnets, nil
 }
 
-func AWSSizes(region string, quota kubermaticv1.MachineDeploymentVMResourceQuota) (apiv1.AWSSizeList, error) {
+func AWSSizes(region, architecture string, quota kubermaticv1.MachineDeploymentVMResourceQuota) (apiv1.AWSSizeList, error) {
 	if data == nil {
 		return nil, fmt.Errorf("AWS instance type data not initialized")
 	}
@@ -245,18 +245,23 @@ func AWSSizes(region string, quota kubermaticv1.MachineDeploymentVMResourceQuota
 			continue
 		}
 
-		// We do not support ARM, so we filter them out here
-		if isARM64Architecture(i.PhysicalProcessor) {
+		if !isValidArchitecture(architecture, i.PhysicalProcessor) {
 			continue
 		}
 
+		machineArchitecture := handlercommon.X64Architecture
+		if isARM64Architecture(i.PhysicalProcessor) {
+			machineArchitecture = handlercommon.ARM64Architecture
+		}
+
 		sizes = append(sizes, apiv1.AWSSize{
-			Name:       i.InstanceType,
-			PrettyName: i.PrettyName,
-			Memory:     i.Memory,
-			VCPUs:      i.VCPU,
-			GPUs:       i.GPU,
-			Price:      price,
+			Name:         i.InstanceType,
+			PrettyName:   i.PrettyName,
+			Memory:       i.Memory,
+			VCPUs:        i.VCPU,
+			GPUs:         i.GPU,
+			Price:        price,
+			Architecture: machineArchitecture,
 		})
 	}
 
@@ -266,6 +271,18 @@ func AWSSizes(region string, quota kubermaticv1.MachineDeploymentVMResourceQuota
 func isARM64Architecture(physicalProcessor string) bool {
 	// right now there is only one Arm-based processors: Graviton2
 	return strings.Contains(physicalProcessor, "Graviton")
+}
+
+func isValidArchitecture(architecture, processorType string) bool {
+
+	if architecture == handlercommon.ARM64Architecture {
+		return isARM64Architecture(processorType)
+	}
+	if architecture == handlercommon.X64Architecture {
+		return !isARM64Architecture(processorType)
+	}
+	// otherwise don't filter out
+	return true
 }
 
 func filterAWSByQuota(instances apiv1.AWSSizeList, quota kubermaticv1.MachineDeploymentVMResourceQuota) apiv1.AWSSizeList {

--- a/pkg/handler/common/provider/aws_test.go
+++ b/pkg/handler/common/provider/aws_test.go
@@ -28,12 +28,14 @@ func TestAWSSizeARMFiltering(t *testing.T) {
 	tests := []struct {
 		name                 string
 		region               string
+		architecture         string
 		resourceQuota        v1.MachineDeploymentVMResourceQuota
 		unexpectedNamePrefix []string
 	}{
 		{
 			name:          "test ARM filtering",
 			region:        "eu-central-1",
+			architecture:  "x64",
 			resourceQuota: genDefaultMachineDeploymentVMResourceQuota(),
 			// Instance List for ARM:
 			// a1.2xlarge
@@ -83,7 +85,7 @@ func TestAWSSizeARMFiltering(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			awsSizeList, err := provider.AWSSizes(test.region, test.resourceQuota)
+			awsSizeList, err := provider.AWSSizes(test.region, test.architecture, test.resourceQuota)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -2285,7 +2285,7 @@ func (r Routing) listAWSSizesNoCredentials() http.Handler {
 			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 		)(provider.AWSSizeNoCredentialsEndpoint(r.projectProvider, r.privilegedProjectProvider, r.seedsGetter, r.settingsProvider, r.userInfoGetter)),
-		cluster.DecodeGetClusterReq,
+		provider.DecodeAWSSizeNoCredentialsReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/pkg/test/e2e/utils/apiclient/client/aws/list_a_w_s_sizes_no_credentials_v2_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/aws/list_a_w_s_sizes_no_credentials_v2_parameters.go
@@ -60,6 +60,11 @@ for the list a w s sizes no credentials v2 operation typically these are written
 */
 type ListAWSSizesNoCredentialsV2Params struct {
 
+	/*Architecture
+	  architecture query parameter. Supports: arm64 and x64 types.
+
+	*/
+	Architecture *string
 	/*ClusterID*/
 	ClusterID string
 	/*ProjectID*/
@@ -103,6 +108,17 @@ func (o *ListAWSSizesNoCredentialsV2Params) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithArchitecture adds the architecture to the list a w s sizes no credentials v2 params
+func (o *ListAWSSizesNoCredentialsV2Params) WithArchitecture(architecture *string) *ListAWSSizesNoCredentialsV2Params {
+	o.SetArchitecture(architecture)
+	return o
+}
+
+// SetArchitecture adds the architecture to the list a w s sizes no credentials v2 params
+func (o *ListAWSSizesNoCredentialsV2Params) SetArchitecture(architecture *string) {
+	o.Architecture = architecture
+}
+
 // WithClusterID adds the clusterID to the list a w s sizes no credentials v2 params
 func (o *ListAWSSizesNoCredentialsV2Params) WithClusterID(clusterID string) *ListAWSSizesNoCredentialsV2Params {
 	o.SetClusterID(clusterID)
@@ -132,6 +148,22 @@ func (o *ListAWSSizesNoCredentialsV2Params) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
+
+	if o.Architecture != nil {
+
+		// query param architecture
+		var qrArchitecture string
+		if o.Architecture != nil {
+			qrArchitecture = *o.Architecture
+		}
+		qArchitecture := qrArchitecture
+		if qArchitecture != "" {
+			if err := r.SetQueryParam("architecture", qArchitecture); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param cluster_id
 	if err := r.SetPathParam("cluster_id", o.ClusterID); err != nil {

--- a/pkg/test/e2e/utils/apiclient/client/aws/list_a_w_s_sizes_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/aws/list_a_w_s_sizes_parameters.go
@@ -62,6 +62,11 @@ type ListAWSSizesParams struct {
 
 	/*Region*/
 	Region *string
+	/*Architecture
+	  architecture query parameter. Supports: arm64 and x64 types.
+
+	*/
+	Architecture *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -112,6 +117,17 @@ func (o *ListAWSSizesParams) SetRegion(region *string) {
 	o.Region = region
 }
 
+// WithArchitecture adds the architecture to the list a w s sizes params
+func (o *ListAWSSizesParams) WithArchitecture(architecture *string) *ListAWSSizesParams {
+	o.SetArchitecture(architecture)
+	return o
+}
+
+// SetArchitecture adds the architecture to the list a w s sizes params
+func (o *ListAWSSizesParams) SetArchitecture(architecture *string) {
+	o.Architecture = architecture
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListAWSSizesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -125,6 +141,22 @@ func (o *ListAWSSizesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		// header param Region
 		if err := r.SetHeaderParam("Region", *o.Region); err != nil {
 			return err
+		}
+
+	}
+
+	if o.Architecture != nil {
+
+		// query param architecture
+		var qrArchitecture string
+		if o.Architecture != nil {
+			qrArchitecture = *o.Architecture
+		}
+		qArchitecture := qrArchitecture
+		if qArchitecture != "" {
+			if err := r.SetQueryParam("architecture", qArchitecture); err != nil {
+				return err
+			}
 		}
 
 	}

--- a/pkg/test/e2e/utils/apiclient/models/a_w_s_size.go
+++ b/pkg/test/e2e/utils/apiclient/models/a_w_s_size.go
@@ -15,6 +15,9 @@ import (
 // swagger:model AWSSize
 type AWSSize struct {
 
+	// architecture
+	Architecture string `json:"architecture,omitempty"`
+
 	// g p us
 	GPUs int64 `json:"gpus,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: filter AWS machine types by architecture
When creating user clusters in AWS, instance types should be grouped by architecture.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6928

```release-note
NONE
```
