### PR TITLE
Allow passing MLA namespace to the seed-controller-manager

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -414,6 +414,7 @@ func createMLAController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.versions,
+		ctrlCtx.runOptions.mlaNamespace,
 		ctrlCtx.runOptions.grafanaURL,
 		ctrlCtx.runOptions.grafanaHeaderName,
 		ctrlCtx.runOptions.grafanaSecret,

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -101,6 +101,7 @@ type controllerRunOptions struct {
 	featureGates features.FeatureGate
 
 	// MLA configuration
+	mlaNamespace      string
 	grafanaURL        string
 	grafanaHeaderName string
 	grafanaSecret     string
@@ -165,6 +166,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.IntVar(&c.addonEnforceInterval, "addon-enforce-interval", 5, "Check and ensure default usercluster addons are deployed every interval in minutes. Set to 0 to disable.")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all userclusters")
 	flag.Var(&c.tunnelingAgentIP, "tunneling-agent-ip", "The address used by the tunneling agents.")
+	flag.StringVar(&c.mlaNamespace, "mla-namespace", "mla", "The namespace in which the user cluster MLA stack is running.")
 	flag.StringVar(&c.grafanaURL, "grafana-url", "http://grafana.mla.svc.cluster.local", "The URL of Grafana instance which in running for MLA stack.")
 	flag.StringVar(&c.grafanaHeaderName, "grafana-header-name", "X-WEBAUTH-USER", "Grafana Auth Proxy HTTP Header that will contain the username or email")
 	flag.StringVar(&c.grafanaSecret, "grafana-secret-name", "mla/grafana", "Grafana secret name in format namespace/secretname, that contains basic auth info")

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -54,6 +54,7 @@ const (
 type datasourceGrafanaReconciler struct {
 	ctrlruntimeclient.Client
 	grafanaClient *grafanasdk.Client
+	mlaNamespace  string
 
 	log        *zap.SugaredLogger
 	workerName string
@@ -69,6 +70,7 @@ func newDatasourceGrafanaReconciler(
 	workerName string,
 	versions kubermatic.Versions,
 	grafanaClient *grafanasdk.Client,
+	mlaNamespace string,
 	overwriteRegistry string,
 ) error {
 	log = log.Named(ControllerName)
@@ -79,6 +81,7 @@ func newDatasourceGrafanaReconciler(
 	reconciler := &datasourceGrafanaReconciler{
 		Client:        client,
 		grafanaClient: grafanaClient,
+		mlaNamespace:  mlaNamespace,
 
 		log:        log,
 		workerName: workerName,
@@ -258,7 +261,7 @@ func (r *datasourceGrafanaReconciler) ensureDeployments(ctx context.Context, c *
 
 func (r *datasourceGrafanaReconciler) ensureConfigMaps(ctx context.Context, c *kubermaticv1.Cluster) error {
 	creators := []reconciling.NamedConfigMapCreatorGetter{
-		GatewayConfigMapCreator(c),
+		GatewayConfigMapCreator(c, r.mlaNamespace),
 	}
 	if err := reconciling.ReconcileConfigMaps(ctx, creators, c.Status.NamespaceName, r.Client, reconciling.OwnerRefWrapper(resources.GetClusterRef(c))); err != nil {
 		return fmt.Errorf("failed to ensure that the ConfigMap exists: %v", err)

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -66,6 +66,7 @@ func Add(
 	numWorkers int,
 	workerName string,
 	versions kubermatic.Versions,
+	mlaNamespace string,
 	grafanaURL string,
 	grafanaHeader string,
 	grafanaSecret string,
@@ -101,7 +102,7 @@ func Add(
 	if err := newUserGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, httpClient, grafanaURL, grafanaHeader); err != nil {
 		return fmt.Errorf("failed to create mla userprojectbinding controller: %v", err)
 	}
-	if err := newDatasourceGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, overwriteRegistry); err != nil {
+	if err := newDatasourceGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, mlaNamespace, overwriteRegistry); err != nil {
 		return fmt.Errorf("failed to create mla cluster controller: %v", err)
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -164,12 +164,12 @@ func renderTemplate(tpl string, data interface{}) (string, error) {
 	return strings.TrimSpace(output.String()), nil
 }
 
-func GatewayConfigMapCreator(c *kubermaticv1.Cluster) reconciling.NamedConfigMapCreatorGetter {
+func GatewayConfigMapCreator(c *kubermaticv1.Cluster, mlaNamespace string) reconciling.NamedConfigMapCreatorGetter {
 	return func() (string, reconciling.ConfigMapCreator) {
 		return gatewayName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				configData := configTemplateData{
-					Namespace: resources.MLANamespace,
+					Namespace: mlaNamespace,
 					TenantID:  c.Name,
 				}
 				config, err := renderTemplate(nginxConfig, configData)

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -245,8 +245,8 @@ func (r *reconciler) reconcileServiceAcconts(ctx context.Context) error {
 		)
 	}
 	if len(creators) != 0 {
-		if err := reconciling.ReconcileServiceAccounts(ctx, creators, resources.MLANamespace, r.Client); err != nil {
-			return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", resources.MLANamespace, err)
+		if err := reconciling.ReconcileServiceAccounts(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+			return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", resources.UserClusterMLANamespace, err)
 		}
 	}
 
@@ -573,8 +573,8 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 				MLAGatewayURL: r.userClusterMLA.MLAGatewayURL + "/api/v1/push",
 			}),
 		}
-		if err := reconciling.ReconcileConfigMaps(ctx, creators, resources.MLANamespace, r.Client); err != nil {
-			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %v", resources.MLANamespace, err)
+		if err := reconciling.ReconcileConfigMaps(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %v", resources.UserClusterMLANamespace, err)
 		}
 	}
 	return nil
@@ -620,8 +620,8 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 				MLAGatewayURL: r.userClusterMLA.MLAGatewayURL + "/loki/api/v1/push",
 			}),
 		}
-		if err := reconciling.ReconcileSecrets(ctx, creators, resources.MLANamespace, r.Client); err != nil {
-			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %v", resources.MLANamespace, err)
+		if err := reconciling.ReconcileSecrets(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %v", resources.UserClusterMLANamespace, err)
 		}
 	}
 
@@ -649,7 +649,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context) error {
 		dsCreators = []reconciling.NamedDaemonSetCreatorGetter{
 			promtail.DaemonSetCreator(),
 		}
-		if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, resources.MLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, resources.UserClusterMLANamespace, r.Client); err != nil {
 			return fmt.Errorf("failed to reconcile the DaemonSet: %v", err)
 		}
 	}
@@ -707,8 +707,8 @@ func (r *reconciler) reconcileDeployments(ctx context.Context) error {
 		creators := []reconciling.NamedDeploymentCreatorGetter{
 			userclusterprometheus.DeploymentCreator(),
 		}
-		if err := reconciling.ReconcileDeployments(ctx, creators, resources.MLANamespace, r.Client); err != nil {
-			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", resources.MLANamespace, err)
+		if err := reconciling.ReconcileDeployments(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", resources.UserClusterMLANamespace, err)
 		}
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/deletion.go
@@ -28,7 +28,7 @@ func ResourcesOnDeletion() []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: resources.MLANamespace,
+				Name: resources.UserClusterMLANamespace,
 			},
 		},
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
@@ -24,7 +24,7 @@ import (
 )
 
 func NamespaceCreator() (string, reconciling.NamespaceCreator) {
-	return resources.MLANamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+	return resources.UserClusterMLANamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/clusterrolebinding.go
@@ -37,7 +37,7 @@ func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGette
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      resources.UserClusterPrometheusServiceAccountName,
-					Namespace: resources.MLANamespace,
+					Namespace: resources.UserClusterMLANamespace,
 				},
 			}
 			return crb, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deletion.go
@@ -31,19 +31,19 @@ func ResourcesOnDeletion() []ctrlruntimeclient.Object {
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.UserClusterPrometheusDeploymentName,
-				Namespace: resources.MLANamespace,
+				Namespace: resources.UserClusterMLANamespace,
 			},
 		},
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.UserClusterPrometheusConfigMapName,
-				Namespace: resources.MLANamespace,
+				Namespace: resources.UserClusterMLANamespace,
 			},
 		},
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.UserClusterPrometheusServiceAccountName,
-				Namespace: resources.MLANamespace,
+				Namespace: resources.UserClusterMLANamespace,
 			},
 		},
 		&rbacv1.ClusterRole{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/clusterrolebinding.go
@@ -37,7 +37,7 @@ func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGette
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      resources.PromtailServiceAccountName,
-					Namespace: resources.MLANamespace,
+					Namespace: resources.UserClusterMLANamespace,
 				},
 			}
 			return crb, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/deletion.go
@@ -31,19 +31,19 @@ func ResourcesOnDeletion() []ctrlruntimeclient.Object {
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.PromtailDaemonSetName,
-				Namespace: resources.MLANamespace,
+				Namespace: resources.UserClusterMLANamespace,
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.PromtailSecretName,
-				Namespace: resources.MLANamespace,
+				Namespace: resources.UserClusterMLANamespace,
 			},
 		},
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.PromtailServiceAccountName,
-				Namespace: resources.MLANamespace,
+				Namespace: resources.UserClusterMLANamespace,
 			},
 		},
 		&rbacv1.ClusterRole{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -575,7 +575,7 @@ const (
 )
 
 const (
-	MLANamespace                   = "mla-system"
+	UserClusterMLANamespace        = "mla-system"
 	PromtailServiceAccountName     = "promtail"
 	PromtailClusterRoleName        = "system:kubermatic:mla:promtail"
 	PromtailClusterRoleBindingName = "system:kubermatic:mla:promtail"


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Allows to pass the namespace in which the user cluster MLA stack is running in the seed cluster to the to the seed-controller-manager. Fixes the incorrect MLA namespace in the MLA Gateway configMap, which currently points to a constant that is valid only for the MLA resources in user clusters. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
