### PR TITLE
Filtered out ARM instances from AWS size list as KKP does not support it

### DIFF
--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	ec2 "github.com/cristim/ec2-instances-info"
 
@@ -244,6 +245,11 @@ func AWSSizes(region string, quota kubermaticv1.MachineDeploymentVMResourceQuota
 			continue
 		}
 
+		// We do not support ARM, so we filter them out here
+		if isARM64Architecture(i.PhysicalProcessor) {
+			continue
+		}
+
 		sizes = append(sizes, apiv1.AWSSize{
 			Name:       i.InstanceType,
 			PrettyName: i.PrettyName,
@@ -255,6 +261,11 @@ func AWSSizes(region string, quota kubermaticv1.MachineDeploymentVMResourceQuota
 	}
 
 	return filterAWSByQuota(sizes, quota), nil
+}
+
+func isARM64Architecture(physicalProcessor string) bool {
+	// right now there is only one Arm-based processors: Graviton2
+	return strings.Contains(physicalProcessor, "Graviton")
 }
 
 func filterAWSByQuota(instances apiv1.AWSSizeList, quota kubermaticv1.MachineDeploymentVMResourceQuota) apiv1.AWSSizeList {

--- a/pkg/handler/common/provider/aws_test.go
+++ b/pkg/handler/common/provider/aws_test.go
@@ -17,28 +17,67 @@ limitations under the License.
 package provider_test
 
 import (
-	"reflect"
+	"strings"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/diff"
 
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/common/provider"
 )
 
-func TestAWSSize(t *testing.T) {
+func TestAWSSizeARMFiltering(t *testing.T) {
 	tests := []struct {
-		name          string
-		region        string
-		resourceQuota v1.MachineDeploymentVMResourceQuota
-		expectedNames []string
+		name                 string
+		region               string
+		resourceQuota        v1.MachineDeploymentVMResourceQuota
+		unexpectedNamePrefix []string
 	}{
 		{
 			name:          "test ARM filtering",
 			region:        "eu-central-1",
 			resourceQuota: genDefaultMachineDeploymentVMResourceQuota(),
-			// t4g.small is a instance with ARM which is filtered out here
-			expectedNames: []string{"t3a.small", "t3.small"},
+			// Instance List for ARM:
+			// a1.2xlarge
+			// a1.4xlarge
+			// a1.large
+			// a1.medium
+			// a1.metal
+			// a1.xlarge
+			// c6g.12xlarge
+			// c6g.16xlarge
+			// c6g.2xlarge
+			// c6g.4xlarge
+			// c6g.8xlarge
+			// c6g.large
+			// c6g.medium
+			// c6g.metal
+			// c6g.xlarge
+			// m6g.12xlarge
+			// m6g.16xlarge
+			// m6g.2xlarge
+			// m6g.4xlarge
+			// m6g.8xlarge
+			// m6g.large
+			// m6g.medium
+			// m6g.metal
+			// m6g.xlarge
+			// r6g.12xlarge
+			// r6g.16xlarge
+			// r6g.2xlarge
+			// r6g.4xlarge
+			// r6g.8xlarge
+			// r6g.large
+			// r6g.medium
+			// r6g.metal
+			// r6g.xlarge
+			// t4g.2xlarge
+			// t4g.large
+			// t4g.medium
+			// t4g.micro
+			// t4g.nano
+			// t4g.small
+			// t4g.xlarge
+			// ARM instances on AWS are marked with these prefixes
+			unexpectedNamePrefix: []string{"t4g", "c6g", "r6g", "m6g", "a1"},
 		},
 	}
 
@@ -49,13 +88,12 @@ func TestAWSSize(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var resultNames []string
 			for _, size := range awsSizeList {
-				resultNames = append(resultNames, size.Name)
-			}
-
-			if !reflect.DeepEqual(resultNames, test.expectedNames) {
-				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(resultNames, test.expectedNames))
+				for _, prefix := range test.unexpectedNamePrefix {
+					if strings.HasPrefix(size.Name, prefix) {
+						t.Fatalf("Resulting list has an ARM instance %s with unexpected prefix %s", size.Name, prefix)
+					}
+				}
 			}
 		})
 	}
@@ -63,10 +101,10 @@ func TestAWSSize(t *testing.T) {
 
 func genDefaultMachineDeploymentVMResourceQuota() v1.MachineDeploymentVMResourceQuota {
 	return v1.MachineDeploymentVMResourceQuota{
-		MinCPU:    2,
-		MaxCPU:    2,
-		MinRAM:    2,
-		MaxRAM:    2,
-		EnableGPU: false,
+		MinCPU:    0,
+		MaxCPU:    20,
+		MinRAM:    0,
+		MaxRAM:    64,
+		EnableGPU: true,
 	}
 }

--- a/pkg/handler/common/provider/aws_test.go
+++ b/pkg/handler/common/provider/aws_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider_test
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/common/provider"
+)
+
+func TestAWSSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		region        string
+		resourceQuota v1.MachineDeploymentVMResourceQuota
+		expectedNames []string
+	}{
+		{
+			name:          "test ARM filtering",
+			region:        "eu-central-1",
+			resourceQuota: genDefaultMachineDeploymentVMResourceQuota(),
+			// t4g.small is a instance with ARM which is filtered out here
+			expectedNames: []string{"t3a.small", "t3.small"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			awsSizeList, err := provider.AWSSizes(test.region, test.resourceQuota)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var resultNames []string
+			for _, size := range awsSizeList {
+				resultNames = append(resultNames, size.Name)
+			}
+
+			if !reflect.DeepEqual(resultNames, test.expectedNames) {
+				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(resultNames, test.expectedNames))
+			}
+		})
+	}
+}
+
+func genDefaultMachineDeploymentVMResourceQuota() v1.MachineDeploymentVMResourceQuota {
+	return v1.MachineDeploymentVMResourceQuota{
+		MinCPU:    2,
+		MaxCPU:    2,
+		MinRAM:    2,
+		MaxRAM:    2,
+		EnableGPU: false,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Filters our ARM instances for the AWS size list, as KKP does not support it. 

Replaces https://github.com/kubermatic/kubermatic/pull/6927, as it seems we dont need to support ARM at all here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6928 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
ARM instances for AWS are now being filtered out from the instance size list as KKP does not support ARM. 
```
