### PR TITLE
add rbac for constraints owners,editors,viewers

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -598,7 +598,7 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 }
 
 func generateVerbsForClusterNamespaceResource(cluster *kubermaticv1.Cluster, groupName, kind string) ([]string, error) {
-	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && kind == kubermaticv1.AddonKindName {
+	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && (kind == kubermaticv1.AddonKindName || kind == kubermaticv1.ConstraintKind) {
 		return []string{"get", "list"}, nil
 	}
 

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -123,6 +123,12 @@ func (c *resourcesController) syncProjectResource(ctx context.Context, key ctrlr
 			if err := c.ensureRBACRoleBindingForClusterAlertmanagerConfigSecrets(ctx, projectName, metaObject); err != nil {
 				return fmt.Errorf("failed to sync RBAC RoleBinding for %s resource for %s cluster provider in namespace %s, due to = %v", rmapping, c.providerName, metaObject.GetNamespace(), err)
 			}
+			if err := c.ensureRBACRoleForClusterConstraints(ctx, projectName, metaObject); err != nil {
+				return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", rmapping, c.providerName, metaObject.GetNamespace(), err)
+			}
+			if err := c.ensureRBACRoleBindingForClusterConstraints(ctx, projectName, metaObject); err != nil {
+				return fmt.Errorf("failed to sync RBAC RoleBinding for %s resource for %s cluster provider in namespace %s, due to = %v", rmapping, c.providerName, metaObject.GetNamespace(), err)
+			}
 		}
 
 		return nil
@@ -861,6 +867,113 @@ func (c *resourcesController) ensureRBACRoleBindingForClusterAlertmanagerConfigS
 			GenerateActualGroupNameFor(projectName, groupPrefix),
 			"Secret",
 			defaultAlertmanagerConfigSecretName,
+		)
+
+		var sharedExistingRoleBinding rbacv1.RoleBinding
+		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
+		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
+			if kerrors.IsNotFound(err) {
+				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+
+		// sharedExistingRoleBinding found
+		if equality.Semantic.DeepEqual(sharedExistingRoleBinding.Subjects, generatedRoleBinding.Subjects) {
+			continue
+		}
+		existingRoleBinding := sharedExistingRoleBinding.DeepCopy()
+		existingRoleBinding.Subjects = generatedRoleBinding.Subjects
+		if err := c.client.Update(ctx, existingRoleBinding); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *resourcesController) ensureRBACRoleForClusterConstraints(ctx context.Context, projectName string, object metav1.Object) error {
+	cluster, ok := object.(*kubermaticv1.Cluster)
+	if !ok {
+		return fmt.Errorf("ensureRBACRoleForClusterConstraints called with non-cluster: %+v", object)
+	}
+
+	var roleList rbacv1.RoleList
+	opts := &ctrlruntimeclient.ListOptions{Namespace: cluster.Status.NamespaceName}
+	if err := c.client.List(ctx, &roleList, opts); err != nil {
+		return err
+	}
+
+	for _, groupPrefix := range AllGroupsPrefixes {
+		skip, generatedRole, err := shouldSkipRBACRoleForClusterNamespaceResource(
+			projectName,
+			cluster,
+			kubermaticv1.ConstraintResourceName,
+			kubermaticv1.GroupName,
+			kubermaticv1.ConstraintKind,
+			groupPrefix)
+		if err != nil {
+			return err
+		}
+		if skip {
+			klog.V(4).Infof("skipping Role generation for cluster constraints for group %q and cluster namespace %q", groupPrefix, cluster.Status.NamespaceName)
+			continue
+		}
+
+		var sharedExistingRole rbacv1.Role
+		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
+		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
+			if kerrors.IsNotFound(err) {
+				if err := c.client.Create(ctx, generatedRole); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+
+		// make sure that existing rbac role has appropriate rules/policies
+
+		if equality.Semantic.DeepEqual(sharedExistingRole.Rules, generatedRole.Rules) {
+			continue
+		}
+		existingRole := sharedExistingRole.DeepCopy()
+		existingRole.Rules = generatedRole.Rules
+		if err := c.client.Update(ctx, existingRole); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *resourcesController) ensureRBACRoleBindingForClusterConstraints(ctx context.Context, projectName string, object metav1.Object) error {
+	cluster, ok := object.(*kubermaticv1.Cluster)
+	if !ok {
+		return fmt.Errorf("ensureRBACRoleBindingForClusterConstraints called with non-cluster: %+v", object)
+	}
+
+	for _, groupPrefix := range AllGroupsPrefixes {
+		skip, _, err := shouldSkipRBACRoleForClusterNamespaceResource(
+			projectName,
+			cluster,
+			kubermaticv1.ConstraintResourceName,
+			kubermaticv1.GroupName,
+			kubermaticv1.ConstraintKind,
+			groupPrefix)
+		if err != nil {
+			return err
+		}
+		if skip {
+			klog.V(4).Infof("skipping RoleBinding generation for cluster constraints for group %q and cluster namespace %q", groupPrefix, cluster.Status.NamespaceName)
+			continue
+		}
+
+		generatedRoleBinding := generateRBACRoleBindingForClusterNamespaceResource(
+			cluster,
+			GenerateActualGroupNameFor(projectName, groupPrefix),
+			kubermaticv1.ConstraintKind,
 		)
 
 		var sharedExistingRoleBinding rbacv1.RoleBinding

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestSyncProjectResourcesClusterWide(t *testing.T) {
@@ -719,8 +720,10 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)
-			key := ctrlruntimeclient.ObjectKey{Name: objmeta.GetName(), Namespace: objmeta.GetNamespace()}
-			err = target.syncProjectResource(ctx, key)
+			_, err = target.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: objmeta.GetNamespace(),
+				Name:      objmeta.GetName(),
+			}})
 
 			// validate
 			if err != nil && !test.expectError {
@@ -893,8 +896,10 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)
-			key := ctrlruntimeclient.ObjectKey{Name: objmeta.GetName(), Namespace: objmeta.GetNamespace()}
-			err = target.syncProjectResource(ctx, key)
+			_, err = target.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: objmeta.GetNamespace(),
+				Name:      objmeta.GetName(),
+			}})
 
 			// validate
 			if !test.expectError {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds proper RBAC for owner/editors/viewers groups for Kubermatic Constraints.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6941 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix issue where Kubermatic non-admin users were not allowed to manage Kubermatic Constraints
```
