### PR TITLE
Fix missed cluster-autoscale resource from the ClusterRole

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -103,6 +103,7 @@ rules:
     - cluster.k8s.io
     resources:
     - machinedeployments
+    - machinedeployments/scale
     - machines
     - machinesets
     verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally reported at the https://github.com/kubermatic/kubeone/issues/1299


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix missed cluster-autoscale resource from the ClusterRole
```
