### PR TITLE
Check MLA gateway before deleting Alertmanager configuration.

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -224,6 +224,12 @@ func TestAlertmanagerReconcile(t *testing.T) {
 						resources.AlertmanagerConfigSecretKey: []byte(generateAlertmanagerConfig("test-user")),
 					},
 				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      gatewayAlertName,
+						Namespace: "cluster-test",
+					},
+				},
 				&kubermaticv1.Alertmanager{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resources.AlertmanagerName,
@@ -253,6 +259,12 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
 				generateCluster("test", false, true),
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      gatewayAlertName,
+						Namespace: "cluster-test",
+					},
+				},
 			},
 			requests: []request{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an MLA gateway check before deleting the Alertmanager configuration in alertmanager controller, otherwise, it returns no such host consistently.

Note that it can be the case that mla gateway service is deleted before the controller cleans alertmanager configuration up. For fixing that controller needs to send requests to cortex alertmanager endpoints with `X-Scope-OrgID` header directly. The issue is created here: #6959 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
