### PR TITLE
Add SIG App Management as OWNERS of MLA packages

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/OWNERS
+++ b/pkg/controller/seed-controller-manager/mla/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig/app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/OWNERS
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig/app-management
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:

The SIG App Management folks are doing an amazing job with the new MLA controller, however, they need approval from SIG  Cluster Management for every PR.

This can be a big blocker and considering that they have created the controller and that they know how it should look and work like, it makes sense for them to own the MLA controller.

This PR adds SIG App Management as OWNERS to the following packages:

* `pkg/controller/seed-controller-manager/mla`
* `pkg/controller/user-cluster-controller-manager/resources/resources/mla`

They will still need approval for SIG Cluster Management for larger PRs, but I think that this will help at least for smaller PRs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @shaase-ctrl @moadqassem @kron4eg @moelsayed 
cc @rastislavs @jiachengxu @aborilov 
/hold
for discussion