### PR TITLE
Initialize the vsphere govmoni client with a ca-bundled soap client

### DIFF
--- a/pkg/provider/cloud/vsphere/ca_test.go
+++ b/pkg/provider/cloud/vsphere/ca_test.go
@@ -56,10 +56,8 @@ func TestVSphereCA(t *testing.T) {
 				if !strings.Contains(err.Error(), test.errMsgContains) {
 					t.Fatalf("expected err msg %q to contain %q", err.Error(), test.errMsgContains)
 				}
-			} else {
-				if err != nil {
-					t.Fatal(err)
-				}
+			} else if err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/pkg/provider/cloud/vsphere/ca_test.go
+++ b/pkg/provider/cloud/vsphere/ca_test.go
@@ -1,0 +1,66 @@
+// +build integration
+
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"crypto/x509"
+	"strings"
+	"testing"
+
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+)
+
+func TestVSphereCA(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedError  bool
+		caBundle       *x509.CertPool
+		errMsgContains string
+	}{
+		{
+			name:           "fail accessing vSphere with fake certificate",
+			expectedError:  true,
+			caBundle:       certificates.NewFakeCABundle().CertPool(),
+			errMsgContains: "certificate",
+		},
+		{
+			name:          "succeed accessing vSphere with root/host certificate",
+			expectedError: false,
+			caBundle:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := GetNetworks(getTestDC(), vSphereUsername, vSpherePassword, test.caBundle)
+			if test.expectedError {
+				if err == nil {
+					t.Fatal("expected err, got nil")
+				}
+				if !strings.Contains(err.Error(), test.errMsgContains) {
+					t.Fatalf("expected err msg %q to contain %q", err.Error(), test.errMsgContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/provider/cloud/vsphere/folder_test.go
+++ b/pkg/provider/cloud/vsphere/folder_test.go
@@ -23,11 +23,10 @@ import (
 	"path"
 	"testing"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
-
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 func TestCreateVMFolder(t *testing.T) {
@@ -38,7 +37,7 @@ func TestCreateVMFolder(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	session, err := newSession(ctx, dc, vSphereUsername, vSpherePassword, certificates.NewFakeCABundle().CertPool())
+	session, err := newSession(ctx, dc, vSphereUsername, vSpherePassword, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +94,7 @@ func TestProvider_GetVMFolders(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			folders, err := GetVMFolders(test.dc, vSphereUsername, vSpherePassword, certificates.NewFakeCABundle().CertPool())
+			folders, err := GetVMFolders(test.dc, vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/cloud/vsphere/folder_test.go
+++ b/pkg/provider/cloud/vsphere/folder_test.go
@@ -23,10 +23,10 @@ import (
 	"path"
 	"testing"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 func TestCreateVMFolder(t *testing.T) {

--- a/pkg/provider/cloud/vsphere/network_test.go
+++ b/pkg/provider/cloud/vsphere/network_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 )
 
 func TestGetPossibleVMNetworks(t *testing.T) {
@@ -52,7 +50,7 @@ func TestGetPossibleVMNetworks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			networkInfos, err := GetNetworks(getTestDC(), vSphereUsername, vSpherePassword, certificates.NewFakeCABundle().CertPool())
+			networkInfos, err := GetNetworks(getTestDC(), vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the vSphere client issue where it doesnt use the provided CA bundle. Based on https://github.com/vmware/govmomi/issues/1200. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6863 

**Special notes for your reviewer**:
WIP until @toschneck  confirms if fix works

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
fix KKP vSphere client not using the provided custom CA bundle
```
