### PR TITLE
Fix import order

### DIFF
--- a/.gimps.yaml
+++ b/.gimps.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the configuration for https://github.com/xrstf/gimps.
+
+importOrder: [std, external, envoy, kubermatic, kubernetes]
+sets:
+  - name: kubermatic
+    patterns:
+      - 'k8c.io/**'
+      - 'github.com/kubermatic/**'
+  - name: kubernetes
+    patterns:
+      - 'k8s.io/**'
+      - '*.k8s.io/**'
+  - name: envoy
+    patterns:
+      - 'github.com/envoyproxy/**'

--- a/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/cmd/conformance-tests/scenarios_kubevirt.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"k8c.io/kubermatic/v2/pkg/semver"
 	apimodels "k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/models"
 
-	"go.uber.org/zap"
 	utilpointer "k8s.io/utils/pointer"
 )
 

--- a/cmd/conformance-tests/usercluster_controller_tests.go
+++ b/cmd/conformance-tests/usercluster_controller_tests.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
 
 	rbacusercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/rbac"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -30,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -50,7 +50,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kubermaticclientset "k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned"

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
@@ -38,7 +39,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/edition"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"

--- a/cmd/kubermatic-installer/cmd_version.go
+++ b/cmd/kubermatic-installer/cmd_version.go
@@ -106,8 +106,10 @@ func VersionAction(logger *logrus.Logger, versions kubermaticversion.Versions) c
 // HelmCharts is used to sort Helm charts by their name.
 type HelmCharts []helm.Chart
 
-func (a HelmCharts) Len() int           { return len(a) }
-func (a HelmCharts) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a HelmCharts) Len() int { return len(a) }
+
+func (a HelmCharts) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
 func (a HelmCharts) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
 func loadCharts(chartDirectory string) ([]helm.Chart, error) {

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )

--- a/cmd/node-resource-documenter/main.go
+++ b/cmd/node-resource-documenter/main.go
@@ -27,9 +27,9 @@ import (
 	"text/template"
 	"time"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-
 	"github.com/Masterminds/sprig/v3"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 // createFuncMap creates a function map needed for template execution.

--- a/cmd/s3-storeuploader/main.go
+++ b/cmd/s3-storeuploader/main.go
@@ -220,6 +220,7 @@ func store(c *cli.Context) error {
 		c.Bool("create-bucket"),
 	)
 }
+
 func deleteOldRevisions(c *cli.Context) error {
 	uploader, err := getUploaderFromCtx(c)
 	if err != nil {
@@ -232,6 +233,7 @@ func deleteOldRevisions(c *cli.Context) error {
 		c.Int("max-revisions"),
 	)
 }
+
 func deleteAll(c *cli.Context) error {
 	uploader, err := getUploaderFromCtx(c)
 	if err != nil {

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	clusterrolelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/cluster-role-labeler"
 	constraintsyncer "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/constraint-syncer"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar"

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -19,6 +19,7 @@ package tools
 
 import (
 	_ "github.com/go-swagger/go-swagger/cmd/swagger"
+
 	_ "k8s.io/code-generator"
 	_ "k8s.io/code-generator/cmd/client-gen"
 	_ "k8s.io/code-generator/cmd/conversion-gen"

--- a/pkg/controller/master-controller-manager/rbac/test/helper.go
+++ b/pkg/controller/master-controller-manager/rbac/test/helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/zapr"
-
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"

--- a/pkg/controller/master-controller-manager/user-project-binding/user_project_binding_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/user_project_binding_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -28,9 +28,6 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	envoyaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -48,6 +45,10 @@ import (
 	envoywellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const clusterConnectTimeout = 1 * time.Second

--- a/pkg/controller/nodeport-proxy/envoymanager/utils.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 )
 
 // SortServicesByCreationTimestamp sorts the Service slice in descending order

--- a/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/go-test/deep"
 
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 )
 
 func TestExtractExposeType(t *testing.T) {

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/docker/distribution/reference"
 	"github.com/ghodss/yaml"
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -32,7 +33,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/version"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -19,10 +19,11 @@ package kubermatic
 import (
 	"fmt"
 
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/controller/operator/seed/reconciler_test.go
+++ b/pkg/controller/operator/seed/reconciler_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
@@ -32,7 +34,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/seed-controller-manager/clustercomponentdefaulter/clustercomponentdefaulter_test.go
+++ b/pkg/controller/seed-controller-manager/clustercomponentdefaulter/clustercomponentdefaulter_test.go
@@ -24,9 +24,9 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilpointer "k8s.io/utils/pointer"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -40,6 +40,7 @@ func exampleCluster(settings *kubermaticv1.ComponentSettings) *kubermaticv1.Clus
 	}
 	return cluster
 }
+
 func exampleSettings(reconciling *bool, replicas bool) *kubermaticv1.ComponentSettings {
 	settings := &kubermaticv1.ComponentSettings{
 		Apiserver: kubermaticv1.APIServerSettings{EndpointReconcilingDisabled: reconciling},

--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (r *Reconciler) clusterHealth(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.ExtendedClusterHealth, error) {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -21,18 +21,18 @@ import (
 	"fmt"
 	"testing"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
-	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 )
 
 func init() {

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -249,6 +249,7 @@ func (r *datasourceGrafanaReconciler) reconcileDatasource(ctx context.Context, e
 	return nil
 
 }
+
 func (r *datasourceGrafanaReconciler) ensureDeployments(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := []reconciling.NamedDeploymentCreatorGetter{
 		GatewayDeploymentCreator(data),

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -25,7 +25,6 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	grafanasdk "github.com/kubermatic/grafanasdk"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const nginxConfig = `worker_processes  1;

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -25,11 +25,13 @@ import (
 	"testing"
 	"time"
 
-	grafanasdk "github.com/kubermatic/grafanasdk"
 	"github.com/stretchr/testify/assert"
+
+	grafanasdk "github.com/kubermatic/grafanasdk"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"

--- a/pkg/controller/seed-controller-manager/monitoring/resources.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources.go
@@ -27,8 +27,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/kubestatemetrics"
 	"k8c.io/kubermatic/v2/pkg/resources/prometheus"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8s.io/apimachinery/pkg/api/resource"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/controller/seed-controller-manager/monitoring/resources_test.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources_test.go
@@ -23,11 +23,11 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestCreateConfigMap(t *testing.T) {

--- a/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -22,9 +22,9 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
-	"github.com/prometheus/client_golang/prometheus"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
@@ -24,6 +24,7 @@ import (
 
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/user-cluster-controller-manager/rbac/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/controller.go
@@ -23,9 +23,8 @@ import (
 	"net/http"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/clusterrolebinding.go
@@ -19,6 +19,7 @@ package cloudcontroller
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 

--- a/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/secret.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/secret.go
@@ -19,6 +19,7 @@ package cloudcontroller
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/clusterrolebinding.go
@@ -21,7 +21,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -26,10 +26,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
-
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 var (

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/secret.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/secret.go
@@ -17,10 +17,10 @@ limitations under the License.
 package gatekeeper
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // SecretCreator creates the secret for gatekeeper webhook controller

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/secret.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/secret.go
@@ -17,10 +17,10 @@ limitations under the License.
 package kubernetesdashboard
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // KeyHolderSecretCreator  creates key holder secret for the Kubernetes Dashboard

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
@@ -17,11 +17,11 @@ limitations under the License.
 package kubernetesdashboard
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ServiceCreator creates the service for the dashboard-metrics-scraper

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/serviceaccount.go
@@ -17,10 +17,10 @@ limitations under the License.
 package kubernetesdashboard
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ServiceAccountCreator creates the service account for the dashboard-metrics-scraper

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/apiservice.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/apiservice.go
@@ -19,9 +19,9 @@ package metricsserver
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 
 const (

--- a/pkg/crd/kubermatic/v1/admission_plugin.go
+++ b/pkg/crd/kubermatic/v1/admission_plugin.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"k8c.io/kubermatic/v2/pkg/semver"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/crd/kubermatic/v1/constraint_template.go
+++ b/pkg/crd/kubermatic/v1/constraint_template.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/crd/kubermatic/v1/external_cluster.go
+++ b/pkg/crd/kubermatic/v1/external_cluster.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/crd/kubermatic/v1/user.go
+++ b/pkg/crd/kubermatic/v1/user.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -19,11 +19,11 @@ package v1alpha1
 import (
 	"github.com/Masterminds/semver/v3"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/ee/conversion/helm.go
+++ b/pkg/ee/conversion/helm.go
@@ -30,6 +30,8 @@ import (
 	"strconv"
 	"strings"
 
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/crd/migrations/util"
@@ -39,7 +41,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/handler/auth/oidc.go
+++ b/pkg/handler/auth/oidc.go
@@ -22,13 +22,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
+
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 )
 
 // OIDCToken represents the credentials used to authorize

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -48,7 +48,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
-
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -27,14 +27,14 @@ import (
 	"strings"
 
 	"github.com/gorilla/securecookie"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/auth"
-	kcerrors "k8c.io/kubermatic/v2/pkg/util/errors"
-
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	kcerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"

--- a/pkg/handler/common/provider/azure.go
+++ b/pkg/handler/common/provider/azure.go
@@ -156,6 +156,7 @@ func (s *azureClientSetImpl) ListResourceGroups(ctx context.Context) ([]resource
 	return resourceGroups.Values(), nil
 
 }
+
 func (s *azureClientSetImpl) ListSubnets(ctx context.Context, resourceGroupName, virtualNetworkName string) ([]network.Subnet, error) {
 	subnets, err := s.subnetsClient.List(ctx, resourceGroupName, virtualNetworkName)
 	if err != nil {

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"net/http"
 
-	"k8c.io/kubermatic/v2/pkg/util/errors"
-
 	"github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -29,12 +27,12 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	"k8c.io/kubermatic/v2/pkg/version"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/handler/routes_v1.go
+++ b/pkg/handler/routes_v1.go
@@ -41,8 +41,6 @@ package handler
 import (
 	"net/http"
 
-	admissionplugin "k8c.io/kubermatic/v2/pkg/handler/v1/admission-plugin"
-
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
@@ -50,6 +48,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	v1 "k8c.io/kubermatic/v2/pkg/handler/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/addon"
+	admissionplugin "k8c.io/kubermatic/v2/pkg/handler/v1/admission-plugin"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/cluster"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/dc"

--- a/pkg/handler/routes_v1_legacy.go
+++ b/pkg/handler/routes_v1_legacy.go
@@ -19,10 +19,10 @@ package handler
 import (
 	"net/http"
 
+	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
 
-	"github.com/go-kit/kit/endpoint"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/node"
 )

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/auth"
 	wsh "k8c.io/kubermatic/v2/pkg/handler/websocket"
@@ -29,9 +32,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/util/hash"
 	"k8c.io/kubermatic/v2/pkg/watcher"
-
-	"github.com/gorilla/mux"
-	"github.com/gorilla/websocket"
 )
 
 var upgrader = websocket.Upgrader{

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -19,24 +19,23 @@ package hack
 import (
 	"net/http"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	v2 "k8c.io/kubermatic/v2/pkg/handler/v2"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
-	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
-
 	"github.com/gorilla/mux"
 	prometheusapi "github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/prometheus"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler"
 	"k8c.io/kubermatic/v2/pkg/handler/auth"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
+	v2 "k8c.io/kubermatic/v2/pkg/handler/v2"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/version"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1526,6 +1526,7 @@ func GenDefaultAPIConstraint(name, kind string) apiv2.Constraint {
 		},
 	}
 }
+
 func GenAlertmanager(namespace, configSecretName string) *kubermaticv1.Alertmanager {
 	return &kubermaticv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/handler/v1/admin/seed.go
+++ b/pkg/handler/v1/admin/seed.go
@@ -22,10 +22,6 @@ import (
 	"fmt"
 	"net/http"
 
-	corev1 "k8s.io/api/core/v1"
-
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
@@ -36,6 +32,9 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ListSeedsEndpoint returns seed list

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
@@ -36,6 +37,7 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
 	"k8s.io/klog"
 )
 

--- a/pkg/handler/v1/cluster/kubeconfig.go
+++ b/pkg/handler/v1/cluster/kubeconfig.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
+
 	"k8c.io/kubermatic/v2/pkg/handler/auth"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"

--- a/pkg/handler/v1/common/event.go
+++ b/pkg/handler/v1/common/event.go
@@ -19,12 +19,12 @@ package common
 import (
 	"context"
 
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 )
 
 // FilterEventsByType filters Kubernetes Events based on their type. Empty type string will return all of them.

--- a/pkg/handler/v1/common/request.go
+++ b/pkg/handler/v1/common/request.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"net/http"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
-
 	"github.com/gorilla/mux"
+
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 )
 
 func DecodeEmptyReq(c context.Context, r *http.Request) (interface{}, error) {

--- a/pkg/handler/v1/provider/azure_test.go
+++ b/pkg/handler/v1/provider/azure_test.go
@@ -227,6 +227,7 @@ func (s *mockSizeClientImpl) ListVMSize(ctx context.Context, location string) ([
 func (s *mockSizeClientImpl) ListSecurityGroups(_ context.Context, _ string) ([]network.SecurityGroup, error) {
 	return nil, nil
 }
+
 func (s *mockSizeClientImpl) ListResourceGroups(_ context.Context) ([]resources.Group, error) {
 	return nil, nil
 }

--- a/pkg/handler/v1/user/user_test.go
+++ b/pkg/handler/v1/user/user_test.go
@@ -25,14 +25,13 @@ import (
 	"time"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	"k8c.io/kubermatic/v2/pkg/resources"
-	corev1 "k8s.io/api/core/v1"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
+	"k8c.io/kubermatic/v2/pkg/resources"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/handler/v1/version.go
+++ b/pkg/handler/v1/version.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/go-kit/kit/endpoint"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 )

--- a/pkg/handler/v2/cluster/upgrade.go
+++ b/pkg/handler/v2/cluster/upgrade.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"

--- a/pkg/handler/v2/constraint/constraint.go
+++ b/pkg/handler/v2/constraint/constraint.go
@@ -28,7 +28,6 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
-	"k8s.io/utils/pointer"
 
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -44,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 )
 
 const (

--- a/pkg/handler/v2/constraint/constraint_test.go
+++ b/pkg/handler/v2/constraint/constraint_test.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/utils/pointer"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -37,6 +35,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/handler/v2/constraint_template/constraint_template.go
+++ b/pkg/handler/v2/constraint_template/constraint_template.go
@@ -27,13 +27,14 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ListEndpoint(constraintTemplateProvider provider.ConstraintTemplateProvider) endpoint.Endpoint {

--- a/pkg/handler/v2/machine/machine_test.go
+++ b/pkg/handler/v2/machine/machine_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"

--- a/pkg/handler/websocket/settings.go
+++ b/pkg/handler/websocket/settings.go
@@ -19,12 +19,12 @@ package websocket
 import (
 	"encoding/json"
 
+	"github.com/gorilla/websocket"
+
 	api "k8c.io/kubermatic/v2/pkg/api/v1"
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/watcher"
-
-	"github.com/gorilla/websocket"
 )
 
 func WriteSettings(providers watcher.Providers, ws *websocket.Conn) {

--- a/pkg/handler/websocket/user.go
+++ b/pkg/handler/websocket/user.go
@@ -19,13 +19,13 @@ package websocket
 import (
 	"encoding/json"
 
+	"code.cloudfoundry.org/go-pubsub"
+	"github.com/gorilla/websocket"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/watcher"
-
-	"code.cloudfoundry.org/go-pubsub"
-	"github.com/gorilla/websocket"
 )
 
 func WriteUser(providers watcher.Providers, ws *websocket.Conn, userEmail string) {

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/sirupsen/logrus"
 
 	"k8c.io/kubermatic/v2/pkg/install/helm"
@@ -32,9 +34,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/install/util"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/log"
-
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
-	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"strconv"
 
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
-
-	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 )
 
 const (

--- a/pkg/machine/util_test.go
+++ b/pkg/machine/util_test.go
@@ -19,9 +19,8 @@ package machine_test
 import (
 	"testing"
 
-	"k8c.io/kubermatic/v2/pkg/machine"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	"k8c.io/kubermatic/v2/pkg/machine"
 )
 
 func TestCredentialEndpoint(t *testing.T) {

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -20,9 +20,9 @@ import (
 	"net/url"
 	"time"
 
-	"k8s.io/client-go/tools/metrics"
-
 	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/client-go/tools/metrics"
 )
 
 // Copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/client/metrics/prometheus/prometheus.go

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -17,9 +17,9 @@ limitations under the License.
 package metrics
 
 import (
-	"k8s.io/client-go/util/workqueue"
-
 	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/util/workqueue/prometheus/prometheus.go
@@ -164,7 +164,10 @@ func (prometheusMetricsProvider) NewDeprecatedRetriesMetric(queue string) workqu
 
 type noopMetric struct{}
 
-func (noopMetric) Inc()            {}
-func (noopMetric) Dec()            {}
-func (noopMetric) Set(float64)     {}
+func (noopMetric) Inc() {}
+
+func (noopMetric) Dec() {}
+
+func (noopMetric) Set(float64) {}
+
 func (noopMetric) Observe(float64) {}

--- a/pkg/metrics/serve.go
+++ b/pkg/metrics/serve.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 	"sync"
 
-	"k8c.io/kubermatic/v2/pkg/log"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"k8c.io/kubermatic/v2/pkg/log"
 )
 
 var once = &sync.Once{}

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -22,6 +22,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -29,13 +35,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 const (

--- a/pkg/provider/cloud/digitalocean/provider.go
+++ b/pkg/provider/cloud/digitalocean/provider.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"errors"
 
+	"github.com/digitalocean/godo"
+	"golang.org/x/oauth2"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-
-	"github.com/digitalocean/godo"
-	"golang.org/x/oauth2"
 )
 
 type digitalocean struct {

--- a/pkg/provider/cloud/hetzner/provider.go
+++ b/pkg/provider/cloud/hetzner/provider.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -37,6 +37,7 @@ import (
 	osports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	ossubnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/gophercloud/pagination"
+
 	"k8c.io/kubermatic/v2/pkg/provider"
 )
 

--- a/pkg/provider/cloud/provider.go
+++ b/pkg/provider/cloud/provider.go
@@ -19,11 +19,11 @@ package cloud
 import (
 	"crypto/x509"
 	"errors"
-	"k8c.io/kubermatic/v2/pkg/provider/cloud/anexia"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/alibaba"
+	"k8c.io/kubermatic/v2/pkg/provider/cloud/anexia"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/aws"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/azure"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/bringyourown"

--- a/pkg/provider/cloud/vsphere/network.go
+++ b/pkg/provider/cloud/vsphere/network.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/object"
+
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 

--- a/pkg/provider/cloud/vsphere/provider_test.go
+++ b/pkg/provider/cloud/vsphere/provider_test.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vmware/govmomi/simulator"
+
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-
-	"github.com/vmware/govmomi/simulator"
 )
 
 func TestGetCredentialsForCluster(t *testing.T) {

--- a/pkg/provider/kubernetes/cluster.go
+++ b/pkg/provider/kubernetes/cluster.go
@@ -23,8 +23,6 @@ import (
 	"reflect"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	k8cuserclusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -37,13 +35,13 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/provider/kubernetes/constraint_template.go
+++ b/pkg/provider/kubernetes/constraint_template.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/types"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ConstraintTemplateProvider struct that holds required components in order manage constraint templates

--- a/pkg/provider/kubernetes/constraint_template_test.go
+++ b/pkg/provider/kubernetes/constraint_template_test.go
@@ -22,14 +22,15 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 )
 
 func TestListConstraintTemplates(t *testing.T) {

--- a/pkg/provider/kubernetes/external_cluster_test.go
+++ b/pkg/provider/kubernetes/external_cluster_test.go
@@ -24,6 +24,7 @@ import (
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"

--- a/pkg/provider/kubernetes/util_test.go
+++ b/pkg/provider/kubernetes/util_test.go
@@ -26,16 +26,16 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
-	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8s.io/apimachinery/pkg/types"
-
 	"gopkg.in/square/go-jose.v2/jwt"
+
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"

--- a/pkg/resources/apiserver/cabundle.go
+++ b/pkg/resources/apiserver/cabundle.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/resources/apiserver/pdb.go
+++ b/pkg/resources/apiserver/pdb.go
@@ -19,10 +19,10 @@ package apiserver
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // PodDisruptionBudgetCreator returns a func to create/update the apiserver PodDisruptionBudget

--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"

--- a/pkg/resources/apiserver/token-users.go
+++ b/pkg/resources/apiserver/token-users.go
@@ -21,7 +21,6 @@ import (
 	"encoding/csv"
 
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 

--- a/pkg/resources/cloudconfig/configmap_test.go
+++ b/pkg/resources/cloudconfig/configmap_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/go-test/deep"
 	"gopkg.in/gcfg.v1"
-	"k8s.io/utils/pointer"
 
 	openstack "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/types"
 	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
+
+	"k8s.io/utils/pointer"
 )
 
 func TestVSphereCloudConfig(t *testing.T) {

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -22,10 +22,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -23,10 +23,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 	"k8c.io/kubermatic/v2/pkg/semver"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -33,8 +33,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
-	appsv1 "k8s.io/api/apps/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -19,11 +19,11 @@ package resources
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestGetCSIMigrationFeatureGates(t *testing.T) {

--- a/pkg/resources/etcd/backupconfig.go
+++ b/pkg/resources/etcd/backupconfig.go
@@ -18,11 +18,13 @@ package etcd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/robfig/cron"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/pkg/resources/etcd/pdb.go
+++ b/pkg/resources/etcd/pdb.go
@@ -17,10 +17,10 @@ limitations under the License.
 package etcd
 
 import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/resources/kubeconfig_test.go
+++ b/pkg/resources/kubeconfig_test.go
@@ -95,12 +95,18 @@ type fakeDataProvider struct {
 	caPair *triple.KeyPair
 }
 
-func (fake *fakeDataProvider) Cluster() *kubermaticv1.Cluster             { return &kubermaticv1.Cluster{} }
-func (fake *fakeDataProvider) ExternalIP() (*net.IP, error)               { return nil, nil }
-func (fake *fakeDataProvider) GetClusterRef() metav1.OwnerReference       { return metav1.OwnerReference{} }
-func (fake *fakeDataProvider) GetFrontProxyCA() (*triple.KeyPair, error)  { return nil, nil }
-func (fake *fakeDataProvider) GetRootCA() (*triple.KeyPair, error)        { return fake.caPair, nil }
-func (fake *fakeDataProvider) GetOpenVPNCA() (*ECDSAKeyPair, error)       { return &ECDSAKeyPair{}, nil }
+func (fake *fakeDataProvider) Cluster() *kubermaticv1.Cluster { return &kubermaticv1.Cluster{} }
+
+func (fake *fakeDataProvider) ExternalIP() (*net.IP, error) { return nil, nil }
+
+func (fake *fakeDataProvider) GetClusterRef() metav1.OwnerReference { return metav1.OwnerReference{} }
+
+func (fake *fakeDataProvider) GetFrontProxyCA() (*triple.KeyPair, error) { return nil, nil }
+
+func (fake *fakeDataProvider) GetRootCA() (*triple.KeyPair, error) { return fake.caPair, nil }
+
+func (fake *fakeDataProvider) GetOpenVPNCA() (*ECDSAKeyPair, error) { return &ECDSAKeyPair{}, nil }
+
 func (fake *fakeDataProvider) InClusterApiserverAddress() (string, error) { return "", nil }
 
 func checkKubeConfigRegeneration(t *testing.T, orgs []string) {

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -39,7 +39,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/rhel"
 	"github.com/kubermatic/machine-controller/pkg/userdata/sles"
 	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"

--- a/pkg/resources/rancherserver/service.go
+++ b/pkg/resources/rancherserver/service.go
@@ -17,13 +17,13 @@ limitations under the License.
 package rancherserver
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ServiceCreator creates the service for rancher server

--- a/pkg/resources/reconciling/wrapper_test.go
+++ b/pkg/resources/reconciling/wrapper_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	controllerruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -34,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	controllerruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestDefaultPodSpec(t *testing.T) {

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/go-test/deep"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 func TestInClusterApiserverIP(t *testing.T) {

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -19,10 +19,9 @@ package scheduler
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-
-	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/resources/usercluster/deployment_test.go
+++ b/pkg/resources/usercluster/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-test/deep"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -19,11 +19,11 @@ package usercluster
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 const (

--- a/pkg/resources/vpa.go
+++ b/pkg/resources/vpa.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8s.io/apimachinery/pkg/types"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -21,8 +21,10 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/uuid"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/test/e2e/api/user_test.go
+++ b/pkg/test/e2e/api/user_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -25,15 +25,15 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/pkg/test/e2e/expose-strategy/client.go
+++ b/pkg/test/e2e/expose-strategy/client.go
@@ -22,13 +22,13 @@ import (
 	"strconv"
 	"strings"
 
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/semver"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
 )
 
 const (

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 var _ = ginkgo.Describe("The Tunneling strategy", func() {

--- a/pkg/test/e2e/nodeport-proxy/deployer.go
+++ b/pkg/test/e2e/nodeport-proxy/deployer.go
@@ -24,13 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -39,6 +32,13 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/pkg/test/e2e/nodeport-proxy/network.go
+++ b/pkg/test/e2e/nodeport-proxy/network.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"time"
 
+	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-
-	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 )
 
 const (

--- a/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
+++ b/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
@@ -24,13 +24,13 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/test"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var _ = ginkgo.Describe("NodeportProxy", func() {

--- a/pkg/test/e2e/nodeport-proxy/services.go
+++ b/pkg/test/e2e/nodeport-proxy/services.go
@@ -24,14 +24,14 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 )
 
 // Based on:

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -29,13 +29,13 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -28,13 +28,8 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
-	"k8s.io/client-go/tools/clientcmd"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
-	"k8s.io/client-go/kubernetes/scheme"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -51,6 +46,9 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TestClient wraps the Swagger-generated API client with some more

--- a/pkg/test/e2e/utils/kubernetes.go
+++ b/pkg/test/e2e/utils/kubernetes.go
@@ -24,8 +24,11 @@ import (
 	"net/url"
 	"time"
 
+	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,9 +42,6 @@ import (
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-
-	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 const (

--- a/pkg/test/e2e/utils/log.go
+++ b/pkg/test/e2e/utils/log.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"github.com/onsi/ginkgo"
 	"go.uber.org/zap"
+
 	ctrlruntimelogzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/coreos/locksmith/pkg/timeutil"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -30,7 +32,6 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
-	"github.com/coreos/locksmith/pkg/timeutil"
 	"k8s.io/apimachinery/pkg/api/equality"
 	utilerror "k8s.io/apimachinery/pkg/util/errors"
 )

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	"k8s.io/utils/pointer"
 )
 

--- a/pkg/validation/node_test.go
+++ b/pkg/validation/node_test.go
@@ -20,10 +20,9 @@ import (
 	"errors"
 	"testing"
 
-	"k8c.io/kubermatic/v2/pkg/validation"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/validation"
 )
 
 // EqualError reports whether errors a and b are considered equal.

--- a/pkg/watcher/kubernetes/settings.go
+++ b/pkg/watcher/kubernetes/settings.go
@@ -19,11 +19,12 @@ package kubernetes
 import (
 	"reflect"
 
+	"code.cloudfoundry.org/go-pubsub"
+
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	"code.cloudfoundry.org/go-pubsub"
 	"k8s.io/apimachinery/pkg/watch"
 )
 

--- a/pkg/watcher/kubernetes/user.go
+++ b/pkg/watcher/kubernetes/user.go
@@ -21,11 +21,12 @@ import (
 	"reflect"
 
 	"code.cloudfoundry.org/go-pubsub"
-	"k8s.io/apimachinery/pkg/watch"
 
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
+
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // UserWatcher watches user and notifies its subscribers about any changes.

--- a/pkg/watcher/kubernetes/user_test.go
+++ b/pkg/watcher/kubernetes/user_test.go
@@ -19,10 +19,11 @@ package kubernetes
 import (
 	"testing"
 
+	"code.cloudfoundry.org/go-pubsub"
+
 	kubermaticfakeclentset "k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/fake"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 
-	"code.cloudfoundry.org/go-pubsub"
 	"k8s.io/client-go/kubernetes/scheme"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/watcher/types.go
+++ b/pkg/watcher/types.go
@@ -17,9 +17,9 @@ limitations under the License.
 package watcher
 
 import (
-	"k8c.io/kubermatic/v2/pkg/provider"
-
 	"code.cloudfoundry.org/go-pubsub"
+
+	"k8c.io/kubermatic/v2/pkg/provider"
 )
 
 type Providers struct {

--- a/pkg/webhook/seed/builder.go
+++ b/pkg/webhook/seed/builder.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"fmt"
 
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/provider"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ValidationHandlerBuilder struct {

--- a/pkg/webhook/seed/handler_test.go
+++ b/pkg/webhook/seed/handler_test.go
@@ -22,14 +22,15 @@ import (
 	"testing"
 
 	logrtesting "github.com/go-logr/logr/testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the import order in all Go source files using https://github.com/xrstf/gimps.

To run it yourself, just `go get go.xrstf.de/gimps` and run it in the repo root: `gimps .`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
