### PR TITLE
Do not assign admin role in Grafana for project owners

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -48,7 +48,7 @@ const (
 var (
 	// groupToRole map kubermatic groups to grafana roles
 	groupToRole = map[string]models.RoleType{
-		rbac.OwnerGroupNamePrefix:  models.ROLE_ADMIN,
+		rbac.OwnerGroupNamePrefix:  models.ROLE_EDITOR, // we assign the editor (not admin) role to project owners, to make sure they cannot edit datasources in Grafana
 		rbac.EditorGroupNamePrefix: models.ROLE_EDITOR,
 		rbac.ViewerGroupNamePrefix: models.ROLE_VIEWER,
 	}

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -119,7 +119,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Admin"}`)),
+					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -162,7 +162,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				},
 				{
 					name:     "update org user",
-					request:  httptest.NewRequest(http.MethodPatch, "/api/orgs/1/users/1", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Admin"}`)),
+					request:  httptest.NewRequest(http.MethodPatch, "/api/orgs/1/users/1", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User updated"}`)), StatusCode: http.StatusOK},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Prevents KKP project owners to modify datasources in Grafana.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
