### PR TITLE
Use Cortex Alertmanager endpoint in alertmanager controller

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -420,6 +420,7 @@ func createMLAController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.grafanaHeaderName,
 		ctrlCtx.runOptions.grafanaSecret,
 		ctrlCtx.runOptions.overwriteRegistry,
+		ctrlCtx.runOptions.cortexAlertmanagerURL,
 	)
 }
 

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -101,11 +101,12 @@ type controllerRunOptions struct {
 	featureGates features.FeatureGate
 
 	// MLA configuration
-	enableUserClusterMLA bool
-	mlaNamespace         string
-	grafanaURL           string
-	grafanaHeaderName    string
-	grafanaSecret        string
+	enableUserClusterMLA  bool
+	mlaNamespace          string
+	grafanaURL            string
+	grafanaHeaderName     string
+	grafanaSecret         string
+	cortexAlertmanagerURL string
 }
 
 func newControllerRunOptions() (controllerRunOptions, error) {
@@ -172,6 +173,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.grafanaURL, "grafana-url", "http://grafana.mla.svc.cluster.local", "The URL of Grafana instance which in running for MLA stack.")
 	flag.StringVar(&c.grafanaHeaderName, "grafana-header-name", "X-Forwarded-Email", "Grafana Auth Proxy HTTP Header that will contain the username or email")
 	flag.StringVar(&c.grafanaSecret, "grafana-secret-name", "mla/grafana", "Grafana secret name in format namespace/secretname, that contains basic auth info")
+	flag.StringVar(&c.cortexAlertmanagerURL, "cortex-alertmanager-url", "http://cortex-alertmanager.mla.svc.cluster.local:8080", "The URL of cortex alertmanager which is running for MLA stack.")
 	c.admissionWebhook.AddFlags(flag.CommandLine, true)
 	addFlags(flag.CommandLine)
 	flag.Parse()

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -61,11 +61,11 @@ func newTestAlertmanagerReconciler(objects []ctrlruntimeclient.Object, handler h
 	ts := httptest.NewServer(handler)
 
 	reconciler := alertmanagerReconciler{
-		Client:              fakeClient,
-		httpClient:          ts.Client(),
-		log:                 kubermaticlog.Logger,
-		recorder:            record.NewFakeRecorder(10),
-		mlaGatewayURLGetter: newFakeMLAGatewayURLGetter(ts),
+		Client:                fakeClient,
+		httpClient:            ts.Client(),
+		log:                   kubermaticlog.Logger,
+		recorder:              record.NewFakeRecorder(10),
+		cortexAlertmanagerURL: ts.URL,
 	}
 	return &reconciler, ts
 }
@@ -224,12 +224,6 @@ func TestAlertmanagerReconcile(t *testing.T) {
 						resources.AlertmanagerConfigSecretKey: []byte(generateAlertmanagerConfig("test-user")),
 					},
 				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      gatewayAlertName,
-						Namespace: "cluster-test",
-					},
-				},
 				&kubermaticv1.Alertmanager{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resources.AlertmanagerName,
@@ -259,12 +253,6 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
 				generateCluster("test", false, true),
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      gatewayAlertName,
-						Namespace: "cluster-test",
-					},
-				},
 			},
 			requests: []request{
 				{
@@ -355,18 +343,4 @@ alertmanager_config: |
       email_configs:
       - to: '%s@example.org'
 `, name, name)
-}
-
-type fakeMLAGatewayURLGetter struct {
-	*httptest.Server
-}
-
-func newFakeMLAGatewayURLGetter(server *httptest.Server) *fakeMLAGatewayURLGetter {
-	return &fakeMLAGatewayURLGetter{
-		Server: server,
-	}
-}
-
-func (f *fakeMLAGatewayURLGetter) mlaGatewayURL(cluster *kubermaticv1.Cluster) string {
-	return f.URL
 }

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -299,7 +299,6 @@ func (r *datasourceGrafanaReconciler) ensureSecrets(ctx context.Context, c *kube
 
 func (r *datasourceGrafanaReconciler) ensureServices(ctx context.Context, c *kubermaticv1.Cluster) error {
 	creators := []reconciling.NamedServiceCreatorGetter{
-		GatewayAlertServiceCreator(),
 		GatewayInternalServiceCreator(),
 		GatewayExternalServiceCreator(c),
 	}

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -499,13 +499,6 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			} else {
 				assert.True(t, errors.IsNotFound(err))
 			}
-			request = reconcile.Request{NamespacedName: types.NamespacedName{Name: gatewayAlertName, Namespace: cluster.Status.NamespaceName}}
-			err = controller.Get(ctx, request.NamespacedName, svc)
-			if tc.hasResources {
-				assert.Nil(t, err)
-			} else {
-				assert.True(t, errors.IsNotFound(err))
-			}
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Name: gatewayExternalName, Namespace: cluster.Status.NamespaceName}}
 			err = controller.Get(ctx, request.NamespacedName, svc)
 			if tc.hasResources {

--- a/pkg/controller/seed-controller-manager/mla/deletion.go
+++ b/pkg/controller/seed-controller-manager/mla/deletion.go
@@ -51,12 +51,6 @@ func ResourcesOnDeletion(clusterNamespace string) []ctrlruntimeclient.Object {
 				Namespace: clusterNamespace,
 			},
 		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      gatewayAlertName,
-				Namespace: clusterNamespace,
-			},
-		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.MLAGatewayCASecretName,

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -72,6 +72,7 @@ func Add(
 	grafanaHeader string,
 	grafanaSecret string,
 	overwriteRegistry string,
+	cortexAlertmanagerURL string,
 ) error {
 
 	split := strings.Split(grafanaSecret, "/")
@@ -108,7 +109,7 @@ func Add(
 	if err := newDatasourceGrafanaReconciler(mgr, log, 1, workerName, versions, grafanaClient, mlaNamespace, overwriteRegistry); err != nil {
 		return fmt.Errorf("failed to create mla cluster controller: %v", err)
 	}
-	if err := newAlertmanagerReconciler(mgr, log, numWorkers, workerName, versions, httpClient); err != nil {
+	if err := newAlertmanagerReconciler(mgr, log, numWorkers, workerName, versions, httpClient, cortexAlertmanagerURL); err != nil {
 		return fmt.Errorf("failed to create mla alertmanager configuration controller: %v", err)
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses cortex alertmanager endpoints in alertmanager controller and deprecates the alertmanager gateway

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6959 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
