### PR TITLE
Multiarch image for user-ssh-keys-agent

### DIFF
--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -20,5 +20,12 @@ build:
 	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
 
 .PHONY: docker
-docker: build
-	docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
+docker: build configure-buildx
+	docker buildx build --platform linux/arm64,linux/amd64 --push -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
+
+.PHONY: configure-buildx
+configure-buildx:
+	docker buildx create --use --name multiarch
+	docker buildx inspect multiarch --bootstrap
+	docker run --privileged --rm tonistiigi/binfmt --install all
+

--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -79,7 +79,7 @@ for TAG in "$@"; do
   docker tag "${DOCKER_REPO}/nodeport-proxy:${PRIMARY_TAG}" "${DOCKER_REPO}/nodeport-proxy:${TAG}"
   docker tag "${DOCKER_REPO}/kubeletdnat-controller:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeletdnat-controller:${TAG}"
   docker tag "${DOCKER_REPO}/addons:${PRIMARY_TAG}" "${DOCKER_REPO}/addons:${TAG}"
-  docker tag "${DOCKER_REPO}/user-ssh-keys-agent:${PRIMARY_TAG}" "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}"
+  docker buildx imagetools create -t "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" "${DOCKER_REPO}/user-ssh-keys-agent:${PRIMARY_TAG}"
   docker tag "${DOCKER_REPO}/etcd-launcher:${PRIMARY_TAG}" "${DOCKER_REPO}/etcd-launcher:${TAG}"
 
   echodate "Pushing images"
@@ -87,7 +87,6 @@ for TAG in "$@"; do
   docker push "${DOCKER_REPO}/nodeport-proxy:${TAG}"
   docker push "${DOCKER_REPO}/kubeletdnat-controller:${TAG}"
   docker push "${DOCKER_REPO}/addons:${TAG}"
-  docker push "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}"
   docker push "${DOCKER_REPO}/etcd-launcher:${TAG}"
 
   if [ "$KUBERMATIC_EDITION" == "ee" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
The image for user-ssh-keys-agent is now built by docker buildx, which allows the creation of multi-arch images. The architectures supported so far are linux/amd64 and linux/arm64. This PR is in scope of #6584.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
