### PR TITLE
[WIP] [OpenStack] Install the controller from CSI cinder addon to seed cluster

### DIFF
--- a/addons/csi/openstack/controllerplugin-rbac.yaml
+++ b/addons/csi/openstack/controllerplugin-rbac.yaml
@@ -14,11 +14,13 @@
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "openstack" }}
+{{ if eq .AddonCluster "seed" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-cinder-controller-sa
-  namespace: kube-system
+  namespace: {{ .Cluster.Namespace }}
+{{ end }}
 
 ---
 # external attacher

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -15,6 +15,7 @@
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 
 {{ if eq .Cluster.CloudProviderName "openstack" }}
+{{ if eq .AddonCluster "seed" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.17" }}
 {{ $version = "v1.17.1 "}}
@@ -37,7 +38,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: csi-cinder-controller-service
-  namespace: kube-system
+  namespace: {{ .Cluster.Namespace }}
   labels:
     app: csi-cinder-controllerplugin
 spec:
@@ -52,7 +53,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-cinder-controllerplugin
-  namespace: kube-system
+  namespace: {{ .Cluster.Namespace }}
 spec:
   serviceName: "csi-cinder-controller-service"
   replicas: 1
@@ -71,6 +72,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--kubeconfig=/etc/kube/kubeconfig"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -78,12 +80,15 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: kubeconfig
+              mountPath: /etc/kube
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--default-fstype=ext4"
+            - "--kubeconfig=/etc/kube/kubeconfig"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -91,11 +96,14 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: kubeconfig
+              mountPath: /etc/kube
         - name: csi-snapshotter
           image: k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--kubeconfig=/etc/kube/kubeconfig"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -103,12 +111,15 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            - name: kubeconfig
+              mountPath: /etc/kube
         - name: csi-resizer
           image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--handle-volume-inuse-error=false"
+            - "--kubeconfig=/etc/kube/kubeconfig"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -116,6 +127,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: kubeconfig
+              mountPath: /etc/kube
         - name: liveness-probe
           image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
           args:
@@ -169,7 +182,11 @@ spec:
         - name: socket-dir
           emptyDir:
         - name: cloud-config
+          configMap:
+            name: cloud-config
+        - name: kubeconfig
           secret:
-            secretName: cloud-config
+            secretName: internal-admin-kubeconfig
+{{ end }}
 {{ end }}
 {{ end }}

--- a/cmd/image-loader/addons.go
+++ b/cmd/image-loader/addons.go
@@ -35,7 +35,7 @@ import (
 func getImagesFromAddons(log *zap.SugaredLogger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
 	credentials := resources.Credentials{}
 
-	addonData, err := addonutil.NewTemplateData(cluster, credentials, "", "", "", nil)
+	addonData, err := addonutil.NewTemplateData(cluster, credentials, "", "", "", nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create addon template data: %v", err)
 	}

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -5,6 +5,7 @@ type TemplateData struct {
 	Cluster        ClusterData
 	Credentials    Credentials
 	Variables      map[string]interface{}
+	AddonCluster   string
 }
 
 // ClusterData contains data related to the user cluster

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -65,6 +65,7 @@ type TemplateData struct {
 	Cluster        ClusterData
 	Credentials    Credentials
 	Variables      map[string]interface{}
+	AddonCluster   string
 }
 
 func NewTemplateData(
@@ -74,6 +75,7 @@ func NewTemplateData(
 	dnsClusterIP string,
 	dnsResolverIP string,
 	variables map[string]interface{},
+	addonCluster string,
 ) (*TemplateData, error) {
 	providerName, err := provider.ClusterCloudProviderName(cluster.Spec.Cloud)
 	if err != nil {
@@ -88,6 +90,7 @@ func NewTemplateData(
 		DatacenterName: cluster.Spec.Cloud.DatacenterName,
 		Variables:      variables,
 		Credentials:    credentials,
+		AddonCluster:   addonCluster,
 		Cluster: ClusterData{
 			Type:                 ClusterTypeKubernetes,
 			Name:                 cluster.Name,

--- a/pkg/addon/template_test.go
+++ b/pkg/addon/template_test.go
@@ -88,7 +88,7 @@ func testRenderAddonsForOrchestrator(t *testing.T, orchestrator string) {
 
 	for _, cluster := range clusters {
 		for _, addon := range addons {
-			data, err := NewTemplateData(&cluster, credentials, "kubeconfig", "1.2.3.4", "5.6.7.8", variables)
+			data, err := NewTemplateData(&cluster, credentials, "kubeconfig", "1.2.3.4", "5.6.7.8", variables, "")
 			if err != nil {
 				t.Fatalf("Rendering %s addon %s for cluster %s failed: %v", orchestrator, addon.Name, cluster.Name, err)
 			}
@@ -117,7 +117,7 @@ func TestNewTemplateData(t *testing.T) {
 
 	credentials := resources.Credentials{}
 
-	templateData, err := NewTemplateData(&cluster, credentials, "", "", "", nil)
+	templateData, err := NewTemplateData(&cluster, credentials, "", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("Failed to create template data: %v", err)
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -212,7 +212,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 		kubernetesAddonDir: addonDir,
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(ctx, log, addon, cluster)
+	manifests, err := controller.getAddonManifests(ctx, log, addon, cluster, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	}
 
 	cluster = setupTestCluster("172.25.0.0/16")
-	manifests, err = controller.getAddonManifests(ctx, log, addon, cluster)
+	manifests, err = controller.getAddonManifests(ctx, log, addon, cluster, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +267,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 		overwriteRegistry:  "bar.io",
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster)
+	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +305,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 		kubernetesAddonDir: addonDir,
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster)
+	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func TestController_getAddonManifests(t *testing.T) {
 		kubernetesAddonDir: addonDir,
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster)
+	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func TestHugeManifest(t *testing.T) {
 		kubernetesAddonDir: "./testdata",
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	if _, _, _, err := r.setupManifestInteraction(context.Background(), log, addon, cluster); err != nil {
-		t.Fatalf("failed to setup manifest interaction: %v", err)
+	if mi := r.setupManifestInteraction(context.Background(), log, addon, cluster); mi.err != nil {
+		t.Fatalf("failed to setup manifest interaction: %v", mi.err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup logic for OpenStack clusters can leave an undesired residue when the cinder CSI plugin is deleted before it gets a chance to deprovision all PVs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/kubermatic/issues/6406

**Special notes for your reviewer**:
This PR proposes a change in addons handling. Previously addons got templated and deployed entirely to the user cluster, now it would be possible to define parts of the addon to get deployed to the seed cluster. And this is directly demonstrated by the cinder CSI plugin.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
