### PR TITLE
Duplicate buildx builder fix

### DIFF
--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -20,12 +20,5 @@ build:
 	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
 
 .PHONY: docker
-docker: build configure-buildx
+docker: build
 	docker buildx build --platform linux/arm64,linux/amd64 --push -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
-
-.PHONY: configure-buildx
-configure-buildx:
-	docker buildx create --use --name multiarch
-	docker buildx inspect multiarch --bootstrap
-	docker run --privileged --rm tonistiigi/binfmt --install all
-

--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -54,6 +54,15 @@ if [ "$KUBERMATIC_EDITION" != "ce" ]; then
   REPOSUFFIX="-$KUBERMATIC_EDITION"
 fi
 
+# configure buildx
+cleanup() {
+  docker buildx rm multiarch
+}
+docker buildx create --use --name multiarch
+trap "cleanup" EXIT SIGINT
+docker buildx inspect multiarch --bootstrap
+docker run --privileged --rm tonistiigi/binfmt --install all
+
 # build Docker images
 PRIMARY_TAG="${1}"
 make docker-build TAGS="${PRIMARY_TAG}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to #7032, where the buildx builder was attempted to be created twice, raising an error. Now, before exiting the `release-docker-images.sh` script, the builder is deleted. Additionally, the buildx setup has been moved to the calling script for the sake of clarity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
