### PR TITLE
cleanup MLA resources when userClusterMLA disabled

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -405,7 +405,7 @@ func createInitialMachineDeploymentController(ctrlCtx *controllerContext) error 
 }
 
 func createMLAController(ctrlCtx *controllerContext) error {
-	if !userClusterMLAEnabled(ctrlCtx) {
+	if !ctrlCtx.runOptions.featureGates.Enabled(features.UserClusterMLA) {
 		return nil
 	}
 	return mla.Add(
@@ -421,6 +421,7 @@ func createMLAController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.grafanaSecret,
 		ctrlCtx.runOptions.overwriteRegistry,
 		ctrlCtx.runOptions.cortexAlertmanagerURL,
+		ctrlCtx.runOptions.enableUserClusterMLA,
 	)
 }
 

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -65,6 +65,8 @@ type alertmanagerReconciler struct {
 	versions   kubermatic.Versions
 
 	cortexAlertmanagerURL string
+
+	mlaEnabled bool
 }
 
 func newAlertmanagerReconciler(
@@ -75,6 +77,7 @@ func newAlertmanagerReconciler(
 	versions kubermatic.Versions,
 	httpClient *http.Client,
 	cortexAlertmanagerURL string,
+	mlaEnabled bool,
 ) error {
 	log = log.Named(ControllerName)
 	client := mgr.GetClient()
@@ -88,6 +91,7 @@ func newAlertmanagerReconciler(
 		recorder:              mgr.GetEventRecorderFor(ControllerName),
 		versions:              versions,
 		cortexAlertmanagerURL: cortexAlertmanagerURL,
+		mlaEnabled:            mlaEnabled,
 	}
 
 	ctrlOptions := controller.Options{
@@ -206,7 +210,7 @@ func (r *alertmanagerReconciler) reconcile(ctx context.Context, cluster *kuberma
 		return nil, nil
 	}
 
-	monitoringEnabled := cluster.Spec.MLA != nil && cluster.Spec.MLA.MonitoringEnabled
+	monitoringEnabled := r.mlaEnabled && cluster.Spec.MLA != nil && cluster.Spec.MLA.MonitoringEnabled
 	// Currently, we don't have a dedicated flag for enabling/disabling Alertmanager, and Alertmanager will be enabled
 	// or disabled based on the monitoring flag.
 	if !monitoringEnabled {

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -66,6 +66,7 @@ func newTestAlertmanagerReconciler(objects []ctrlruntimeclient.Object, handler h
 		log:                   kubermaticlog.Logger,
 		recorder:              record.NewFakeRecorder(10),
 		cortexAlertmanagerURL: ts.URL,
+		mlaEnabled:            true,
 	}
 	return &reconciler, ts
 }

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -60,6 +60,7 @@ func newTestDatasourceGrafanaReconciler(t *testing.T, objects []ctrlruntimeclien
 		grafanaAuth: "admin:admin",
 		log:         kubermaticlog.Logger,
 		recorder:    record.NewFakeRecorder(10),
+		mlaEnabled:  true,
 	}
 	return &reconciler, ts
 }

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -106,10 +106,10 @@ func Add(
 	if err := newUserGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, httpClient, grafanaURL, grafanaHeader, mlaEnabled); err != nil {
 		return fmt.Errorf("failed to create mla userprojectbinding controller: %v", err)
 	}
-	if err := newDatasourceGrafanaReconciler(mgr, log, numWorkers, workerName, versions, httpClient, grafanaURL, grafanaAuth, mlaNamespace, overwriteRegistry); err != nil {
+	if err := newDatasourceGrafanaReconciler(mgr, log, numWorkers, workerName, versions, httpClient, grafanaURL, grafanaAuth, mlaNamespace, overwriteRegistry, mlaEnabled); err != nil {
 		return fmt.Errorf("failed to create mla cluster controller: %v", err)
 	}
-	if err := newAlertmanagerReconciler(mgr, log, numWorkers, workerName, versions, httpClient, cortexAlertmanagerURL); err != nil {
+	if err := newAlertmanagerReconciler(mgr, log, numWorkers, workerName, versions, httpClient, cortexAlertmanagerURL, mlaEnabled); err != nil {
 		return fmt.Errorf("failed to create mla alertmanager configuration controller: %v", err)
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -73,6 +73,7 @@ func Add(
 	grafanaSecret string,
 	overwriteRegistry string,
 	cortexAlertmanagerURL string,
+	mlaEnabled bool,
 ) error {
 
 	split := strings.Split(grafanaSecret, "/")
@@ -99,10 +100,10 @@ func Add(
 	grafanaAuth := fmt.Sprintf("%s:%s", adminName, adminPass)
 	httpClient := &http.Client{Timeout: 15 * time.Second}
 	grafanaClient := grafanasdk.NewClient(grafanaURL, grafanaAuth, httpClient)
-	if err := newOrgGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient); err != nil {
+	if err := newOrgGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, mlaEnabled); err != nil {
 		return fmt.Errorf("failed to create mla project controller: %v", err)
 	}
-	if err := newUserGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, httpClient, grafanaURL, grafanaHeader); err != nil {
+	if err := newUserGrafanaReconciler(mgr, log, numWorkers, workerName, versions, grafanaClient, httpClient, grafanaURL, grafanaHeader, mlaEnabled); err != nil {
 		return fmt.Errorf("failed to create mla userprojectbinding controller: %v", err)
 	}
 	if err := newDatasourceGrafanaReconciler(mgr, log, numWorkers, workerName, versions, httpClient, grafanaURL, grafanaAuth, mlaNamespace, overwriteRegistry); err != nil {

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -66,6 +66,7 @@ func newTestOrgGrafanaReconciler(t *testing.T, objects []ctrlruntimeclient.Objec
 		grafanaClient: grafanaClient,
 		log:           kubermaticlog.Logger,
 		recorder:      record.NewFakeRecorder(10),
+		mlaEnabled:    true,
 	}
 	return &reconciler, ts
 }

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -51,6 +51,7 @@ type userGrafanaReconciler struct {
 	versions      kubermatic.Versions
 	grafanaURL    string
 	grafanaHeader string
+	mlaEnabled    bool
 }
 
 func newUserGrafanaReconciler(
@@ -63,6 +64,7 @@ func newUserGrafanaReconciler(
 	httpClient *http.Client,
 	grafanaURL string,
 	grafanaHeader string,
+	mlaEnabled bool,
 ) error {
 	log = log.Named(ControllerName)
 	client := mgr.GetClient()
@@ -78,6 +80,7 @@ func newUserGrafanaReconciler(
 		versions:      versions,
 		grafanaURL:    grafanaURL,
 		grafanaHeader: grafanaHeader,
+		mlaEnabled:    mlaEnabled,
 	}
 
 	ctrlOptions := controller.Options{
@@ -104,7 +107,7 @@ func (r *userGrafanaReconciler) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
-	if !userProjectBinding.DeletionTimestamp.IsZero() {
+	if !userProjectBinding.DeletionTimestamp.IsZero() || !r.mlaEnabled {
 		if err := r.handleDeletion(ctx, userProjectBinding); err != nil {
 			return reconcile.Result{}, fmt.Errorf("handling deletion: %w", err)
 		}

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -57,6 +57,7 @@ func newTestUserGrafanaReconciler(t *testing.T, objects []ctrlruntimeclient.Obje
 		grafanaHeader: "X-WEBAUTH-USER",
 		grafanaURL:    ts.URL,
 		httpClient:    ts.Client(),
+		mlaEnabled:    true,
 	}
 	return &reconciler, ts
 }


### PR DESCRIPTION
**What this PR does / why we need it**: In this PR we changed the way MLA controller running, now they are running even when `userClusterMLA` disable, in that way they can clean up MLA resource when `userClusterMLA` switched from enabled to disabled.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7019 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
