### PR TITLE
project creation supports multiple owners as owner references 

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/sync_project.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project.go
@@ -108,7 +108,7 @@ func (c *projectController) ensureProjectIsInActivePhase(ctx context.Context, pr
 
 // ensureProjectOwner makes sure that the owner of the project is assign to "owners" group
 func (c *projectController) ensureProjectOwner(ctx context.Context, project *kubermaticv1.Project) error {
-	var sharedOwnerPtr *kubermaticv1.User
+	var sharedOwnerPtrList []*kubermaticv1.User
 	for _, ref := range project.OwnerReferences {
 		if ref.Kind == kubermaticv1.UserKindName {
 			var sharedOwner kubermaticv1.User
@@ -116,26 +116,45 @@ func (c *projectController) ensureProjectOwner(ctx context.Context, project *kub
 			if err := c.client.Get(ctx, key, &sharedOwner); err != nil {
 				return err
 			}
-			sharedOwnerPtr = &sharedOwner
+			sharedOwnerPtrList = append(sharedOwnerPtrList, sharedOwner.DeepCopy())
 		}
 	}
-	if sharedOwnerPtr == nil {
+	if len(sharedOwnerPtrList) == 0 {
 		return fmt.Errorf("the given project %s doesn't have associated owner/user", project.Name)
 	}
-	owner := sharedOwnerPtr.DeepCopy()
 
 	var bindings kubermaticv1.UserProjectBindingList
 	if err := c.client.List(ctx, &bindings); err != nil {
 		return err
 	}
 
-	for _, binding := range bindings.Items {
-		if binding.Spec.ProjectID == project.Name && strings.EqualFold(binding.Spec.UserEmail, owner.Spec.Email) &&
-			binding.Spec.Group == GenerateActualGroupNameFor(project.Name, OwnerGroupNamePrefix) {
-			return nil
+	projectOwnerMap := map[string]bool{}
+
+	for _, owner := range sharedOwnerPtrList {
+		for _, binding := range bindings.Items {
+			if binding.Spec.ProjectID == project.Name && strings.EqualFold(binding.Spec.UserEmail, owner.Spec.Email) &&
+				binding.Spec.Group == GenerateActualGroupNameFor(project.Name, OwnerGroupNamePrefix) {
+				projectOwnerMap[owner.Spec.Email] = true
+			}
+
 		}
 	}
-	ownerBinding := &kubermaticv1.UserProjectBinding{
+
+	for _, owner := range sharedOwnerPtrList {
+		// create a new binding for the owner when doesn't exist
+		if !projectOwnerMap[owner.Spec.Email] {
+			ownerBinding := genOwnerBinding(owner.Spec.Email, project)
+			if err := c.client.Create(ctx, ownerBinding); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func genOwnerBinding(ownerEmail string, project *kubermaticv1.Project) *kubermaticv1.UserProjectBinding {
+	return &kubermaticv1.UserProjectBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -149,13 +168,11 @@ func (c *projectController) ensureProjectOwner(ctx context.Context, project *kub
 			Finalizers: []string{CleanupFinalizerName},
 		},
 		Spec: kubermaticv1.UserProjectBindingSpec{
-			UserEmail: owner.Spec.Email,
+			UserEmail: ownerEmail,
 			ProjectID: project.Name,
 			Group:     GenerateActualGroupNameFor(project.Name, OwnerGroupNamePrefix),
 		},
 	}
-
-	return c.client.Create(ctx, ownerBinding)
 }
 
 func (c *projectController) ensureClusterRBACRoleForResources(ctx context.Context) error {

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -1398,31 +1398,89 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 
 func TestEnsureProjectOwner(t *testing.T) {
 	tests := []struct {
-		name            string
-		projectToSync   *kubermaticv1.Project
-		existingUser    *kubermaticv1.User
-		expectedBinding *kubermaticv1.UserProjectBinding
-		existingBinding *kubermaticv1.UserProjectBinding
+		name                   string
+		existingKubermaticObjs []ctrlruntimeclient.Object
+		projectToSync          *kubermaticv1.Project
+		existingUser           *kubermaticv1.User
+		expectedBindings       []kubermaticv1.UserProjectBinding
+		existingBinding        *kubermaticv1.UserProjectBinding
 	}{
 		{
-			name:          "scenario 1: make sure, that the owner of the newly created project is set properly.",
-			projectToSync: test.CreateProject("thunderball", test.CreateUser("James Bond")),
-			existingUser:  test.CreateUser("James Bond"),
-			expectedBinding: func() *kubermaticv1.UserProjectBinding {
+			name:                   "scenario 1: make sure, that the owner of the newly created project is set properly.",
+			existingKubermaticObjs: []ctrlruntimeclient.Object{},
+			projectToSync:          test.CreateProject("thunderball", test.CreateUser("James Bond")),
+			existingUser:           test.CreateUser("James Bond"),
+			expectedBindings: func() []kubermaticv1.UserProjectBinding {
 				binding := test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond")))
 				binding.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
-				binding.ObjectMeta.ResourceVersion = "1"
-				return binding
+				binding.ObjectMeta.Name = ""
+				binding.ResourceVersion = ""
+				return []kubermaticv1.UserProjectBinding{*binding}
 			}(),
 		},
 		{
-			name:            "scenario 2: no op when the owner of the project was set.",
-			projectToSync:   test.CreateProject("thunderball", test.CreateUser("James Bond")),
-			existingUser:    test.CreateUser("James Bond"),
-			existingBinding: test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond"))),
-			expectedBinding: func() *kubermaticv1.UserProjectBinding {
+			name:                   "scenario 2: no op when the owner of the project was set.",
+			existingKubermaticObjs: []ctrlruntimeclient.Object{},
+			projectToSync:          test.CreateProject("thunderball", test.CreateUser("James Bond")),
+			existingUser:           test.CreateUser("James Bond"),
+			existingBinding:        test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond"))),
+			expectedBindings: func() []kubermaticv1.UserProjectBinding {
 				binding := test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond")))
-				return binding
+				binding.ObjectMeta.Name = ""
+				binding.ResourceVersion = ""
+				return []kubermaticv1.UserProjectBinding{*binding}
+			}(),
+		},
+		{
+			name: "scenario 3: make sure, that the owners of the newly created project are set properly.",
+			existingKubermaticObjs: []ctrlruntimeclient.Object{
+				test.CreateUser("Batman"),
+			},
+			projectToSync: func() *kubermaticv1.Project {
+				firstOwner := test.CreateUser("James Bond")
+				secondOwner := test.CreateUser("Batman")
+				return &kubermaticv1.Project{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       kubermaticv1.ProjectKindName,
+						APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:  types.UID("thunderball") + "ID",
+						Name: "thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: firstOwner.APIVersion,
+								Kind:       firstOwner.Kind,
+								UID:        firstOwner.GetUID(),
+								Name:       firstOwner.Name,
+							},
+							{
+								APIVersion: secondOwner.APIVersion,
+								Kind:       secondOwner.Kind,
+								UID:        secondOwner.GetUID(),
+								Name:       secondOwner.Name,
+							},
+						},
+					},
+					Spec: kubermaticv1.ProjectSpec{
+						Name: "thunderball",
+					},
+					Status: kubermaticv1.ProjectStatus{
+						Phase: kubermaticv1.ProjectInactive,
+					},
+				}
+			}(),
+			existingUser: test.CreateUser("James Bond"),
+			expectedBindings: func() []kubermaticv1.UserProjectBinding {
+				binding := test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond")))
+				binding.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding.ObjectMeta.Name = ""
+				binding.ResourceVersion = ""
+				binding2 := test.CreateExpectedOwnerBinding("Batman", test.CreateProject("thunderball", test.CreateUser("Batman")))
+				binding2.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding2.ObjectMeta.Name = ""
+				binding2.ResourceVersion = ""
+				return []kubermaticv1.UserProjectBinding{*binding, *binding2}
 			}(),
 		},
 	}
@@ -1430,7 +1488,7 @@ func TestEnsureProjectOwner(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// setup the test scenario
 			ctx := context.Background()
-			objs := []ctrlruntimeclient.Object{}
+			objs := test.existingKubermaticObjs
 			userIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			if test.existingUser != nil {
 				err := userIndexer.Add(test.existingUser)
@@ -1466,11 +1524,17 @@ func TestEnsureProjectOwner(t *testing.T) {
 			err = masterClient.List(ctx, &userProjectBindingList)
 			assert.NoError(t, err)
 
-			assert.Len(t, userProjectBindingList.Items, 1)
-			// Hack around the fact that the bindings' names are random
-			userProjectBindingList.Items[0].ObjectMeta.Name = test.expectedBinding.ObjectMeta.Name
-			userProjectBindingList.Items[0].ResourceVersion = test.expectedBinding.ResourceVersion
-			assert.Equal(t, userProjectBindingList.Items[0], *test.expectedBinding)
+			assert.Len(t, userProjectBindingList.Items, len(test.expectedBindings))
+
+			var copyUserProjectBindingList kubermaticv1.UserProjectBindingList
+			for _, item := range userProjectBindingList.Items {
+				// Hack around the fact that the bindings' names are random
+				item.ObjectMeta.Name = ""
+				item.ResourceVersion = ""
+				copyUserProjectBindingList.Items = append(copyUserProjectBindingList.Items, item)
+			}
+
+			assert.Equal(t, copyUserProjectBindingList.Items, test.expectedBindings)
 		})
 	}
 }

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -1585,15 +1585,18 @@ func TestEnsureProjectOwner(t *testing.T) {
 
 			assert.Len(t, userProjectBindingList.Items, len(test.expectedBindings))
 
-			var copyUserProjectBindingList kubermaticv1.UserProjectBindingList
+			var copyUserProjectBindingList []kubermaticv1.UserProjectBinding
 			for _, item := range userProjectBindingList.Items {
 				// Hack around the fact that the bindings' names are random
 				item.ObjectMeta.Name = ""
 				item.ResourceVersion = ""
-				copyUserProjectBindingList.Items = append(copyUserProjectBindingList.Items, item)
+				copyUserProjectBindingList = append(copyUserProjectBindingList, item)
 			}
 
-			assert.Equal(t, copyUserProjectBindingList.Items, test.expectedBindings)
+			sortUserProjectBinding(test.expectedBindings)
+			sortUserProjectBinding(copyUserProjectBindingList)
+
+			assert.Equal(t, copyUserProjectBindingList, test.expectedBindings)
 		})
 	}
 }
@@ -2643,4 +2646,11 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func sortUserProjectBinding(bindings []kubermaticv1.UserProjectBinding) {
+	sort.Slice(bindings, func(i, j int) bool {
+		mi, mj := bindings[i], bindings[j]
+		return mi.Spec.UserEmail < mj.Spec.UserEmail
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Update sync project controller to support multiple project owners during project creation. It's needed to create a project by service account. During this process, the endpoint expects a list of human owners. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7053


```release-note
NONE
```
