### PR TITLE
User-ssh-keys-agent multiarch image with Buildah

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1323,7 +1323,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-2
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/golang:1.16.4 as builder
+
+WORKDIR /go/src/github.com/kubermatic/kubermatic
+COPY . .
+ENV CGO_ENABLED=0
+RUN go build ./cmd/user-ssh-keys-agent
+
+FROM docker.io/alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
-
+COPY --from=builder /go/src/github.com/kubermatic/kubermatic/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -20,5 +20,5 @@ build:
 	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
 
 .PHONY: docker
-docker: build
-	docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
+docker:
+	cd ../.. && docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) -f cmd/user-ssh-keys-agent/Dockerfile .

--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -38,6 +38,7 @@ apt install time -y
 echodate "Logging into Quay"
 docker ps > /dev/null 2>&1 || start-docker.sh
 retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
+retry 5 buildah login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
 echodate "Successfully logged into Quay"
 
 # prepare special variables that will be injected into the Kubermatic Operator;

--- a/hack/ci/run-offline-test.sh
+++ b/hack/ci/run-offline-test.sh
@@ -128,6 +128,7 @@ trap finish EXIT
 docker ps &> /dev/null || start-docker.sh
 
 retry 5 docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io
+retry 5 buildah login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
 
 echodate "Building and pushing Docker images"
 

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -112,11 +112,9 @@ beforeDockerBuild=$(nowms)
 (
   echodate "Building user-ssh-keys-agent image"
   TEST_NAME="Build user-ssh-keys-agent Docker image"
-  cd cmd/user-ssh-keys-agent
-  make build
   retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
   IMAGE_NAME=quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION
-  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 docker build -f cmd/user-ssh-keys-agent/Dockerfile -t "${IMAGE_NAME}" .
   time retry 5 docker push "${IMAGE_NAME}"
 )
 (


### PR DESCRIPTION
**What this PR does / why we need it**:
Once Buildah will be included in the e2e docker image [infra-1367](https://github.com/kubermatic/infra/pull/1367), it will be possible to build multi-arch images. The image this PR is referred to is the `user-ssh-keys-agent`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7059 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
