### PR TITLE
Implement User synchronizer controller

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -176,6 +176,11 @@ func main() {
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",
 			},
+			{
+				ResourceName:     "User",
+				ImportAlias:      "kubermaticv1",
+				APIVersionPrefix: "KubermaticV1",
+			},
 		},
 	}
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2170,6 +2170,8 @@ const (
 	SeedProjectCleanupFinalizer = "kubermatic.io/cleanup-seed-projects"
 	// SeedUserProjectBindingCleanupFinalizer indicates that Kubermatic UserProjectBindings on the seed clusters need cleanup
 	SeedUserProjectBindingCleanupFinalizer = "kubermatic.io/cleanup-seed-user-project-bindings"
+	// SeedUserCleanupFinalizer indicates that Kubermatic Users on the seed clusters need cleanup
+	SeedUserCleanupFinalizer = "kubermatic.io/cleanup-seed-users"
 	// ClusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup
 	ClusterRoleBindingsCleanupFinalizer = "kubermatic.io/cleanup-cluster-role-bindings"
 )

--- a/pkg/controller/master-controller-manager/user-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/user-synchronizer/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig-app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usersynchronizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "user-synchronizer"
+	saPrefix       = "serviceaccount-"
+)
+
+type reconciler struct {
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	masterClient ctrlruntimeclient.Client
+	seedClients  map[string]ctrlruntimeclient.Client
+}
+
+func Add(
+	masterManager manager.Manager,
+	seedManagers map[string]manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+) error {
+
+	r := &reconciler{
+		log:          log.Named(ControllerName),
+		recorder:     masterManager.GetEventRecorderFor(ControllerName),
+		masterClient: masterManager.GetClient(),
+		seedClients:  map[string]ctrlruntimeclient.Client{},
+	}
+
+	c, err := controller.New(ControllerName, masterManager, controller.Options{Reconciler: r, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	serviceAccountPredicate := predicate.NewPredicateFuncs(func(object ctrlruntimeclient.Object) bool {
+		// We don't trigger reconciliation for service account.
+		return !strings.HasPrefix(object.GetName(), saPrefix)
+	})
+
+	for seedName, seedManager := range seedManagers {
+		r.seedClients[seedName] = seedManager.GetClient()
+		seedClusterWatch := &source.Kind{Type: &kubermaticv1.User{}}
+		if err := seedClusterWatch.InjectCache(seedManager.GetCache()); err != nil {
+			return fmt.Errorf("failed to inject cache for seed %q in to watch: %w", seedName, err)
+		}
+		if err := c.Watch(seedClusterWatch, &handler.EnqueueRequestForObject{}, serviceAccountPredicate); err != nil {
+			return fmt.Errorf("failed to watch user objects in seed %q: %w", seedName, err)
+		}
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.User{}}, &handler.EnqueueRequestForObject{}, serviceAccountPredicate,
+	); err != nil {
+		return fmt.Errorf("failed to create watch for user objects in master cluster: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles Kubermatic User objects (excluding service account users) on the master cluster to all seed clusters
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+
+	user := &kubermaticv1.User{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, user); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if !user.DeletionTimestamp.IsZero() {
+		if err := r.handleDeletion(ctx, log, user); err != nil {
+			return reconcile.Result{}, fmt.Errorf("handling deletion: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !kuberneteshelper.HasFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer) {
+		kuberneteshelper.AddFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer)
+		if err := r.masterClient.Update(ctx, user); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to add user finalizer %s: %w", user.Name, err)
+		}
+	}
+
+	userCreatorGetters := []reconciling.NamedKubermaticV1UserCreatorGetter{
+		userCreatorGetter(user),
+	}
+	err := r.syncAllSeeds(log, user, func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error {
+		return reconciling.ReconcileKubermaticV1Users(ctx, userCreatorGetters, "", seedClusterClient)
+	})
+	if err != nil {
+		r.recorder.Eventf(user, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		return reconcile.Result{}, fmt.Errorf("reconciled user: %s: %w", user.Name, err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, user *kubermaticv1.User) error {
+	err := r.syncAllSeeds(log, user, func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error {
+		if err := seedClusterClient.Delete(ctx, user); err != nil {
+			return ctrlruntimeclient.IgnoreNotFound(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if kuberneteshelper.HasFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer) {
+		kuberneteshelper.RemoveFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer)
+		if err := r.masterClient.Update(ctx, user); err != nil {
+			return fmt.Errorf("failed to remove user finalizer %s: %w", user.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) syncAllSeeds(
+	log *zap.SugaredLogger,
+	user *kubermaticv1.User,
+	action func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error) error {
+	for seedName, seedClient := range r.seedClients {
+		err := action(seedClient, user)
+		if err != nil {
+			return fmt.Errorf("failed syncing user for seed %s: %w", seedName, err)
+		}
+		log.Debugw("Reconciled user with seed", "seed", seedName)
+	}
+	return nil
+}

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -76,13 +76,6 @@ func Add(
 
 	for seedName, seedManager := range seedManagers {
 		r.seedClients[seedName] = seedManager.GetClient()
-		seedClusterWatch := &source.Kind{Type: &kubermaticv1.User{}}
-		if err := seedClusterWatch.InjectCache(seedManager.GetCache()); err != nil {
-			return fmt.Errorf("failed to inject cache for seed %q in to watch: %w", seedName, err)
-		}
-		if err := c.Watch(seedClusterWatch, &handler.EnqueueRequestForObject{}, serviceAccountPredicate); err != nil {
-			return fmt.Errorf("failed to watch user objects in seed %q: %w", seedName, err)
-		}
 	}
 
 	if err := c.Watch(

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -19,13 +19,13 @@ package usersynchronizer
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -41,7 +41,6 @@ import (
 
 const (
 	ControllerName = "user-synchronizer"
-	saPrefix       = "serviceaccount-"
 )
 
 type reconciler struct {
@@ -72,7 +71,7 @@ func Add(
 
 	serviceAccountPredicate := predicate.NewPredicateFuncs(func(object ctrlruntimeclient.Object) bool {
 		// We don't trigger reconciliation for service account.
-		return !strings.HasPrefix(object.GetName(), saPrefix)
+		return !kubernetes.IsProjectServiceAccount(object.GetName())
 	})
 
 	for seedName, seedManager := range seedManagers {

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usersynchronizer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const userName = "user-test"
+
+func TestReconcile(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		requestName  string
+		expectedUser *kubermaticv1.User
+		masterClient ctrlruntimeclient.Client
+		seedClient   ctrlruntimeclient.Client
+	}{
+		{
+			name:         "scenario 1: sync user from master cluster to seed cluster",
+			requestName:  userName,
+			expectedUser: generateUser(userName, false),
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateUser(userName, false)).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				Build(),
+		},
+		{
+			name:         "scenario 2: cleanup user on the seed cluster when master user is being terminated",
+			requestName:  userName,
+			expectedUser: nil,
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateUser(userName, true)).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateUser(userName, false)).
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: tc.masterClient,
+				seedClients:  map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			seedUser := &kubermaticv1.User{}
+			err := tc.seedClient.Get(ctx, request.NamespacedName, seedUser)
+			if tc.expectedUser == nil {
+				if err == nil {
+					t.Fatal("failed clean up user on the seed cluster")
+				} else if !errors.IsNotFound(err) {
+					t.Fatalf("failed to get user: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("failed to get user: %v", err)
+				}
+				if !reflect.DeepEqual(seedUser.Spec, tc.expectedUser.Spec) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedUser, tc.expectedUser))
+				}
+				if !reflect.DeepEqual(seedUser.Name, tc.expectedUser.Name) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedUser, tc.expectedUser))
+				}
+			}
+		})
+	}
+}
+
+func generateUser(name string, deleted bool) *kubermaticv1.User {
+	user := test.GenDefaultUser()
+	user.Name = name
+	if deleted {
+		deleteTime := metav1.NewTime(time.Now())
+		user.DeletionTimestamp = &deleteTime
+		user.Finalizers = append(user.Finalizers, v1.SeedUserCleanupFinalizer)
+	}
+	return user
+}

--- a/pkg/controller/master-controller-manager/user-synchronizer/doc.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package usersynchronizer contains a controller that is responsible for ensuring that the
+kubermatic User objects (excluding service account users) are synced from master to the seed clusters.
+*/
+package usersynchronizer

--- a/pkg/controller/master-controller-manager/user-synchronizer/resources.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/resources.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usersynchronizer
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+func userCreatorGetter(user *kubermaticv1.User) reconciling.NamedKubermaticV1UserCreatorGetter {
+	return func() (string, reconciling.KubermaticV1UserCreator) {
+		return user.Name, func(u *kubermaticv1.User) (*kubermaticv1.User, error) {
+			u.Name = user.Name
+			u.Spec = user.Spec
+			return u, nil
+		}
+	}
+}

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1025,3 +1025,40 @@ func ReconcileKubermaticV1UserProjectBindings(ctx context.Context, namedGetters 
 
 	return nil
 }
+
+// KubermaticV1UserCreator defines an interface to create/update Users
+type KubermaticV1UserCreator = func(existing *kubermaticv1.User) (*kubermaticv1.User, error)
+
+// NamedKubermaticV1UserCreatorGetter returns the name of the resource and the corresponding creator function
+type NamedKubermaticV1UserCreatorGetter = func() (name string, create KubermaticV1UserCreator)
+
+// KubermaticV1UserObjectWrapper adds a wrapper so the KubermaticV1UserCreator matches ObjectCreator.
+// This is needed as Go does not support function interface matching.
+func KubermaticV1UserObjectWrapper(create KubermaticV1UserCreator) ObjectCreator {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return create(existing.(*kubermaticv1.User))
+		}
+		return create(&kubermaticv1.User{})
+	}
+}
+
+// ReconcileKubermaticV1Users will create and update the KubermaticV1Users coming from the passed KubermaticV1UserCreator slice
+func ReconcileKubermaticV1Users(ctx context.Context, namedGetters []NamedKubermaticV1UserCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
+	for _, get := range namedGetters {
+		name, create := get()
+		createObject := KubermaticV1UserObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			createObject = objectModifier(createObject)
+		}
+
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.User{}, false); err != nil {
+			return fmt.Errorf("failed to ensure User %s/%s: %v", namespace, name, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a user synchronizer controller to propagate KKP User objects from Master to all Seeds.
This is needed for:
- KKP admins to access the MLA stack at the Seed level. 
- Manage Users in Grafana based on KKP Users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7055 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
