### PR TITLE
add aws-node-termination-handler as an addon

### DIFF
--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -1,0 +1,302 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{ if eq .Cluster.CloudProviderName "aws" }}
+---
+# Source: aws-node-termination-handler/templates/psp.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: aws-node-termination-handler
+  labels:
+    app.kubernetes.io/name: aws-node-termination-handler
+    app.kubernetes.io/instance: aws-node-termination-handler
+    k8c.io/aws-spot: aws-node-termination-handler
+    app.kubernetes.io/version: "1.13.0"
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  hostIPC: false
+  hostNetwork: true
+  hostPID: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+    - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+# Source: aws-node-termination-handler/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node-termination-handler
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node-termination-handler
+    app.kubernetes.io/instance: aws-node-termination-handler
+    k8c.io/aws-spot: aws-node-termination-handler
+    app.kubernetes.io/version: "1.13.0"
+---
+# Source: aws-node-termination-handler/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-node-termination-handler
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - get
+---
+# Source: aws-node-termination-handler/templates/psp.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-node-termination-handler-psp
+  labels:
+    app.kubernetes.io/name: aws-node-termination-handler
+    app.kubernetes.io/instance: aws-node-termination-handler
+    k8c.io/aws-spot: aws-node-termination-handler
+    app.kubernetes.io/version: "1.13.0"
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - aws-node-termination-handler
+---
+# Source: aws-node-termination-handler/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-node-termination-handler
+subjects:
+  - kind: ServiceAccount
+    name: aws-node-termination-handler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: aws-node-termination-handler
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: aws-node-termination-handler/templates/psp.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-node-termination-handler-psp
+  labels:
+    app.kubernetes.io/name: aws-node-termination-handler
+    app.kubernetes.io/instance: aws-node-termination-handler
+    k8c.io/aws-spot: aws-node-termination-handler
+    app.kubernetes.io/version: "1.13.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node-termination-handler-psp
+subjects:
+  - kind: ServiceAccount
+    name: aws-node-termination-handler
+    namespace: kube-system
+---
+# Source: aws-node-termination-handler/templates/daemonset.linux.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-node-termination-handler
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node-termination-handler
+    app.kubernetes.io/instance: aws-node-termination-handler
+    k8c.io/aws-spot: aws-node-termination-handler
+    app.kubernetes.io/version: "1.13.0"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aws-node-termination-handler
+      app.kubernetes.io/instance: aws-node-termination-handler
+      kubernetes.io/os: linux
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-node-termination-handler
+        app.kubernetes.io/instance: aws-node-termination-handler
+        k8c.io/aws-spot: aws-node-termination-handler
+        kubernetes.io/os: linux
+    spec:
+      volumes:
+        - name: "uptime"
+          hostPath:
+            path: "/proc/uptime"
+      priorityClassName: "system-node-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - arm
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
+      serviceAccountName: aws-node-termination-handler
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
+      containers:
+        - name: aws-node-termination-handler
+          image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.13.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: "uptime"
+              mountPath: "/proc/uptime"
+              readOnly: true
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DELETE_LOCAL_DATA
+              value: ""
+            - name: IGNORE_DAEMON_SETS
+              value: ""
+            - name: GRACE_PERIOD
+              value: ""
+            - name: POD_TERMINATION_GRACE_PERIOD
+              value: ""
+            - name: INSTANCE_METADATA_URL
+              value: ""
+            - name: NODE_TERMINATION_GRACE_PERIOD
+              value: ""
+            - name: WEBHOOK_URL
+              value: ""
+            - name: WEBHOOK_HEADERS
+              value: ""
+            - name: WEBHOOK_TEMPLATE
+              value: ""
+            - name: DRY_RUN
+              value: "false"
+            - name: ENABLE_SPOT_INTERRUPTION_DRAINING
+              value: ""
+            - name: ENABLE_SCHEDULED_EVENT_DRAINING
+              value: ""
+            - name: ENABLE_REBALANCE_MONITORING
+              value: "false"
+            - name: ENABLE_REBALANCE_DRAINING
+              value: "false"
+            - name: CHECK_ASG_TAG_BEFORE_DRAINING
+              value: "true"
+            - name: MANAGED_ASG_TAG
+              value: "aws-node-termination-handler/managed"
+            - name: METADATA_TRIES
+              value: "3"
+            - name: CORDON_ONLY
+              value: "false"
+            - name: TAINT_NODE
+              value: "false"
+            - name: JSON_LOGGING
+              value: "false"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: WEBHOOK_PROXY
+              value: ""
+            - name: UPTIME_FROM_FILE
+              value: ""
+            - name: ENABLE_PROMETHEUS_SERVER
+              value: "false"
+            - name: PROMETHEUS_SERVER_PORT
+              value: "9092"
+            - name: ENABLE_PROBES_SERVER
+              value: "false"
+            - name: PROBES_SERVER_PORT
+              value: "8080"
+            - name: PROBES_SERVER_ENDPOINT
+              value: "/healthz"
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      nodeSelector:
+        kubernetes.io/os: linux
+        k8c.io/aws-spot: aws-node-termination-handler
+      tolerations:
+        - operator: Exists
+{{ end }}

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.42
+version: 1.1.43
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/kubermatic/static/master/kubernetes-addons.yaml
+++ b/charts/kubermatic/static/master/kubernetes-addons.yaml
@@ -53,3 +53,9 @@ items:
     name: logrotate
     labels:
       addons.kubermatic.io/ensure: true
+- apiVersion: kubermatic.k8s.io/v1
+  kind: Addon
+  metadata:
+    name: aws-node-termination-handler
+    labels:
+      addons.kubermatic.io/ensure: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -346,6 +346,12 @@ spec:
               name: logrotate
               labels:
                 addons.kubermatic.io/ensure: true
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+              name: aws-node-termination-handler
+              labels:
+                addons.kubermatic.io/ensure: true
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/addons

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -844,6 +844,12 @@ items:
     name: logrotate
     labels:
       addons.kubermatic.io/ensure: true
+- apiVersion: kubermatic.k8s.io/v1
+  kind: Addon
+  metadata:
+    name: aws-node-termination-handler
+    labels:
+      addons.kubermatic.io/ensure: true
 `
 
 type versionsYAML struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds aws-node-termination-handler as an addon for aws spot instances.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6723

**Special notes for your reviewer**:
Please have a look on this PR as well: 
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
AWS Spot instances support
```
