### PR TITLE
Re-enable NodeLocal DNS Cache in user clusters

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -159,7 +159,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.inClusterPrometheusScrapingConfigsFile,
 		userClusterMLAEnabled(ctrlCtx),
 		ctrlCtx.dockerPullConfigJSON,
-		ctrlCtx.runOptions.nodeLocalDNSCacheEnabled(),
+		ctrlCtx.runOptions.enableNodeLocalDNSCache,
 		ctrlCtx.runOptions.concurrentClusterUpdate,
 		ctrlCtx.runOptions.enableEtcdBackupRestoreController,
 		backupInterval,
@@ -345,7 +345,7 @@ func createAddonController(ctrlCtx *controllerContext) error {
 		},
 		ctrlCtx.runOptions.kubernetesAddonsPath,
 		ctrlCtx.runOptions.overwriteRegistry,
-		ctrlCtx.runOptions.nodeLocalDNSCacheEnabled(),
+		ctrlCtx.runOptions.enableNodeLocalDNSCache,
 		ctrlCtx.clientProvider,
 		ctrlCtx.versions,
 	)

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -62,6 +62,7 @@ type controllerRunOptions struct {
 	overwriteRegistry                                string
 	nodePortRange                                    string
 	nodeAccessNetwork                                string
+	enableNodeLocalDNSCache                          bool
 	kubernetesAddonsPath                             string
 	kubernetesAddons                                 kubermaticv1.AddonList
 	backupContainerFile                              string
@@ -136,6 +137,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.StringVar(&c.nodePortRange, "nodeport-range", "30000-32767", "NodePort range to use for new clusters. It must be within the NodePort range of the seed-cluster")
 	flag.StringVar(&c.nodeAccessNetwork, "node-access-network", kubermaticv1.DefaultNodeAccessNetwork, "A network which allows direct access to nodes via VPN. Uses CIDR notation.")
+	flag.BoolVar(&c.enableNodeLocalDNSCache, "enable-nodelocal-dns-cache", true, "Enable NodeLocal DNS Cache in user clusters.")
 	flag.StringVar(&c.kubernetesAddonsPath, "kubernetes-addons-path", "/opt/addons/kubernetes", "Path to addon manifests. Should contain sub-folders for each addon")
 	flag.StringVar(&defaultKubernetesAddonsList, "kubernetes-addons-list", "", "Comma separated list of Addons to install into every user-cluster. Mutually exclusive with `--kubernetes-addons-file`")
 	flag.StringVar(&defaultKubernetesAddonsFile, "kubernetes-addons-file", "", "File that contains a list of default kubernetes addons. Mutually exclusive with `--kubernetes-addons-list`")
@@ -268,15 +270,6 @@ func (o controllerRunOptions) validate() error {
 	}
 
 	return nil
-}
-
-func (o controllerRunOptions) nodeLocalDNSCacheEnabled() bool {
-	for _, addon := range o.kubernetesAddons.Items {
-		if addon.Name == "nodelocal-dns-cache" {
-			return true
-		}
-	}
-	return false
 }
 
 // controllerContext holds all controllerRunOptions plus everything that


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
The NodeLocal DNS Cache is unconditionally deployed into user clusters, but currently it is not used due to https://github.com/kubermatic/kubermatic/issues/7058. This PR re-enables it.

The NodeLocal DNS Cache will be still deployed & enabled unconditionally, config / API option for enabling/disabling it will be introduced in https://github.com/kubermatic/kubermatic/issues/7074.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7058

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Re-enable NodeLocal DNS Cache in user clusters.
```
