### PR TITLE
define namespace for dex pods to work with kubernetes 1.21+

### DIFF
--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -19,7 +19,9 @@ dex:
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec
-  env: []
+  env:
+    - name: KUBERNETES_POD_NAMESPACE
+      value: oauth
   #  - name: HTTP_PROXY
   #    value: "http://USER:PASSWORD@IPADDR:PORT"
   #  - name: HTTPS_PROXY


### PR DESCRIPTION
Signed-off-by: Elias Wallat <walle@strlnd.net>

**What this PR does / why we need it**:
When we try to install Kubermatic Master on a Kubernetes cluster in version 1.21+ the dex pods end up in a crash loop. This is prevented by explicitly defining the namespace in which dex is running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7051

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
