### PR TITLE
Don't Sync User and UserProjectBinding objects of service accounts

### DIFF
--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -71,7 +71,8 @@ func Add(
 
 	serviceAccountPredicate := predicate.NewPredicateFuncs(func(object ctrlruntimeclient.Object) bool {
 		// We don't trigger reconciliation for service account.
-		return !kubernetes.IsProjectServiceAccount(object.GetName())
+		user := object.(*kubermaticv1.User)
+		return !kubernetes.IsProjectServiceAccount(user.Spec.Email)
 	})
 
 	for seedName, seedManager := range seedManagers {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets `User` and `Userprojectbinding` sync controllers not sync those objects of service account users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
