### PR TITLE
Adds seedconstraintsynchronizer controller 

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -27,6 +27,7 @@ import (
 	backupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/backup"
 	cloudcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/clustercomponentdefaulter"
+	seedconstraintsynchronizer "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/constraint-controller"
 	constrainttemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/constraint-template-controller"
 	etcdbackupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdbackup"
 	etcdrestorecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdrestore"
@@ -64,6 +65,7 @@ var AllControllers = map[string]controllerCreator{
 	seedresourcesuptodatecondition.ControllerName: createSeedConditionUpToDateController,
 	rancher.ControllerName:                        createRancherController,
 	pvwatcher.ControllerName:                      createPvWatcherController,
+	seedconstraintsynchronizer.ControllerName:     createConstraintController,
 	constrainttemplatecontroller.ControllerName:   createConstraintTemplateController,
 	initialmachinedeployment.ControllerName:       createInitialMachineDeploymentController,
 	mla.ControllerName:                            createMLAController,
@@ -429,4 +431,15 @@ func createMLAController(ctrlCtx *controllerContext) error {
 
 func userClusterMLAEnabled(ctrlCtx *controllerContext) bool {
 	return ctrlCtx.runOptions.featureGates.Enabled(features.UserClusterMLA) && ctrlCtx.runOptions.enableUserClusterMLA
+}
+
+func createConstraintController(ctrlCtx *controllerContext) error {
+	return seedconstraintsynchronizer.Add(
+		ctrlCtx.ctx,
+		ctrlCtx.mgr,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.namespace,
+		ctrlCtx.runOptions.workerCount,
+	)
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2166,6 +2166,8 @@ const (
 	GatekeeperSeedConstraintCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-seed-constraint"
 	// GatekeeperConstraintCleanupFinalizer indicates that gatkeeper constraints on the user cluster need cleanup
 	GatekeeperConstraintCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-constraints"
+	// KubermaticUserClusterNsDefaultConstraintCleanupFinalizer indicates that kubermatic constraints on the user cluster namespace need cleanup
+	KubermaticUserClusterNsDefaultConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-usercluster-ns-default-constraints"
 	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup
 	KubermaticConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-constraints"
 	// SeedProjectCleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seedconstraintsynchronizer
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"go.uber.org/zap"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
+	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// This controller syncs the kubermatic constraints to constraint on the user cluster.
+	ControllerName = "constraint_syncing_controller"
+	finalizer      = kubermaticapiv1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer
+	Key            = "default"
+	Value          = "true"
+	AddAction      = "add"
+	RemoveAction   = "remove"
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	recorder                record.EventRecorder
+	namespace               string
+	seedClient              ctrlruntimeclient.Client
+}
+
+func opaPredicate() predicate.Funcs {
+	return kubermaticpred.Factory(func(o ctrlruntimeclient.Object) bool {
+		cluster, ok := o.(*kubermaticv1.Cluster)
+		if !ok {
+			return false
+		}
+		return cluster.Spec.OPAIntegration != nil && cluster.Spec.OPAIntegration.Enabled
+	})
+}
+
+func withEventFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldConstraint, ok := e.ObjectOld.(*kubermaticv1.Constraint)
+			if !ok {
+				return false
+			}
+			newConstraint, ok := e.ObjectNew.(*kubermaticv1.Constraint)
+			if !ok {
+				return false
+			}
+			return !reflect.DeepEqual(oldConstraint.Spec, newConstraint.Spec)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func Add(ctx context.Context,
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	namespace string,
+	numWorkers int) error {
+
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %v", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		namespace:               namespace,
+		seedClient:              mgr.GetClient(),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Cluster{}},
+		enqueueConstraints(reconciler.seedClient, reconciler.log, namespace),
+		workerlabel.Predicates(workerName),
+		opaPredicate(),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for clusters: %w", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Constraint{}},
+		&handler.EnqueueRequestForObject{},
+		kubermaticpred.ByNamespace(namespace),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for seed constraints: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Constraint{}},
+		handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: a.GetName(), Namespace: namespace}}}
+		}),
+		kubermaticpred.ByLabel(Key, Value),
+		withEventFilter(),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for user cluster namespace constraints: %v", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles the kubermatic constraints in the seed cluster and syncs them to all user clusters namespace
+// which have opa integration enabled
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+	log.Debug("Reconciling")
+
+	constraint := &kubermaticv1.Constraint{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, constraint); err != nil {
+		if controllerutil.IsCacheNotStarted(err) {
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get constraint %s: %v", constraint.Name, ctrlruntimeclient.IgnoreNotFound(err))
+
+	}
+
+	err := r.reconcile(ctx, constraint, log)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Eventf(constraint, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func addLabel(constraint *kubermaticv1.Constraint) *kubermaticv1.Constraint {
+	if constraint.Labels != nil {
+		constraint.Labels[Key] = Value
+	} else {
+		constraint.Labels = map[string]string{Key: Value}
+	}
+	return constraint
+}
+
+func constraintCreatorGetter(constraint *kubermaticv1.Constraint) reconciling.NamedKubermaticV1ConstraintCreatorGetter {
+	return func() (string, reconciling.KubermaticV1ConstraintCreator) {
+		return constraint.Name, func(c *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
+			c.Name = constraint.Name
+			c.Spec = constraint.Spec
+			c = addLabel(c)
+			return c, nil
+		}
+	}
+}
+
+func (r *reconciler) patchFinalizer(ctx context.Context, constraint *kubermaticv1.Constraint, action string) error {
+	oldconstraint := constraint.DeepCopy()
+
+	if action == AddAction {
+		kuberneteshelper.AddFinalizer(constraint, finalizer)
+	} else if action == RemoveAction {
+		kuberneteshelper.RemoveFinalizer(constraint, finalizer)
+	}
+
+	if err := r.seedClient.Patch(ctx, constraint, ctrlruntimeclient.MergeFrom(oldconstraint)); err != nil {
+		return fmt.Errorf("failed to %s constraint finalizer %s: %v", action, constraint.Name, err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
+
+	// constraint deletion
+	if !constraint.DeletionTimestamp.IsZero() {
+		if !kuberneteshelper.HasFinalizer(constraint, finalizer) {
+			return nil
+		}
+
+		if err := r.cleanupConstraint(ctx, log, constraint); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// constraint initialization
+	if !kuberneteshelper.HasFinalizer(constraint, finalizer) {
+		if err := r.patchFinalizer(ctx, constraint, AddAction); err != nil {
+			return err
+		}
+	}
+
+	// constraint creation
+	constraintCreatorGetters := []reconciling.NamedKubermaticV1ConstraintCreatorGetter{
+		constraintCreatorGetter(constraint),
+	}
+
+	return r.syncAllClustersNS(ctx, log, constraint, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint, namespace string) error {
+		return reconciling.ReconcileKubermaticV1Constraints(ctx, constraintCreatorGetters, namespace, seedClient)
+	})
+}
+
+func (r *reconciler) cleanupConstraint(ctx context.Context, log *zap.SugaredLogger, constraint *kubermaticv1.Constraint) error {
+
+	if err := r.syncAllClustersNS(ctx, log, constraint, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint, namespace string) error {
+
+		log := log.With("constraint", constraint)
+		log.Debugw("cleanup processing:", namespace)
+
+		err := seedClient.Delete(ctx, &kubermaticv1.Constraint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constraint.Name,
+				Namespace: namespace,
+			},
+		})
+		return ctrlruntimeclient.IgnoreNotFound(err)
+
+	}); err != nil {
+		return err
+	}
+
+	if err := r.patchFinalizer(ctx, constraint, RemoveAction); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isOPAEnabled(userCluster *kubermaticv1.Cluster) bool {
+	return userCluster.Spec.OPAIntegration != nil && userCluster.Spec.OPAIntegration.Enabled
+}
+
+func (r *reconciler) syncAllClustersNS(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	constraint *kubermaticv1.Constraint,
+	actionFunc func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint, namespace string) error) error {
+
+	clusterList := &kubermaticv1.ClusterList{}
+	if err := r.seedClient.List(ctx, clusterList, &ctrlruntimeclient.ListOptions{LabelSelector: r.workerNameLabelSelector}); err != nil {
+		return fmt.Errorf("failed listing clusters: %w", err)
+	}
+
+	for _, userCluster := range clusterList.Items {
+
+		clusterName := userCluster.Spec.HumanReadableName
+
+		// instance Validation
+		if userCluster.Spec.Pause {
+			log.Debugw("Cluster paused, skipping", "cluster", clusterName)
+			continue
+		}
+
+		if isOPAEnabled(&userCluster) {
+			if err := actionFunc(r.seedClient, constraint, userCluster.Status.NamespaceName); err != nil {
+				return fmt.Errorf("failed syncing constraint for cluster %s namespace: %w", clusterName, err)
+			}
+
+			log.Debugw("Reconciled constraint with cluster", "cluster", clusterName)
+		} else {
+			log.Debugw("Cluster does not integrate with OPA, skipping", "cluster", clusterName)
+		}
+	}
+
+	return nil
+}
+
+func enqueueConstraints(client ctrlruntimeclient.Client, log *zap.SugaredLogger, namespace string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		constraintList := &kubermaticv1.ConstraintList{}
+		if err := client.List(context.Background(), constraintList, &ctrlruntimeclient.ListOptions{Namespace: namespace}); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list constraints: %v", err))
+		}
+
+		for _, constraint := range constraintList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      constraint.Name,
+				Namespace: constraint.Namespace,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package seedconstraintsynchronizer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/diff"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	constraintName = "constraint"
+	kind           = "RequiredLabel"
+	key            = "default"
+	value          = "true"
+)
+
+func TestReconcile(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	seedNamespace := "namespace"
+	clusterNamespace := test.GenDefaultCluster().Status.NamespaceName
+
+	testCases := []struct {
+		name                 string
+		namespacedName       types.NamespacedName
+		expectedConstraint   *kubermaticv1.Constraint
+		expectedGetErrStatus metav1.StatusReason
+		seedClient           ctrlruntimeclient.Client
+	}{
+		{
+			name: "scenario 1: sync constraint to user cluster ns",
+			namespacedName: types.NamespacedName{
+				Namespace: seedNamespace,
+				Name:      constraintName,
+			},
+			expectedConstraint: genConstraint(constraintName, clusterNamespace, kind, true, false),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(genConstraint(constraintName, seedNamespace, kind, false, false), genCluster(true)).
+				Build(),
+		},
+		{
+			name: "scenario 2: dont sync constraint to user cluster ns which has opa-integration off",
+			namespacedName: types.NamespacedName{
+				Namespace: seedNamespace,
+				Name:      constraintName,
+			},
+			expectedGetErrStatus: metav1.StatusReasonNotFound,
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(genConstraint(constraintName, seedNamespace, kind, false, false), genCluster(false)).
+				Build(),
+		},
+		{
+			name: "scenario 3: cleanup constraint on user cluster ns when seed constraint is being terminated",
+			namespacedName: types.NamespacedName{
+				Namespace: seedNamespace,
+				Name:      constraintName,
+			},
+			expectedGetErrStatus: metav1.StatusReasonNotFound,
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(
+					genConstraint(constraintName, seedNamespace, kind, false, true),
+					genConstraint(constraintName, clusterNamespace, kind, true, false),
+					genCluster(true),
+				).
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				namespace:               seedNamespace,
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				seedClient:              tc.seedClient,
+			}
+
+			request := reconcile.Request{NamespacedName: tc.namespacedName}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			constraint := &kubermaticv1.Constraint{}
+			err = tc.seedClient.Get(ctx, types.NamespacedName{Name: tc.namespacedName.Name, Namespace: clusterNamespace}, constraint)
+			if tc.expectedGetErrStatus != "" {
+				if err == nil {
+					t.Fatalf("expected error status %s, instead got ct: %v", tc.expectedGetErrStatus, constraint)
+				}
+				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed get constraint: %v", err)
+			}
+
+			// set resource version to empty as it messes up tests
+			constraint.ResourceVersion = ""
+			if !reflect.DeepEqual(constraint, tc.expectedConstraint) {
+				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(constraint, tc.expectedConstraint))
+			}
+		})
+	}
+}
+
+func genConstraint(name, namespace, kind string, label, delete bool) *kubermaticv1.Constraint {
+	constraint := test.GenConstraint(name, namespace, kind)
+	if label {
+		if constraint.Labels != nil {
+			constraint.Labels[key] = value
+		} else {
+			constraint.Labels = map[string]string{key: value}
+		}
+	}
+	if delete {
+		deleteTime := metav1.NewTime(time.Now())
+		constraint.DeletionTimestamp = &deleteTime
+		constraint.Finalizers = append(constraint.Finalizers, v1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer)
+	}
+	return constraint
+}
+
+func genCluster(opaEnabled bool) *kubermaticv1.Cluster {
+	cluster := test.GenDefaultCluster()
+	cluster.Spec.OPAIntegration = &kubermaticv1.OPAIntegrationSettings{
+		Enabled: opaEnabled,
+	}
+	return cluster
+}

--- a/pkg/controller/seed-controller-manager/constraint-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package seedconstraintsynchronizer contains a controller that is responsible for ensuring that the
+kubermatic constraints are synced to the user cluster namespace.
+
+*/
+package seedconstraintsynchronizer


### PR DESCRIPTION
Signed-off-by: Harshita <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**:
Adds a seed controller for default constraints which syncs from to the seed kubermatic ns to user cluster ns.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6804

**Documentation**: [Default Constraints Proposal](https://github.com/kubermatic/kubermatic/blob/master/docs/proposals/default-constraints.md)

<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
