### PR TITLE
Allow nil for nodeLocalDNSCacheEnabled

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -87,9 +87,6 @@ func ValidateClusterNetworkConfig(n *kubermaticv1.ClusterNetworkingConfig, fldPa
 	if len(n.Services.CIDRBlocks) == 0 && !allowEmpty {
 		allErrs = append(allErrs, field.Required(fldPath.Child("services", "cidrBlocks"), "service CIDR must be provided"))
 	}
-	if n.NodeLocalDNSCacheEnabled == nil && !allowEmpty {
-		allErrs = append(allErrs, field.Required(fldPath.Child("nodeLocalDNSCacheEnabled"), "nodeLocalDNSCacheEnabled must be provided"))
-	}
 
 	// Verify that provided CIDR are well formed
 	if podsCIDR := n.Pods.CIDRBlocks; len(podsCIDR) == 1 {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -304,17 +304,6 @@ func TestValidateClusterNetworkingConfig(t *testing.T) {
 			allowEmpty: false,
 		},
 		{
-			name: "missing NodeLocal DNSCache",
-			networkConfig: kubermaticv1.ClusterNetworkingConfig{
-				Pods:      kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
-				Services:  kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
-				DNSDomain: "cluster.local",
-				ProxyMode: "ipvs",
-			},
-			wantErr:    true,
-			allowEmpty: false,
-		},
-		{
 			name: "invalid pod cidr",
 			networkConfig: kubermaticv1.ClusterNetworkingConfig{
 				Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"192.127.0.0:20"}},


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Allows nil value for `NodeLocalDNSCacheEnabled` in the Cluster API introduced in https://github.com/kubermatic/kubermatic/pull/7091, to prevent validation errors in existing clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
