### PR TITLE
rerun of cloud initialization duplicates finalizers

### DIFF
--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -208,7 +208,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 	// conflicts to retry later.
 	if len(finalizers) > 0 {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = append(cluster.Finalizers, finalizers...)
+			kubernetes.AddFinalizer(cluster, finalizers...)
 		}, provider.UpdaterOptionOptimisticLock)
 		if err != nil {
 			return nil, fmt.Errorf("failed to add finalizers: %w", err)

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -29,6 +29,7 @@ import (
 	ostesting "k8c.io/kubermatic/v2/pkg/provider/cloud/openstack/internal/testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestIgnoreRouterAlreadyHasPortInSubnetError(t *testing.T) {
@@ -349,6 +350,15 @@ func TestInitializeCloudProvider(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
+			// We cannot guarantee order if finalizers serialized using sets and deep.Equal fails if order is different,
+			// thus we test finalizers equality separately.
+			if w, g := sets.NewString(tt.wantCluster.Finalizers...), sets.NewString(c.Finalizers...); !w.Equal(g) {
+				t.Errorf("Want finalizers: %v, got: %v", w, g)
+			} else {
+				tt.wantCluster.Finalizers = nil
+				c.Finalizers = nil
+			}
+
 			if diff := deep.Equal(tt.wantCluster, *c); len(diff) > 0 {
 				t.Errorf("Diff found between actual and wanted cluster: %v", diff)
 			}


### PR DESCRIPTION
Signed-off-by: Furkhat Kasymovgeniiuulu <vailodf@gmail.com>

**What this PR does / why we need it**: If `InitializeCloudProvider` fails, second run re-adds finalizers. For example we added finalizer for a network but could not create the network, thus spec.network is still empty, and on the next run we add finalizer again. And this can continue indefinitely. 

**Which issue(s) this PR fixes**:
Continuation of #6759

**Does this PR introduce a user-facing change?**:
```release-note
Fix finalizers duplication.
```