### PR TITLE
Increase memory limits for ip-fixup

### DIFF
--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -53,7 +53,7 @@ var (
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
 			},
 		},
 		"openvpn-exporter": openvpnResourceRequirements.DeepCopy(),

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server-externalCloudProvider.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server-externalCloudProvider.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server-externalCloudProvider.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server-externalCloudProvider.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server-externalCloudProvider.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server.yaml
@@ -141,7 +141,7 @@ spec:
         name: ip-fixup
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           requests:
             cpu: 5m


### PR DESCRIPTION
**What this PR does / why we need it**:
The current memory limit of 10m is too little which gives prometheus
warning alerts about the container being throttled. The metric is around
0.75 with the alert triggering at > 0.6.

Increasing the memory limits to 50m gets the metric down to ~ 0.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
