### PR TITLE
Bump Gatekeeper version to 3.2.3

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
@@ -34,7 +34,7 @@ const (
 	controllerName = resources.GatekeeperControllerDeploymentName
 	auditName      = resources.GatekeeperAuditDeploymentName
 	imageName      = "openpolicyagent/gatekeeper"
-	tag            = "v3.1.3"
+	tag            = "v3.2.3"
 	// Namespace used by Dashboard to find required resources.
 	webhookServerPort  = 8443
 	metricsPort        = 8888


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps Gatekeeper version from 3.1.3 to 3.2.3. 

We need it because it contains the fix for selfLink in Gatekeeper audit (https://github.com/open-policy-agent/gatekeeper/pull/1007) which causes Constraints violations to mix (#7105)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7105 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Bumped Gatekeeper version to 3.2.3
```
