### PR TITLE
Be explicit about the need of the NET_RAW capability for OpenVPN Init…

### DIFF
--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -169,7 +169,10 @@ iptables -A INPUT -i tun0 -j DROP
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Capabilities: &corev1.Capabilities{
-							Add: []corev1.Capability{"NET_ADMIN"},
+							Add: []corev1.Capability{
+								"NET_ADMIN",
+								"NET_RAW",
+							},
 						},
 						ProcMount: &procMountType,
 					},

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server-externalCloudProvider.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server-externalCloudProvider.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server-externalCloudProvider.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server-externalCloudProvider.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server-externalCloudProvider.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server.yaml
@@ -204,6 +204,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           procMount: Default
       volumes:
       - name: ca


### PR DESCRIPTION
…Container.

**What this PR does / why we need it**:

Explicitly adds NET_RAW capability to OpenVPN-server container, it seems to be required for the iptables InitContainer setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7147 

**Special notes for your reviewer**:

I'm not familiar with Go at all, and haven't really tested compiling this change :/

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
