### PR TITLE
Set kube-system as a namespace for aws-node-termination-handler role-binding

### DIFF
--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -134,6 +134,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aws-node-termination-handler-psp
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting a namespace for the role-binding yaml file. When the namespace is not set, kubectl will try to apply the role binding on the default namespace inside the seed controller container which is kubermatic.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
aws-node-termination-handler is deployed successfully and no error is printed out while installing addons 
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
