### PR TITLE
add vnet rg in azure ccm cloud config

### DIFF
--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -116,7 +116,7 @@ func CloudConfig(
 			RouteTableName:             cloud.Azure.RouteTableName,
 			SecurityGroupName:          cloud.Azure.SecurityGroup,
 			PrimaryAvailabilitySetName: cloud.Azure.AvailabilitySet,
-			VnetResourceGroup:          cloud.Azure.ResourceGroup,
+			VnetResourceGroup:          cloud.Azure.VNetResourceGroup,
 			UseInstanceMetadata:        false,
 		}
 		cloudConfig, err = azure.CloudConfigToString(azureCloudConfig)

--- a/pkg/resources/test/fixtures/configmap-azure-1.17.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.17.0-cloud-config.yaml
@@ -1,7 +1,7 @@
 # This file has been generated, DO NOT EDIT.
 
 data:
-  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"az-res-group","useInstanceMetadata":false}'
+  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"","useInstanceMetadata":false}'
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.18.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.18.0-cloud-config.yaml
@@ -1,7 +1,7 @@
 # This file has been generated, DO NOT EDIT.
 
 data:
-  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"az-res-group","useInstanceMetadata":false}'
+  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"","useInstanceMetadata":false}'
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.19.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.19.0-cloud-config.yaml
@@ -1,7 +1,7 @@
 # This file has been generated, DO NOT EDIT.
 
 data:
-  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"az-res-group","useInstanceMetadata":false}'
+  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"","useInstanceMetadata":false}'
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-cloud-config.yaml
@@ -1,7 +1,7 @@
 # This file has been generated, DO NOT EDIT.
 
 data:
-  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"az-res-group","useInstanceMetadata":false}'
+  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"","useInstanceMetadata":false}'
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.21.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.21.0-cloud-config.yaml
@@ -1,7 +1,7 @@
 # This file has been generated, DO NOT EDIT.
 
 data:
-  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"az-res-group","useInstanceMetadata":false}'
+  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"","useInstanceMetadata":false}'
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the right resource group for azure clusters. In the past the field vNet Resource Group was assigned to be the same as the global resource group which led to a cluster creation failure due to looking for resources in the wrong resource group

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7137

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
