### PR TITLE
Do not return an error if MLA is disabled and not installed in Seed

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -96,6 +96,9 @@ func Add(
 		return err
 	}
 	if err := client.Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
+		if !mlaEnabled {
+			return nil // do not return an error if MLA is disabled (e.g. if MLA is not installed in Seed)
+		}
 		return fmt.Errorf("failed to get Grafana Secret: %v", err)
 	}
 	adminName, ok := secret.Data[grafanaUserKey]


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
If MLA is not installed in Seed, en error is returned when creating MLA controller even if MLA is disabled in Seed. This PR fixes it. The MLA cleanup controller will not be started, but that should not be a problem in this case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
