### PR TITLE
Cluster deletion to leave dynamic PVs cleanup to provisioner

### DIFF
--- a/pkg/clusterdeletion/volumes.go
+++ b/pkg/clusterdeletion/volumes.go
@@ -55,7 +55,7 @@ func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Clu
 
 	allPVList := &corev1.PersistentVolumeList{}
 	if err := userClusterClient.List(ctx, allPVList); err != nil {
-		return deletedSomeResource, fmt.Errorf("failed to list PVs from user cluster: %v", err)
+		return false, fmt.Errorf("failed to list PVs from user cluster: %v", err)
 	}
 	pvList := &corev1.PersistentVolumeList{}
 	for _, pv := range allPVList.Items {

--- a/pkg/clusterdeletion/volumes.go
+++ b/pkg/clusterdeletion/volumes.go
@@ -30,6 +30,11 @@ import (
 
 const (
 	annotationKeyDescription = "description"
+
+	// AnnDynamicallyProvisioned is added to a PV that is dynamically provisioned by kubernetes
+	// Because the annotation is defined only at k8s.io/kubernetes, copying the content instead of vendoring
+	// https://github.com/kubernetes/kubernetes/blob/v1.21.0/pkg/controller/volume/persistentvolume/util/util.go#L65
+	AnnDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
 )
 
 func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Cluster) (deletedSomeResource bool, err error) {
@@ -48,9 +53,17 @@ func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Clu
 		return false, fmt.Errorf("failed to list PVCs from user cluster: %v", err)
 	}
 
-	pvList := &corev1.PersistentVolumeList{}
-	if err := userClusterClient.List(ctx, pvList); err != nil {
+	allPVList := &corev1.PersistentVolumeList{}
+	if err := userClusterClient.List(ctx, allPVList); err != nil {
 		return deletedSomeResource, fmt.Errorf("failed to list PVs from user cluster: %v", err)
+	}
+	pvList := &corev1.PersistentVolumeList{}
+	for _, pv := range allPVList.Items {
+		// Check only dynamically provisioned PVs with delete reclaim policy to verify provisioner has done the cleanup
+		// this filters out everything else because we leave those be
+		if pv.Annotations[AnnDynamicallyProvisioned] != "" && pv.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
+			pvList.Items = append(pvList.Items, pv)
+		}
 	}
 
 	// Do not attempt to delete any pods when there are no PVs and PVCs
@@ -72,11 +85,9 @@ func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Clu
 		deletedSomeResource = true
 	}
 
-	// Delete PV's
-	for _, pv := range pvList.Items {
-		if err := userClusterClient.Delete(ctx, &pv); err != nil && !kerrors.IsNotFound(err) {
-			return deletedSomeResource, fmt.Errorf("failed to delete PV '%s' from user cluster: %v", pv.Name, err)
-		}
+	if len(pvList.Items) > 0 {
+		// We don't delete PVs but we want to wait for provisioners to cleanup dynamically provisioned PVs
+		// pretend we need to requeue to avoid removing finalizer prematurely
 		deletedSomeResource = true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster deletion cleanup leaves volumes in a cloud provider.
This avoids deleting `PV`s entirely, only waits for dynamically provisioned `PV`s with delete reclamation policy to be deleted by the provisioner.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
touching https://github.com/kubermatic/kubermatic/issues/6406#issuecomment-848689649

**Special notes for your reviewer**:
The `DeleteVolume` CSI gRPC call for cinder plugin is responsible for cleanup of the OpenStack volumes. For CSI, deleting PV manually doesn't trigger `DeleteVolume` which can leave unexpected residue behind the cleanup logic. 

https://github.com/kubernetes/community/blob/9d56458d1d8aadcba53a664b0ccf080d07583e45/contributors/design-proposals/storage/container-storage-interface.md#deleting-volumes

Issue #6406 touched the topic of OpenStack volumes cleanup and will require a different fix but it also uncovered that during cluster cleanup we leak volumes that stay after the cluster no longer exist. An example can be found in https://cloud.syseleven.de/horizon/project/volumes/. The plan for #6406 is still to split the CSI installation between seed and user cluster, not using addon anymore but install similarly to `pkg/resources/openvpn/` (that will be another PR). Eventually, I would also like to examine the cinder CSI plugin and see if there is room for improvement.

<details><summary>screenshot</summary>
<p>

![cinder-leaked-volumes](https://user-images.githubusercontent.com/1529535/121136921-7a440780-c836-11eb-9019-271e9b0d5797.png)

</p>
</details>

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
kubermatic/dashboard#3429 - informing better user that some volumes may not get deleted in cloud provider

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
