### PR TITLE
Fixed openstack client ca bundle handling

### DIFF
--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -477,13 +477,19 @@ func getAuthClient(username, password, domain, tenant, tenantID, authURL string,
 		TenantID:         tenantID,
 	}
 
-	client, err := goopenstack.AuthenticatedClient(opts)
+	client, err := goopenstack.NewClient(authURL)
 	if err != nil {
 		return nil, err
 	}
+
 	if client != nil {
 		// overwrite the default host/root CA Bundle with the proper CA Bundle
 		client.HTTPClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caBundle}}
+	}
+
+	err = goopenstack.Authenticate(client, opts)
+	if err != nil {
+		return nil, err
 	}
 
 	return client, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the issue where using a custom CA Bundle for Openstack would fail because the client tries to authenticate before setting the custom CA bundle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7191 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed using a custom CA Bundle for Openstack by authenticating after setting the proper CA bundle
```
