### PR TITLE
Add Log type support in RuleGroup controller

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -413,6 +413,7 @@ func createMLAController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.overwriteRegistry,
 		ctrlCtx.runOptions.cortexAlertmanagerURL,
 		ctrlCtx.runOptions.cortexRulerURL,
+		ctrlCtx.runOptions.lokiRulerURL,
 		ctrlCtx.runOptions.enableUserClusterMLA,
 	)
 }

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -108,6 +108,7 @@ type controllerRunOptions struct {
 	grafanaSecret         string
 	cortexAlertmanagerURL string
 	cortexRulerURL        string
+	lokiRulerURL          string
 
 	// Machine Controller configuration
 	machineControllerImageTag        string
@@ -180,6 +181,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.grafanaSecret, "grafana-secret-name", "mla/grafana", "Grafana secret name in format namespace/secretname, that contains basic auth info")
 	flag.StringVar(&c.cortexAlertmanagerURL, "cortex-alertmanager-url", "http://cortex-alertmanager.mla.svc.cluster.local:8080", "The URL of cortex alertmanager which is running for MLA stack.")
 	flag.StringVar(&c.cortexRulerURL, "cortex-ruler-url", "http://cortex-ruler.mla.svc.cluster.local:8080", "The URL of cortex ruler which is running for MLA stack.")
+	flag.StringVar(&c.lokiRulerURL, "loki-ruler-url", "http://loki-distributed-ruler.mla.svc.cluster.local:3100", "The URL of loki ruler which is running for MLA stack.")
 	flag.StringVar(&c.machineControllerImageTag, "machine-controller-image-tag", "", "The Machine Controller image tag.")
 	flag.StringVar(&c.machineControllerImageRepository, "machine-controller-image-repository", "", "The Machine Controller image repository.")
 	c.admissionWebhook.AddFlags(flag.CommandLine, true)

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -81,6 +81,7 @@ func Add(
 	overwriteRegistry string,
 	cortexAlertmanagerURL string,
 	cortexRulerURL string,
+	lokiRulerURL string,
 	mlaEnabled bool,
 ) error {
 	log = log.Named(ControllerName)
@@ -118,7 +119,7 @@ func Add(
 	alertmanagerController := newAlertmanagerController(mgr.GetClient(), log, httpClient, cortexAlertmanagerURL)
 	datasourceGrafanaController := newDatasourceGrafanaController(mgr.GetClient(), httpClient, grafanaURL, grafanaAuth, mlaNamespace, log, overwriteRegistry)
 	userGrafanaController := newUserGrafanaController(mgr.GetClient(), log, grafanaClient, httpClient, grafanaURL, grafanaHeader)
-	ruleGroupController := newRuleGroupController(mgr.GetClient(), log, httpClient, cortexRulerURL)
+	ruleGroupController := newRuleGroupController(mgr.GetClient(), log, httpClient, cortexRulerURL, lokiRulerURL)
 	if mlaEnabled {
 		if err := newOrgGrafanaReconciler(mgr, log, numWorkers, workerName, versions, orgGrafanaController); err != nil {
 			return fmt.Errorf("failed to create mla project controller: %w", err)

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -50,6 +50,7 @@ import (
 const (
 	ruleGroupFinalizer             = "kubermatic.io/rule-group"
 	metricsRuleGroupConfigEndpoint = "/api/v1/rules"
+	logRuleGroupConfigEndpoint     = "/loki/api/v1/rules"
 	ruleGroupTenantHeaderName      = "X-Scope-OrgID"
 	defaultNamespace               = "/default"
 )
@@ -190,6 +191,7 @@ type ruleGroupController struct {
 
 	log            *zap.SugaredLogger
 	cortexRulerURL string
+	lokiRulerURL   string
 }
 
 func newRuleGroupController(
@@ -197,12 +199,14 @@ func newRuleGroupController(
 	log *zap.SugaredLogger,
 	httpClient *http.Client,
 	cortexRulerURL string,
+	lokiRulerURL string,
 ) *ruleGroupController {
 	return &ruleGroupController{
 		Client:         client,
 		httpClient:     httpClient,
 		log:            log,
 		cortexRulerURL: cortexRulerURL,
+		lokiRulerURL:   lokiRulerURL,
 	}
 }
 
@@ -265,6 +269,9 @@ func (r *ruleGroupController) cleanUp(ctx context.Context) error {
 func (r *ruleGroupController) getRequestURL(ruleGroup *kubermaticv1.RuleGroup) (string, error) {
 	if ruleGroup.Spec.RuleGroupType == kubermaticv1.RuleGroupTypeMetrics {
 		return fmt.Sprintf("%s%s%s", r.cortexRulerURL, metricsRuleGroupConfigEndpoint, defaultNamespace), nil
+	}
+	if ruleGroup.Spec.RuleGroupType == kubermaticv1.RuleGroupTypeLogs {
+		return fmt.Sprintf("%s%s%s", r.lokiRulerURL, logRuleGroupConfigEndpoint, defaultNamespace), nil
 	}
 	return "", fmt.Errorf("unknown rule group type: %s", ruleGroup.Spec.RuleGroupType)
 }

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
@@ -48,7 +48,7 @@ func newTestRuleGroupReconciler(objects []ctrlruntimeclient.Object, handler http
 		Build()
 	ts := httptest.NewServer(handler)
 
-	controller := newRuleGroupController(fakeClient, kubermaticlog.Logger, ts.Client(), ts.URL)
+	controller := newRuleGroupController(fakeClient, kubermaticlog.Logger, ts.Client(), ts.URL, ts.URL)
 	reconciler := ruleGroupReconciler{
 		Client:              fakeClient,
 		log:                 kubermaticlog.Logger,
@@ -69,7 +69,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 		hasFinalizer bool
 	}{
 		{
-			name: "create rule group",
+			name: "create metrics rule group",
 			request: types.NamespacedName{
 				Name:      "test-rule",
 				Namespace: "cluster-test",
@@ -97,6 +97,34 @@ func TestRuleGroupReconcile(t *testing.T) {
 			hasFinalizer: true,
 		},
 		{
+			name: "create logs rule group",
+			request: types.NamespacedName{
+				Name:      "test-rule",
+				Namespace: "cluster-test",
+			},
+			objects: []ctrlruntimeclient.Object{
+				generateCluster("test", true, false),
+				generateRuleGroup("test-rule", "test", kubermaticv1.RuleGroupTypeLogs, false),
+			},
+			requests: []request{
+				{
+					name: "get",
+					request: httptest.NewRequest(http.MethodGet,
+						fmt.Sprintf("%s%s/%s", logRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
+						nil),
+					response: &http.Response{StatusCode: http.StatusNotFound},
+				},
+				{
+					name: "post",
+					request: httptest.NewRequest(http.MethodPost,
+						logRuleGroupConfigEndpoint+defaultNamespace,
+						bytes.NewBuffer(test.GenerateTestRuleGroupData("test-rule"))),
+					response: &http.Response{StatusCode: http.StatusAccepted},
+				},
+			},
+			hasFinalizer: true,
+		},
+		{
 			name: "create rule group with unknown type",
 			request: types.NamespacedName{
 				Name:      "test-rule",
@@ -109,7 +137,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "clean up rule group",
+			name: "clean up metrics rule group",
 			request: types.NamespacedName{
 				Name:      "test-rule",
 				Namespace: "cluster-test",
@@ -123,6 +151,27 @@ func TestRuleGroupReconcile(t *testing.T) {
 					name: "delete",
 					request: httptest.NewRequest(http.MethodDelete,
 						fmt.Sprintf("%s%s/%s", metricsRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
+						nil),
+					response: &http.Response{StatusCode: http.StatusAccepted},
+				},
+			},
+			hasFinalizer: false,
+		},
+		{
+			name: "clean up logs rule group",
+			request: types.NamespacedName{
+				Name:      "test-rule",
+				Namespace: "cluster-test",
+			},
+			objects: []ctrlruntimeclient.Object{
+				generateCluster("test", true, false),
+				generateRuleGroup("test-rule", "test", kubermaticv1.RuleGroupTypeLogs, true),
+			},
+			requests: []request{
+				{
+					name: "delete",
+					request: httptest.NewRequest(http.MethodDelete,
+						fmt.Sprintf("%s%s/%s", logRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusAccepted},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to create RuleGroup which will be used to generate alerts from logs in RuleGroup controller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref: #7097 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
