### PR TITLE
Allow to configure Alertmanager and Alert Rule Groups when MLA logging is enabled.

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -2786,7 +2786,7 @@ func TestSyncClusterAlertmanagerRBAC(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					MLA: &kubermaticv1.MLASettings{
-						MonitoringEnabled: true,
+						LoggingEnabled: true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -3097,7 +3097,7 @@ func TestSyncClusterRuleGroupsRBAC(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					MLA: &kubermaticv1.MLASettings{
-						MonitoringEnabled: true,
+						LoggingEnabled: true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -210,10 +210,10 @@ func newAlertmanagerController(
 
 func (r *alertmanagerController) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 
-	monitoringEnabled := cluster.Spec.MLA != nil && cluster.Spec.MLA.MonitoringEnabled
+	mlaEnabled := cluster.Spec.MLA != nil && (cluster.Spec.MLA.MonitoringEnabled || cluster.Spec.MLA.LoggingEnabled)
 	// Currently, we don't have a dedicated flag for enabling/disabling Alertmanager, and Alertmanager will be enabled
-	// or disabled based on the monitoring flag.
-	if !cluster.DeletionTimestamp.IsZero() || !monitoringEnabled {
+	// or disabled based on MLA flag.
+	if !cluster.DeletionTimestamp.IsZero() || !mlaEnabled {
 		return nil, r.handleDeletion(ctx, cluster)
 	}
 

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -85,7 +85,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			name:        "create default alertmanager configuration when no alertmanager is created",
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", true, false, false),
 			},
 			requests: []request{
 				{
@@ -108,7 +108,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			name:        "create default alertmanager configuration if alertmanager is found but config secret is not set",
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", false, true, false),
 				&kubermaticv1.Alertmanager{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resources.AlertmanagerName,
@@ -137,7 +137,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			name:        "create default alertmanager configuration if config secret is set but not found",
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", true, false, false),
 				&kubermaticv1.Alertmanager{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resources.AlertmanagerName,
@@ -171,7 +171,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			name:        "create alertmanager configuration based on the config secret",
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", false, true, false),
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "config-secret",
@@ -211,10 +211,10 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			hasResources: true,
 		},
 		{
-			name:        "clean up alertmanager configuration when monitoring is disabled",
+			name:        "clean up alertmanager configuration when mla is disabled",
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", false, false),
+				generateCluster("test", false, false, false),
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "config-secret",
@@ -252,7 +252,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			name:        "clean up alertmanager configuration when cluster is removed",
 			requestName: "test",
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", false, true),
+				generateCluster("test", false, true, true),
 			},
 			requests: []request{
 				{
@@ -312,14 +312,17 @@ func TestAlertmanagerReconcile(t *testing.T) {
 	}
 }
 
-func generateCluster(name string, monitoringEnabled, deleted bool) *kubermaticv1.Cluster {
+func generateCluster(name string, monitoringEnabled, loggingEnabled, deleted bool) *kubermaticv1.Cluster {
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: kubermaticv1.ClusterSpec{
 			HumanReadableName: name,
-			MLA:               &kubermaticv1.MLASettings{MonitoringEnabled: monitoringEnabled},
+			MLA: &kubermaticv1.MLASettings{
+				MonitoringEnabled: monitoringEnabled,
+				LoggingEnabled:    loggingEnabled,
+			},
 		},
 		Status: kubermaticv1.ClusterStatus{NamespaceName: fmt.Sprintf("cluster-%s", name)},
 	}

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
@@ -75,7 +75,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 				Namespace: "cluster-test",
 			},
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", true, false, false),
 				generateRuleGroup("test-rule", "test", kubermaticv1.RuleGroupTypeMetrics, false),
 			},
 			requests: []request{
@@ -103,7 +103,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 				Namespace: "cluster-test",
 			},
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", false, true, false),
 				generateRuleGroup("test-rule", "test", kubermaticv1.RuleGroupTypeLogs, false),
 			},
 			requests: []request{
@@ -131,7 +131,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 				Namespace: "cluster-test",
 			},
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", true, true, false),
 				generateRuleGroup("test-rule", "test", "type", false),
 			},
 			expectedErr: true,
@@ -143,7 +143,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 				Namespace: "cluster-test",
 			},
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", true, true, false),
 				generateRuleGroup("test-rule", "test", kubermaticv1.RuleGroupTypeMetrics, true),
 			},
 			requests: []request{
@@ -164,7 +164,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 				Namespace: "cluster-test",
 			},
 			objects: []ctrlruntimeclient.Object{
-				generateCluster("test", true, false),
+				generateCluster("test", true, true, false),
 				generateRuleGroup("test-rule", "test", kubermaticv1.RuleGroupTypeLogs, true),
 			},
 			requests: []request{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to allow to configure Alertmanager and Alert Rule Groups when MLA logging is enabled.
Previously, we only allow that if monitoring is enabled, now since we already support generating alerts from logs, so we will allow that when logging is enabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
