### PR TITLE
Mount gocache when building user-ssh-keys-agent image

### DIFF
--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -14,13 +14,21 @@
 
 FROM docker.io/golang:1.16.4 as builder
 
+ARG HOST_GOCACHE
 WORKDIR /go/src/github.com/kubermatic/kubermatic
-COPY . .
+
+COPY ./cmd/user-ssh-keys-agent ./cmd/user-ssh-keys-agent
+COPY ./cmd/http-prober/api ./cmd/http-prober/api
+COPY ./pkg ./pkg
+COPY ./go.mod ./go.mod
+COPY ./go.sum ./go.sum
+
 ENV CGO_ENABLED=0
-RUN go build ./cmd/user-ssh-keys-agent
+ENV GOCACHE=/go/src/github.com/kubermatic/kubermatic/cmd/user-ssh-keys-agent/$HOST_GOCACHE
+RUN go build -v -o ./_build/user-ssh-keys-agent ./cmd/user-ssh-keys-agent
 
 FROM docker.io/alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY --from=builder /go/src/github.com/kubermatic/kubermatic/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY --from=builder /go/src/github.com/kubermatic/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -14,11 +14,24 @@
 
 DOCKER_REPO ?= "quay.io/kubermatic"
 GOOS ?= $(shell go env GOOS)
+GOPATH ?= $(shell go env GOPATH)
+GOCACHE ?= $(shell go env GOCACHE)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
+	docker run \
+		-e GOCACHE=/go/.cache/go-build \
+ 		-e CGO_ENABLED=0 \
+		-v $(GOPATH)/src/github.com/kubermatic/kubermatic/:/go/src/github.com/kubermatic/kubermatic \
+		-v $(GOCACHE):/go/.cache/go-build \
+		-w /go/src/github.com/kubermatic/kubermatic/cmd/user-ssh-keys-agent \
+		docker.io/golang:1.16.4 \
+		go build -v -o ./_build/
 
 .PHONY: docker
 docker:
-	cd ../.. && docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) -f cmd/user-ssh-keys-agent/Dockerfile .
+	cd ../.. && cp -r $(GOCACHE) cmd/user-ssh-keys-agent && \
+	docker build \
+		-t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) \
+		--build-arg HOST_GOCACHE=$(shell basename $$GOCACHE) \
+		-f cmd/user-ssh-keys-agent/Dockerfile .

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -114,7 +114,8 @@ beforeDockerBuild=$(nowms)
   TEST_NAME="Build user-ssh-keys-agent Docker image"
   retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
   IMAGE_NAME=quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION
-  time retry 5 docker build -f cmd/user-ssh-keys-agent/Dockerfile -t "${IMAGE_NAME}" .
+  cd cmd/user-ssh-keys-agent
+  time retry 5 make docker TAG="${KUBERMATIC_VERSION}" .
   time retry 5 docker push "${IMAGE_NAME}"
 )
 (


### PR DESCRIPTION
**What this PR does / why we need it**:
gocache mount while building user-ssh-keys-agent container

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7222 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
