### PR TITLE
Fix verify-swagger flakiness

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -48,7 +48,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.16.1
+      - image: quay.io/kubermatic/build:go-1.16-node-14-0
         command:
         - make
         args:

--- a/hack/verify-swagger.sh
+++ b/hack/verify-swagger.sh
@@ -33,6 +33,11 @@ TMP_SWAGGER="${SWAGGER_FILE}.tmp"
 
 cd cmd/kubermatic-api/
 go run github.com/go-swagger/go-swagger/cmd/swagger generate spec --scan-models -o ${TMP_SWAGGER}
-diff -Naup ${SWAGGER_FILE} ${TMP_SWAGGER}
-
+# The parameters order in the generated swagger spec json file is not
+# deterministic, sort in order to avoid flake results.
+# The sorting here is applied only to first level arrays, nested arrays are not
+# sorted.
+curr="$(jq --argfile f ${SWAGGER_FILE} -n '($f | (..  | arrays) |= sort)')"
+exp="$(jq --argfile f ${TMP_SWAGGER} -n '($f | (..  | arrays) |= sort)')"
+diff -Naup <(echo "${curr}") <(echo "${exp}")
 go run github.com/go-swagger/go-swagger/cmd/swagger validate ${SWAGGER_FILE}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR tentatively fixes the flakiness of `hack/verify-swagger.sh` script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
