### PR TITLE
Fix KubeVirt cluster network collision

### DIFF
--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -105,11 +105,21 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) {
 	}
 
 	if len(c.Spec.ClusterNetwork.Services.CIDRBlocks) == 0 {
-		c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.240.16.0/20"}
+		if c.Spec.Cloud.Kubevirt != nil {
+			// KubeVirt cluster can be provisioned on top of k8s cluster created by KKP
+			// thus we have to avoid network collision
+			c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.241.0.0/20"}
+		} else {
+			c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.240.16.0/20"}
+		}
 	}
 
 	if len(c.Spec.ClusterNetwork.Pods.CIDRBlocks) == 0 {
-		c.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"172.25.0.0/16"}
+		if c.Spec.Cloud.Kubevirt != nil {
+			c.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"172.26.0.0/16"}
+		} else {
+			c.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"172.25.0.0/16"}
+		}
 	}
 
 	if c.Spec.ClusterNetwork.DNSDomain == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
If k8s cluster that containts KubeVirt was installedby KKP then we have a problem with network collision.
This PR changes the default CIDR for KubeVirt clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Change the default cluster CIDR for KubeVirt cloud provider
```
