### PR TITLE
Allow preset filtering by domains and emails

### DIFF
--- a/pkg/crd/kubermatic/v1/preset.go
+++ b/pkg/crd/kubermatic/v1/preset.go
@@ -107,9 +107,10 @@ type PresetSpec struct {
 	Alibaba      *Alibaba      `json:"alibaba,omitempty"`
 	Anexia       *Anexia       `json:"anexia,omitempty"`
 
-	Fake                *Fake  `json:"fake,omitempty"`
-	RequiredEmailDomain string `json:"requiredEmailDomain,omitempty"`
-	Enabled             *bool  `json:"enabled,omitempty"`
+	Fake                *Fake    `json:"fake,omitempty"`
+	RequiredEmailDomain string   `json:"requiredEmailDomain,omitempty"`
+	RequiredEmails      []string `json:"requiredEmails,omitempty"`
+	Enabled             *bool    `json:"enabled,omitempty"`
 }
 
 func (s *PresetSpec) getProviderValue(providerType ProviderType) reflect.Value {

--- a/pkg/crd/kubermatic/v1/preset.go
+++ b/pkg/crd/kubermatic/v1/preset.go
@@ -107,10 +107,18 @@ type PresetSpec struct {
 	Alibaba      *Alibaba      `json:"alibaba,omitempty"`
 	Anexia       *Anexia       `json:"anexia,omitempty"`
 
-	Fake                *Fake    `json:"fake,omitempty"`
-	RequiredEmailDomain string   `json:"requiredEmailDomain,omitempty"`
-	RequiredEmails      []string `json:"requiredEmails,omitempty"`
-	Enabled             *bool    `json:"enabled,omitempty"`
+	Fake *Fake `json:"fake,omitempty"`
+	// see RequiredEmails
+	RequiredEmailDomain string `json:"requiredEmailDomain,omitempty"`
+	// RequiredEmails: specify emails and domains
+	// RequiredEmailDomain is appended to RequiredEmails for backward compatibility.
+	// e.g.:
+	//   RequiredEmailDomain: "example.com"
+	//   RequiredEmails: ["foo.com", "foo.bar@test.com"]
+	// Result:
+	//   *@example.com, *@foo.com and foo.bar@test.com can use the Preset
+	RequiredEmails []string `json:"requiredEmails,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
 }
 
 func (s *PresetSpec) getProviderValue(providerType ProviderType) reflect.Value {

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -3028,6 +3028,11 @@ func (in *PresetSpec) DeepCopyInto(out *PresetSpec) {
 		*out = new(Fake)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RequiredEmails != nil {
+		in, out := &in.RequiredEmails, &out.RequiredEmails
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Enabled != nil {
 		in, out := &in.Enabled, &out.Enabled
 		*out = new(bool)

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -209,13 +209,18 @@ func filterOutPresets(userInfo *provider.UserInfo, list *kubermaticv1.PresetList
 		if len(requiredEmails) != 0 {
 			userDomain := strings.Split(userInfo.Email, "@")
 			for _, emailItem := range requiredEmails {
-				domain := strings.Split(emailItem, "@")
+				// Special case:
+				//   userDomain = foo@bar@acme.com
+				//     user: foo@bar
+				//     domain: acme.com
+				//   --> take last element: userDomain[len(userDomain)-1]
+				reqEmail := strings.Split(emailItem, "@")
 
 				// if it's a domain, we compare it against the userDomain,
 				// otherwise, it has to match the whole email
-				if len(domain) == 1 {
+				if len(reqEmail) == 1 {
 					// domain provided
-					if len(userDomain) == 2 && strings.EqualFold(userDomain[1], domain[0]) {
+					if len(userDomain) >= 2 && strings.EqualFold(userDomain[len(userDomain)-1], reqEmail[0]) {
 						presetList = append(presetList, preset)
 						break
 					}

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -196,15 +196,42 @@ func filterOutPresets(userInfo *provider.UserInfo, list *kubermaticv1.PresetList
 
 	for _, preset := range list.Items {
 		requiredEmailDomain := preset.Spec.RequiredEmailDomain
-		// find preset for specific email domain
+		// find preset for specific email domain (deprecated)
 		if requiredEmailDomain != "" {
 			userDomain := strings.Split(userInfo.Email, "@")
 			if len(userDomain) == 2 && strings.EqualFold(userDomain[1], requiredEmailDomain) {
 				presetList = append(presetList, preset)
 			}
 		} else {
-			// find preset for "all" without RequiredEmailDomain field
-			presetList = append(presetList, preset)
+			// find preset based on domain and email list
+			// Example: [ "example.com", "foobar@example.com", "foo.bar@test.com"]
+			// --> all "example.com" emails and "foo.bar@test.com" will get the preset
+			requiredEmails := preset.Spec.RequiredEmails
+			if len(requiredEmails) != 0 {
+				userDomain := strings.Split(userInfo.Email, "@")
+				for _, emailItem := range requiredEmails {
+					domain := strings.Split(emailItem, "@")
+
+					// if it's a domain, we compare it against the userDomain,
+					// otherwise, it has to match the whole email
+					if len(domain) == 1 {
+						// domain provided
+						if len(userDomain) == 2 && strings.EqualFold(userDomain[1], domain[0]) {
+							presetList = append(presetList, preset)
+							break
+						}
+					} else {
+						// email provided
+						if strings.EqualFold(userInfo.Email, emailItem) {
+							presetList = append(presetList, preset)
+							break
+						}
+					}
+				}
+			} else {
+				// find preset for "all" without RequiredEmailDomain field
+				presetList = append(presetList, preset)
+			}
 		}
 	}
 	return presetList, nil

--- a/pkg/provider/kubernetes/preset_test.go
+++ b/pkg/provider/kubernetes/preset_test.go
@@ -280,7 +280,7 @@ func TestGetPresets(t *testing.T) {
 			},
 		},
 		{
-			name:     "test 1: get Presets for the all users, not for the specific email group",
+			name:     "test 2: get Presets for the all users, not for the specific email group",
 			userInfo: provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
 				&kubermaticv1.Preset{
@@ -333,6 +333,234 @@ func TestGetPresets(t *testing.T) {
 					Spec: kubermaticv1.PresetSpec{
 						Fake: &kubermaticv1.Fake{
 							Token: "bbbbb",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test 3: get Presets for a specific user",
+			userInfo: provider.UserInfo{Email: "test@example.com"},
+			presets: []ctrlruntimeclient.Object{
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"test@example.com", "pleaseno.org"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"foo@bar.com", "pleaseno.org"},
+						Fake: &kubermaticv1.Fake{
+							Token: "bbbbb",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"foobar@example.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
+						},
+					},
+				},
+			},
+			expected: []kubermaticv1.Preset{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"test@example.com", "pleaseno.org"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test 4: get Presets for a specific user including group mail preset",
+			userInfo: provider.UserInfo{Email: "test@example.com"},
+			presets: []ctrlruntimeclient.Object{
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"test@example.com", "pleaseno.org"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"foo@bar.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "bbbbb",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"example.com", "foobar.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
+						},
+					},
+				},
+			},
+			expected: []kubermaticv1.Preset{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"test@example.com", "pleaseno.org"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"example.com", "foobar.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test 5: get Presets for a specific user including generic preset",
+			userInfo: provider.UserInfo{Email: "test@example.com"},
+			presets: []ctrlruntimeclient.Object{
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"test@example.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"foo@bar.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "bbbbb",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
+						},
+					},
+				},
+			},
+			expected: []kubermaticv1.Preset{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"test@example.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test 6: get Presets for a specific user, requiredEmailDomain precedence",
+			userInfo: provider.UserInfo{Email: "test@example.com"},
+			presets: []ctrlruntimeclient.Object{
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						// RequiredEmailDomain has precedence, such that this will be filtered.
+						RequiredEmailDomain: "foobar.com",
+						RequiredEmails:      []string{"test@example.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmails: []string{"foo@bar.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "bbbbb",
+						},
+					},
+				},
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
+						},
+					},
+				},
+			},
+			expected: []kubermaticv1.Preset{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						Fake: &kubermaticv1.Fake{
+							Token: "abc",
 						},
 					},
 				},

--- a/pkg/provider/kubernetes/preset_test.go
+++ b/pkg/provider/kubernetes/preset_test.go
@@ -515,8 +515,8 @@ func TestGetPresets(t *testing.T) {
 			},
 		},
 		{
-			name:     "test 6: get Presets for a specific user, requiredEmailDomain precedence",
-			userInfo: provider.UserInfo{Email: "test@example.com"},
+			name:     "test 6: get Presets for a specific user - RequiredEmailDomain and RequiredEmails defined",
+			userInfo: provider.UserInfo{Email: "test@foobar.com"},
 			presets: []ctrlruntimeclient.Object{
 				&kubermaticv1.Preset{
 					ObjectMeta: metav1.ObjectMeta{
@@ -554,6 +554,18 @@ func TestGetPresets(t *testing.T) {
 				},
 			},
 			expected: []kubermaticv1.Preset{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmailDomain: "foobar.com",
+						RequiredEmails:      []string{"test@example.com"},
+						Fake: &kubermaticv1.Fake{
+							Token: "aaaaa",
+						},
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-3",


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
It improves the preset filtering but keeps things simple and backwards compatible. 
I introduced RequiredEmails as an option on the preset type. It gives users the possibility to limit certain presets to a list of domains and even on specific emails. Both in parallel. This includes the RequiredEmailDomain functionality but the variable is kept in place for backward compatibility.

The RequiredEmailDomain is appended to RequiredEmails such that both work in parallel and that the backward compatibility is assured. Added tests will take care of that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I added several tests in order to verify the functionality.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Adds support for RequiredEmails for improved presets filtering. RequiredEmailDomain is deprecated and might go away in a future release.
```
