### PR TITLE
Add exclusion for envoyagent interface for Calico IP discovery

### DIFF
--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -14,7 +14,8 @@
 
 # Source: https://docs.projectcalico.org/v3.19/manifests/canal.yaml
 # 1 modification:
-#   - Remove the flexvolume installation as its broken for Flatcar Linux & only required for application policies (Which we don't use.)
+#   - Remove the flexvolume installation as its broken for Flatcar Linux & only required for application policies (Which we don't use).
+#   - Add envoyagent interface to the exclusion list for Calico IP autodetection. 
 {{ if eq .Cluster.CNIPlugin.Type "canal" }}
 {{ if eq .Cluster.CNIPlugin.Version "v3.19" }}
 ---
@@ -3618,6 +3619,11 @@ spec:
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"
+            # Skips envoyagent interface created in scope of Tunneling expose
+            # strategy from IP autodetection.
+            # https://docs.projectcalico.org/networking/ip-autodetection#change-the-autodetection-method
+            - name: IP_AUTODETECTION_METHOD
+              value: "skip-interface=envoyagent"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
**What this PR does / why we need it**:
After updating Canal in #7174, we encountered a regression when Tunneling expose strategy is used. The IP detection mechanism in `calico-node` is detecting the `envoyagent` interface used to tunnel the traffic for the control plane and is failing with the following error:

```
2021-06-15 06:23:59.287 [INFO][9] startup/startup.go 774: Using autodetected IPv4 address on interface envoyagent: 192.168.30.10/32
2021-06-15 06:23:59.287 [INFO][9] startup/startup.go 591: Node IPv4 changed, will check for conflicts
2021-06-15 06:23:59.303 [WARNING][9] startup/startup.go 1135: Calico node 'ip-172-31-87-227.eu-central-1.compute.internal' is already using the IPv4 address 192.168.30.10.
2021-06-15 06:23:59.303 [WARNING][9] startup/startup.go 1347: Terminating
```

This PR fixes this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
