### PR TITLE
Add feature gate to enable Konnectivity service deployment.

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -53,6 +53,11 @@ const (
 
 	// UserClusterMLA if enabled MonitoringLoggingAlerting stack will be deployed with corresponding controller
 	UserClusterMLA = "UserClusterMLA"
+
+	// KonnectivityService enables the deployment of Konnectivity proxy for hte
+	// control plane to cluster communication, instead of relying on the legacy
+	// solution based on OpenVPN.
+	KonnectivityService = "KonnectivityService"
 )
 
 // FeatureGate is map of key=value pairs that enables/disables various features.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -54,7 +54,7 @@ const (
 	// UserClusterMLA if enabled MonitoringLoggingAlerting stack will be deployed with corresponding controller
 	UserClusterMLA = "UserClusterMLA"
 
-	// KonnectivityService enables the deployment of Konnectivity proxy for hte
+	// KonnectivityService enables the deployment of Konnectivity proxy for the
 	// control plane to cluster communication, instead of relying on the legacy
 	// solution based on OpenVPN.
 	KonnectivityService = "KonnectivityService"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a feature gate to be used to enable Konnectivity service deployment instead of OpenVPN.
Partly implements #7114 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I did not implement the default addition of the feature gate for newly created clusters, as this should be done as last step of #6188.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
