### PR TITLE
Move environment variable to skip envoyagent interface to right container

### DIFF
--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -3619,11 +3619,6 @@ spec:
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"
-            # Skips envoyagent interface created in scope of Tunneling expose
-            # strategy from IP autodetection.
-            # https://docs.projectcalico.org/networking/ip-autodetection#change-the-autodetection-method
-            - name: IP_AUTODETECTION_METHOD
-              value: "skip-interface=envoyagent"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
@@ -3685,6 +3680,11 @@ spec:
               value: "false"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            # Skips envoyagent interface created in scope of Tunneling expose
+            # strategy from IP autodetection.
+            # https://docs.projectcalico.org/networking/ip-autodetection#change-the-autodetection-method
+            - name: IP_AUTODETECTION_METHOD
+              value: "skip-interface=envoyagent"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the calico-node interface discovery, the previous attempt failed #7244 because the environment variable was assigned to the wrong container by mistake.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
