### PR TITLE
[release/v2.17] extend RBAC controller for `projectmanagers` group. 

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper_test.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper_test.go
@@ -49,10 +49,16 @@ func TestGenerateVerbsForNamedResources(t *testing.T) {
 			expectedVerbs: []string{"get"},
 			resourceKind:  "",
 		},
+		{
+			name:          "scenario 4: projectmanagers of a project can manage any named resource",
+			groupName:     "projectmanagers-projectID",
+			expectedVerbs: []string{"get", "update", "delete"},
+			resourceKind:  "",
+		},
 
 		// test for Project named resource
 		{
-			name:          "scenario 4: editors of a project cannot delete the project",
+			name:          "scenario 5: editors of a project cannot delete the project",
 			groupName:     "editors-projectID",
 			expectedVerbs: []string{"get", "update"},
 			resourceKind:  "Project",
@@ -60,33 +66,39 @@ func TestGenerateVerbsForNamedResources(t *testing.T) {
 
 		// tests for UserProjectBinding named resource
 		{
-			name:          "scenario 5: owners of a project can interact with UserProjectBinding named resource",
+			name:          "scenario 6: owners of a project can interact with UserProjectBinding named resource",
 			groupName:     "owners-projectID",
 			expectedVerbs: []string{"get", "update", "delete"},
 			resourceKind:  "UserProjectBinding",
 		},
 		{
-			name:          "scenario 6: editors of a project cannot interact with UserProjectBinding named resource",
+			name:          "scenario 7: editors of a project cannot interact with UserProjectBinding named resource",
 			groupName:     "editors-projectID",
 			expectedVerbs: []string{},
 			resourceKind:  "UserProjectBinding",
 		},
 		{
-			name:          "scenario 7: viewers of a project cannot interact with UserProjectBinding named resource",
+			name:          "scenario 8: viewers of a project cannot interact with UserProjectBinding named resource",
 			groupName:     "viewers-projectID",
 			expectedVerbs: []string{},
 			resourceKind:  "UserProjectBinding",
 		},
 		{
-			name:          "scenario 8: viewers of a project cannot interact with ServiceAccount (User) named resource",
+			name:          "scenario 9: viewers of a project cannot interact with ServiceAccount (User) named resource",
 			groupName:     "viewers-projectID",
 			expectedVerbs: []string{},
 			resourceKind:  "User",
 		},
 		{
-			name:          "scenario 8: editors of a project cannot interact with ServiceAccount (User) named resource",
+			name:          "scenario 10: editors of a project cannot interact with ServiceAccount (User) named resource",
 			groupName:     "editors-projectID",
 			expectedVerbs: []string{},
+			resourceKind:  "User",
+		},
+		{
+			name:          "scenario 11: projectmanagers of a project can interact with ServiceAccount (User) named resource",
+			groupName:     "projectmanagers-projectID",
+			expectedVerbs: []string{"get", "update", "delete"},
 			resourceKind:  "User",
 		},
 	}
@@ -171,6 +183,18 @@ func TestGenerateVerbsForResources(t *testing.T) {
 			groupName:     "viewers-projectID",
 			expectedVerbs: []string{},
 			resourceKind:  "User",
+		},
+		{
+			name:          "scenario 11: the projectmanagers can create ServiceAccounts (aka. User) resources",
+			groupName:     "projectmanagers-projectID",
+			expectedVerbs: []string{"create"},
+			resourceKind:  "User",
+		},
+		{
+			name:          "scenario 12: the projectmanagers can create UserProjectBinding resources",
+			groupName:     "projectmanagers-projectID",
+			expectedVerbs: []string{"create"},
+			resourceKind:  "UserProjectBinding",
 		},
 	}
 

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -1254,6 +1254,19 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 						},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:userprojectbindings:projectmanagers",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources: []string{"userprojectbindings"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
 			},
 		},
 
@@ -1516,12 +1529,40 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 						},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							Resources: []string{"secrets"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
 			},
 
 			expectedRolesForMaster: []*rbacv1.Role{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "kubermatic:secrets:owners",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							Resources: []string{"secrets"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
 						Namespace:       "kubermatic",
 						ResourceVersion: "1",
 					},
@@ -1579,11 +1620,39 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 						},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							Resources: []string{"secrets"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
 			},
 			expectedRolesForMaster: []*rbacv1.Role{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "kubermatic:secrets:owners",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							Resources: []string{"secrets"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
 						Namespace:       "kubermatic",
 						ResourceVersion: "1",
 					},
@@ -1767,6 +1836,25 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 						Name:     "kubermatic:secrets:owners",
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
 			},
 			seedClusters:            1,
 			expectedActionsForSeeds: []string{"create"},
@@ -1788,6 +1876,25 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 						Kind:     "Role",
 						Name:     "kubermatic:secrets:owners",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
 					},
 				},
 			},
@@ -1838,8 +1945,55 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 						Name:     "kubermatic:secrets:owners",
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubermatic:secrets:projectmanagers",
+						Namespace: "kubermatic",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-existing-project-1",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
 			},
 			expectedRoleBindingsForMaster: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-existing-project-1",
+						},
+						{
+
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "kubermatic:secrets:owners",
@@ -1875,6 +2029,24 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 			existingRoleBindingsForSeeds: []*rbacv1.RoleBinding{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubermatic:secrets:projectmanagers",
+						Namespace: "kubermatic",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-existing-project-1",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kubermatic:secrets:owners",
 						Namespace: "kubermatic",
 					},
@@ -1893,6 +2065,34 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 				},
 			},
 			expectedRoleBindingsForSeeds: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-existing-project-1",
+						},
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "kubermatic:secrets:owners",
@@ -2068,6 +2268,23 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 			expectedRoleBindingsForMaster: []*rbacv1.RoleBinding{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Subjects: nil,
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:            "kubermatic:secrets:owners",
 						Namespace:       "kubermatic",
 						ResourceVersion: "1",
@@ -2085,6 +2302,24 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 				},
 			},
 			existingRoleBindingsForMaster: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubermatic:secrets:projectmanagers",
+						Namespace: "kubermatic",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-plan9",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kubermatic:secrets:owners",
@@ -2109,6 +2344,23 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 			expectedRoleBindingsForSeeds: []*rbacv1.RoleBinding{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:secrets:projectmanagers",
+						Namespace:       "kubermatic",
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Subjects: nil,
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:            "kubermatic:secrets:owners",
 						Namespace:       "kubermatic",
 						ResourceVersion: "1",
@@ -2126,6 +2378,24 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 				},
 			},
 			existingRoleBindingsForSeeds: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubermatic:secrets:projectmanagers",
+						Namespace: "kubermatic",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-plan9",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secrets:projectmanagers",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kubermatic:secrets:owners",

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -272,6 +272,29 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 			expectedClusterRoles: []*rbacv1.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.SSHKeyResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:usersshkey-abcd:owners-thunderball",
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -340,6 +363,32 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 			},
 
 			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:usersshkey-abcd:projectmanagers-thunderball",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:usersshkey-abcd:owners-thunderball",
@@ -452,6 +501,28 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 			expectedClusterRoles: []*rbacv1.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:userprojectbinding-abcd:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.UserProjectBindingKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.UserProjectBindingResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:userprojectbinding-abcd:owners-thunderball",
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -475,6 +546,32 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 			},
 
 			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:userprojectbinding-abcd:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.UserProjectBindingKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:userprojectbinding-abcd:projectmanagers-thunderball",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:userprojectbinding-abcd:owners-thunderball",
@@ -840,9 +937,59 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 						},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubermatic:secret-abcd:projectmanagers-thunderball",
+						Namespace: "kubermatic",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: k8scorev1.SchemeGroupVersion.String(),
+								Kind:       "Secret",
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{k8scorev1.SchemeGroupVersion.Group},
+							Resources:     []string{"secrets"},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
 			},
 
 			expectedRoleBindings: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubermatic:secret-abcd:projectmanagers-thunderball",
+						Namespace: "kubermatic",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: k8scorev1.SchemeGroupVersion.String(),
+								Kind:       "Secret",
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "kubermatic:secret-abcd:projectmanagers-thunderball",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kubermatic:secret-abcd:owners-thunderball",
@@ -974,6 +1121,32 @@ func TestEnsureProjectClusterRBACRoleBindingForNamedResource(t *testing.T) {
 			projectToSync:   test.CreateProject("thunderball", test.CreateUser("James Bond")),
 			expectedActions: []string{"create", "create", "create"},
 			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:project-thunderball:projectmanagers-thunderball",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
@@ -1142,6 +1315,32 @@ func TestEnsureProjectClusterRBACRoleBindingForNamedResource(t *testing.T) {
 			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:project-thunderball:projectmanagers-thunderball",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -1227,6 +1426,36 @@ func TestEnsureProjectClusterRBACRoleBindingForNamedResource(t *testing.T) {
 			projectToSync:   test.CreateProject("thunderball", test.CreateUser("James Bond")),
 			expectedActions: []string{"update", "update", "update"},
 			existingClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterRoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:project-thunderball:projectmanagers-thunderball",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
@@ -1319,6 +1548,36 @@ func TestEnsureProjectClusterRBACRoleBindingForNamedResource(t *testing.T) {
 				},
 			},
 			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterRoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:project-thunderball:projectmanagers-thunderball",
+					},
+				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
@@ -1467,6 +1726,29 @@ func TestEnsureProjectClusterRBACRoleForNamedResource(t *testing.T) {
 			expectedClusterRoles: []*rbacv1.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"projects"},
+							ResourceNames: []string{"thunderball"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -1608,6 +1890,28 @@ func TestEnsureProjectClusterRBACRoleForNamedResource(t *testing.T) {
 			expectedClusterRoles: []*rbacv1.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"projects"},
+							ResourceNames: []string{"thunderball"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -1679,6 +1983,33 @@ func TestEnsureProjectClusterRBACRoleForNamedResource(t *testing.T) {
 			projectToSync:   test.CreateProject("thunderball", test.CreateUser("James Bond")),
 			expectedActions: []string{"update", "update"},
 			existingClusterRoles: []*rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterRole",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"projects"},
+							ResourceNames: []string{"thunderball"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",
@@ -1761,6 +2092,33 @@ func TestEnsureProjectClusterRBACRoleForNamedResource(t *testing.T) {
 				},
 			},
 			expectedClusterRoles: []*rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterRole",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"projects"},
+							ResourceNames: []string{"thunderball"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:project-thunderball:owners-thunderball",

--- a/pkg/handler/v1/serviceaccount/sa.go
+++ b/pkg/handler/v1/serviceaccount/sa.go
@@ -38,6 +38,7 @@ import (
 var serviceAccountGroupsPrefixes = []string{
 	rbac.EditorGroupNamePrefix,
 	rbac.ViewerGroupNamePrefix,
+	rbac.ProjectManagerGroupNamePrefix,
 }
 
 // CreateEndpoint adds the given service account to the given project


### PR DESCRIPTION
**What this PR does / why we need it**: extend RBAC controller for `projectmanagers` group. The SA user in this group can manage projects and members & service accounts in the projects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7001


```release-note
Add `projectmanagers` group for RBAC controller. The new group will be assigned to service accounts.
```