### PR TITLE
change KKP admin grafana role to Editor

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
@@ -212,7 +212,7 @@ func (r *orgGrafanaController) createGrafanaOrg(ctx context.Context, expected gr
 		if err != nil {
 			return expected, err
 		}
-		if err := addUserToOrg(ctx, r.grafanaClient, expected, &grafanaUser, models.ROLE_ADMIN); err != nil {
+		if err := addUserToOrg(ctx, r.grafanaClient, expected, &grafanaUser, models.ROLE_EDITOR); err != nil {
 			return expected, err
 		}
 

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -145,7 +145,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Admin"}`)),
+					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -223,7 +223,7 @@ func (r *userGrafanaController) ensureGrafanaUser(ctx context.Context, user *kub
 				return err
 			}
 			if grafanaUser.IsGrafanaAdmin {
-				if err := addUserToOrg(ctx, r.grafanaClient, org, grafanaUser, models.ROLE_ADMIN); err != nil {
+				if err := addUserToOrg(ctx, r.grafanaClient, org, grafanaUser, models.ROLE_EDITOR); err != nil {
 					return err
 				}
 			} else {

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -145,7 +145,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Admin"}`)),
+					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed KKP admin Grafana role in other orgs to Editor.
We don't want KKP Admins to have Admin role in others Organization cause in that way they can incidentally change or remove datasources, only MLA controller should manage datasources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7262 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
