### PR TITLE
Revert "disable opa e2e tests temporarily"

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1240,8 +1240,8 @@ presubmits:
   #########################################################
 
   - name: pre-kubermatic-opa-e2e
+    run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
     decorate: true
-    always_run: false
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-digitalocean: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts kubermatic/kubermatic#7242, since #7233 is merged, we can enable OPA tests again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```