### PR TITLE
Fixes network not found issue

### DIFF
--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -52,11 +52,11 @@ const (
 func getSecurityGroups(netClient *gophercloud.ServiceClient, opts ossecuritygroups.ListOpts) ([]ossecuritygroups.SecGroup, error) {
 	page, err := ossecuritygroups.List(netClient, opts).AllPages()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list security groups: %v", err)
+		return nil, fmt.Errorf("failed to list security groups: %w", err)
 	}
 	secGroups, err := ossecuritygroups.ExtractGroups(page)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract security groups: %v", err)
+		return nil, fmt.Errorf("failed to extract security groups: %w", err)
 	}
 	return secGroups, nil
 }

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -98,7 +98,7 @@ func getNetworkByName(netClient *gophercloud.ServiceClient, name string, isExter
 	case 1:
 		return candidates[0], nil
 	case 0:
-		return nil, fmt.Errorf("no network named '%s' with external=%v found", name, isExternal)
+		return nil, fmt.Errorf("network named '%s' with external=%v not found", name, isExternal)
 	default:
 		return nil, fmt.Errorf("found %d networks for name '%s' (external=%v), expected exactly one", len(candidates), name, isExternal)
 	}
@@ -135,7 +135,7 @@ func validateSecurityGroupsExist(netClient *gophercloud.ServiceClient, securityG
 func deleteSecurityGroup(netClient *gophercloud.ServiceClient, sgName string) error {
 	results, err := getSecurityGroups(netClient, ossecuritygroups.ListOpts{Name: sgName})
 	if err != nil {
-		return fmt.Errorf("failed to get security group: %v", err)
+		return fmt.Errorf("failed to get security group: %w", err)
 	}
 
 	for _, sg := range results {
@@ -277,7 +277,7 @@ func createKubermaticNetwork(netClient *gophercloud.ServiceClient, clusterName s
 func deleteNetworkByName(netClient *gophercloud.ServiceClient, networkName string) error {
 	network, err := getNetworkByName(netClient, networkName, false)
 	if err != nil {
-		return fmt.Errorf("failed to get network '%s' by name: %v", networkName, err)
+		return fmt.Errorf("failed to get network '%s' by name: %w", networkName, err)
 	}
 
 	res := osnetworks.Delete(netClient, network.ID)
@@ -468,7 +468,7 @@ func getSubnetForNetwork(netClient *gophercloud.ServiceClient, networkIDOrName s
 }
 
 func isNotFoundErr(err error) bool {
-	if _, ok := err.(gophercloud.ErrDefault404); ok || strings.Contains(err.Error(), "not found") {
+	if _, ok := err.(gophercloud.ErrDefault404); ok || strings.Contains(errors.Unwrap(err).Error(), "not found") {
 		return true
 	}
 	return false

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -468,7 +468,8 @@ func getSubnetForNetwork(netClient *gophercloud.ServiceClient, networkIDOrName s
 }
 
 func isNotFoundErr(err error) bool {
-	if _, ok := err.(gophercloud.ErrDefault404); ok || strings.Contains(errors.Unwrap(err).Error(), "not found") {
+	var errNotFound gophercloud.ErrDefault404
+	if errors.As(err, &errNotFound) || strings.Contains(err.Error(), "not found") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Harshita <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**:
This PR fixes the issue of `failed cloud provider cleanup: failed to delete network 'kubernetes-xxx': failed to get network 'kubernetes-xxx' by name: no network named 'kubernetes-xlkxth9pbp' with external=false found` by wrapping  error and unwrapping it to verify if the error is of kind `not found`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7241 #7112

**Special notes for your reviewer**:
Steps performed to test the changes:
- Create a openstack cluster and delete the network
- Check if the `seed-controller-manager` throws error
- Check if openstack cluster is deleted

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
