### PR TITLE
Default to DockerRegistry only if provided repo has less than 3 parts

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -169,6 +169,9 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		Client:               mgr.GetClient(),
 		dockerPullConfigJSON: []byte("{}"),
 		nodeAccessNetwork:    kubermaticv1.DefaultNodeAccessNetwork,
+		kubermaticImage:      resources.DefaultKubermaticImage,
+		dnatControllerImage:  resources.DefaultDNATControllerImage,
+		etcdLauncherImage:    resources.DefaultEtcdLauncherImage,
 		seedGetter: func() (*kubermaticv1.Seed, error) {
 			return &kubermaticv1.Seed{
 				Spec: kubermaticv1.SeedSpec{

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -333,7 +333,7 @@ func (d *TemplateData) EtcdDiskSize() resource.Quantity {
 func (d *TemplateData) EtcdLauncherImage() string {
 	imageSplit := strings.Split(d.etcdLauncherImage, "/")
 	var registry, imageWithoutRegistry string
-	if len(imageSplit) != 3 {
+	if len(imageSplit) < 3 {
 		registry = RegistryDocker
 		imageWithoutRegistry = strings.Join(imageSplit, "/")
 	} else {
@@ -534,7 +534,7 @@ func (d *TemplateData) NodeLocalDNSCacheEnabled() bool {
 func (d *TemplateData) KubermaticAPIImage() string {
 	apiImageSplit := strings.Split(d.kubermaticImage, "/")
 	var registry, imageWithoutRegistry string
-	if len(apiImageSplit) != 3 {
+	if len(apiImageSplit) < 3 {
 		registry = RegistryDocker
 		imageWithoutRegistry = strings.Join(apiImageSplit, "/")
 	} else {
@@ -551,7 +551,7 @@ func (d *TemplateData) KubermaticDockerTag() string {
 func (d *TemplateData) DNATControllerImage() string {
 	dnatControllerImageSplit := strings.Split(d.dnatControllerImage, "/")
 	var registry, imageWithoutRegistry string
-	if len(dnatControllerImageSplit) != 3 {
+	if len(dnatControllerImageSplit) < 3 {
 		registry = RegistryDocker
 		imageWithoutRegistry = strings.Join(dnatControllerImageSplit, "/")
 	} else {

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -109,3 +109,231 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 		})
 	}
 }
+
+func TestKubermaticAPIImage(t *testing.T) {
+	testCases := []struct {
+		name         string
+		templateData *TemplateData
+		wantAPIImage string
+	}{
+		{
+			name: "default image",
+			templateData: &TemplateData{
+				kubermaticImage: "quay.io/kubermatic/kubermatic",
+			},
+			wantAPIImage: "quay.io/kubermatic/kubermatic",
+		},
+		{
+			name: "default image with overwrite registry",
+			templateData: &TemplateData{
+				kubermaticImage:   "quay.io/kubermatic/kubermatic",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantAPIImage: "custom-registry.kubermatic.io/kubermatic/kubermatic",
+		},
+		{
+			name: "custom image with 2 parts",
+			templateData: &TemplateData{
+				kubermaticImage: "kubermatic/kubermatic",
+			},
+			wantAPIImage: "docker.io/kubermatic/kubermatic",
+		},
+		{
+			name: "custom image with 2 parts with overwrite registry",
+			templateData: &TemplateData{
+				kubermaticImage:   "kubermatic/kubermatic",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantAPIImage: "custom-registry.kubermatic.io/kubermatic/kubermatic",
+		},
+		{
+			name: "custom image with 1 part",
+			templateData: &TemplateData{
+				kubermaticImage: "kubermatic",
+			},
+			wantAPIImage: "docker.io/kubermatic",
+		},
+		{
+			name: "custom image with 1 part with overwrite registry",
+			templateData: &TemplateData{
+				kubermaticImage:   "kubermatic",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantAPIImage: "custom-registry.kubermatic.io/kubermatic",
+		},
+		{
+			name: "custom image with 4 parts",
+			templateData: &TemplateData{
+				kubermaticImage: "registry.kubermatic.io/images/kubermatic/kubermatic",
+			},
+			wantAPIImage: "registry.kubermatic.io/images/kubermatic/kubermatic",
+		},
+		{
+			name: "custom image with 4 parts with overwrite registry",
+			templateData: &TemplateData{
+				kubermaticImage:   "registry.kubermatic.io/images/kubermatic/kubermatic",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantAPIImage: "custom-registry.kubermatic.io/images/kubermatic/kubermatic",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if img := tc.templateData.KubermaticAPIImage(); img != tc.wantAPIImage {
+				t.Errorf("want kubermatic api image %q, but got %q", tc.wantAPIImage, img)
+			}
+		})
+	}
+}
+
+func TestEtcdLauncherImage(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		templateData          *TemplateData
+		wantEtcdLauncherImage string
+	}{
+		{
+			name: "default image",
+			templateData: &TemplateData{
+				etcdLauncherImage: "quay.io/kubermatic/etcd-launcher",
+			},
+			wantEtcdLauncherImage: "quay.io/kubermatic/etcd-launcher",
+		},
+		{
+			name: "default image with overwrite registry",
+			templateData: &TemplateData{
+				etcdLauncherImage: "quay.io/kubermatic/etcd-launcher",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantEtcdLauncherImage: "custom-registry.kubermatic.io/kubermatic/etcd-launcher",
+		},
+		{
+			name: "custom image with 2 parts",
+			templateData: &TemplateData{
+				etcdLauncherImage: "kubermatic/etcd-launcher",
+			},
+			wantEtcdLauncherImage: "docker.io/kubermatic/etcd-launcher",
+		},
+		{
+			name: "custom image with 2 parts with overwrite registry",
+			templateData: &TemplateData{
+				etcdLauncherImage: "kubermatic/etcd-launcher",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantEtcdLauncherImage: "custom-registry.kubermatic.io/kubermatic/etcd-launcher",
+		},
+		{
+			name: "custom image with 1 part",
+			templateData: &TemplateData{
+				etcdLauncherImage: "etcd-launcher",
+			},
+			wantEtcdLauncherImage: "docker.io/etcd-launcher",
+		},
+		{
+			name: "custom image with 1 part with overwrite registry",
+			templateData: &TemplateData{
+				etcdLauncherImage: "etcd-launcher",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantEtcdLauncherImage: "custom-registry.kubermatic.io/etcd-launcher",
+		},
+		{
+			name: "custom image with 4 parts",
+			templateData: &TemplateData{
+				etcdLauncherImage: "registry.kubermatic.io/images/kubermatic/etcd-launcher",
+			},
+			wantEtcdLauncherImage: "registry.kubermatic.io/images/kubermatic/etcd-launcher",
+		},
+		{
+			name: "custom image with 4 parts with overwrite registry",
+			templateData: &TemplateData{
+				etcdLauncherImage: "registry.kubermatic.io/images/kubermatic/etcd-launcher",
+				OverwriteRegistry: "custom-registry.kubermatic.io",
+			},
+			wantEtcdLauncherImage: "custom-registry.kubermatic.io/images/kubermatic/etcd-launcher",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if img := tc.templateData.EtcdLauncherImage(); img != tc.wantEtcdLauncherImage {
+				t.Errorf("want etcd-launcher image %q, but got %q", tc.wantEtcdLauncherImage, img)
+			}
+		})
+	}
+}
+
+func TestDNATControllerImage(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		templateData            *TemplateData
+		wantDNATControllerImage string
+	}{
+		{
+			name: "default image",
+			templateData: &TemplateData{
+				dnatControllerImage: "quay.io/kubermatic/kubeletdnat-controller",
+			},
+			wantDNATControllerImage: "quay.io/kubermatic/kubeletdnat-controller",
+		},
+		{
+			name: "default image with overwrite registry",
+			templateData: &TemplateData{
+				dnatControllerImage: "quay.io/kubermatic/kubeletdnat-controller",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantDNATControllerImage: "custom-registry.kubermatic.io/kubermatic/kubeletdnat-controller",
+		},
+		{
+			name: "custom image with 2 parts",
+			templateData: &TemplateData{
+				dnatControllerImage: "kubermatic/kubeletdnat-controller",
+			},
+			wantDNATControllerImage: "docker.io/kubermatic/kubeletdnat-controller",
+		},
+		{
+			name: "custom image with 2 parts with overwrite registry",
+			templateData: &TemplateData{
+				dnatControllerImage: "kubermatic/kubeletdnat-controller",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantDNATControllerImage: "custom-registry.kubermatic.io/kubermatic/kubeletdnat-controller",
+		},
+		{
+			name: "custom image with 1 part",
+			templateData: &TemplateData{
+				dnatControllerImage: "kubeletdnat-controller",
+			},
+			wantDNATControllerImage: "docker.io/kubeletdnat-controller",
+		},
+		{
+			name: "custom image with 1 part with overwrite registry",
+			templateData: &TemplateData{
+				dnatControllerImage: "kubeletdnat-controller",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantDNATControllerImage: "custom-registry.kubermatic.io/kubeletdnat-controller",
+		},
+		{
+			name: "custom image with 4 parts",
+			templateData: &TemplateData{
+				dnatControllerImage: "registry.kubermatic.io/images/kubermatic/kubeletdnat-controller",
+			},
+			wantDNATControllerImage: "registry.kubermatic.io/images/kubermatic/kubeletdnat-controller",
+		},
+		{
+			name: "custom image with 4 parts with overwrite registry",
+			templateData: &TemplateData{
+				dnatControllerImage: "registry.kubermatic.io/images/kubermatic/kubeletdnat-controller",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantDNATControllerImage: "custom-registry.kubermatic.io/images/kubermatic/kubeletdnat-controller",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if img := tc.templateData.DNATControllerImage(); img != tc.wantDNATControllerImage {
+				t.Errorf("want kubeletdnat-controller image %q, but got %q", tc.wantDNATControllerImage, img)
+			}
+		})
+	}
+}

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -147,21 +147,6 @@ func TestKubermaticAPIImage(t *testing.T) {
 			wantAPIImage: "custom-registry.kubermatic.io/kubermatic/kubermatic",
 		},
 		{
-			name: "custom image with 1 part",
-			templateData: &TemplateData{
-				kubermaticImage: "kubermatic",
-			},
-			wantAPIImage: "docker.io/kubermatic",
-		},
-		{
-			name: "custom image with 1 part with overwrite registry",
-			templateData: &TemplateData{
-				kubermaticImage:   "kubermatic",
-				OverwriteRegistry: "custom-registry.kubermatic.io",
-			},
-			wantAPIImage: "custom-registry.kubermatic.io/kubermatic",
-		},
-		{
 			name: "custom image with 4 parts",
 			templateData: &TemplateData{
 				kubermaticImage: "registry.kubermatic.io/images/kubermatic/kubermatic",
@@ -223,21 +208,6 @@ func TestEtcdLauncherImage(t *testing.T) {
 			wantEtcdLauncherImage: "custom-registry.kubermatic.io/kubermatic/etcd-launcher",
 		},
 		{
-			name: "custom image with 1 part",
-			templateData: &TemplateData{
-				etcdLauncherImage: "etcd-launcher",
-			},
-			wantEtcdLauncherImage: "docker.io/etcd-launcher",
-		},
-		{
-			name: "custom image with 1 part with overwrite registry",
-			templateData: &TemplateData{
-				etcdLauncherImage: "etcd-launcher",
-				OverwriteRegistry: "custom-registry.kubermatic.io",
-			},
-			wantEtcdLauncherImage: "custom-registry.kubermatic.io/etcd-launcher",
-		},
-		{
 			name: "custom image with 4 parts",
 			templateData: &TemplateData{
 				etcdLauncherImage: "registry.kubermatic.io/images/kubermatic/etcd-launcher",
@@ -297,21 +267,6 @@ func TestDNATControllerImage(t *testing.T) {
 				OverwriteRegistry:   "custom-registry.kubermatic.io",
 			},
 			wantDNATControllerImage: "custom-registry.kubermatic.io/kubermatic/kubeletdnat-controller",
-		},
-		{
-			name: "custom image with 1 part",
-			templateData: &TemplateData{
-				dnatControllerImage: "kubeletdnat-controller",
-			},
-			wantDNATControllerImage: "docker.io/kubeletdnat-controller",
-		},
-		{
-			name: "custom image with 1 part with overwrite registry",
-			templateData: &TemplateData{
-				dnatControllerImage: "kubeletdnat-controller",
-				OverwriteRegistry:   "custom-registry.kubermatic.io",
-			},
-			wantDNATControllerImage: "custom-registry.kubermatic.io/kubeletdnat-controller",
 		},
 		{
 			name: "custom image with 4 parts",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the way how we default the registry for Kubermatic API, etcd-launcher, and dnat-controller images.

Currently, we're splitting the provided image by `/` and checking the number of parts:

* if there are 3 parts, use the first element of the slice as the registry
* otherwise, default to `docker.io`

That's causing problems if the provided image has more than 3 parts, for example: `registry/part2/part3/part4/kubermatic-ee`. In that case, KKP will try to use `docker.io/registry/part2/part3/part4/kubermatic-ee` as an image for running UCCM (which is incorrect).

I think that we should default to `docker.io` only in case the number of parts (when split by `/`) is less than 3, otherwise, use the first element of the slice as the registry.

**Special notes for your reviewer**:

I'm not sure is this going to break the backward compatibility for some users. We don't have any unit tests to confirm if this function is going to work as expected. I can work on some unit tests in the meanwhile.

**Does this PR introduce a user-facing change?**:
```release-note
Kubermatic API, etcd-launcher, and dnat-controller images are defaulted to the docker.io registry only if the provided custom image has less than 3 parts
```
