### PR TITLE
Allow configuring remote_write in Prometheus Helm chart

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.3.2
+version: 2.3.3
 appVersion: v2.25.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/config/prometheus.yaml
+++ b/charts/monitoring/prometheus/config/prometheus.yaml
@@ -63,3 +63,10 @@ scrape_configs:
 - {{ . | toJson }}
 {{- end }}
 {{- end }}
+
+{{- if .Values.prometheus.remoteWrite }}
+remote_write:
+{{- range .Values.prometheus.remoteWrite }}
+- {{ . | toJson }}
+{{- end }}
+{{- end }}

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -118,6 +118,11 @@ prometheus:
   #  mountPath: /initech/recordings
   #  secretName: initech-recording-rules-secret
 
+  # Optionally configure remote write from Prometheus instances to given targets.
+  # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+  remoteWrite:
+  #- url: http://host.example.com:12345/api/v1/receive
+
   # Thanos can be used to handle long-term storage of metrics by
   # shipping the data blocks into an object storage like Minio. Note that
   # this is considered EXPERIMENTAL and can be removed or significantly


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Adds an option to configure remote_write in Prometheus Helm chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allow configuring remote_write in Prometheus Helm chart.
```
