### PR TITLE
Exclude user ssh key nil value in the validation webhook

### DIFF
--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -181,11 +181,19 @@ func validateUpdateImmutability(c, oldC *kubermaticv1.Cluster) field.ErrorList {
 		oldC.Spec.ExposeStrategy,
 		specFldPath.Child("exposeStrategy"),
 	)...)
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
-		c.Spec.EnableUserSSHKeyAgent,
-		oldC.Spec.EnableUserSSHKeyAgent,
-		specFldPath.Child("enableUserSSHKeyAgent"),
-	)...)
+
+	if oldC.Spec.EnableUserSSHKeyAgent != nil {
+		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
+			c.Spec.EnableUserSSHKeyAgent,
+			oldC.Spec.EnableUserSSHKeyAgent,
+			specFldPath.Child("enableUserSSHKeyAgent"),
+		)...)
+	} else if c.Spec.EnableUserSSHKeyAgent != nil && !*c.Spec.EnableUserSSHKeyAgent {
+		path := field.NewPath("cluster", "spec", "enableUserSSHKeyAgent")
+		allErrs = append(allErrs, field.Invalid(path, *c.Spec.EnableUserSSHKeyAgent, "UserSSHKey agent is enabled by default "+
+			"for user clusters created prior KKP 2.16 version"))
+
+	}
 
 	allErrs = append(allErrs, validateClusterNetworkingConfigUpdateImmutability(&c.Spec.ClusterNetwork, &oldC.Spec.ClusterNetwork, specFldPath.Child("clusterNetwork"))...)
 	allErrs = append(allErrs, validateComponentSettingsImmutability(&c.Spec.ComponentsOverride, &oldC.Spec.ComponentsOverride, specFldPath.Child("componentsOverride"))...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Exclude the user ssh key agent validation webhook for the cluster which the enabledUserSSHKeyAgent field is nil(migrated from older KKP versions clusters). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7296 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
https://github.com/kubermatic/docs/pull/725

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
