### PR TITLE
fix resource requests and limits setting for seed components

### DIFF
--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -578,15 +578,17 @@ func defaultResources(settings *corev1.ResourceRequirements, defaults corev1.Res
 }
 
 func defaultResourceList(list *corev1.ResourceList, defaults corev1.ResourceList, key string, logger *zap.SugaredLogger) error {
-	if list == nil || *list == nil {
+	if *list == nil {
 		*list = defaults
 		logger.Debugw("Defaulting resource constraints", "field", key, "memory", defaults.Memory(), "cpu", defaults.Cpu())
 		return nil
 	}
 
 	for _, name := range []corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU} {
-		(*list)[name] = defaults[name]
-		logger.Debugw("Defaulting resource constraint", "field", key+"."+name.String(), "value", (*list)[name])
+		if _, ok := (*list)[name]; !ok {
+			(*list)[name] = defaults[name]
+			logger.Debugw("Defaulting resource constraint", "field", key+"."+name.String(), "value", (*list)[name])
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The defaultResourceList() function erroneously always sets only the default values, even if the input list already contained overridden values. This leads to resource requests and limits not being properly transferred from the KubermaticConfiguration to the respective target objects.

For the master components, this problem is masked by https://github.com/kubermatic/kubermatic/blob/38cf6e1ab738d145fe53bb7e2d2ae4decb04bcfb/pkg/controller/operator/master/reconciler.go#L101, which reads the in-cluster KubermaticConfiguration back into "config", but for seed components, most prominently the seed controller manager, you can easily reproduce that it always receives the default resource requests and limits no matter what you set in KubermaticConfiguration.spec.seedController.resources.

Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed seed components resource requests and limits setting via KubermaticConfiguration
```
