### PR TITLE
check if resource quantity is set before apply defaults

### DIFF
--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -585,6 +585,11 @@ func defaultResourceList(list *corev1.ResourceList, defaults corev1.ResourceList
 	}
 
 	for _, name := range []corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU} {
+		quantity := (*list)[name]
+		if !quantity.IsZero() {
+			continue
+		}
+
 		(*list)[name] = defaults[name]
 		logger.Debugw("Defaulting resource constraint", "field", key+"."+name.String(), "value", (*list)[name])
 	}


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6995


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix a bug that always applies default values to container resources 
```
