### PR TITLE
Delete flatcar update operator if flatcar nodes are not schedulable.

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -61,7 +61,8 @@ func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv
 	}
 
 	predicate := predicateutil.Factory(func(o ctrlruntimeclient.Object) bool {
-		return o.GetLabels()[nodelabelerapi.DistributionLabelKey] == nodelabelerapi.FlatcarLabelValue
+		node := o.(*corev1.Node)
+		return o.GetLabels()[nodelabelerapi.DistributionLabelKey] == nodelabelerapi.FlatcarLabelValue && !node.Spec.Unschedulable
 	})
 
 	return c.Watch(&source.Kind{Type: &corev1.Node{}}, controllerutil.EnqueueConst(""), predicate)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR attempts to delete flatcar update operator deployment if no flatcar nodes are available.
This is needed because if a cluster changes the nodes OSs there will still be flatcar controllers pending in the cluster.

**Special notes for your reviewer**:

### How to review

- Test cluster creation with flatcar.

- Create a new node deployment with a different OS in the cluster and delete the initial node deployment.

- Check if flatcar update operator does not exist after the procedure.

```release-note
Delete flatcar update operator if flatcar nodes are not schedulable
```