### PR TITLE
Allow to specify sidecars in Alertmanager Helm Chart

### DIFF
--- a/charts/monitoring/alertmanager/Chart.yaml
+++ b/charts/monitoring/alertmanager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: alertmanager
-version: 2.0.14
+version: 2.0.15
 appVersion: v0.21.0
 description: Alertmanager for Kubermatic
 keywords:

--- a/charts/monitoring/alertmanager/templates/service.yaml
+++ b/charts/monitoring/alertmanager/templates/service.yaml
@@ -22,6 +22,16 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
+{{- if .Values.alertmanager.sidecarServicePorts }}
+{{- range $name, $spec :=  .Values.alertmanager.sidecarServicePorts }}
+  - name: {{ $name }}
+    {{- if kindIs "string" $spec }}
+      {{- tpl $spec $ | nindent 4 }}
+    {{- else }}
+      {{- toYaml $spec | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}
   - name: web
     port: 9093
     protocol: TCP

--- a/charts/monitoring/alertmanager/templates/statefulset.yaml
+++ b/charts/monitoring/alertmanager/templates/statefulset.yaml
@@ -32,6 +32,16 @@ spec:
         app: {{ template "name" . }}
     spec:
       containers:
+  {{- if .Values.alertmanager.sidecarContainers }}
+    {{- range $name, $spec :=  .Values.alertmanager.sidecarContainers }}
+      - name: {{ $name }}
+        {{- if kindIs "string" $spec }}
+          {{- tpl $spec $ | nindent 8 }}
+        {{- else }}
+          {{- toYaml $spec | nindent 8 }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
       - name: alertmanager
         image: '{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.version | default .Values.alertmanager.image.tag }}'
         imagePullPolicy: {{ .Values.alertmanager.image.pullPolicy }}

--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -13,6 +13,27 @@
 # limitations under the License.
 
 alertmanager:
+  sidecarContainers:
+    prom-label-proxy:
+      args:
+        - -enable-label-apis
+        - -label=tenant_id
+        - -upstream=http://127.0.0.1:9093
+        - -insecure-listen-address=0.0.0.0:8080
+        - -header=X-Scope-OrgID
+      image: aborilov/prom-label-proxy:latest
+      # image: quay.io/prometheuscommunity/prom-label-proxy:master
+      imagePullPolicy: Always
+      ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
   image:
     repository: quay.io/prometheus/alertmanager
     tag: v0.21.0

--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -13,27 +13,6 @@
 # limitations under the License.
 
 alertmanager:
-  sidecarContainers:
-    prom-label-proxy:
-      args:
-        - -enable-label-apis
-        - -label=tenant_id
-        - -upstream=http://127.0.0.1:9093
-        - -insecure-listen-address=0.0.0.0:8080
-        - -header=X-Scope-OrgID
-      image: aborilov/prom-label-proxy:latest
-      # image: quay.io/prometheuscommunity/prom-label-proxy:master
-      imagePullPolicy: Always
-      ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - ALL
-        readOnlyRootFilesystem: true
   image:
     repository: quay.io/prometheus/alertmanager
     tag: v0.21.0


### PR DESCRIPTION
to be able to add prom-label-proxy as sidecar to alertmanager we need to add generic support of sidecar containers to alertmanager charts

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allow to specify sidecars in Alertmanager Helm Chart
```
