### PR TITLE
Add ClusterFeatureCCMClusterName feature for OpenStack clusters

### DIFF
--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -198,6 +198,10 @@ const (
 	// not be set if its not supported.
 	ClusterFeatureExternalCloudProvider = "externalCloudProvider"
 
+	// ClusterFeatureCCMClusterName sets the cluster-name flag on the external CCM deployment.
+	// The cluster-name flag is often used for naming cloud resources, such as load balancers.
+	ClusterFeatureCCMClusterName = "ccmClusterName"
+
 	// ClusterFeatureRancherIntegration enables the rancher server integration feature.
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.
 	ClusterFeatureRancherIntegration = "rancherIntegration"

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -191,6 +191,9 @@ func CreateEndpoint(ctx context.Context, projectID string, body apiv1.CreateClus
 
 	if cloudcontroller.ExternalCloudControllerFeatureSupported(dc, partialCluster) {
 		partialCluster.Spec.Features = map[string]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}
+		if cloudcontroller.ExternalCloudControllerClusterName(partialCluster) {
+			partialCluster.Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] = true
+		}
 	}
 
 	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -19,6 +19,7 @@ package cloudcontroller
 import (
 	"fmt"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
@@ -133,6 +134,9 @@ func getOSFlags(data *resources.TemplateData) []string {
 		"--v=1",
 		"--cloud-config=/etc/kubernetes/cloud/config",
 		"--cloud-provider=openstack",
+	}
+	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] {
+		flags = append(flags, "--cluster-name", data.Cluster().Name)
 	}
 	return flags
 }

--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -25,7 +25,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ExternalCloudControllerFeatureSupported checks if the
+// ExternalCloudControllerFeatureSupported checks if the cloud provider supports
+// external CCM.
 func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluster *kubermaticv1.Cluster) bool {
 	switch {
 	case cluster.Spec.Cloud.Openstack != nil:
@@ -46,6 +47,17 @@ func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluste
 	case cluster.Spec.Cloud.Hetzner != nil:
 		return dc.Spec.Hetzner.Network != "" && cluster.Spec.Version.Minor() >= 18
 
+	default:
+		return false
+	}
+}
+
+// ExternalCloudControllerClusterName checks if the ClusterFeatureCCMClusterName is supported
+// for the cloud provider.
+func ExternalCloudControllerClusterName(cluster *kubermaticv1.Cluster) bool {
+	switch {
+	case cluster.Spec.Cloud.Openstack != nil:
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a cluster feature called `ccmClusterName`, which is used to apply the `--cluster-name` flag on the external CCMs. Currently, this flag is only applied on the OpenStack CCM. In the future, it will be applied for the other cloud providers that support the external CCM as well.

The `--cluster-name` flag is often used for naming cloud resources, such as Load Balancers. If it's not provided, the CCM would default it to `kubernetes`.

Not providing the `cluster-name` flag can cause conflicts as described in issue #7229.

It's not possible to easily change this flag for the existing user clusters, as it can cause the external CCM to lose track of the existing cloud resources. Therefore, we're introducing a feature flag with the following behavior:

* if it's enabled, add the `--cluster-name` flag on the external CCM deployment
* enable the flag by default for newly created clusters
* allow users to explicitly enable this flag for the existing clusters
  * in this case, it's up to the user to clean up any leftover resources
  * in the future, we might implement a migration mechanism that would automatically clean up leftover resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7332

**Does this PR introduce a user-facing change?**:
```release-note
Add ClusterFeatureCCMClusterName feature for OpenStack clusters. This feature adds the --cluster-name flag to the OpenStack external CCM deployment. The feature gate is enabled by default for newly created clusters. Enabling this feature gate for existing clusters can cause the external CCM to lose the track of the existing cloud resources, so it's up to the users to clean up any leftover resources.
```

/assign @kron4eg 