### PR TITLE
Exclude user ssh key nil value in the validation webhook

### DIFF
--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -167,9 +167,14 @@ func (h *AdmissionHandler) rejectUserSSHKeyAgentChanges(ctx context.Context, clu
 			return fmt.Errorf("failed to fetch cluster name=%s: %v", cluster.Name, err)
 		}
 
-		if !reflect.DeepEqual(oldCluster.Spec.EnableUserSSHKeyAgent, cluster.Spec.EnableUserSSHKeyAgent) {
-			return errors.New("enableUserSSHKeyAgent field cannot be updated after cluster creation")
+		if oldCluster.Spec.EnableUserSSHKeyAgent != nil {
+			if !reflect.DeepEqual(oldCluster.Spec.EnableUserSSHKeyAgent, cluster.Spec.EnableUserSSHKeyAgent) {
+				return errors.New("enableUserSSHKeyAgent field cannot be updated after cluster creation")
+			}
+		} else if cluster.Spec.EnableUserSSHKeyAgent != nil && !*cluster.Spec.EnableUserSSHKeyAgent {
+			return errors.New("UserSSHKey agent is enabled by default for user clusters created prior KKP 2.16 version")
 		}
+
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Exclude the user ssh key agent validation webhook for the cluster which the enabledUserSSHKeyAgent field is nil(migrated from older KKP versions clusters).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/kubermatic/issues/7296
**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
https://github.com/kubermatic/docs/pull/725

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
