### PR TITLE
define namespace for dex pods in oauth chart

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.5.4
+version: 1.5.5
 appVersion: v2.27.0
 description: Dex
 keywords:

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -19,7 +19,9 @@ dex:
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec
-  env: []
+  env:
+    - name: KUBERNETES_POD_NAMESPACE
+      value: oauth
   #  - name: HTTP_PROXY
   #    value: "http://USER:PASSWORD@IPADDR:PORT"
   #  - name: HTTPS_PROXY

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -21,7 +21,9 @@ dex:
   # this list is directly handed to the container spec
   env:
     - name: KUBERNETES_POD_NAMESPACE
-      value: oauth
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
   #  - name: HTTP_PROXY
   #    value: "http://USER:PASSWORD@IPADDR:PORT"
   #  - name: HTTPS_PROXY


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7051

**Special notes for your reviewer**:
Original PR: https://github.com/kubermatic/kubermatic/pull/7083 by @ewallat 

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Explicitly set the namespace for Dex pods in the oauth chart. This fixes the problem with KKP installation failing on Kubernetes 1.21 clusters.
```
