### PR TITLE
Save forceRestart annotation in correct place

### DIFF
--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -539,10 +539,10 @@ func RestartMachineDeployment(ctx context.Context, userInfoGetter provider.UserI
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	if machineDeployment.Annotations == nil {
-		machineDeployment.Annotations = map[string]string{}
+	if machineDeployment.Spec.Template.Annotations == nil {
+		machineDeployment.Spec.Template.Annotations = map[string]string{}
 	}
-	machineDeployment.Annotations[kubermaticv1.ForceRestartAnnotation] = strconv.FormatInt(time.Now().UnixNano(), 10)
+	machineDeployment.Spec.Template.Annotations[kubermaticv1.ForceRestartAnnotation] = strconv.FormatInt(time.Now().UnixNano(), 10)
 
 	if err := client.Update(ctx, machineDeployment); err != nil {
 		return nil, fmt.Errorf("failed to update machine deployment: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**: Previously I've used wrong field. This time it should be correct: https://docs.kubermatic.com/kubeone/master/cheat_sheets/rollout_machinedeployment/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Required for https://github.com/kubermatic/dashboard/pull/3491.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
