### PR TITLE
add controller for cluster templates

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -26,6 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addoninstaller"
 	backupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/backup"
 	cloudcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
+	clustertemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-template-controller"
 	seedconstraintsynchronizer "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/constraint-controller"
 	constrainttemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/constraint-template-controller"
 	etcdbackupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdbackup"
@@ -67,6 +68,7 @@ var AllControllers = map[string]controllerCreator{
 	constrainttemplatecontroller.ControllerName:   createConstraintTemplateController,
 	initialmachinedeployment.ControllerName:       createInitialMachineDeploymentController,
 	mla.ControllerName:                            createMLAController,
+	clustertemplatecontroller.ControllerName:      createClusterTemplateController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -425,6 +427,16 @@ func userClusterMLAEnabled(ctrlCtx *controllerContext) bool {
 func createConstraintController(ctrlCtx *controllerContext) error {
 	return seedconstraintsynchronizer.Add(
 		ctrlCtx.ctx,
+		ctrlCtx.mgr,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.namespace,
+		ctrlCtx.runOptions.workerCount,
+	)
+}
+
+func createClusterTemplateController(ctrlCtx *controllerContext) error {
+	return clustertemplatecontroller.Add(
 		ctrlCtx.mgr,
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerName,

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2216,6 +2216,8 @@ const (
 	ClusterTemplateSeedCleanupFinalizer = "kubermatic.io/cleanup-seed-cluster-template"
 	// WhitelistedRegistryCleanupFinalizer indicates that whitelisted registry Constraints need to be cleaned up
 	WhitelistedRegistryCleanupFinalizer = "kubermatic.io/cleanup-whitelisted-registry"
+	// ClusterTemplateSeedCleanupFinalizer indicates that cluster template instance on seed clusters need cleanup
+	SeedClusterTemplateInstanceFinalizer = "kubermatic.io/cleanup-seed-cluster-template-instance"
 )
 
 func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType {

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -200,7 +200,9 @@ func clusterTemplateCreatorGetter(template *kubermaticv1.ClusterTemplate) reconc
 			c.Name = template.Name
 			c.Spec = template.Spec
 			c.Labels = template.Labels
-
+			c.Annotations = template.Annotations
+			c.InheritedClusterLabels = template.InheritedClusterLabels
+			c.Credential = template.Credential
 			return c, nil
 		}
 	}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"sort"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -36,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 	"sort"
 
-	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -37,7 +34,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -125,7 +124,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) reconcile(ctx context.Context, instance *kubermaticv1.ClusterTemplateInstance, log *zap.SugaredLogger) error {
-
+	var remove = true
+	var add = false
 	clusterTemplateLabelSelector := ctrlruntimeclient.MatchingLabels{kubernetes.ClusterTemplateInstanceLabelKey: instance.Name}
 
 	clusterList := &kubermaticv1.ClusterList{}
@@ -139,7 +139,7 @@ func (r *reconciler) reconcile(ctx context.Context, instance *kubermaticv1.Clust
 			return nil
 		}
 
-		if err := r.patchFinalizer(ctx, instance, true); err != nil {
+		if err := r.patchFinalizer(ctx, instance, remove); err != nil {
 			return err
 		}
 
@@ -148,7 +148,7 @@ func (r *reconciler) reconcile(ctx context.Context, instance *kubermaticv1.Clust
 
 	// initialization
 	if !kuberneteshelper.HasFinalizer(instance, finalizer) {
-		if err := r.patchFinalizer(ctx, instance, false); err != nil {
+		if err := r.patchFinalizer(ctx, instance, add); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustertemplatecontroller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"go.uber.org/zap"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "cluster_template_controller"
+
+	finalizer = kubermaticapiv1.SeedClusterTemplateInstanceFinalizer
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	workerName              string
+	recorder                record.EventRecorder
+	namespace               string
+	seedClient              ctrlruntimeclient.Client
+}
+
+func Add(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	namespace string,
+	numWorkers int) error {
+
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %v", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		workerName:              workerName,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		namespace:               namespace,
+		seedClient:              mgr.GetClient(),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %v", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.ClusterTemplateInstance{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch for seed cluster template instance: %v", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Cluster{}},
+		enqueueClusterTemplateInstances(reconciler.seedClient, reconciler.log),
+		workerlabel.Predicates(workerName),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for clusters: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles the kubermatic cluster template instance in the seed cluster
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+
+	log := r.log.With("request", request)
+	log.Debug("Reconciling")
+
+	instance := &kubermaticv1.ClusterTemplateInstance{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, instance); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get cluster template instance %s: %w", instance.Name, ctrlruntimeclient.IgnoreNotFound(err))
+	}
+
+	err := r.reconcile(ctx, instance, log)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Eventf(instance, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+
+}
+
+func (r *reconciler) reconcile(ctx context.Context, instance *kubermaticv1.ClusterTemplateInstance, log *zap.SugaredLogger) error {
+
+	clusterTemplateLabelSelector := ctrlruntimeclient.MatchingLabels{kubernetes.ClusterTemplateInstanceLabelKey: instance.Name}
+
+	clusterList := &kubermaticv1.ClusterList{}
+	if err := r.seedClient.List(ctx, clusterList, &ctrlruntimeclient.ListOptions{LabelSelector: r.workerNameLabelSelector}, clusterTemplateLabelSelector); err != nil {
+		return fmt.Errorf("failed listing clusters: %w", err)
+	}
+
+	// deletion
+	if !instance.DeletionTimestamp.IsZero() {
+		if !kuberneteshelper.HasFinalizer(instance, finalizer) {
+			return nil
+		}
+
+		if err := r.patchFinalizer(ctx, instance, true); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// initialization
+	if !kuberneteshelper.HasFinalizer(instance, finalizer) {
+		if err := r.patchFinalizer(ctx, instance, false); err != nil {
+			return err
+		}
+	}
+
+	nc := len(clusterList.Items)
+	currentNumberOfClusters := int64(nc)
+	desiredNumberOfClusters := instance.Spec.Replicas
+
+	switch {
+	case currentNumberOfClusters == desiredNumberOfClusters:
+		return nil
+	case currentNumberOfClusters > desiredNumberOfClusters:
+		toDelete := currentNumberOfClusters - desiredNumberOfClusters
+		if err := r.deleteClusters(ctx, clusterList, toDelete, log); err != nil {
+			log.Errorf("failed to delete clusters %v", err)
+			return err
+		}
+	case currentNumberOfClusters < desiredNumberOfClusters:
+		toCreate := desiredNumberOfClusters - currentNumberOfClusters
+		if err := r.createClusters(ctx, instance, toCreate, currentNumberOfClusters, log); err != nil {
+			log.Errorf("failed to create clusters %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *reconciler) patchFinalizer(ctx context.Context, instance *kubermaticv1.ClusterTemplateInstance, remove bool) error {
+	oldInstance := instance.DeepCopy()
+
+	kuberneteshelper.AddFinalizer(instance, finalizer)
+
+	if remove {
+		kuberneteshelper.RemoveFinalizer(instance, finalizer)
+	}
+
+	if err := r.seedClient.Patch(ctx, instance, ctrlruntimeclient.MergeFrom(oldInstance)); err != nil {
+		return fmt.Errorf("failed to update cluster template instance %s finalizer: %v", instance.Name, err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) deleteClusters(ctx context.Context, clusterList *kubermaticv1.ClusterList, numberOfClusters int64, log *zap.SugaredLogger) error {
+	log.Debugf("delete %d clusters", numberOfClusters)
+	if numberOfClusters > 0 {
+		clusters := []*kubermaticv1.Cluster{}
+
+		for _, cluster := range clusterList.Items {
+			clusters = append(clusters, cluster.DeepCopy())
+		}
+		// delete always with the highest index
+		sortClustersByIndexedName(clusters)
+
+		for index, cluster := range clusters {
+			if err := r.seedClient.Delete(ctx, cluster); err != nil {
+				return err
+			}
+			if int64(index+1) == numberOfClusters {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func sortClustersByIndexedName(clusters []*kubermaticv1.Cluster) {
+	sort.SliceStable(clusters, func(i, j int) bool {
+		mi, mj := clusters[i], clusters[j]
+		return mi.Spec.HumanReadableName > mj.Spec.HumanReadableName
+	})
+}
+
+func (r *reconciler) createClusters(ctx context.Context, instance *kubermaticv1.ClusterTemplateInstance, numberOfClusters, index int64, log *zap.SugaredLogger) error {
+
+	log.Debugf("create clusters from template %s, number of clusters: %d", instance.Spec.ClusterTemplateID, numberOfClusters)
+
+	template := &kubermaticv1.ClusterTemplate{}
+	if err := r.seedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: instance.Spec.ClusterTemplateID}, template); err != nil {
+		return fmt.Errorf("failed to get template %s: %w", instance.Spec.ClusterTemplateID, err)
+	}
+
+	// This is temporary cluster with cloud spec from the template.
+	// It holds credential for the new cluster
+	partialCluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: template.Name,
+		},
+	}
+	partialCluster.Spec = template.Spec
+
+	for i := 0; i < int(numberOfClusters); i++ {
+
+		newCluster := genNewCluster(template, instance, r.workerName, int(index)+i)
+
+		// Here partialCluster is used to copy credentials to the new cluster
+		err := resources.CopyCredentials(resources.NewCredentialsData(context.Background(), partialCluster, r.seedClient), newCluster)
+		if err != nil {
+			return fmt.Errorf("failed to get credentials: %v", err)
+		}
+		if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster); err != nil {
+			return err
+		}
+		kuberneteshelper.AddFinalizer(newCluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
+
+		if err := r.seedClient.Create(ctx, newCluster); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func genNewCluster(template *kubermaticv1.ClusterTemplate, instance *kubermaticv1.ClusterTemplateInstance, workerName string, index int) *kubermaticv1.Cluster {
+
+	newCluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        rand.String(10),
+			Labels:      template.ClusterLabels,
+			Annotations: template.Annotations,
+		},
+		Status: kubermaticv1.ClusterStatus{},
+	}
+
+	if newCluster.Labels == nil {
+		newCluster.Labels = map[string]string{}
+	}
+
+	if len(workerName) > 0 {
+		newCluster.Labels[kubermaticv1.WorkerNameLabelKey] = workerName
+	}
+	newCluster.Labels[kubermaticv1.ProjectIDLabelKey] = instance.Spec.ProjectID
+	newCluster.Labels[kubernetes.ClusterTemplateInstanceLabelKey] = instance.Name
+	newCluster.Spec = template.Spec
+
+	newCluster.Spec.HumanReadableName = fmt.Sprintf("%s-%d", newCluster.Spec.HumanReadableName, index)
+	newCluster.Status.UserEmail = template.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey]
+
+	return newCluster
+}
+
+func enqueueClusterTemplateInstances(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		instanceList := &kubermaticv1.ClusterTemplateInstanceList{}
+
+		if err := client.List(context.Background(), instanceList); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list cluster template instances: %v", err))
+		}
+
+		for _, instance := range instanceList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: instance.Name,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustertemplatecontroller
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcile(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+	seedNamespace := "namespace"
+
+	testCases := []struct {
+		name                 string
+		namespacedName       types.NamespacedName
+		expectedClusters     []*kubermaticv1.Cluster
+		expectedGetErrStatus metav1.StatusReason
+		seedClient           ctrlruntimeclient.Client
+	}{
+		{
+			name: "scenario 1: generates new clusters according to the template instance object",
+			namespacedName: types.NamespacedName{
+				Name: "my-first-project-ID-ctID2",
+			},
+			expectedClusters: []*kubermaticv1.Cluster{
+				genCluster("ct2-0", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+				genCluster("ct2-1", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+				genCluster("ct2-2", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+			},
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(
+					test.GenClusterTemplate("ct1", "ctID1", test.GenDefaultProject().Name, kubermaticv1.UserClusterTemplateScope, test.GenDefaultAPIUser().Email),
+					test.GenClusterTemplate("ct2", "ctID2", "", kubermaticv1.GlobalClusterTemplateScope, "john@acme.com"),
+					test.GenClusterTemplate("ct3", "ctID3", test.GenDefaultProject().Name, kubermaticv1.UserClusterTemplateScope, "john@acme.com"),
+					test.GenClusterTemplate("ct4", "ctID4", test.GenDefaultProject().Name, kubermaticv1.ProjectClusterTemplateScope, "john@acme.com"),
+					test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID1", 2),
+					test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3),
+					test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID3", 10),
+				).
+				Build(),
+		},
+
+		{
+			name: "scenario 2: shrank number of clusters from 3 to 1",
+			namespacedName: types.NamespacedName{
+				Name: "my-first-project-ID-ctID2",
+			},
+			expectedClusters: []*kubermaticv1.Cluster{
+				genCluster("ct2-0", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+			},
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(
+					test.GenClusterTemplate("ct1", "ctID1", test.GenDefaultProject().Name, kubermaticv1.UserClusterTemplateScope, test.GenDefaultAPIUser().Email),
+					test.GenClusterTemplate("ct2", "ctID2", "", kubermaticv1.GlobalClusterTemplateScope, "john@acme.com"),
+					test.GenClusterTemplate("ct3", "ctID3", test.GenDefaultProject().Name, kubermaticv1.UserClusterTemplateScope, "john@acme.com"),
+					test.GenClusterTemplate("ct4", "ctID4", test.GenDefaultProject().Name, kubermaticv1.ProjectClusterTemplateScope, "john@acme.com"),
+					test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID1", 2),
+					test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 1),
+					test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID3", 10),
+					genCluster("ct2-0", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+					genCluster("ct2-1", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+					genCluster("ct2-2", "john@acme.com", *test.GenClusterTemplateInstance(test.GenDefaultProject().Name, "ctID2", 3)),
+				).
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				namespace:               seedNamespace,
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				seedClient:              tc.seedClient,
+			}
+
+			request := reconcile.Request{NamespacedName: tc.namespacedName}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			clusterTemplateLabelSelector := ctrlruntimeclient.MatchingLabels{kubernetes.ClusterTemplateInstanceLabelKey: tc.namespacedName.Name}
+			clusters := &kubermaticv1.ClusterList{}
+			err = tc.seedClient.List(ctx, clusters, clusterTemplateLabelSelector)
+
+			if tc.expectedGetErrStatus != "" {
+				if err == nil {
+					t.Fatalf("expected error status %v", tc.expectedGetErrStatus)
+				}
+				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed get constraint: %v", err)
+			}
+
+			// remove autogenerated name
+			clusterList := []*kubermaticv1.Cluster{}
+			for _, cluster := range clusters.Items {
+				modifiedCluster := cluster.DeepCopy()
+				modifiedCluster.Name = ""
+				clusterList = append(clusterList, modifiedCluster)
+			}
+			expectedClusterList := []*kubermaticv1.Cluster{}
+			for _, cluster := range tc.expectedClusters {
+				modifiedCluster := cluster.DeepCopy()
+				modifiedCluster.Name = ""
+				expectedClusterList = append(expectedClusterList, modifiedCluster)
+			}
+
+			sortClusters(clusterList)
+			sortClusters(expectedClusterList)
+			if !reflect.DeepEqual(clusterList, expectedClusterList) {
+				t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(clusterList, expectedClusterList))
+			}
+
+		})
+	}
+}
+
+func sortClusters(clusters []*kubermaticv1.Cluster) {
+	sort.SliceStable(clusters, func(i, j int) bool {
+		mi, mj := clusters[i], clusters[j]
+		return mi.Spec.HumanReadableName < mj.Spec.HumanReadableName
+	})
+}
+
+func genCluster(name, userEmail string, instance kubermaticv1.ClusterTemplateInstance) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Labels:          map[string]string{kubermaticv1.ProjectIDLabelKey: instance.Spec.ProjectID, kubernetes.ClusterTemplateInstanceLabelKey: instance.Name},
+			ResourceVersion: "1",
+			Finalizers:      []string{kubermaticapiv1.CredentialsSecretsCleanupFinalizer},
+			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail},
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			HumanReadableName: name,
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: "fake-dc",
+				Fake:           &kubermaticv1.FakeCloudSpec{},
+			},
+		},
+		Status: kubermaticv1.ClusterStatus{
+			UserEmail: userEmail,
+		},
+	}
+}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package clustertemplatecontroller contains a controller that is responsible for managing cluster template instances.
+According to this the controller creates, updates, and deletes clusters from the template.
+*/
+package clustertemplatecontroller

--- a/pkg/provider/kubernetes/cluster_template_instance.go
+++ b/pkg/provider/kubernetes/cluster_template_instance.go
@@ -29,7 +29,10 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const ClusterTemplateLabelKey = "template-id"
+const (
+	ClusterTemplateLabelKey         = "template-id"
+	ClusterTemplateInstanceLabelKey = "template-instance-id"
+)
 
 // AlertmanagerProvider struct that holds required components in order to manage alertmanager objects.
 type ClusterTemplateInstanceProvider struct {

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -186,6 +186,95 @@ func GetCredentials(data CredentialsData) (Credentials, error) {
 	return credentials, err
 }
 
+func CopyCredentials(data CredentialsData, cluster *kubermaticv1.Cluster) error {
+	credentials := Credentials{}
+	var err error
+
+	if data.Cluster().Spec.Cloud.AWS != nil {
+		if credentials.AWS, err = GetAWSCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.AWS.AccessKeyID = credentials.AWS.AccessKeyID
+		cluster.Spec.Cloud.AWS.SecretAccessKey = credentials.AWS.SecretAccessKey
+	}
+	if data.Cluster().Spec.Cloud.Azure != nil {
+		if credentials.Azure, err = GetAzureCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Azure.TenantID = credentials.Azure.TenantID
+		cluster.Spec.Cloud.Azure.ClientID = credentials.Azure.ClientID
+		cluster.Spec.Cloud.Azure.ClientSecret = credentials.Azure.ClientSecret
+		cluster.Spec.Cloud.Azure.SubscriptionID = credentials.Azure.SubscriptionID
+	}
+	if data.Cluster().Spec.Cloud.Digitalocean != nil {
+		if credentials.Digitalocean, err = GetDigitaloceanCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Digitalocean.Token = credentials.Digitalocean.Token
+	}
+	if data.Cluster().Spec.Cloud.GCP != nil {
+		if credentials.GCP, err = GetGCPCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.GCP.ServiceAccount = credentials.GCP.ServiceAccount
+	}
+	if data.Cluster().Spec.Cloud.Hetzner != nil {
+		if credentials.Hetzner, err = GetHetznerCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Hetzner.Token = credentials.Hetzner.Token
+	}
+	if data.Cluster().Spec.Cloud.Openstack != nil {
+		if credentials.Openstack, err = GetOpenstackCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Openstack.Token = credentials.Openstack.Token
+		cluster.Spec.Cloud.Openstack.TenantID = credentials.Openstack.TenantID
+		cluster.Spec.Cloud.Openstack.Tenant = credentials.Openstack.Tenant
+		cluster.Spec.Cloud.Openstack.Domain = credentials.Openstack.Domain
+		cluster.Spec.Cloud.Openstack.ApplicationCredentialID = credentials.Openstack.ApplicationCredentialID
+		cluster.Spec.Cloud.Openstack.ApplicationCredentialSecret = credentials.Openstack.ApplicationCredentialSecret
+		cluster.Spec.Cloud.Openstack.Password = credentials.Openstack.Password
+		cluster.Spec.Cloud.Openstack.Username = credentials.Openstack.Username
+
+	}
+	if data.Cluster().Spec.Cloud.Packet != nil {
+		if credentials.Packet, err = GetPacketCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Packet.ProjectID = credentials.Packet.ProjectID
+		cluster.Spec.Cloud.Packet.APIKey = credentials.Packet.APIKey
+	}
+	if data.Cluster().Spec.Cloud.Kubevirt != nil {
+		if credentials.Kubevirt, err = GetKubevirtCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Kubevirt.Kubeconfig = credentials.Kubevirt.KubeConfig
+	}
+	if data.Cluster().Spec.Cloud.VSphere != nil {
+		if credentials.VSphere, err = GetVSphereCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.VSphere.Username = credentials.VSphere.Username
+		cluster.Spec.Cloud.VSphere.Password = credentials.VSphere.Password
+	}
+	if data.Cluster().Spec.Cloud.Alibaba != nil {
+		if credentials.Alibaba, err = GetAlibabaCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Alibaba.AccessKeyID = credentials.Alibaba.AccessKeyID
+		cluster.Spec.Cloud.Alibaba.AccessKeySecret = credentials.Alibaba.AccessKeySecret
+	}
+	if data.Cluster().Spec.Cloud.Anexia != nil {
+		if credentials.Anexia, err = GetAnexiaCredentials(data); err != nil {
+			return err
+		}
+		cluster.Spec.Cloud.Anexia.Token = credentials.Anexia.Token
+	}
+
+	return nil
+}
+
 func GetAWSCredentials(data CredentialsData) (AWSCredentials, error) {
 	spec := data.Cluster().Spec.Cloud.AWS
 	awsCredentials := AWSCredentials{}


### PR DESCRIPTION
**What this PR does / why we need it**: add a controller for cluster templates. This controller monitors cluster template instances and creates/deletes the user clusters depends on the number of replicas

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7319


```release-note
Templates for cluster creation
```
