### PR TITLE
fix DeepEqual method for different types

### DIFF
--- a/pkg/crd/equality/semantic.go
+++ b/pkg/crd/equality/semantic.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	"time"
+
+	semverlib "github.com/Masterminds/semver/v3"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"k8s.io/apimachinery/pkg/conversion"
+)
+
+// Semantic can do semantic deep equality checks for objects.
+// Example: equality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var Semantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		return a.Cmp(b) == 0
+	},
+	func(a, b *semverlib.Version) bool {
+		return a.Compare(b) == 0
+	},
+	func(a, b time.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+)

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -19,15 +19,13 @@ package reconciling
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/go-test/deep"
 	"go.uber.org/zap"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	k8cequality "k8c.io/kubermatic/v2/pkg/crd/equality"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -40,17 +38,8 @@ func init() {
 
 // DeepEqual compares both objects for equality
 func DeepEqual(a, b metav1.Object) bool {
-	// The ClusterTemplate consist with ClusterSpec which has nested Semver type.
-	// The semverlib.Version doesn't implement Equality function. Using equality.Semantic.DeepEqual for this object cause
-	// an informative panic.
-	if _, ok := a.(*kubermaticv1.ClusterTemplate); ok {
-		if reflect.DeepEqual(a, b) {
-			return true
-		}
-	} else {
-		if equality.Semantic.DeepEqual(a, b) {
-			return true
-		}
+	if k8cequality.Semantic.DeepEqual(a, b) {
+		return true
 	}
 
 	// For some reason unstructured objects returned from the api have types for their fields

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -24,8 +24,10 @@ import (
 	"github.com/go-test/deep"
 	"go.uber.org/zap"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -38,8 +40,17 @@ func init() {
 
 // DeepEqual compares both objects for equality
 func DeepEqual(a, b metav1.Object) bool {
-	if reflect.DeepEqual(a, b) {
-		return true
+	// The ClusterTemplate consist with ClusterSpec which has nested Semver type.
+	// The semverlib.Version doesn't implement Equality function. Using equality.Semantic.DeepEqual for this object cause
+	// an informative panic.
+	if _, ok := a.(*kubermaticv1.ClusterTemplate); ok {
+		if reflect.DeepEqual(a, b) {
+			return true
+		}
+	} else {
+		if equality.Semantic.DeepEqual(a, b) {
+			return true
+		}
 	}
 
 	// For some reason unstructured objects returned from the api have types for their fields


### PR DESCRIPTION
**What this PR does / why we need it**: fix DeepEqual method for different types

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7386

```release-note
NONE
```
