### PR TITLE
Add option to specify initContainer in promtail chart

### DIFF
--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: "v1"
 name: promtail
-version: 0.2.0
+version: 0.2.1
 appVersion: v2.1.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:

--- a/charts/logging/promtail/templates/daemonset.yaml
+++ b/charts/logging/promtail/templates/daemonset.yaml
@@ -49,6 +49,18 @@ spec:
     {{- if .Values.promtail.priorityClassName }}
       priorityClassName: {{ .Values.promtail.priorityClassName }}
     {{- end }}
+      {{- if .Values.promtail.initContainer.enabled }}
+      initContainers:
+        - name: init
+          image: "{{ .Values.promtail.initContainer.image.registry }}/{{ .Values.promtail.initContainer.image.repository }}:{{ .Values.promtail.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.promtail.initContainer.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - sysctl -w fs.inotify.max_user_instances={{ .Values.promtail.initContainer.fsInotifyMaxUserInstances }}
+          securityContext:
+            privileged: true
+      {{- end }}
       containers:
         - name: promtail
           image: "{{ .Values.promtail.image.repository }}:{{ .Values.promtail.image.tag }}"

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -25,6 +25,21 @@ promtail:
     servicePort: 3100
     serviceScheme: http
 
+  initContainer:
+    # -- Specifies whether the init container for setting inotify max user instances is to be enabled
+    enabled: false
+    image:
+      # -- The Docker registry for the init container
+      registry: docker.io
+      # -- Docker image repository for the init container
+      repository: busybox
+      # -- Docker tag for the init container
+      tag: 1.33
+      # -- Docker image pull policy for the init container image
+      pullPolicy: IfNotPresent
+    # -- The inotify max user instances to configure
+    fsInotifyMaxUserInstances: 128
+
   nodeSelector: {}
   affinity: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds option to specify initContainer to override inotify max user instances for promtail chart.

We observed that if we restart containerd (needed to update custom CA certificates) on worker nodes, some worker nodes become unstable as kubelet fails to start back after containerd restart. We zeroed it down to below error in kubelet logs:

`Jul 12 04:32:16 worker-695bffcf55-thznv kubelet[1885829]: F0712 04:32:16.087835 1885829 kubelet.go:1352] Failed to start cAdvisor inotify_init: too many open files`

Upon investigation, it revealed that the maximum files were open by promtail on this node.

So following the official promtail upstream chart, I am proposing to add option to add a initContainer which will allow me to specify non-default inotify max_user_sessions value which will allow containerd restart without promtail getting in the way. [Original pull req for promtail chart](https://github.com/grafana/loki/pull/1620)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
NA

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add option to specify initContainer to override inotify max user instances for promtail chart.
```