### PR TITLE
Apiserver network policies

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -191,6 +191,12 @@ func main() {
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",
 			},
+			{
+				ResourceName:       "NetworkPolicy",
+				ResourceNamePlural: "NetworkPolicies",
+				ImportAlias:        "networkingv1",
+				ResourceImportPath: "k8s.io/api/networking/v1",
+			},
 		},
 	}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -409,6 +409,8 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 		apiserver.DNSAllowCreator(c),
 		apiserver.EctdAllowCreator(c),
 		apiserver.OpenVPNServerAllowCreator(c),
+		apiserver.MachineControllerWebhookCreator(c),
+		apiserver.MetricsServerAllowCreator(c),
 	}
 	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, c.Status.NamespaceName, r.Client); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %v", err)

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -406,7 +406,7 @@ func (r *Reconciler) ensureClusterRoleBindings(ctx context.Context, c *kubermati
 func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.Cluster) error {
 	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
 		apiserver.DenyAllPolicyCreator(),
-		apiserver.DnsAllowCreator(c),
+		apiserver.DNSAllowCreator(c),
 		apiserver.EctdAllowCreator(c),
 		apiserver.OpenVPNServerAllowCreator(c),
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -410,7 +410,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 		apiserver.EctdAllowCreator(c),
 		apiserver.OpenVPNServerAllowCreator(c),
 	}
-	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, "", r.Client); err != nil {
+	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, c.Status.NamespaceName, r.Client); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %v", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -404,16 +404,18 @@ func (r *Reconciler) ensureClusterRoleBindings(ctx context.Context, c *kubermati
 }
 
 func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.Cluster) error {
-	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
-		apiserver.DenyAllPolicyCreator(),
-		apiserver.DNSAllowCreator(c),
-		apiserver.EctdAllowCreator(c),
-		apiserver.OpenVPNServerAllowCreator(c),
-		apiserver.MachineControllerWebhookCreator(c),
-		apiserver.MetricsServerAllowCreator(c),
-	}
-	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, c.Status.NamespaceName, r.Client); err != nil {
-		return fmt.Errorf("failed to ensure Network Policies: %v", err)
+	if c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] {
+		namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
+			apiserver.DenyAllPolicyCreator(),
+			apiserver.DNSAllowCreator(c),
+			apiserver.EctdAllowCreator(c),
+			apiserver.OpenVPNServerAllowCreator(c),
+			apiserver.MachineControllerWebhookCreator(c),
+			apiserver.MetricsServerAllowCreator(c),
+		}
+		if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, c.Status.NamespaceName, r.Client); err != nil {
+			return fmt.Errorf("failed to ensure Network Policies: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -213,6 +213,10 @@ const (
 	// ClusterFeatureEtcdLauncher enables features related to the experimental etcd-launcher. This includes user-cluster
 	// etcd scaling, automatic volume recovery and new backup/restore contorllers.
 	ClusterFeatureEtcdLauncher = "etcdLauncher"
+
+	// ApiserverNetworkPolicy enables the deployment of network policies that
+	// restrict the egress traffic from Apiserver pods.
+	ApiserverNetworkPolicy = "apiserverNetworkPolicy"
 )
 
 // ClusterConditionType is used to indicate the type of a cluster condition. For all condition

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -151,3 +151,67 @@ func OpenVPNServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 		}
 	}
 }
+
+func MachineControllerWebhookCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "machine-controller-webhook-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: "machine-controller-webhook",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}
+
+func MetricsServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "metrics-server-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: "metrics-server",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DenyAllPolicyCreator returns a func to create/update the apiserver
+// deny all egress policy.
+func DenyAllPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "default-deny-all-egress", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{},
+			}
+
+			return np, nil
+		}
+	}
+}
+
+// EtcdAllowCreator returns a func to create/update the apiserver
+// deny all egress policy.
+func EctdAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "etcd-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: "etcd",
+										"cluster":             c.Status.NamespaceName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}
+
+// DnsAllowCreator returns a func to create/update the apiserver
+// deny all egress policy.
+func DnsAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "dns-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: "dns-resolver",
+										"cluster":             c.Status.NamespaceName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}
+
+// OpenVPNServerAllowCreator returns a func to create/update the apiserver
+// deny all egress policy.
+func OpenVPNServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "openvpn-server-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: "openvpn-server",
+										"cluster":             c.Status.NamespaceName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -82,9 +82,9 @@ func EctdAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCre
 	}
 }
 
-// DnsAllowCreator returns a func to create/update the apiserver
+// DNSAllowCreator returns a func to create/update the apiserver
 // deny all egress policy.
-func DnsAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+func DNSAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return "dns-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -68,7 +68,7 @@ func EctdAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCre
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										resources.AppLabelKey: "etcd",
-										"cluster":             c.Status.NamespaceName,
+										"cluster":             c.ObjectMeta.Name,
 									},
 								},
 							},
@@ -103,7 +103,7 @@ func DNSAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCrea
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										resources.AppLabelKey: "dns-resolver",
-										"cluster":             c.Status.NamespaceName,
+										"cluster":             c.ObjectMeta.Name,
 									},
 								},
 							},
@@ -138,7 +138,7 @@ func OpenVPNServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										resources.AppLabelKey: "openvpn-server",
-										"cluster":             c.Status.NamespaceName,
+										"cluster":             c.ObjectMeta.Name,
 									},
 								},
 							},

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -142,6 +142,11 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) {
 		}
 	}
 
+	// Network policies for Apiserver are deployed by default
+	if ok, _ := c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
+		c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] = true
+	}
+
 	if c.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled == nil {
 		c.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled = pointer.BoolPtr(true)
 	}

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -144,6 +144,9 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) {
 
 	// Network policies for Apiserver are deployed by default
 	if ok, _ := c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
+		if c.Spec.Features == nil {
+			c.Spec.Features = map[string]bool{}
+		}
 		c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] = true
 	}
 

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -143,7 +143,7 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) {
 	}
 
 	// Network policies for Apiserver are deployed by default
-	if ok, _ := c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
+	if _, ok := c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
 		if c.Spec.Features == nil {
 			c.Spec.Features = map[string]bool{}
 		}

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -193,6 +193,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/diskSize", "1G"),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/prometheus/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
 			},
 		},
 		{
@@ -399,6 +400,9 @@ func TestHandle(t *testing.T) {
 							},
 							NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 								IPVS: &kubermaticv1.IPVSConfiguration{},
+							},
+							Features: map[string]bool{
+								kubermaticv1.ApiserverNetworkPolicy: true,
 							},
 						}.Do(),
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the deployment of NetworkPolicies to constraint the egress traffic of KAS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
It applies to newly created clusters, the feature can be activated on old clusters by adding the feature gate to the `Cluster` resource. The same feature gate can be used to disable reconciliation of the `NetworkPolicies`, which have to be manually deleted in case of need.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add Apiserver network policy.
```
