### PR TITLE
Fix prometheus chart to allow flux2 post-render

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.3.6
+version: 2.3.7
 appVersion: v2.25.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/templates/role.yaml
+++ b/charts/monitoring/prometheus/templates/role.yaml
@@ -49,6 +49,7 @@ rules:
   - list
   - watch
 
+{{ if and (ne .Release.Namespace "default") (ne .Release.Namespace "kube-system") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -67,3 +68,5 @@ rules:
   - get
   - list
   - watch
+
+{{- end }}

--- a/charts/monitoring/prometheus/templates/role.yaml
+++ b/charts/monitoring/prometheus/templates/role.yaml
@@ -54,6 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
 rules:
 - apiGroups:
   - ""

--- a/charts/monitoring/prometheus/templates/rolebinding.yaml
+++ b/charts/monitoring/prometheus/templates/rolebinding.yaml
@@ -46,6 +46,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/monitoring/prometheus/templates/rolebinding.yaml
+++ b/charts/monitoring/prometheus/templates/rolebinding.yaml
@@ -41,6 +41,7 @@ subjects:
   name: '{{ template "name" . }}'
   namespace: '{{ .Release.Namespace }}'
 
+{{- if and (ne .Release.Namespace "default") (ne .Release.Namespace "kube-system") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -54,3 +55,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: '{{ template "name" . }}'
+
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
Adds missing namespace metadata to `Role` and `RoleBinding` in prometheus chart to fix Flux2 post-rendering.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7424

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix helm post-rendering problems within monitoring/prometheus chart due to duplicate resource definitions.
```
