### PR TITLE
Fix cluster list endpoint and improve error codes

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -246,7 +246,7 @@ func GenerateCluster(ctx context.Context, projectID string, body apiv1.CreateClu
 	return partialCluster, nil
 }
 
-func GetExternalClusters(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID string) ([]*apiv1.Cluster, error) {
+func GetClusters(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID string) ([]*apiv1.Cluster, error) {
 	project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, projectID, nil)
 	if err != nil {
 		return nil, err
@@ -261,7 +261,17 @@ func GetExternalClusters(ctx context.Context, userInfoGetter provider.UserInfoGe
 		return nil, err
 	}
 
-	return convertInternalClustersToExternal(clusters.Items, adminUserInfo, seedsGetter)
+	apiClusters := make([]*apiv1.Cluster, len(clusters.Items))
+	for i, internalCluster := range clusters.Items {
+		_, dc, err := provider.DatacenterFromSeedMap(adminUserInfo, seedsGetter, internalCluster.Spec.Cloud.DatacenterName)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		apiClusters[i] = ConvertInternalClusterToExternal(internalCluster.DeepCopy(), dc, true)
+	}
+
+	return apiClusters, nil
 }
 
 // GetCluster returns the cluster for a given request
@@ -828,18 +838,6 @@ func updateAndDeleteClusterForRegularUser(ctx context.Context, userInfoGetter pr
 		return common.KubernetesErrorToHTTPError(err)
 	}
 	return nil
-}
-
-func convertInternalClustersToExternal(internalClusters []kubermaticv1.Cluster, adminUserInfo *provider.UserInfo, seedsGetter provider.SeedsGetter) ([]*apiv1.Cluster, error) {
-	apiClusters := make([]*apiv1.Cluster, len(internalClusters))
-	for index, cluster := range internalClusters {
-		_, dc, err := provider.DatacenterFromSeedMap(adminUserInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
-		if err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
-		}
-		apiClusters[index] = ConvertInternalClusterToExternal(cluster.DeepCopy(), dc, true)
-	}
-	return apiClusters, nil
 }
 
 func createNewCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, privilegedClusterProvider provider.PrivilegedClusterProvider, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -261,8 +261,8 @@ func GetClusters(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 		return nil, err
 	}
 
-	apiClusters := make([]*apiv1.Cluster, len(clusters.Items))
-	for i, internalCluster := range clusters.Items {
+	apiClusters := make([]*apiv1.Cluster, 0, len(clusters.Items))
+	for _, internalCluster := range clusters.Items {
 		_, dc, err := provider.DatacenterFromSeedMap(adminUserInfo, seedsGetter, internalCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			// Ignore 403 errors and omit clusters with not accessible datacenters in the result.
@@ -272,7 +272,7 @@ func GetClusters(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		apiClusters[i] = ConvertInternalClusterToExternal(internalCluster.DeepCopy(), dc, true)
+		apiClusters = append(apiClusters, ConvertInternalClusterToExternal(internalCluster.DeepCopy(), dc, true))
 	}
 
 	return apiClusters, nil

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -265,6 +265,10 @@ func GetClusters(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 	for i, internalCluster := range clusters.Items {
 		_, dc, err := provider.DatacenterFromSeedMap(adminUserInfo, seedsGetter, internalCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
+			// Ignore 403 errors and omit clusters with not accessible datacenters in the result.
+			if asserted, ok := err.(errors.HTTPError); ok && asserted.StatusCode() == http.StatusForbidden {
+				continue
+			}
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -79,7 +79,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(ListReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
-		apiClusters, err := handlercommon.GetExternalClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID)
+		apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -105,7 +105,7 @@ func ListAllEndpoint(projectProvider provider.ProjectProvider, privilegedProject
 				klog.Errorf("failed to create cluster provider for seed %s: %v", seed.Name, err)
 				continue
 			}
-			apiClusters, err := handlercommon.GetExternalClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID)
+			apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v1/cluster/cluster_test.go
+++ b/pkg/handler/v1/cluster/cluster_test.go
@@ -761,9 +761,9 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 9a: rejected an attempt to create a cluster in email-restricted datacenter - legacy single domain restriction with requiredEmailDomains",
 			Body:             `{"cluster":{"name":"keen-snyder","spec":{"version":"1.15.0","cloud":{"fake":{"token":"dummy_token"},"dc":"restricted-fake-dc"}}}}`,
-			ExpectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc\" not found"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"cannot access restricted-fake-dc datacenter due to email domain requirements"}}`,
 			RewriteClusterID: false,
-			HTTPStatus:       http.StatusNotFound,
+			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
@@ -773,9 +773,9 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 9b: rejected an attempt to create a cluster in email-restricted datacenter - domain array restriction with `requiredEmailDomains`",
 			Body:             `{"cluster":{"name":"keen-snyder","spec":{"version":"1.15.0","cloud":{"fake":{"token":"dummy_token"},"dc":"restricted-fake-dc2"}}}}`,
-			ExpectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc2\" not found"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"cannot access restricted-fake-dc2 datacenter due to email domain requirements"}}`,
 			RewriteClusterID: false,
-			HTTPStatus:       http.StatusNotFound,
+			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),

--- a/pkg/handler/v2/cluster/cluster.go
+++ b/pkg/handler/v2/cluster/cluster.go
@@ -76,7 +76,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 				klog.Errorf("failed to create cluster provider for seed %s: %v", seed.Name, err)
 				continue
 			}
-			apiClusters, err := handlercommon.GetExternalClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID)
+			apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -134,9 +134,9 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 9a: rejected an attempt to create a cluster in email-restricted datacenter - legacy single domain restriction with requiredEmailDomains",
 			Body:             `{"cluster":{"name":"keen-snyder","spec":{"version":"1.15.0","cloud":{"fake":{"token":"dummy_token"},"dc":"restricted-fake-dc"}}}}`,
-			ExpectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc\" not found"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"cannot access restricted-fake-dc datacenter due to email domain requirements"}}`,
 			RewriteClusterID: false,
-			HTTPStatus:       http.StatusNotFound,
+			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
@@ -146,9 +146,9 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 9b: rejected an attempt to create a cluster in email-restricted datacenter - domain array restriction with `requiredEmailDomains`",
 			Body:             `{"cluster":{"name":"keen-snyder","spec":{"version":"1.15.0","cloud":{"fake":{"token":"dummy_token"},"dc":"restricted-fake-dc2"}}}}`,
-			ExpectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc2\" not found"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"cannot access restricted-fake-dc2 datacenter due to email domain requirements"}}`,
 			RewriteClusterID: false,
-			HTTPStatus:       http.StatusNotFound,
+			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),

--- a/pkg/provider/conversions.go
+++ b/pkg/provider/conversions.go
@@ -25,9 +25,11 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
-// DatacenterFromSeedMap is needed because the cloud providers are initialized once during startup and get all DCs.
-// We need to change the cloud providers to by dynamically initialized when needed instead once we support datacenters
-// as CRDs.
+// DatacenterFromSeedMap returns datacenter from the seed:datacenter map.
+//
+// It is needed because the cloud providers are initialized once during startup and get all DCs. We need to change
+// the cloud providers to by dynamically initialized when needed instead once we support datacenters as CRDs.
+//
 // TODO: Find a way to lift the current requirement of unique datacenter names. It is needed only because we put
 // 	 the datacenter name in the cluster object but not the seed name.
 func DatacenterFromSeedMap(userInfo *UserInfo, seedsGetter SeedsGetter, datacenterName string) (*kubermaticv1.Seed, *kubermaticv1.Datacenter, error) {
@@ -36,22 +38,25 @@ func DatacenterFromSeedMap(userInfo *UserInfo, seedsGetter SeedsGetter, datacent
 		return nil, nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
 
-	var datacenters []kubermaticv1.Datacenter
+	var matchingDatacenters []kubermaticv1.Datacenter
+	var matchingSeeds []*kubermaticv1.Seed
 	for _, seed := range seeds {
 		if dc, exists := seed.Spec.Datacenters[datacenterName]; exists {
-			datacenters = append(datacenters, dc)
+			matchingDatacenters = append(matchingDatacenters, dc)
+			matchingSeeds = append(matchingSeeds, seed)
 		}
 	}
 
-	if len(datacenters) == 0 {
+	if len(matchingDatacenters) == 0 {
 		return nil, nil, errors.New(http.StatusNotFound, fmt.Sprintf("datacenter %q not found", datacenterName))
 	}
 
-	if count := len(datacenters); count > 1 {
+	if count := len(matchingDatacenters); count > 1 {
 		return nil, nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("expected to find exactly one datacenter with name %q, got %d", datacenterName, count))
 	}
 
-	matchingDatacenter := datacenters[0]
+	matchingDatacenter := matchingDatacenters[0]
+	matchingSeed := matchingSeeds[0]
 
 	if !userInfo.IsAdmin {
 		emailDomain, err := getUserEmailDomain(userInfo)
@@ -60,12 +65,11 @@ func DatacenterFromSeedMap(userInfo *UserInfo, seedsGetter SeedsGetter, datacent
 		}
 
 		if !canAccessDatacenter(matchingDatacenter, emailDomain) {
-			return nil, nil, errors.New(http.StatusUnauthorized, fmt.Sprintf("cannot access %s datacenter due to email domain requirements", datacenterName))
+			return nil, nil, errors.New(http.StatusForbidden, fmt.Sprintf("cannot access %s datacenter due to email domain requirements", datacenterName))
 		}
 	}
 
-	// TODO: Get seed.
-	return nil, &matchingDatacenter, nil
+	return matchingSeed, &matchingDatacenter, nil
 }
 
 // canAccessDatacenter returns information if user with provided email domain can access given datacenter


### PR DESCRIPTION
**What this PR does / why we need it**: At the moment when user doesn't have access to at least one of the datacenters that are used by the clusters, error will be returned. After this change problematic clusters will be filtered out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubermatic/dashboard/issues/2866

**Does this PR introduce a user-facing change?**:
```release-note
Fix cluster list endpoint that was returning errors when user didn't have access to at least one cluster datacenter.
```
