### PR TITLE
add extra args support to prometheus chart

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.3.4
+version: 2.3.5
 appVersion: v2.25.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -18,7 +18,7 @@ kind: StatefulSet
 metadata:
   name: '{{ template "name" . }}'
 spec:
-  replicas: 2
+  replicas: {{ .Values.prometheus.replicas }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -104,6 +104,9 @@ spec:
             --web.enable-admin-api \
             {{- end }}
             --web.external-url=https://{{ .Values.prometheus.host | trim }}
+            {{- range $key, $value := .Values.prometheus.extraArgs }}
+            --{{ $key }}={{ $value }}
+            {{- end }}
           {{- end }}
         ports:
         - containerPort: 9090

--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -86,6 +86,9 @@ spec:
             --web.enable-lifecycle \
             --web.external-url=https://{{ .Values.prometheus.host | trim }} \
             --web.enable-admin-api
+          {{- range $key, $value := .Values.prometheus.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
           {{- else }}
           echo "Starting Prometheus..."
           exec /bin/prometheus \

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -128,6 +128,10 @@ prometheus:
   remoteWrite:
   #- url: http://host.example.com:12345/api/v1/receive
 
+  ## Additional Prometheus server container arguments
+  ##
+  extraArgs: {}
+
   # Thanos can be used to handle long-term storage of metrics by
   # shipping the data blocks into an object storage like Minio. Note that
   # this is considered EXPERIMENTAL and can be removed or significantly

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 prometheus:
+  replicas: 2
   image:
     repository: quay.io/prometheus/prometheus
     tag: v2.25.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an option to configure extra args in Prometheus Helm chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allow configuring extra args in Prometheus Helm chart.
```
