### PR TITLE
[promtail] kubelet log capturing and kubernetes event capturing

### DIFF
--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: "v1"
 name: promtail
-version: 0.2.1
+version: 0.2.2
 appVersion: v2.1.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:

--- a/charts/logging/promtail/templates/daemonset.yaml
+++ b/charts/logging/promtail/templates/daemonset.yaml
@@ -83,6 +83,9 @@ spec:
           - name: pods
             mountPath: /var/log/pods
             readOnly: true
+          {{- with .Values.promtail.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           env:
           - name: HOSTNAME
             valueFrom:
@@ -121,3 +124,6 @@ spec:
         - name: pods
           hostPath:
             path: /var/log/pods
+        {{- with .Values.promtail.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -27,7 +27,7 @@ promtail:
 
   initContainer:
     # -- Specifies whether the init container for setting inotify max user instances is to be enabled
-    enabled: false
+    enabled: true
     image:
       # -- The Docker registry for the init container
       registry: docker.io
@@ -38,7 +38,7 @@ promtail:
       # -- Docker image pull policy for the init container image
       pullPolicy: IfNotPresent
     # -- The inotify max user instances to configure
-    fsInotifyMaxUserInstances: 128
+    fsInotifyMaxUserInstances: 256
 
   nodeSelector: {}
   affinity: {}
@@ -288,6 +288,41 @@ promtail:
         - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
         - __meta_kubernetes_pod_container_name
         target_label: __path__
+    - job_name: kubelet-journal-logs
+      journal:
+        path: /var/log/journal
+        max_age: 12h
+        labels:
+          job: systemd-journal
+      pipeline_stages:
+      - match:
+          selector: '{unit="kubelet.service"}'
+      relabel_configs:
+        - source_labels: ['__journal__systemd_unit']
+          target_label: 'unit'
+        - source_labels: ['__journal__hostname']
+          target_label: 'hostname'
+    - job_name: kubernetes-events
+      pipeline_stages:
+      - docker:
+      - match:
+          selector: '{app="eventrouter"}'
+          stages:
+          - json:
+              expressions:
+                namespace: event.metadata.namespace
+          - labels:
+              namespace: ""
+
+  extraVolumes:
+    - name: journal
+      hostPath:
+        path: /var/log/journal
+
+  extraVolumeMounts:
+    - name: journal
+      mountPath: /var/log/journal
+      readOnly: true
 
   tolerations:
   - key: node-role.kubernetes.io/master


### PR DESCRIPTION
**What this PR does / why we need it**:
* kubelet log capturing and kubernetes event capturing only if [eventrouter](https://github.com/heptiolabs/eventrouter) is installed)
* Also marks initContainer for promtail to be enabled by default and marks no of inotify instances to 256 as default as we observed that this has positive impact on worker machines's stable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
