### PR TITLE
Stop assigning availability  set unconditionally

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -16352,6 +16352,10 @@
       "type": "object",
       "title": "AzureCloudSpec specifies access credentials to Azure cloud.",
       "properties": {
+        "assignAvailabilitySet": {
+          "type": "boolean",
+          "x-go-name": "AssignAvailabilitySet"
+        },
         "availabilitySet": {
           "type": "string",
           "x-go-name": "AvailabilitySet"
@@ -16412,6 +16416,11 @@
         "size"
       ],
       "properties": {
+        "assignAvailabilitySet": {
+          "description": "AssignAvailabilitySet is used to check if an availability set should be created and assigned to the cluster.",
+          "type": "boolean",
+          "x-go-name": "AssignAvailabilitySet"
+        },
         "assignPublicIP": {
           "description": "should the machine have a publicly accessible IP address",
           "type": "boolean",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1322,6 +1322,8 @@ type AzureNodeSpec struct {
 	// ImageID represents the ID of the image that should be used to run the node
 	// required: false
 	ImageID string `json:"imageID"`
+	// AssignAvailabilitySet is used to check if an availability set should be created adn assigned to the cluster.
+	AssignAvailabilitySet bool `json:"assignAvailabilitySet"`
 }
 
 func (spec *AzureNodeSpec) MarshalJSON() ([]byte, error) {
@@ -1336,21 +1338,23 @@ func (spec *AzureNodeSpec) MarshalJSON() ([]byte, error) {
 	}
 
 	res := struct {
-		Size           string            `json:"size"`
-		AssignPublicIP bool              `json:"assignPublicIP"`
-		Tags           map[string]string `json:"tags,omitempty"`
-		OSDiskSize     int32             `json:"osDiskSize"`
-		DataDiskSize   int32             `json:"dataDiskSize"`
-		Zones          []string          `json:"zones"`
-		ImageID        string            `json:"imageID"`
+		Size                  string            `json:"size"`
+		AssignPublicIP        bool              `json:"assignPublicIP"`
+		Tags                  map[string]string `json:"tags,omitempty"`
+		OSDiskSize            int32             `json:"osDiskSize"`
+		DataDiskSize          int32             `json:"dataDiskSize"`
+		Zones                 []string          `json:"zones"`
+		ImageID               string            `json:"imageID"`
+		AssignAvailabilitySet bool              `json:"assignAvailabilitySet"`
 	}{
-		Size:           spec.Size,
-		AssignPublicIP: spec.AssignPublicIP,
-		Tags:           spec.Tags,
-		OSDiskSize:     spec.OSDiskSize,
-		DataDiskSize:   spec.DataDiskSize,
-		Zones:          spec.Zones,
-		ImageID:        spec.ImageID,
+		Size:                  spec.Size,
+		AssignPublicIP:        spec.AssignPublicIP,
+		Tags:                  spec.Tags,
+		OSDiskSize:            spec.OSDiskSize,
+		DataDiskSize:          spec.DataDiskSize,
+		Zones:                 spec.Zones,
+		ImageID:               spec.ImageID,
+		AssignAvailabilitySet: spec.AssignAvailabilitySet,
 	}
 
 	return json.Marshal(&res)

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1322,7 +1322,7 @@ type AzureNodeSpec struct {
 	// ImageID represents the ID of the image that should be used to run the node
 	// required: false
 	ImageID string `json:"imageID"`
-	// AssignAvailabilitySet is used to check if an availability set should be created adn assigned to the cluster.
+	// AssignAvailabilitySet is used to check if an availability set should be created and assigned to the cluster.
 	AssignAvailabilitySet bool `json:"assignAvailabilitySet"`
 }
 

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -244,7 +244,7 @@ func TestAzureNodeSpec_MarshalJSON(t *testing.T) {
 			&AzureNodeSpec{
 				Size: "test-size",
 			},
-			"{\"size\":\"test-size\",\"assignPublicIP\":false,\"osDiskSize\":0,\"dataDiskSize\":0,\"zones\":null,\"imageID\":\"\"}",
+			"{\"size\":\"test-size\",\"assignPublicIP\":false,\"osDiskSize\":0,\"dataDiskSize\":0,\"zones\":null,\"imageID\":\"\",\"assignAvailabilitySet\":false}",
 		},
 	}
 

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -566,13 +566,14 @@ type AzureCloudSpec struct {
 	ClientID       string `json:"clientID,omitempty"`
 	ClientSecret   string `json:"clientSecret,omitempty"`
 
-	ResourceGroup     string `json:"resourceGroup"`
-	VNetResourceGroup string `json:"vnetResourceGroup"`
-	VNetName          string `json:"vnet"`
-	SubnetName        string `json:"subnet"`
-	RouteTableName    string `json:"routeTable"`
-	SecurityGroup     string `json:"securityGroup"`
-	AvailabilitySet   string `json:"availabilitySet"`
+	ResourceGroup         string `json:"resourceGroup"`
+	VNetResourceGroup     string `json:"vnetResourceGroup"`
+	VNetName              string `json:"vnet"`
+	SubnetName            string `json:"subnet"`
+	RouteTableName        string `json:"routeTable"`
+	SecurityGroup         string `json:"securityGroup"`
+	AssignAvailabilitySet *bool  `json:"assignAvailabilitySet"`
+	AvailabilitySet       string `json:"availabilitySet"`
 	// LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used
 	LoadBalancerSKU LBSKU `json:"loadBalancerSKU"`
 }

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -645,6 +645,11 @@ func (in *AzureCloudSpec) DeepCopyInto(out *AzureCloudSpec) {
 		*out = new(types.GlobalSecretKeySelector)
 		**out = **in
 	}
+	if in.AssignAvailabilitySet != nil {
+		in, out := &in.AssignAvailabilitySet, &out.AssignAvailabilitySet
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -627,19 +627,22 @@ func (a *Azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	if cluster.Spec.Cloud.Azure.AvailabilitySet == "" {
-		asName := resourceNamePrefix + cluster.Name
-		logger.Infow("ensuring AvailabilitySet", "availabilitySet", asName)
+		if cluster.Spec.Cloud.Azure.AssignAvailabilitySet == nil ||
+			*cluster.Spec.Cloud.Azure.AssignAvailabilitySet {
+			asName := resourceNamePrefix + cluster.Name
+			logger.Infow("ensuring AvailabilitySet", "availabilitySet", asName)
 
-		if err := ensureAvailabilitySet(a.ctx, asName, location, cluster.Spec.Cloud, credentials); err != nil {
-			return nil, fmt.Errorf("failed to ensure AvailabilitySet exists: %v", err)
-		}
+			if err := ensureAvailabilitySet(a.ctx, asName, location, cluster.Spec.Cloud, credentials); err != nil {
+				return nil, fmt.Errorf("failed to ensure AvailabilitySet exists: %v", err)
+			}
 
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Spec.Cloud.Azure.AvailabilitySet = asName
-			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerAvailabilitySet)
-		})
-		if err != nil {
-			return nil, err
+			cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+				updatedCluster.Spec.Cloud.Azure.AvailabilitySet = asName
+				kuberneteshelper.AddFinalizer(updatedCluster, FinalizerAvailabilitySet)
+			})
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -138,19 +138,20 @@ func getAWSProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 
 func getAzureProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
 	config := azure.RawConfig{
-		Location:          providerconfig.ConfigVarString{Value: dc.Spec.Azure.Location},
-		ResourceGroup:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ResourceGroup},
-		VNetResourceGroup: providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetResourceGroup},
-		VMSize:            providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.Size},
-		OSDiskSize:        nodeSpec.Cloud.Azure.OSDiskSize,
-		DataDiskSize:      nodeSpec.Cloud.Azure.DataDiskSize,
-		VNetName:          providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetName},
-		SubnetName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubnetName},
-		RouteTableName:    providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.RouteTableName},
-		AvailabilitySet:   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.AvailabilitySet},
-		SecurityGroupName: providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SecurityGroup},
-		Zones:             nodeSpec.Cloud.Azure.Zones,
-		ImageID:           providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.ImageID},
+		Location:              providerconfig.ConfigVarString{Value: dc.Spec.Azure.Location},
+		ResourceGroup:         providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ResourceGroup},
+		VNetResourceGroup:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetResourceGroup},
+		VMSize:                providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.Size},
+		OSDiskSize:            nodeSpec.Cloud.Azure.OSDiskSize,
+		DataDiskSize:          nodeSpec.Cloud.Azure.DataDiskSize,
+		VNetName:              providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetName},
+		SubnetName:            providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubnetName},
+		RouteTableName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.RouteTableName},
+		AvailabilitySet:       providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.AvailabilitySet},
+		AssignAvailabilitySet: c.Spec.Cloud.Azure.AssignAvailabilitySet,
+		SecurityGroupName:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SecurityGroup},
+		Zones:                 nodeSpec.Cloud.Azure.Zones,
+		ImageID:               providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.ImageID},
 
 		// https://github.com/kubermatic/kubermatic/issues/5013#issuecomment-580357280
 		AssignPublicIP: providerconfig.ConfigVarBool{Value: nodeSpec.Cloud.Azure.AssignPublicIP},

--- a/pkg/test/e2e/utils/apiclient/models/azure_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/azure_cloud_spec.go
@@ -18,6 +18,9 @@ import (
 // swagger:model AzureCloudSpec
 type AzureCloudSpec struct {
 
+	// assign availability set
+	AssignAvailabilitySet bool `json:"assignAvailabilitySet,omitempty"`
+
 	// availability set
 	AvailabilitySet string `json:"availabilitySet,omitempty"`
 

--- a/pkg/test/e2e/utils/apiclient/models/azure_node_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/azure_node_spec.go
@@ -19,6 +19,9 @@ import (
 // swagger:model AzureNodeSpec
 type AzureNodeSpec struct {
 
+	// AssignAvailabilitySet is used to check if an availability set should be created and assigned to the cluster.
+	AssignAvailabilitySet bool `json:"assignAvailabilitySet,omitempty"`
+
 	// should the machine have a publicly accessible IP address
 	AssignPublicIP bool `json:"assignPublicIP,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We create availability sets for azure cloud provider unconditionally. On cluster creation we create those av sets and attach them to the clusters vm. This PR creates av set based on the cluster configs. When the value `AssignAvailabilitySet` is set, the av set will be created and vms are assigned to it.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7357 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Create and assign azure availability sets on demand
```
