### PR TITLE
Add Annotations to type ObjectMeta

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -15851,6 +15851,14 @@
       "description": "Addon represents a predefined addon that users may install into their cluster",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -15883,6 +15891,14 @@
       "description": "AddonConfig represents a addon configuration",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -16758,6 +16774,14 @@
       "type": "object",
       "title": "Cluster defines the cluster resource",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -16902,6 +16926,14 @@
       "description": "ClusterRole defines cluster RBAC role for the user cluster",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -18129,6 +18161,14 @@
       "type": "object",
       "title": "Event is a report of an event somewhere in the cluster.",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "count": {
           "description": "The number of times this event has occurred.",
           "type": "integer",
@@ -19412,6 +19452,14 @@
       "description": "Node represents a worker node that is part of a cluster",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -19504,6 +19552,14 @@
       "description": "NodeDeployment represents a set of worker nodes that is part of a cluster",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -19900,6 +19956,14 @@
       "description": "ObjectMeta defines the set of fields that objects returned from the API have",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -20576,6 +20640,14 @@
       "description": "Project is a top-level container for a set of resources",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "clustersNumber": {
           "type": "integer",
           "format": "int64",
@@ -20809,6 +20881,14 @@
       "description": "PublicServiceAccountToken represent an API service account token without secret fields",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -20896,6 +20976,14 @@
       "description": "Role defines RBAC role for the user cluster",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -21032,6 +21120,14 @@
       "description": "SSHKey represents a ssh key",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -21202,6 +21298,14 @@
       "description": "ServiceAccount represent an API service account",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -21264,6 +21368,14 @@
       "description": "ServiceAccountToken represent an API service account token",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",
@@ -21509,6 +21621,14 @@
       "description": "User represent an API user",
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Annotations that can be added to the resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
           "type": "string",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -42,6 +42,9 @@ type ObjectMeta struct {
 	// Name represents human readable name for the resource
 	Name string `json:"name"`
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// DeletionTimestamp is a timestamp representing the server time when this object was deleted.
 	// swagger:strfmt date-time
 	DeletionTimestamp *Time `json:"deletionTimestamp,omitempty"`

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -163,6 +163,7 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 		ObjectMeta: apiv1.ObjectMeta{
 			ID:                md.Name,
 			Name:              md.Name,
+			Annotations:       md.Annotations,
 			DeletionTimestamp: deletionTimestamp,
 			CreationTimestamp: apiv1.NewTime(md.CreationTimestamp.Time),
 		},

--- a/pkg/handler/v1/common/event_test.go
+++ b/pkg/handler/v1/common/event_test.go
@@ -19,6 +19,7 @@ package common_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 
@@ -82,7 +83,7 @@ func equal(a, b []v1.Event) bool {
 		return false
 	}
 	for i, v := range a {
-		if v != b[i] {
+		if !cmp.Equal(v, b[i]) {
 			return false
 		}
 	}

--- a/pkg/handler/v1/node/node_test.go
+++ b/pkg/handler/v1/node/node_test.go
@@ -293,6 +293,20 @@ func TestCreateNodeDeployment(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+		// scenario 8
+		{
+			Name:             "scenario 8: create a node deployment with annotations",
+			Body:             `{"annotations":{"test/annotations":"true"},"spec":{"replicas":1,"dynamicConfig":true,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
+			ExpectedResponse: `{"id":"%s","name":"%s","annotations":{"test/annotations":"true"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":true},"status":{}}`,
+			HTTPStatus:       http.StatusCreated,
+			ProjectID:        test.GenDefaultProject().Name,
+			ClusterID:        test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/handler/v2/machine/machine_test.go
+++ b/pkg/handler/v2/machine/machine_test.go
@@ -158,6 +158,21 @@ func TestCreateMachineDeployment(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+
+		// scenario 8
+		{
+			Name:             "scenario 8: create a machine deployment with annotations",
+			Body:             `{"annotations":{"test/annotations":"true"},"spec":{"replicas":1,"dynamicConfig":true,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
+			ExpectedResponse: `{"id":"%s","name":"%s","annotations":{"test/annotations":"true"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":true},"status":{}}`,
+			HTTPStatus:       http.StatusCreated,
+			ProjectID:        test.GenDefaultProject().Name,
+			ClusterID:        test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -52,6 +52,9 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 		md.GenerateName = fmt.Sprintf("%s-worker-", c.Spec.HumanReadableName)
 	}
 
+	// Add Annotations to Machine Deployment
+	md.Annotations = nd.Annotations
+
 	md.Namespace = metav1.NamespaceSystem
 	md.Finalizers = []string{metav1.FinalizerDeleteDependents}
 

--- a/pkg/test/e2e/utils/apiclient/models/addon.go
+++ b/pkg/test/e2e/utils/apiclient/models/addon.go
@@ -19,6 +19,9 @@ import (
 // swagger:model Addon
 type Addon struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/addon_config.go
+++ b/pkg/test/e2e/utils/apiclient/models/addon_config.go
@@ -19,6 +19,9 @@ import (
 // swagger:model AddonConfig
 type AddonConfig struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/cluster.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster.go
@@ -23,6 +23,9 @@ import (
 // swagger:model Cluster
 type Cluster struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/cluster_role.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster_role.go
@@ -20,6 +20,9 @@ import (
 // swagger:model ClusterRole
 type ClusterRole struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/event.go
+++ b/pkg/test/e2e/utils/apiclient/models/event.go
@@ -19,6 +19,9 @@ import (
 // swagger:model Event
 type Event struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// The number of times this event has occurred.
 	Count int32 `json:"count,omitempty"`
 

--- a/pkg/test/e2e/utils/apiclient/models/node.go
+++ b/pkg/test/e2e/utils/apiclient/models/node.go
@@ -19,6 +19,9 @@ import (
 // swagger:model Node
 type Node struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/node_deployment.go
+++ b/pkg/test/e2e/utils/apiclient/models/node_deployment.go
@@ -19,6 +19,9 @@ import (
 // swagger:model NodeDeployment
 type NodeDeployment struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/object_meta.go
+++ b/pkg/test/e2e/utils/apiclient/models/object_meta.go
@@ -19,6 +19,9 @@ import (
 // swagger:model ObjectMeta
 type ObjectMeta struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/project.go
+++ b/pkg/test/e2e/utils/apiclient/models/project.go
@@ -20,6 +20,9 @@ import (
 // swagger:model Project
 type Project struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// clusters number
 	ClustersNumber int64 `json:"clustersNumber,omitempty"`
 

--- a/pkg/test/e2e/utils/apiclient/models/public_service_account_token.go
+++ b/pkg/test/e2e/utils/apiclient/models/public_service_account_token.go
@@ -19,6 +19,9 @@ import (
 // swagger:model PublicServiceAccountToken
 type PublicServiceAccountToken struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/role.go
+++ b/pkg/test/e2e/utils/apiclient/models/role.go
@@ -20,6 +20,9 @@ import (
 // swagger:model Role
 type Role struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/service_account.go
+++ b/pkg/test/e2e/utils/apiclient/models/service_account.go
@@ -19,6 +19,9 @@ import (
 // swagger:model ServiceAccount
 type ServiceAccount struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/service_account_token.go
+++ b/pkg/test/e2e/utils/apiclient/models/service_account_token.go
@@ -19,6 +19,9 @@ import (
 // swagger:model ServiceAccountToken
 type ServiceAccountToken struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/ssh_key.go
+++ b/pkg/test/e2e/utils/apiclient/models/ssh_key.go
@@ -19,6 +19,9 @@ import (
 // swagger:model SSHKey
 type SSHKey struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/user.go
+++ b/pkg/test/e2e/utils/apiclient/models/user.go
@@ -20,6 +20,9 @@ import (
 // swagger:model User
 type User struct {
 
+	// Annotations that can be added to the resource
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// CreationTimestamp is a timestamp representing the server time when this object was created.
 	// Format: date-time
 	CreationTimestamp strfmt.DateTime `json:"creationTimestamp,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds the Annotations to the type `ObjectMeta` and adds the required checks for the MachineDeployment. This allows to set certain annotations to the MachineDeployment while creating these resources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7446

**Special notes for your reviewer**:
The change of type "ObjectMeta" is the clean way of doing this change, even though it requires all dependent types to add the Annotation field.
One could only limit this change to MachineDeployment by adding the Annotations field to the NodeDeployment type but IMO, this is not how one should resolve this because Annotations is obviously a metadata information and has to go into the ObjectMeta type.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
-

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for creating MachineDeployment with annotations.
```
