### PR TITLE
Remove non-existing field from kube-proxy configmap

### DIFF
--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -32,7 +32,6 @@ data:
     clusterCIDR: "{{ first .Cluster.Network.PodCIDRBlocks }}"
     configSyncPeriod: 15m0s
     conntrack:
-      max: null
       maxPerCore: 0
       # Following the recommendation from thz #3026
       min: 524288


### PR DESCRIPTION
**What this PR does / why we need it**:
It's causing unmarshal errors during e2e tests

```
using lenient decoding as strict decoding failed: strict decoder error ReadObject: found unknown field: max, error found in #10 byte of ...|ck":{"max":null,"max|..., bigger context ...|/16","configSyncPeriod":"15m0s","conntrack":{"max":null,"maxPerCore":0,"min":524288,"tcpCloseWaitTim|...
```

```release-note
NONE
```
