### PR TITLE
prevent kubevirt kubeconfig from confusing the conformance tester

### DIFF
--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -158,11 +158,12 @@ type secrets struct {
 }
 
 var (
-	providers             string
-	pubKeyPath            string
-	sversions             string
-	sdistributions        string
-	sexcludeDistributions string
+	providers              string
+	pubKeyPath             string
+	sversions              string
+	sdistributions         string
+	sexcludeDistributions  string
+	kubevirtKubeconfigFile string
 )
 
 //nolint:gocritic,exitAfterDefer
@@ -241,7 +242,7 @@ func main() {
 	flag.StringVar(&opts.secrets.GCP.Zone, "gcp-zone", "europe-west3-c", "GCP: Zone")
 	flag.StringVar(&opts.secrets.GCP.Network, "gcp-network", "", "GCP: Network")
 	flag.StringVar(&opts.secrets.GCP.Subnetwork, "gcp-subnetwork", "", "GCP: Subnetwork")
-	flag.StringVar(&opts.secrets.Kubevirt.Kubeconfig, "kubevirt-kubeconfig", "", "Kubevirt: Cluster Kubeconfig")
+	flag.StringVar(&kubevirtKubeconfigFile, "kubevirt-kubeconfig", "", "Kubevirt: Cluster Kubeconfig filename")
 	flag.StringVar(&opts.secrets.Alibaba.AccessKeyID, "alibaba-access-key-id", "", "Alibaba: AccessKeyID")
 	flag.StringVar(&opts.secrets.Alibaba.AccessKeySecret, "alibaba-access-key-secret", "", "Alibaba: AccessKeySecret")
 
@@ -264,6 +265,15 @@ func main() {
 
 	if opts.existingClusterLabel != "" && opts.clusterParallelCount != 1 {
 		log.Fatal("-cluster-parallel-count must be 1 when testing an existing cluster")
+	}
+
+	if kubevirtKubeconfigFile != "" {
+		content, err := ioutil.ReadFile(kubevirtKubeconfigFile)
+		if err != nil {
+			log.Fatalw("Failed to read kubevirt kubeconfig file", zap.Error(err))
+		}
+
+		opts.secrets.Kubevirt.Kubeconfig = string(content)
 	}
 
 	opts.distributions, err = getEffectiveDistributions(sdistributions, sexcludeDistributions)

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -67,7 +67,9 @@ elif [[ $provider == "vsphere" ]]; then
   EXTRA_ARGS="-vsphere-username=${VSPHERE_E2E_USERNAME}
     -vsphere-password=${VSPHERE_E2E_PASSWORD}"
 elif [[ $provider == "kubevirt" ]]; then
-  EXTRA_ARGS="-kubevirt-kubeconfig=${KUBEVIRT_E2E_TESTS_KUBECONFIG}"
+  tmpFile="$(mktemp)"
+  echo "$KUBEVIRT_E2E_TESTS_KUBECONFIG" > "$tmpFile"
+  EXTRA_ARGS="-kubevirt-kubeconfig=$tmpFile"
 elif [[ $provider == "alibaba" ]]; then
   EXTRA_ARGS="-alibaba-access-key-id=${ALIBABA_E2E_TESTS_KEY_ID}
     -alibaba-secret-access-key=${ALIBABA_E2E_TESTS_SECRET}"

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -96,7 +96,9 @@ hetzner)
   ;;
 
 kubevirt)
-  extraArgs="-kubevirt-kubeconfig=${KUBEVIRT_KUBECONFIG}"
+  tmpFile="$(mktemp)"
+  echo "$KUBEVIRT_KUBECONFIG" > "$tmpFile"
+  extraArgs="-kubevirt-kubeconfig=$tmpFile"
   ;;
 
 openstack)


### PR DESCRIPTION
**What this PR does / why we need it**:
Handing the multiline JSON kubeconfig as an unquoted CLI flag caused lots of trouble. I tried to `jq -c` the kubeconfig and use quotes, but to no avail. So this PR simply changes the logic to read the kubeconfig from a file.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
