### PR TITLE
fix run_if_changed trigger for pre-kubermatic-ccm-migration-e2e

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1313,7 +1313,7 @@ presubmits:
   #########################################################
 
   - name: pre-kubermatic-ccm-migration-e2e
-    run_if_changed: "(|pkg/|.prow.yaml)"
+    run_if_changed: "(pkg/|.prow.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
This was surely not intended.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
