### PR TITLE
respect cluster pause flag in usercluster-controller-manager

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	ccmcsimigrator "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator"
 	clusterrolelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/cluster-role-labeler"
 	constraintsyncer "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/constraint-syncer"
@@ -37,7 +38,6 @@ import (
 	usercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources"
 	machinecontrolerresources "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
 	rolecloner "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/role-cloner"
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/pprof"
@@ -233,7 +233,7 @@ func main() {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
 
-	isPausedChecker := util.NewClusterPausedChecker(seedMgr.GetClient(), runOp.clusterName)
+	isPausedChecker := userclustercontrollermanager.NewClusterPausedChecker(seedMgr.GetClient(), runOp.clusterName)
 
 	// Setup all Controllers
 	log.Info("registering controllers")

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -37,6 +37,7 @@ import (
 	usercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources"
 	machinecontrolerresources "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
 	rolecloner "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/role-cloner"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/pprof"
@@ -232,6 +233,8 @@ func main() {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
 
+	isPausedChecker := util.NewClusterPausedChecker(seedMgr.GetClient(), runOp.clusterName)
+
 	// Setup all Controllers
 	log.Info("registering controllers")
 	if err := usercluster.Add(mgr,
@@ -240,6 +243,7 @@ func main() {
 		runOp.namespace,
 		runOp.cloudProviderName,
 		clusterURL,
+		isPausedChecker,
 		uint32(runOp.openvpnServerPort),
 		uint32(runOp.kasSecurePort),
 		runOp.tunnelingAgentIP.IP,
@@ -275,13 +279,15 @@ func main() {
 				log.Fatalw("Failed to initially create the Machine CR", zap.Error(err))
 			}
 		}
+
+		// IPAM is critical for a cluster, so the isPauseChecker is not used in this controller
 		if err := ipam.Add(mgr, runOp.networks, log); err != nil {
 			log.Fatalw("Failed to add IPAM controller to mgr", zap.Error(err))
 		}
 		log.Infof("Added IPAM controller to mgr")
 	}
 
-	if err := rbacusercluster.Add(mgr, mgr.AddReadyzCheck); err != nil {
+	if err := rbacusercluster.Add(mgr, mgr.AddReadyzCheck, isPausedChecker); err != nil {
 		log.Fatalw("Failed to add user RBAC controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered user RBAC controller")
@@ -290,40 +296,42 @@ func main() {
 		Start:  runOp.updateWindowStart,
 		Length: runOp.updateWindowLength,
 	}
-	if err := flatcar.Add(mgr, runOp.overwriteRegistry, updateWindow); err != nil {
+	if err := flatcar.Add(mgr, runOp.overwriteRegistry, updateWindow, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register the Flatcar controller", zap.Error(err))
 	}
 	log.Info("Registered Flatcar controller")
 
+	// node labels can be critical to a cluster functioning, so we do not stop applying
+	// labels once a cluster is paused, hence no isPausedChecker here
 	if err := nodelabeler.Add(rootCtx, log, mgr, nodeLabels); err != nil {
 		log.Fatalw("Failed to register nodelabel controller", zap.Error(err))
 	}
 	log.Info("Registered nodelabel controller")
 
-	if err := clusterrolelabeler.Add(rootCtx, log, mgr); err != nil {
+	if err := clusterrolelabeler.Add(rootCtx, log, mgr, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register clusterrolelabeler controller", zap.Error(err))
 	}
 	log.Info("Registered clusterrolelabeler controller")
 
-	if err := rolecloner.Add(rootCtx, log, mgr); err != nil {
+	if err := rolecloner.Add(rootCtx, log, mgr, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register rolecloner controller", zap.Error(err))
 	}
 	log.Info("Registered rolecloner controller")
 
-	if err := ownerbindingcreator.Add(rootCtx, log, mgr, runOp.ownerEmail); err != nil {
+	if err := ownerbindingcreator.Add(rootCtx, log, mgr, runOp.ownerEmail, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register ownerbindingcreator controller", zap.Error(err))
 	}
 	log.Info("Registered ownerbindingcreator controller")
 
 	if runOp.ccmMigration {
-		if err := ccmcsimigrator.Add(rootCtx, log, seedMgr, mgr, versions, runOp.clusterName); err != nil {
+		if err := ccmcsimigrator.Add(rootCtx, log, seedMgr, mgr, versions, runOp.clusterName, isPausedChecker); err != nil {
 			log.Fatalw("failed to register ccm-csi-migrator controller", zap.Error(err))
 		}
 		log.Info("registered ccm-csi-migrator controller")
 	}
 
 	if runOp.opaIntegration {
-		if err := constraintsyncer.Add(rootCtx, log, seedMgr, mgr, runOp.namespace); err != nil {
+		if err := constraintsyncer.Add(rootCtx, log, seedMgr, mgr, runOp.namespace, isPausedChecker); err != nil {
 			log.Fatalw("Failed to register constraintsyncer controller", zap.Error(err))
 		}
 		log.Info("Registered constraintsyncer controller")

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -53,10 +53,10 @@ type reconciler struct {
 	seedRecorder    record.EventRecorder
 	versions        kubermatic.Versions
 	clusterName     string
-	clusterIsPaused util.IsPausedChecker
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, versions kubermatic.Versions, clusterName string, clusterIsPaused util.IsPausedChecker) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, versions kubermatic.Versions, clusterName string, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	v1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -46,24 +47,26 @@ const (
 )
 
 type reconciler struct {
-	log          *zap.SugaredLogger
-	seedClient   ctrlruntimeclient.Client
-	userClient   ctrlruntimeclient.Client
-	seedRecorder record.EventRecorder
-	versions     kubermatic.Versions
-	clusterName  string
+	log             *zap.SugaredLogger
+	seedClient      ctrlruntimeclient.Client
+	userClient      ctrlruntimeclient.Client
+	seedRecorder    record.EventRecorder
+	versions        kubermatic.Versions
+	clusterName     string
+	clusterIsPaused util.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, versions kubermatic.Versions, clusterName string) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, versions kubermatic.Versions, clusterName string, clusterIsPaused util.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
-		log:          log,
-		seedClient:   seedMgr.GetClient(),
-		userClient:   userMgr.GetClient(),
-		seedRecorder: seedMgr.GetEventRecorderFor(controllerName),
-		versions:     versions,
-		clusterName:  clusterName,
+		log:             log,
+		seedClient:      seedMgr.GetClient(),
+		userClient:      userMgr.GetClient(),
+		seedRecorder:    seedMgr.GetEventRecorderFor(controllerName),
+		versions:        versions,
+		clusterName:     clusterName,
+		clusterIsPaused: clusterIsPaused,
 	}
 	c, err := controller.New(controllerName, userMgr, controller.Options{
 		Reconciler: r,
@@ -92,6 +95,14 @@ func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.M
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	log := r.log.With("Request", request.NamespacedName.String())
 	log.Debug("Reconciling")
 
@@ -104,7 +115,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster: %v", err)
 	}
 
-	err := r.reconcile(ctx, log, cluster)
+	err = r.reconcile(ctx, log, cluster)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.seedRecorder.Event(cluster, corev1.EventTypeWarning, "CCMCSIMigrationFailed", err.Error())

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller_test.go
@@ -159,6 +159,9 @@ func TestReconcile(t *testing.T) {
 				seedRecorder: record.NewFakeRecorder(10),
 				versions:     kubermatic.Versions{},
 				clusterName:  tc.userCluster.Name,
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			for range tc.machines {

--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 
@@ -47,10 +47,10 @@ type reconciler struct {
 	log             *zap.SugaredLogger
 	client          ctrlruntimeclient.Client
 	recorder        record.EventRecorder
-	clusterIsPaused util.IsPausedChecker
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, clusterIsPaused util.IsPausedChecker) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{

--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler_test.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler_test.go
@@ -86,6 +86,9 @@ func TestReconcile(t *testing.T) {
 				log:      kubermaticlog.Logger,
 				client:   client,
 				recorder: record.NewFakeRecorder(10),
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	constrainthandler "k8c.io/kubermatic/v2/pkg/handler/v2/constraint"
@@ -50,20 +51,22 @@ const (
 )
 
 type reconciler struct {
-	log        *zap.SugaredLogger
-	seedClient ctrlruntimeclient.Client
-	userClient ctrlruntimeclient.Client
-	recorder   record.EventRecorder
+	log             *zap.SugaredLogger
+	seedClient      ctrlruntimeclient.Client
+	userClient      ctrlruntimeclient.Client
+	recorder        record.EventRecorder
+	clusterIsPaused util.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, namespace string) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, namespace string, clusterIsPaused util.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
-		log:        log,
-		seedClient: seedMgr.GetClient(),
-		userClient: userMgr.GetClient(),
-		recorder:   userMgr.GetEventRecorderFor(controllerName),
+		log:             log,
+		seedClient:      seedMgr.GetClient(),
+		userClient:      userMgr.GetClient(),
+		recorder:        userMgr.GetEventRecorderFor(controllerName),
+		clusterIsPaused: clusterIsPaused,
 	}
 	c, err := controller.New(controllerName, seedMgr, controller.Options{
 		Reconciler: r,
@@ -82,6 +85,14 @@ func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.M
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	log := r.log.With("resource", request)
 	log.Debug("Reconciling")
 
@@ -94,7 +105,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get constraint: %v", err)
 	}
 
-	err := r.reconcile(ctx, constraint, log)
+	err = r.reconcile(ctx, constraint, log)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(constraint, corev1.EventTypeWarning, "ConstraintReconcileFailed", err.Error())

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -23,7 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	constrainthandler "k8c.io/kubermatic/v2/pkg/handler/v2/constraint"
@@ -55,10 +55,10 @@ type reconciler struct {
 	seedClient      ctrlruntimeclient.Client
 	userClient      ctrlruntimeclient.Client
 	recorder        record.EventRecorder
-	clusterIsPaused util.IsPausedChecker
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, namespace string, clusterIsPaused util.IsPausedChecker) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, namespace string, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -212,6 +212,9 @@ func TestReconcile(t *testing.T) {
 				recorder:   &record.FakeRecorder{},
 				seedClient: tc.seedClient,
 				userClient: tc.userClient,
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			request := reconcile.Request{NamespacedName: tc.namespacedName}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar/resources"
 	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -45,10 +45,10 @@ type Reconciler struct {
 	ctrlruntimeclient.Client
 	overwriteRegistry string
 	updateWindow      kubermaticv1.UpdateWindow
-	clusterIsPaused   util.IsPausedChecker
+	clusterIsPaused   userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow, clusterIsPaused util.IsPausedChecker) error {
+func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 
 	reconciler := &Reconciler{
 		Client:            mgr.GetClient(),

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 
@@ -51,10 +51,10 @@ type reconciler struct {
 	client          ctrlruntimeclient.Client
 	recorder        record.EventRecorder
 	ownerEmail      string
-	clusterIsPaused util.IsPausedChecker
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, ownerEmail string, clusterIsPaused util.IsPausedChecker) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, ownerEmail string, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator_test.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator_test.go
@@ -111,6 +111,9 @@ func TestReconcile(t *testing.T) {
 				client:     client,
 				recorder:   record.NewFakeRecorder(10),
 				ownerEmail: tc.ownerEmail,
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			ctx := context.Background()

--- a/pkg/controller/user-cluster-controller-manager/pause.go
+++ b/pkg/controller/user-cluster-controller-manager/pause.go
@@ -37,7 +37,7 @@ func NewClusterPausedChecker(seedClient client.Client, clusterName string) IsPau
 				return false, nil
 			}
 
-			return false, fmt.Errorf("failed to get cluster %q: %v", clusterName, err)
+			return false, fmt.Errorf("failed to get cluster %q: %w", clusterName, err)
 		}
 
 		return cluster.Spec.Pause, nil

--- a/pkg/controller/user-cluster-controller-manager/pause.go
+++ b/pkg/controller/user-cluster-controller-manager/pause.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package userclustercontrollermanager
 
 import (
 	"context"

--- a/pkg/controller/user-cluster-controller-manager/rbac/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/controller.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"sync"
 
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -62,7 +62,7 @@ var mapFn = handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) 
 
 // Add creates a new RBAC generator controller that is responsible for creating Cluster Roles and Cluster Role Bindings
 // for groups: `owners`, `editors` and `viewers``
-func Add(mgr manager.Manager, registerReconciledCheck func(name string, check healthz.Checker) error, clusterIsPaused util.IsPausedChecker) error {
+func Add(mgr manager.Manager, registerReconciledCheck func(name string, check healthz.Checker) error, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	reconcile := &reconcileRBAC{Client: mgr.GetClient(), rLock: &sync.Mutex{}, clusterIsPaused: clusterIsPaused}
 
 	// Create a new controller
@@ -97,7 +97,7 @@ type reconcileRBAC struct {
 	ctrlruntimeclient.Client
 
 	rLock                      *sync.Mutex
-	clusterIsPaused            util.IsPausedChecker
+	clusterIsPaused            userclustercontrollermanager.IsPausedChecker
 	reconciledSuccessfullyOnce bool
 }
 

--- a/pkg/controller/user-cluster-controller-manager/rbac/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/controller.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"sync"
 
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -61,8 +62,8 @@ var mapFn = handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) 
 
 // Add creates a new RBAC generator controller that is responsible for creating Cluster Roles and Cluster Role Bindings
 // for groups: `owners`, `editors` and `viewers``
-func Add(mgr manager.Manager, registerReconciledCheck func(name string, check healthz.Checker) error) error {
-	reconcile := &reconcileRBAC{Client: mgr.GetClient(), rLock: &sync.Mutex{}}
+func Add(mgr manager.Manager, registerReconciledCheck func(name string, check healthz.Checker) error, clusterIsPaused util.IsPausedChecker) error {
+	reconcile := &reconcileRBAC{Client: mgr.GetClient(), rLock: &sync.Mutex{}, clusterIsPaused: clusterIsPaused}
 
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconcile})
@@ -96,11 +97,20 @@ type reconcileRBAC struct {
 	ctrlruntimeclient.Client
 
 	rLock                      *sync.Mutex
+	clusterIsPaused            util.IsPausedChecker
 	reconciledSuccessfullyOnce bool
 }
 
 // Reconcile makes changes in response to Cluster Role and Cluster Role Binding related changes
 func (r *reconcileRBAC) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	rdr := reconciler{client: r.Client}
 
 	if err := rdr.Reconcile(ctx, request.Name); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -72,6 +73,7 @@ func Add(
 	namespace string,
 	cloudProviderName string,
 	clusterURL *url.URL,
+	clusterIsPaused util.IsPausedChecker,
 	openvpnServerPort uint32,
 	kasSecurePort uint32,
 	tunnelingAgentIP net.IP,
@@ -90,6 +92,7 @@ func Add(
 		rLock:             &sync.Mutex{},
 		namespace:         namespace,
 		clusterURL:        clusterURL,
+		clusterIsPaused:   clusterIsPaused,
 		openvpnServerPort: openvpnServerPort,
 		kasSecurePort:     kasSecurePort,
 		tunnelingAgentIP:  tunnelingAgentIP,
@@ -206,6 +209,7 @@ type reconciler struct {
 	cache             cache.Cache
 	namespace         string
 	clusterURL        *url.URL
+	clusterIsPaused   util.IsPausedChecker
 	openvpnServerPort uint32
 	kasSecurePort     uint32
 	tunnelingAgentIP  net.IP
@@ -227,6 +231,15 @@ type reconciler struct {
 
 // Reconcile makes changes in response to objects in the user cluster.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		r.log.Debug("Cluster is paused, not reconciling.")
+		return reconcile.Result{}, nil
+	}
+
 	if err := r.reconcile(ctx); err != nil {
 		r.log.Errorw("Reconciling failed", zap.Error(err))
 		return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -73,7 +73,7 @@ func Add(
 	namespace string,
 	cloudProviderName string,
 	clusterURL *url.URL,
-	clusterIsPaused util.IsPausedChecker,
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker,
 	openvpnServerPort uint32,
 	kasSecurePort uint32,
 	tunnelingAgentIP net.IP,
@@ -209,7 +209,7 @@ type reconciler struct {
 	cache             cache.Cache
 	namespace         string
 	clusterURL        *url.URL
-	clusterIsPaused   util.IsPausedChecker
+	clusterIsPaused   userclustercontrollermanager.IsPausedChecker
 	openvpnServerPort uint32
 	kasSecurePort     uint32
 	tunnelingAgentIP  net.IP

--- a/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -48,18 +49,20 @@ const (
 )
 
 type reconciler struct {
-	log      *zap.SugaredLogger
-	client   ctrlruntimeclient.Client
-	recorder record.EventRecorder
+	log             *zap.SugaredLogger
+	client          ctrlruntimeclient.Client
+	recorder        record.EventRecorder
+	clusterIsPaused util.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, clusterIsPaused util.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
-		log:      log,
-		client:   mgr.GetClient(),
-		recorder: mgr.GetEventRecorderFor(controllerName),
+		log:             log,
+		client:          mgr.GetClient(),
+		recorder:        mgr.GetEventRecorderFor(controllerName),
+		clusterIsPaused: clusterIsPaused,
 	}
 	c, err := controller.New(controllerName, mgr, controller.Options{
 		Reconciler: r,
@@ -80,6 +83,14 @@ func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager) error
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	log := r.log.With("Role", request.Name)
 	log.Debug("Reconciling")
 
@@ -92,7 +103,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get role: %v", err)
 	}
 
-	err := r.reconcile(ctx, log, role)
+	err = r.reconcile(ctx, log, role)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(role, corev1.EventTypeWarning, "CloningRoleFailed", err.Error())

--- a/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
-	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/util"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -52,10 +52,10 @@ type reconciler struct {
 	log             *zap.SugaredLogger
 	client          ctrlruntimeclient.Client
 	recorder        record.EventRecorder
-	clusterIsPaused util.IsPausedChecker
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, clusterIsPaused util.IsPausedChecker) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{

--- a/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner_test.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner_test.go
@@ -314,6 +314,9 @@ func TestReconcile(t *testing.T) {
 				log:      kubermaticlog.Logger,
 				client:   clientBuilder.Build(),
 				recorder: record.NewFakeRecorder(10),
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			ctx := context.Background()

--- a/pkg/controller/user-cluster-controller-manager/util/pause.go
+++ b/pkg/controller/user-cluster-controller-manager/util/pause.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type IsPausedChecker func(context.Context) (bool, error)
+
+func NewClusterPausedChecker(seedClient client.Client, clusterName string) IsPausedChecker {
+	return func(ctx context.Context) (bool, error) {
+		cluster := &kubermaticv1.Cluster{}
+		if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to get cluster %q: %v", clusterName, err)
+		}
+
+		return cluster.Spec.Pause, nil
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Pausing a cluster (setting `spec.pause` to `true`) did so far not affect the UCCM. This was unfortunate because we could, for example, not fix the node-local-dns DaemonSet, because the UCCM would overwrite it constantly.

I propose that all non-critical controllers can respect the pause flag and stop reconciling. Just pausing a cluster and completely shutting off the UCCM will kill the usercluster, as no more CSR's are approved.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7467 

**Does this PR introduce a user-facing change?**:
```release-note
Paused userclusters do not reconcile in-cluster resources via the usercluster-controller-manager anymore.
```
