### PR TITLE
Revert "[promtail] kubelet log capturing and kubernetes event capturing"

### DIFF
--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: "v1"
 name: promtail
-version: 0.2.2
+version: 0.2.1
 appVersion: v2.1.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:

--- a/charts/logging/promtail/templates/daemonset.yaml
+++ b/charts/logging/promtail/templates/daemonset.yaml
@@ -83,9 +83,6 @@ spec:
           - name: pods
             mountPath: /var/log/pods
             readOnly: true
-          {{- with .Values.promtail.extraVolumeMounts }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
           env:
           - name: HOSTNAME
             valueFrom:
@@ -124,6 +121,3 @@ spec:
         - name: pods
           hostPath:
             path: /var/log/pods
-        {{- with .Values.promtail.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -27,7 +27,7 @@ promtail:
 
   initContainer:
     # -- Specifies whether the init container for setting inotify max user instances is to be enabled
-    enabled: true
+    enabled: false
     image:
       # -- The Docker registry for the init container
       registry: docker.io
@@ -38,7 +38,7 @@ promtail:
       # -- Docker image pull policy for the init container image
       pullPolicy: IfNotPresent
     # -- The inotify max user instances to configure
-    fsInotifyMaxUserInstances: 256
+    fsInotifyMaxUserInstances: 128
 
   nodeSelector: {}
   affinity: {}
@@ -288,41 +288,6 @@ promtail:
         - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
         - __meta_kubernetes_pod_container_name
         target_label: __path__
-    - job_name: kubelet-journal-logs
-      journal:
-        path: /var/log/journal
-        max_age: 12h
-        labels:
-          job: systemd-journal
-      pipeline_stages:
-      - match:
-          selector: '{unit="kubelet.service"}'
-      relabel_configs:
-        - source_labels: ['__journal__systemd_unit']
-          target_label: 'unit'
-        - source_labels: ['__journal__hostname']
-          target_label: 'hostname'
-    - job_name: kubernetes-events
-      pipeline_stages:
-      - docker:
-      - match:
-          selector: '{app="eventrouter"}'
-          stages:
-          - json:
-              expressions:
-                namespace: event.metadata.namespace
-          - labels:
-              namespace: ""
-
-  extraVolumes:
-    - name: journal
-      hostPath:
-        path: /var/log/journal
-
-  extraVolumeMounts:
-    - name: journal
-      mountPath: /var/log/journal
-      readOnly: true
 
   tolerations:
   - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Reverts kubermatic/kubermatic#7444

promtail doesn't like the configuration:

```
level=error ts=2021-08-09T16:28:39.342513097Z caller=main.go:106 msg="error creating promtail" error="unknown scrape config"
```

Release note:
```release-note
NONE
```