### PR TITLE
update e2e tests to kind 0.11 with k8s 1.21

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -351,7 +351,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-2
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -386,7 +386,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -427,7 +427,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -468,7 +468,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -509,7 +509,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -550,7 +550,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -597,7 +597,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -643,7 +643,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -686,7 +686,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -734,7 +734,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -777,7 +777,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -820,7 +820,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -863,7 +863,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -908,7 +908,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -953,7 +953,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -998,7 +998,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1042,7 +1042,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1088,7 +1088,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1138,7 +1138,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         imagePullPolicy: Always
         command:
         - "./hack/ci/run-api-e2e.sh"
@@ -1180,7 +1180,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
@@ -1217,15 +1217,10 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         imagePullPolicy: Always
         command:
-        - make
-        args:
-        - run-nodeport-proxy-e2e-test-in-kind
-        env:
-        - name: KIND_NODE_VERSION
-          value: v1.19.1
+        - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
         securityContext:
           privileged: true
         resources:
@@ -1253,7 +1248,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -1290,12 +1285,10 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         imagePullPolicy: Always
         command:
-        - make
-        args:
-        - run-expose-strategy-e2e-test-in-kind
+        - ./hack/run-expose-strategy-e2e-test-in-kind.sh
         env:
         - name: HELM_BINARY
           value: helm3
@@ -1324,16 +1317,14 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
           env:
             - name: KUBERMATIC_EDITION
               value: ce
             - name: HELM_BINARY
               value: helm3
           command:
-            - make
-          args:
-            - run-ccm-migration-e2e-test-in-kind
+            - ./hack/run-ccm-migration-e2e-test-in-kind.sh
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -1359,7 +1350,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.8-2
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode

--- a/Makefile
+++ b/Makefile
@@ -157,18 +157,6 @@ run-operator:
 run-master-controller-manager:
 	./hack/run-master-controller-manager.sh
 
-.PHONY: run-nodeport-proxy-e2e-test-in-kind
-run-nodeport-proxy-e2e-test-in-kind:
-	./hack/run-nodeport-proxy-e2e-test-in-kind.sh
-
-.PHONY: run-expose-strategy-e2e-test-in-kind
-run-expose-strategy-e2e-test-in-kind:
-	./hack/run-expose-strategy-e2e-test-in-kind.sh
-
-.PHONY: run-ccm-migration-e2e-test-in-kind
-run-ccm-migration-e2e-test-in-kind:
-	./hack/run-ccm-migration-e2e-test-in-kind.sh
-
 .PHONY: verify
 verify:
 	./hack/verify-codegen.sh

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -67,7 +67,7 @@ echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 
 beforeKindCreate=$(nowms)
-export KIND_NODE_VERSION=v1.18.2
+export KIND_NODE_VERSION=v1.21.1
 kind create cluster --name "$KIND_CLUSTER_NAME" --image=kindest/node:$KIND_NODE_VERSION
 pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$KIND_NODE_VERSION\""
 

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -32,7 +32,7 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.20.2}"
+KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.21.1}"
 KIND_PORT="${KIND_PORT-31000}"
 USER_CLUSTER_KUBERNETES_VERSION="${USER_CLUSTER_KUBERNETES_VERSION:-v1.20.2}"
 USER_CLUSTER_NAME="${USER_CLUSTER_NAME-$(head -3 /dev/urandom | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]' | cut -c -10)}"
@@ -41,7 +41,7 @@ KUBECONFIG="${KUBECONFIG:-"${HOME}/.kube/config"}"
 HELM_BINARY="${HELM_BINARY:-helm}" # This works when helm 3 is in path
 
 REPOSUFFIX=""
-if [ "${KUBERMATIC_EDITION}" == "ee" ]; then
+if [ "${KUBERMATIC_EDITION:-}" == "ee" ]; then
   REPOSUFFIX="-${KUBERMATIC_EDITION}"
 fi
 

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -44,13 +44,13 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.20.2}"
+KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.21.1}"
 USER_CLUSTER_KUBERNETES_VERSION="${USER_CLUSTER_KUBERNETES_VERSION:-v1.20.2}"
 KUBECONFIG="${KUBECONFIG:-"${HOME}/.kube/config"}"
 HELM_BINARY="${HELM_BINARY:-helm}" # This works when helm 3 is in path
 
 REPOSUFFIX=""
-if [ "${KUBERMATIC_EDITION}" == "ee" ]; then
+if [ "${KUBERMATIC_EDITION:-}" == "ee" ]; then
   REPOSUFFIX="-${KUBERMATIC_EDITION}"
 fi
 

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -27,7 +27,7 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.18.2}"
+KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.21.1}"
 
 type kind > /dev/null || fatal \
   "Kind is required to run this script, please refer to: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"


### PR DESCRIPTION
**What this PR does / why we need it**:
We were using an unsupported version (1.18.2) for our tests, which will cause great headache once we add Kubernetes 1.22 support.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to #7457 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
