### PR TITLE
[release/v2.17] respect cluster pause flag in usercluster-controller-manager (#7470)

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 
 	clusterrolelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/cluster-role-labeler"
 	constraintsyncer "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/constraint-syncer"
@@ -220,6 +221,13 @@ func main() {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", apiregistrationv1beta1.SchemeGroupVersion), zap.Error(err))
 	}
 
+	parts := strings.SplitN(runOp.namespace, "-", 2)
+	if len(parts) < 2 {
+		log.Fatal("Invalid cluster namespace given, must be `cluster-....`.")
+	}
+
+	isPausedChecker := userclustercontrollermanager.NewClusterPausedChecker(seedMgr.GetClient(), parts[1])
+
 	// Setup all Controllers
 	log.Info("registering controllers")
 	if err := usercluster.Add(mgr,
@@ -228,6 +236,7 @@ func main() {
 		runOp.namespace,
 		runOp.cloudProviderName,
 		clusterURL,
+		isPausedChecker,
 		uint32(runOp.openvpnServerPort),
 		uint32(runOp.kasSecurePort),
 		runOp.tunnelingAgentIP.IP,
@@ -265,17 +274,20 @@ func main() {
 				log.Fatalw("Failed to initially create the Machine CR", zap.Error(err))
 			}
 		}
+
+		// IPAM is critical for a cluster, so the isPauseChecker is not used in this controller
 		if err := ipam.Add(mgr, runOp.networks, log); err != nil {
 			log.Fatalw("Failed to add IPAM controller to mgr", zap.Error(err))
 		}
 		log.Infof("Added IPAM controller to mgr")
 	}
 
-	if err := rbacusercluster.Add(mgr, mgr.AddReadyzCheck); err != nil {
+	if err := rbacusercluster.Add(mgr, mgr.AddReadyzCheck, isPausedChecker); err != nil {
 		log.Fatalw("Failed to add user RBAC controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered user RBAC controller")
 
+	// CSRs are critical for a cluster, so the isPauseChecker is not used in this controller
 	if err := nodecsrapprover.Add(mgr, 4, cfg, log); err != nil {
 		log.Fatalw("Failed to add nodecsrapprover controller", zap.Error(err))
 	}
@@ -285,32 +297,34 @@ func main() {
 		Start:  runOp.updateWindowStart,
 		Length: runOp.updateWindowLength,
 	}
-	if err := flatcar.Add(mgr, runOp.overwriteRegistry, updateWindow); err != nil {
+	if err := flatcar.Add(mgr, runOp.overwriteRegistry, updateWindow, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register the Flatcar controller", zap.Error(err))
 	}
 	log.Info("Registered Flatcar controller")
 
+	// node labels can be critical to a cluster functioning, so we do not stop applying
+	// labels once a cluster is paused, hence no isPausedChecker here
 	if err := nodelabeler.Add(rootCtx, log, mgr, nodeLabels); err != nil {
 		log.Fatalw("Failed to register nodelabel controller", zap.Error(err))
 	}
 	log.Info("Registered nodelabel controller")
 
-	if err := clusterrolelabeler.Add(rootCtx, log, mgr); err != nil {
+	if err := clusterrolelabeler.Add(rootCtx, log, mgr, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register clusterrolelabeler controller", zap.Error(err))
 	}
 	log.Info("Registered clusterrolelabeler controller")
 
-	if err := rolecloner.Add(rootCtx, log, mgr); err != nil {
+	if err := rolecloner.Add(rootCtx, log, mgr, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register rolecloner controller", zap.Error(err))
 	}
 	log.Info("Registered rolecloner controller")
-	if err := ownerbindingcreator.Add(rootCtx, log, mgr, runOp.ownerEmail); err != nil {
+	if err := ownerbindingcreator.Add(rootCtx, log, mgr, runOp.ownerEmail, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register ownerbindingcreator controller", zap.Error(err))
 	}
 	log.Info("Registered ownerbindingcreator controller")
 
 	if runOp.opaIntegration {
-		if err := constraintsyncer.Add(rootCtx, log, seedMgr, mgr, runOp.namespace); err != nil {
+		if err := constraintsyncer.Add(rootCtx, log, seedMgr, mgr, runOp.namespace, isPausedChecker); err != nil {
 			log.Fatalw("Failed to register constraintsyncer controller", zap.Error(err))
 		}
 		log.Info("Registered constraintsyncer controller")

--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
@@ -22,6 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 
@@ -43,18 +44,20 @@ const (
 )
 
 type reconciler struct {
-	log      *zap.SugaredLogger
-	client   ctrlruntimeclient.Client
-	recorder record.EventRecorder
+	log             *zap.SugaredLogger
+	client          ctrlruntimeclient.Client
+	recorder        record.EventRecorder
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
-		log:      log,
-		client:   mgr.GetClient(),
-		recorder: mgr.GetEventRecorderFor(controllerName),
+		log:             log,
+		client:          mgr.GetClient(),
+		recorder:        mgr.GetEventRecorderFor(controllerName),
+		clusterIsPaused: clusterIsPaused,
 	}
 	c, err := controller.New(controllerName, mgr, controller.Options{
 		Reconciler: r,
@@ -72,6 +75,14 @@ func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager) error
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	log := r.log.With("ClusterRole", request.Name)
 	log.Debug("Reconciling")
 
@@ -84,7 +95,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster role: %v", err)
 	}
 
-	err := r.reconcile(ctx, log, clusterRole)
+	err = r.reconcile(ctx, log, clusterRole)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(clusterRole, corev1.EventTypeWarning, "AddingLabelFailed", err.Error())

--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler_test.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler_test.go
@@ -86,6 +86,9 @@ func TestReconcile(t *testing.T) {
 				log:      kubermaticlog.Logger,
 				client:   client,
 				recorder: record.NewFakeRecorder(10),
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -139,6 +139,9 @@ func TestReconcile(t *testing.T) {
 				recorder:   &record.FakeRecorder{},
 				seedClient: tc.seedClient,
 				userClient: tc.userClient,
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			request := reconcile.Request{NamespacedName: tc.namespacedName}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar/resources"
 	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
@@ -44,14 +45,16 @@ type Reconciler struct {
 	ctrlruntimeclient.Client
 	overwriteRegistry string
 	updateWindow      kubermaticv1.UpdateWindow
+	clusterIsPaused   userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow) error {
+func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 
 	reconciler := &Reconciler{
 		Client:            mgr.GetClient(),
 		overwriteRegistry: overwriteRegistry,
 		updateWindow:      updateWindow,
+		clusterIsPaused:   clusterIsPaused,
 	}
 
 	ctrlOptions := controller.Options{Reconciler: reconciler}
@@ -68,6 +71,14 @@ func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	if err := r.reconcileUpdateOperatorResources(ctx); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile the UpdateOperator resources: %v", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
@@ -22,6 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	corev1 "k8s.io/api/core/v1"
@@ -45,20 +46,22 @@ const (
 )
 
 type reconciler struct {
-	log        *zap.SugaredLogger
-	client     ctrlruntimeclient.Client
-	recorder   record.EventRecorder
-	ownerEmail string
+	log             *zap.SugaredLogger
+	client          ctrlruntimeclient.Client
+	recorder        record.EventRecorder
+	ownerEmail      string
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, ownerEmail string) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, ownerEmail string, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
-		log:        log,
-		client:     mgr.GetClient(),
-		recorder:   mgr.GetEventRecorderFor(controllerName),
-		ownerEmail: ownerEmail,
+		log:             log,
+		client:          mgr.GetClient(),
+		recorder:        mgr.GetEventRecorderFor(controllerName),
+		ownerEmail:      ownerEmail,
+		clusterIsPaused: clusterIsPaused,
 	}
 	c, err := controller.New(controllerName, mgr, controller.Options{
 		Reconciler: r,
@@ -80,10 +83,18 @@ func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, owner
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	log := r.log.With("ClusterRole", request.Name)
 	log.Debug("Reconciling")
 
-	err := r.reconcile(ctx, log, request.Name)
+	err = r.reconcile(ctx, log, request.Name)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: request.Name}}, corev1.EventTypeWarning, "AddingBindingFailed", err.Error())

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator_test.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator_test.go
@@ -111,6 +111,9 @@ func TestReconcile(t *testing.T) {
 				client:     client,
 				recorder:   record.NewFakeRecorder(10),
 				ownerEmail: tc.ownerEmail,
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			ctx := context.Background()

--- a/pkg/controller/user-cluster-controller-manager/pause.go
+++ b/pkg/controller/user-cluster-controller-manager/pause.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userclustercontrollermanager
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type IsPausedChecker func(context.Context) (bool, error)
+
+func NewClusterPausedChecker(seedClient client.Client, clusterName string) IsPausedChecker {
+	return func(ctx context.Context) (bool, error) {
+		cluster := &kubermaticv1.Cluster{}
+		if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to get cluster %q: %w", clusterName, err)
+		}
+
+		return cluster.Spec.Pause, nil
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/rbac/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/controller.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"sync"
 
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	"k8s.io/apimachinery/pkg/types"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -62,8 +63,8 @@ var mapFn = handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) 
 
 // Add creates a new RBAC generator controller that is responsible for creating Cluster Roles and Cluster Role Bindings
 // for groups: `owners`, `editors` and `viewers``
-func Add(mgr manager.Manager, registerReconciledCheck func(name string, check healthz.Checker) error) error {
-	reconcile := &reconcileRBAC{Client: mgr.GetClient(), rLock: &sync.Mutex{}}
+func Add(mgr manager.Manager, registerReconciledCheck func(name string, check healthz.Checker) error, clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
+	reconcile := &reconcileRBAC{Client: mgr.GetClient(), rLock: &sync.Mutex{}, clusterIsPaused: clusterIsPaused}
 
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconcile})
@@ -97,11 +98,20 @@ type reconcileRBAC struct {
 	ctrlruntimeclient.Client
 
 	rLock                      *sync.Mutex
+	clusterIsPaused            userclustercontrollermanager.IsPausedChecker
 	reconciledSuccessfullyOnce bool
 }
 
 // Reconcile makes changes in response to Cluster Role and Cluster Role Binding related changes
 func (r *reconcileRBAC) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
 	rdr := reconciler{client: r.Client}
 
 	if err := rdr.Reconcile(ctx, request.Name); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -72,6 +73,7 @@ func Add(
 	namespace string,
 	cloudProviderName string,
 	clusterURL *url.URL,
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker,
 	openvpnServerPort uint32,
 	kasSecurePort uint32,
 	tunnelingAgentIP net.IP,
@@ -89,6 +91,7 @@ func Add(
 		rLock:             &sync.Mutex{},
 		namespace:         namespace,
 		clusterURL:        clusterURL,
+		clusterIsPaused:   clusterIsPaused,
 		openvpnServerPort: openvpnServerPort,
 		kasSecurePort:     kasSecurePort,
 		tunnelingAgentIP:  tunnelingAgentIP,
@@ -204,6 +207,7 @@ type reconciler struct {
 	cache             cache.Cache
 	namespace         string
 	clusterURL        *url.URL
+	clusterIsPaused   userclustercontrollermanager.IsPausedChecker
 	openvpnServerPort uint32
 	kasSecurePort     uint32
 	tunnelingAgentIP  net.IP
@@ -224,6 +228,15 @@ type reconciler struct {
 
 // Reconcile makes changes in response to objects in the user cluster.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		r.log.Debug("Cluster is paused, not reconciling.")
+		return reconcile.Result{}, nil
+	}
+
 	if err := r.reconcile(ctx); err != nil {
 		r.log.Errorw("Reconciling failed", zap.Error(err))
 		return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner_test.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner/role_cloner_test.go
@@ -314,6 +314,9 @@ func TestReconcile(t *testing.T) {
 				log:      kubermaticlog.Logger,
 				client:   clientBuilder.Build(),
 				recorder: record.NewFakeRecorder(10),
+				clusterIsPaused: func(c context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 
 			ctx := context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport of #7470.

Co-authored-by: Jiacheng Xu <xjcmaxwellcjx@gmail.com>

**Does this PR introduce a user-facing change?**:
```release-note
Paused userclusters do not reconcile in-cluster resources via the usercluster-controller-manager anymore.
```
