### PR TITLE
Add MLASettings to addon ClusterData

### DIFF
--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -56,6 +56,8 @@ type ClusterData struct {
 	Features sets.String
 	// CNIPlugin contains the CNIPlugin settings
 	CNIPlugin CNIPlugin
+	// MLA contains monitoring, logging and alerting related settings for the user cluster.
+	MLA MLASettings
 }
 
 type ClusterNetwork struct {
@@ -70,6 +72,13 @@ type ClusterNetwork struct {
 type CNIPlugin struct {
 	Type    string
 	Version string
+}
+
+type MLASettings struct {
+	// MonitoringEnabled is the flag for enabling monitoring in user cluster.
+	MonitoringEnabled bool
+	// LoggingEnabled is the flag for enabling logging in user cluster.
+	LoggingEnabled bool
 }
 
 type Credentials struct {

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -129,6 +129,10 @@ func NewTemplateData(
 				ProxyMode:         cluster.Spec.ClusterNetwork.ProxyMode,
 			},
 			CNIPlugin: cniPlugin,
+			MLA: MLASettings{
+				MonitoringEnabled: cluster.Spec.MLA != nil && cluster.Spec.MLA.MonitoringEnabled,
+				LoggingEnabled:    cluster.Spec.MLA != nil && cluster.Spec.MLA.LoggingEnabled,
+			},
 		},
 	}, nil
 }
@@ -182,6 +186,8 @@ type ClusterData struct {
 	Features sets.String
 	// CNIPlugin contains the CNIPlugin settings
 	CNIPlugin CNIPlugin
+	// MLA contains monitoring, logging and alerting related settings for the user cluster.
+	MLA MLASettings
 }
 
 type ClusterNetwork struct {
@@ -196,6 +202,13 @@ type ClusterNetwork struct {
 type CNIPlugin struct {
 	Type    string
 	Version string
+}
+
+type MLASettings struct {
+	// MonitoringEnabled is the flag for enabling monitoring in user cluster.
+	MonitoringEnabled bool
+	// LoggingEnabled is the flag for enabling logging in user cluster.
+	LoggingEnabled bool
 }
 
 func ParseFromFolder(log *zap.SugaredLogger, overwriteRegistry string, manifestPath string, data *TemplateData) ([]runtime.RawExtension, error) {


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Adds `MLASettings` to addon `ClusterData` so that it can be used for addon templating. Will be used in e.g. in coming kube-state-metrics or existing node-exporter addons.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
