### PR TITLE
update Dex to 2.30.0, add 1.22 compatibility

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: oauth
-version: 1.5.5
-appVersion: v2.27.0
+version: 1.6.0
+appVersion: v2.30.0
 description: Dex
 keywords:
 - kubermatic

--- a/charts/oauth/templates/cluster-role-binding.yaml
+++ b/charts/oauth/templates/cluster-role-binding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: '{{ template "name" . }}'

--- a/charts/oauth/templates/cluster-role.yaml
+++ b/charts/oauth/templates/cluster-role.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ template "name" . }}'

--- a/charts/oauth/templates/ingress.yaml
+++ b/charts/oauth/templates/ingress.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{ if ne .Values.dex.ingress.class "non-existent" }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dex
@@ -31,17 +31,22 @@ spec:
   - secretName: dex-tls
     hosts:
     - {{ .Values.dex.ingress.host }}
-  backend:
-    serviceName: dex
-    servicePort: 5556
+  defaultBackend:
+    service:
+      name: dex
+      port:
+        number: 5556
   rules:
   - host: {{ .Values.dex.ingress.host }}
     http:
       paths:
       - path: {{ .Values.dex.ingress.path }}
+        pathType: Prefix
         backend:
-          serviceName: dex
-          servicePort: 5556
+          service:
+            name: dex
+            port:
+              number: 5556
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.ingress | trim | indent 6 }}
 {{- end }}
 {{ end }}

--- a/charts/oauth/templates/pdb.yaml
+++ b/charts/oauth/templates/pdb.yaml
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else }}
 apiVersion: policy/v1beta1
+{{ end }}
 kind: PodDisruptionBudget
 metadata:
   name: dex

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -14,8 +14,8 @@
 
 dex:
   image:
-    repository: "docker.io/dexidp/dex"
-    tag: "v2.27.0"
+    repository: "ghcr.io/dexidp/dex"
+    tag: "v2.30.0"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
**What this PR does / why we need it**:
`policy/v1beta1` is deprecated in 1.21, but `v1` is only available 1.21+, so to be compatible with our range (1.19+), we need a version switch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Actual release-notes, if this wasn't reverted in #7497:

```
update Dex to 2.30.0
Action required: Custom `grpc.ingress` configuration in the Dex chart is now inserted into a `networking/v1` `Ingress`, you must adjust the `service` and `pathType` accordingly.
```