### PR TITLE
Revert "update Dex to 2.30.0, add 1.22 compatibility"

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: oauth
-version: 1.6.0
-appVersion: v2.30.0
+version: 1.5.5
+appVersion: v2.27.0
 description: Dex
 keywords:
 - kubermatic

--- a/charts/oauth/templates/cluster-role-binding.yaml
+++ b/charts/oauth/templates/cluster-role-binding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: '{{ template "name" . }}'

--- a/charts/oauth/templates/cluster-role.yaml
+++ b/charts/oauth/templates/cluster-role.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: '{{ template "name" . }}'

--- a/charts/oauth/templates/ingress.yaml
+++ b/charts/oauth/templates/ingress.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{ if ne .Values.dex.ingress.class "non-existent" }}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: dex
@@ -31,22 +31,17 @@ spec:
   - secretName: dex-tls
     hosts:
     - {{ .Values.dex.ingress.host }}
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
+  backend:
+    serviceName: dex
+    servicePort: 5556
   rules:
   - host: {{ .Values.dex.ingress.host }}
     http:
       paths:
       - path: {{ .Values.dex.ingress.path }}
-        pathType: Prefix
         backend:
-          service:
-            name: dex
-            port:
-              number: 5556
+          serviceName: dex
+          servicePort: 5556
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.ingress | trim | indent 6 }}
 {{- end }}
 {{ end }}

--- a/charts/oauth/templates/pdb.yaml
+++ b/charts/oauth/templates/pdb.yaml
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{ else }}
 apiVersion: policy/v1beta1
-{{ end }}
 kind: PodDisruptionBudget
 metadata:
   name: dex

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -14,8 +14,8 @@
 
 dex:
   image:
-    repository: "ghcr.io/dexidp/dex"
-    tag: "v2.30.0"
+    repository: "docker.io/dexidp/dex"
+    tag: "v2.27.0"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
Reverts kubermatic/kubermatic#7494

This breaks the e2e tests and I don't have time to debug them right now.

```release-note
NONE
```