### PR TITLE
fix Ingress in oauth chart

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.5.6
+version: 1.5.7
 appVersion: v2.27.0
 description: Dex
 keywords:

--- a/charts/oauth/templates/ingress.yaml
+++ b/charts/oauth/templates/ingress.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{ if ne .Values.dex.ingress.class "non-existent" }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dex


### PR DESCRIPTION
**What this PR does / why we need it**:
I made yet another typo...

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
