### PR TITLE
use simple amd64 images for user-ssh-key-agent during e2e tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -395,837 +395,837 @@ presubmits:
   # Base Kubernetes Tests (AWS, Flatcar)
   #########################################################
 
-  - name: pre-kubermatic-e2e-aws-flatcar-1.18
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.18.17"
-        - name: DISTRIBUTIONS
-          value: flatcar
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-flatcar-1.18
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.18.17"
+  #       - name: DISTRIBUTIONS
+  #         value: flatcar
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.19
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.9"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.19
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.9"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.20
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.20.5"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.20
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.20.5"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.21
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.21
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.21-ce
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: "ce"
-        - name: ONLY_TEST_CREATION
-          value: "true"
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.21-ce
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: "ce"
+  #       - name: ONLY_TEST_CREATION
+  #         value: "true"
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  #########################################################
-  # Extended Kubernetes Tests (various cloud providers, OS)
-  #########################################################
+  # #########################################################
+  # # Extended Kubernetes Tests (various cloud providers, OS)
+  # #########################################################
 
-  - name: pre-kubermatic-e2e-azure-ubuntu-1.21
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-azure: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: PROVIDER
-          value: "azure"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-azure-ubuntu-1.21
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-azure: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: PROVIDER
+  #         value: "azure"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.21
-    decorate: true
-    always_run: false
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "gcp"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.21
+  #   decorate: true
+  #   always_run: false
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "gcp"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.21-psp
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "gcp"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: KUBERMATIC_PSP_ENABLED
-          value: "true"
-        - name: ONLY_TEST_CREATION
-          value: "true"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.21-psp
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "gcp"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: KUBERMATIC_PSP_ENABLED
+  #         value: "true"
+  #       - name: ONLY_TEST_CREATION
+  #         value: "true"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-do-centos-1.21
-    decorate: true
-    always_run: false
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: DISTRIBUTIONS
-          value: centos
-        - name: PROVIDER
-          value: "digitalocean"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-do-centos-1.21
+  #   decorate: true
+  #   always_run: false
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: DISTRIBUTIONS
+  #         value: centos
+  #       - name: PROVIDER
+  #         value: "digitalocean"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-packet-ubuntu-1.21
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-packet: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "packet"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-packet-ubuntu-1.21
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-packet: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "packet"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-kubevirt-centos-1.21
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-kubevirt: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "kubevirt"
-        - name: DISTRIBUTIONS
-          value: centos
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-kubevirt-centos-1.21
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-kubevirt: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "kubevirt"
+  #       - name: DISTRIBUTIONS
+  #         value: centos
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.21
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-hetzner: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "hetzner"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-hetzner-ubuntu-1.21
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-hetzner: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "hetzner"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-ubuntu-1.21
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "openstack"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-openstack-ubuntu-1.21
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "openstack"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-centos-1.21
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "openstack"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: DISTRIBUTIONS
-          value: centos
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-openstack-centos-1.21
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "openstack"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: DISTRIBUTIONS
+  #         value: centos
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
-    decorate: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
+  #   decorate: true
+  #   run_if_changed: "pkg/provider/cloud/vsphere"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
-    decorate: true
-    optional: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SCENARIO_OPTIONS
-          value: "custom-folder"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "pkg/provider/cloud/vsphere"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SCENARIO_OPTIONS
+  #         value: "custom-folder"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
-    decorate: true
-    optional: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SCENARIO_OPTIONS
-          value: "datastore-cluster"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "pkg/provider/cloud/vsphere"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.0"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SCENARIO_OPTIONS
+  #         value: "datastore-cluster"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  #########################################################
-  # REST API e2e tests
-  #########################################################
+  # #########################################################
+  # # REST API e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-api-e2e
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-openstack: "true"
-      preset-azure: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-gce: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        imagePullPolicy: Always
-        command:
-        - "./hack/ci/run-api-e2e.sh"
-        env:
-        - name: VERSION_TO_TEST
-          value: v1.18.10
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
+  # - name: pre-kubermatic-api-e2e
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-openstack: "true"
+  #     preset-azure: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-gce: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       imagePullPolicy: Always
+  #       command:
+  #       - "./hack/ci/run-api-e2e.sh"
+  #       env:
+  #       - name: VERSION_TO_TEST
+  #         value: v1.18.10
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
 
-  #########################################################
-  # etcd-launcher e2e tests
-  #########################################################
+  # #########################################################
+  # # etcd-launcher e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-etcd-launcher-e2e
-    run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-        command:
-        - "./hack/ci/run-etcd-launcher-tests.sh"
-        env:
-        - name: VERSION_TO_TEST
-          value: v1.21.0
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
+  # - name: pre-kubermatic-etcd-launcher-e2e
+  #   run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+  #       command:
+  #       - "./hack/ci/run-etcd-launcher-tests.sh"
+  #       env:
+  #       - name: VERSION_TO_TEST
+  #         value: v1.21.0
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
 
   #########################################################
   # NodePort Proxy e2e tests

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -369,13 +369,9 @@ presubmits:
   - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
     decorate: true
     always_run: false
-    optional: true
+    run_if_changed: "cmd/user-ssh-key-agent/"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
       preset-goproxy: "true"
     spec:
       containers:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -396,837 +396,837 @@ presubmits:
   # Base Kubernetes Tests (AWS, Flatcar)
   #########################################################
 
-  # - name: pre-kubermatic-e2e-aws-flatcar-1.18
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.18.17"
-  #       - name: DISTRIBUTIONS
-  #         value: flatcar
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-flatcar-1.18
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.18.17"
+        - name: DISTRIBUTIONS
+          value: flatcar
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.19
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.9"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.19
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.9"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.20
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.20.5"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.20
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.20.5"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.21
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.21
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.21-ce
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: "ce"
-  #       - name: ONLY_TEST_CREATION
-  #         value: "true"
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.21-ce
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: "ce"
+        - name: ONLY_TEST_CREATION
+          value: "true"
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # #########################################################
-  # # Extended Kubernetes Tests (various cloud providers, OS)
-  # #########################################################
+  #########################################################
+  # Extended Kubernetes Tests (various cloud providers, OS)
+  #########################################################
 
-  # - name: pre-kubermatic-e2e-azure-ubuntu-1.21
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-azure: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: PROVIDER
-  #         value: "azure"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.21
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: PROVIDER
+          value: "azure"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.21
-  #   decorate: true
-  #   always_run: false
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "gcp"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.21
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "gcp"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.21-psp
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "gcp"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: KUBERMATIC_PSP_ENABLED
-  #         value: "true"
-  #       - name: ONLY_TEST_CREATION
-  #         value: "true"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.21-psp
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "gcp"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: KUBERMATIC_PSP_ENABLED
+          value: "true"
+        - name: ONLY_TEST_CREATION
+          value: "true"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-do-centos-1.21
-  #   decorate: true
-  #   always_run: false
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: DISTRIBUTIONS
-  #         value: centos
-  #       - name: PROVIDER
-  #         value: "digitalocean"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-do-centos-1.21
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: DISTRIBUTIONS
+          value: centos
+        - name: PROVIDER
+          value: "digitalocean"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-packet-ubuntu-1.21
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-packet: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "packet"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-packet-ubuntu-1.21
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-packet: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "packet"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-kubevirt-centos-1.21
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-kubevirt: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "kubevirt"
-  #       - name: DISTRIBUTIONS
-  #         value: centos
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-kubevirt-centos-1.21
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubevirt: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "kubevirt"
+        - name: DISTRIBUTIONS
+          value: centos
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-hetzner-ubuntu-1.21
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-hetzner: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "hetzner"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.21
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-hetzner: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "hetzner"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-openstack-ubuntu-1.21
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "openstack"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-openstack-ubuntu-1.21
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-openstack-centos-1.21
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "openstack"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: DISTRIBUTIONS
-  #         value: centos
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-openstack-centos-1.21
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: DISTRIBUTIONS
+          value: centos
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
-  #   decorate: true
-  #   run_if_changed: "pkg/provider/cloud/vsphere"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
+    decorate: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "pkg/provider/cloud/vsphere"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SCENARIO_OPTIONS
-  #         value: "custom-folder"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SCENARIO_OPTIONS
+          value: "custom-folder"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "pkg/provider/cloud/vsphere"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.0"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SCENARIO_OPTIONS
-  #         value: "datastore-cluster"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.0"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SCENARIO_OPTIONS
+          value: "datastore-cluster"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # #########################################################
-  # # REST API e2e tests
-  # #########################################################
+  #########################################################
+  # REST API e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-api-e2e
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-openstack: "true"
-  #     preset-azure: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-gce: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       imagePullPolicy: Always
-  #       command:
-  #       - "./hack/ci/run-api-e2e.sh"
-  #       env:
-  #       - name: VERSION_TO_TEST
-  #         value: v1.18.10
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
+  - name: pre-kubermatic-api-e2e
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-openstack: "true"
+      preset-azure: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-gce: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        imagePullPolicy: Always
+        command:
+        - "./hack/ci/run-api-e2e.sh"
+        env:
+        - name: VERSION_TO_TEST
+          value: v1.18.10
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
 
-  # #########################################################
-  # # etcd-launcher e2e tests
-  # #########################################################
+  #########################################################
+  # etcd-launcher e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-etcd-launcher-e2e
-  #   run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
-  #       command:
-  #       - "./hack/ci/run-etcd-launcher-tests.sh"
-  #       env:
-  #       - name: VERSION_TO_TEST
-  #         value: v1.21.0
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
+  - name: pre-kubermatic-etcd-launcher-e2e
+    run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        command:
+        - "./hack/ci/run-etcd-launcher-tests.sh"
+        env:
+        - name: VERSION_TO_TEST
+          value: v1.21.0
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
 
   #########################################################
   # NodePort Proxy e2e tests

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -366,6 +366,35 @@ presubmits:
             limits:
               memory: 6Gi
 
+  - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-0
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        command:
+        - "./hack/ci/run-user-ssh-key-agent-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
+
   #########################################################
   # Base Kubernetes Tests (AWS, Flatcar)
   #########################################################

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -369,7 +369,7 @@ presubmits:
   - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
     decorate: true
     always_run: false
-    run_if_changed: "cmd/user-ssh-key-agent/"
+    run_if_changed: "cmd/user-ssh-keys-agent/"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-goproxy: "true"
@@ -387,9 +387,10 @@ presubmits:
         resources:
           requests:
             memory: 4Gi
-            cpu: 3.5
+            cpu: 3
           limits:
             memory: 4Gi
+            cpu: 3
 
   #########################################################
   # Base Kubernetes Tests (AWS, Flatcar)

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -12,23 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.16.4 as builder
-
-ARG HOST_GOCACHE
-WORKDIR /go/src/github.com/kubermatic/kubermatic
-
-COPY ./cmd/user-ssh-keys-agent ./cmd/user-ssh-keys-agent
-COPY ./cmd/http-prober/api ./cmd/http-prober/api
-COPY ./pkg ./pkg
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-
-ENV CGO_ENABLED=0
-ENV GOCACHE=/go/src/github.com/kubermatic/kubermatic/cmd/user-ssh-keys-agent/$HOST_GOCACHE
-RUN go build -v -o ./_build/user-ssh-keys-agent ./cmd/user-ssh-keys-agent
-
-FROM docker.io/alpine:3.13
+FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY --from=builder /go/src/github.com/kubermatic/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
+FROM docker.io/golang:1.16.1 as builder
 
-.PHONY: build
-build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
+WORKDIR /go/src/github.com/kubermatic/kubermatic
+COPY . .
+RUN make -C /cmd/user-ssh-keys-agent build
 
-.PHONY: docker
-docker: build
-	docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
+FROM docker.io/alpine:3.13
+LABEL maintainer="support@kubermatic.com"
+
+COPY --from=builder /go/src/github.com/kubermatic/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -29,5 +29,5 @@ RUN make -C ./cmd/user-ssh-keys-agent build
 FROM docker.io/alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY --from=builder /go/src/k8c.io/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -14,12 +14,20 @@
 
 FROM docker.io/golang:1.16.1 as builder
 
-WORKDIR /go/src/github.com/kubermatic/kubermatic
+# import the GOPROXY variable from Buildah via an arg and then use
+# that arg to define the environment variable later on
+ARG GOPROXY=
+ARG KUBERMATIC_EDITION=ce
+
+ENV GOPROXY=$GOPROXY
+ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
+
+WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
-RUN make -C /cmd/user-ssh-keys-agent build
+RUN make -C ./cmd/user-ssh-keys-agent build
 
 FROM docker.io/alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY --from=builder /go/src/github.com/kubermatic/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY --from=builder /go/src/k8c.io/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -17,7 +17,7 @@ GOOS ?= $(shell go env GOOS)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/user-ssh-keys-agent
 
 .PHONY: docker
 docker: build

--- a/hack/ci/run-user-ssh-key-agent-tests.sh
+++ b/hack/ci/run-user-ssh-key-agent-tests.sh
@@ -31,14 +31,16 @@ export TAG_NAME=test
 # build multi-arch images
 buildah manifest create "${DOCKER_REPO}/user-ssh-keys-agent:${TAG_NAME}"
 for ARCH in ${ARCHITECTURES}; do
+  echodate "Building image for $ARCH..."
+
   # Building via buildah does not use the gocache, but that's okay, because we
   # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
   # cache size and force every e2e test to download gigabytes worth of unneeded
   # arm64 stuff. We might need to change this once we run e2e tests on arm64.
-  buildah bud \
+  time buildah bud \
     --tag "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${TAG_NAME}" \
     --build-arg "GOPROXY=${GOPROXY:-}" \
-    --build-arg "KUBEMATIC_EDITION=${KUBEMATIC_EDITION}" \
+    --build-arg "KUBERMATIC_EDITION=${KUBERMATIC_EDITION}" \
     --arch "$ARCH" \
     --override-arch "$ARCH" \
     --format=docker \
@@ -46,3 +48,5 @@ for ARCH in ${ARCHITECTURES}; do
     .
   buildah manifest add "${DOCKER_REPO}/user-ssh-keys-agent:${TAG_NAME}" "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${TAG_NAME}"
 done
+
+echodate "Successfully built for all architectures."

--- a/hack/ci/run-user-ssh-key-agent-tests.sh
+++ b/hack/ci/run-user-ssh-key-agent-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script tests whether we can successfully build the multiarch
+### version for the user-ssh-key-agent.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+export DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
+export GOOS="${GOOS:-linux}"
+export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ee}"
+export ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
+export TAG_NAME=test
+
+# build multi-arch images
+buildah manifest create "${DOCKER_REPO}/user-ssh-keys-agent:${TAG_NAME}"
+for ARCH in ${ARCHITECTURES}; do
+  # Building via buildah does not use the gocache, but that's okay, because we
+  # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
+  # cache size and force every e2e test to download gigabytes worth of unneeded
+  # arm64 stuff. We might need to change this once we run e2e tests on arm64.
+  buildah bud \
+    --tag "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${TAG_NAME}" \
+    --arch "$ARCH" \
+    --override-arch "$ARCH" \
+    --format=docker \
+    --file cmd/user-ssh-keys-agent/Dockerfile.multiarch \
+    .
+  buildah manifest add "${DOCKER_REPO}/user-ssh-keys-agent:${TAG_NAME}" "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${TAG_NAME}"
+done

--- a/hack/ci/run-user-ssh-key-agent-tests.sh
+++ b/hack/ci/run-user-ssh-key-agent-tests.sh
@@ -37,6 +37,8 @@ for ARCH in ${ARCHITECTURES}; do
   # arm64 stuff. We might need to change this once we run e2e tests on arm64.
   buildah bud \
     --tag "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${TAG_NAME}" \
+    --build-arg "GOPROXY=${GOPROXY:-}" \
+    --build-arg "KUBEMATIC_EDITION=${KUBEMATIC_EDITION}" \
     --arch "$ARCH" \
     --override-arch "$ARCH" \
     --format=docker \

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -113,9 +113,10 @@ beforeDockerBuild=$(nowms)
   echodate "Building user-ssh-keys-agent image"
   TEST_NAME="Build user-ssh-keys-agent Docker image"
   retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
-  IMAGE_NAME=quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION
   cd cmd/user-ssh-keys-agent
-  time retry 5 make docker TAG="${KUBERMATIC_VERSION}" .
+  make build
+  IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
   time retry 5 docker push "${IMAGE_NAME}"
 )
 (

--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -72,6 +72,8 @@ for ARCH in ${ARCHITECTURES}; do
   # arm64 stuff. We might need to change this once we run e2e tests on arm64.
   buildah bud \
     --tag "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${PRIMARY_TAG}" \
+    --build-arg "GOPROXY=${GOPROXY:-}" \
+    --build-arg "KUBEMATIC_EDITION=${KUBEMATIC_EDITION:-}" \
     --arch "$ARCH" \
     --override-arch "$ARCH" \
     --format=docker \

--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -66,6 +66,8 @@ docker build -t "${DOCKER_REPO}/etcd-launcher:${PRIMARY_TAG}" -f cmd/etcd-launch
 # build multi-arch images
 buildah manifest create "${DOCKER_REPO}/user-ssh-keys-agent:${PRIMARY_TAG}"
 for ARCH in ${ARCHITECTURES}; do
+  echodate "Building user-ssh-keys-agent image for $ARCH..."
+
   # Building via buildah does not use the gocache, but that's okay, because we
   # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
   # cache size and force every e2e test to download gigabytes worth of unneeded
@@ -73,7 +75,7 @@ for ARCH in ${ARCHITECTURES}; do
   buildah bud \
     --tag "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${PRIMARY_TAG}" \
     --build-arg "GOPROXY=${GOPROXY:-}" \
-    --build-arg "KUBEMATIC_EDITION=${KUBEMATIC_EDITION:-}" \
+    --build-arg "KUBERMATIC_EDITION=${KUBERMATIC_EDITION}" \
     --arch "$ARCH" \
     --override-arch "$ARCH" \
     --format=docker \


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the multiarch code for the user-ssh-key-agent is running for everyone who uses `setup-kubermatic-in-kind`, i.e. most tests. We don't actually build anything but the amd64 version, so we waste a lot of time trying to setup a cache and copying 4+GB worth of gazillion of tiny files into the Docker context when building the image.

This PR kind of reverts that and returns the e2e test logic back to the amd64-only code. If also changes the release code to just ignore the gocache entirely. It's slower, but we also don't have to cache arm64 packages that would needlessly blow up the cache.

(EDIT: Actually, building without gocache takes 8min for both amd64 and arm64 -- that is like 20% of the old runtime where we tried to manage the gocache -- i.e. not having a cache for this is actually faster and simpler.)

In the future, we can see if we can maybe separate the caches for architectures, but for now we need to bring our tests back to normal runtimes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
