### PR TITLE
fix typo in iap chart

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: iap
-version: 3.2.1
+version: 3.2.2
 appVersion: v7.0.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:

--- a/charts/iap/templates/pdbs.yaml
+++ b/charts/iap/templates/pdbs.yaml
@@ -14,7 +14,7 @@
 
 {{ range .Values.iap.deployments }}
 ---
-{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
 {{ else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes

> Error: render error in "iap/templates/pdbs.yaml": template: iap/templates/pdbs.yaml:17:19: executing "iap/templates/pdbs.yaml" at <.Capabilities.APIVersions.Has>: nil pointer evaluating interface {}.APIVersions
> Error: UPGRADE FAILED: render error in "iap/templates/pdbs.yaml": template: iap/templates/pdbs.yaml:17:19: executing "iap/templates/pdbs.yaml" at <.Capabilities.APIVersions.Has>: nil pointer evaluating interface {}.APIVersions

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
