### PR TITLE
add konnectivity option for controlplane to cluster communication 

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -209,6 +209,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 			EtcdDataCorruptionChecks:     ctrlCtx.runOptions.featureGates.Enabled(features.EtcdDataCorruptionChecks),
 			KubernetesOIDCAuthentication: ctrlCtx.runOptions.featureGates.Enabled(features.OpenIDAuthPlugin),
 			EtcdLauncher:                 ctrlCtx.runOptions.featureGates.Enabled(features.EtcdLauncher),
+			Konnectivity:                 ctrlCtx.runOptions.featureGates.Enabled(features.KonnectivityService),
 		},
 		ctrlCtx.versions,
 	)

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -90,6 +90,7 @@ type controllerRunOptions struct {
 	userClusterMonitoring        bool
 	prometheusScrapeConfigPrefix string
 	ccmMigration                 bool
+	isKonnectivityEnabled        bool
 }
 
 func main() {
@@ -128,6 +129,7 @@ func main() {
 	flag.BoolVar(&runOp.userClusterMonitoring, "user-cluster-monitoring", false, "Enable monitoring in user cluster.")
 	flag.StringVar(&runOp.prometheusScrapeConfigPrefix, "prometheus-scrape-config-prefix", "prometheus-scraping", fmt.Sprintf("The name prefix of ConfigMaps in namespace %s, which will be used to add customized scrape configs for user cluster Prometheus.", resources.UserClusterMLANamespace))
 	flag.BoolVar(&runOp.ccmMigration, "ccm-migration", false, "Enable ccm migration in user cluster.")
+	flag.BoolVar(&runOp.isKonnectivityEnabled, "konnectivity-enabled", false, "Enable Konnectivity.")
 
 	flag.Parse()
 
@@ -266,6 +268,7 @@ func main() {
 			PrometheusScrapeConfigPrefix: runOp.prometheusScrapeConfigPrefix,
 		},
 		runOp.clusterName,
+		runOp.isKonnectivityEnabled,
 		log,
 	); err != nil {
 		log.Fatalw("Failed to register user cluster controller", zap.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	k8s.io/api v0.21.3
 	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3
+	k8s.io/apiserver v0.21.3
 	k8s.io/autoscaler v0.0.0-20190218140445-7f77136aeea4 // git digest for VPA v0.4.0
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/code-generator v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -2683,6 +2683,7 @@ k8s.io/apimachinery v0.21.3/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCF
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/apiserver v0.17.4/go.mod h1:5ZDQ6Xr5MNBxyi3iUZXS84QOhZl+W7Oq2us/29c0j9I=
 k8s.io/apiserver v0.19.0/go.mod h1:XvzqavYj73931x7FLtyagh8WibHpePJ1QwWrSJs2CLk=
+k8s.io/apiserver v0.21.3 h1:QxAgE1ZPQG5cPlHScHTnLxP9H/kU3zjH1Vnd8G+n5OI=
 k8s.io/apiserver v0.21.3/go.mod h1:eDPWlZG6/cCCMj/JBcEpDoK+I+6i3r9GsChYBHSbAzU=
 k8s.io/autoscaler v0.0.0-20190218140445-7f77136aeea4 h1:My/qvGX4p7+3wWSGZO/QQ4mZq9ly5zoNsMUaec1b/30=
 k8s.io/autoscaler v0.0.0-20190218140445-7f77136aeea4/go.mod h1:QEXezc9uKPT91dwqhSJq3GNI3B1HxFRQHiku9kmrsSA=

--- a/hack/run-seed-controller-manager.sh
+++ b/hack/run-seed-controller-manager.sh
@@ -69,7 +69,7 @@ set -x
   -updates=charts/kubermatic/static/master/updates.yaml \
   -kubernetes-addons-path=addons \
   -kubernetes-addons-file=charts/kubermatic/static/master/kubernetes-addons.yaml \
-  -feature-gates=OpenIDAuthPlugin=true \
+  -feature-gates=OpenIDAuthPlugin=true,KonnectivityService=true \
   -worker-name="$(worker_name)" \
   -external-url=dev.kubermatic.io \
   -backup-container=charts/kubermatic/static/store-container.yaml \

--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -89,4 +89,5 @@ set -x
   -seed-kubeconfig=${SEED_KUBECONFIG} \
   -owner-email=${OWNER_EMAIL} \
   -dns-cluster-ip=10.240.16.10 \
+  -konnectivity-enabled=true \
   ${ARGS}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -67,6 +67,7 @@ type Features struct {
 	EtcdDataCorruptionChecks     bool
 	KubernetesOIDCAuthentication bool
 	EtcdLauncher                 bool
+	Konnectivity                 bool
 }
 
 // Reconciler is a controller which is responsible for managing clusters

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -90,27 +90,29 @@ func Add(
 	caBundle resources.CABundle,
 	userClusterMLA UserClusterMLA,
 	clusterName string,
+	konnectivity bool,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
-		version:           version,
-		rLock:             &sync.Mutex{},
-		namespace:         namespace,
-		clusterURL:        clusterURL,
-		clusterIsPaused:   clusterIsPaused,
-		openvpnServerPort: openvpnServerPort,
-		kasSecurePort:     kasSecurePort,
-		tunnelingAgentIP:  tunnelingAgentIP,
-		log:               log,
-		dnsClusterIP:      dnsClusterIP,
-		nodeLocalDNSCache: nodeLocalDNSCache,
-		opaIntegration:    opaIntegration,
-		opaWebhookTimeout: opaWebhookTimeout,
-		userSSHKeyAgent:   userSSHKeyAgent,
-		versions:          versions,
-		caBundle:          caBundle,
-		userClusterMLA:    userClusterMLA,
-		cloudProvider:     kubermaticv1.ProviderType(cloudProviderName),
-		clusterName:       clusterName,
+		version:               version,
+		rLock:                 &sync.Mutex{},
+		namespace:             namespace,
+		clusterURL:            clusterURL,
+		clusterIsPaused:       clusterIsPaused,
+		openvpnServerPort:     openvpnServerPort,
+		kasSecurePort:         kasSecurePort,
+		tunnelingAgentIP:      tunnelingAgentIP,
+		log:                   log,
+		dnsClusterIP:          dnsClusterIP,
+		nodeLocalDNSCache:     nodeLocalDNSCache,
+		opaIntegration:        opaIntegration,
+		opaWebhookTimeout:     opaWebhookTimeout,
+		userSSHKeyAgent:       userSSHKeyAgent,
+		versions:              versions,
+		caBundle:              caBundle,
+		userClusterMLA:        userClusterMLA,
+		cloudProvider:         kubermaticv1.ProviderType(cloudProviderName),
+		clusterName:           clusterName,
+		isKonnectivityEnabled: konnectivity,
 	}
 
 	var err error
@@ -229,26 +231,27 @@ func Add(
 // reconcileUserCluster reconciles objects in the user cluster
 type reconciler struct {
 	ctrlruntimeclient.Client
-	seedClient        ctrlruntimeclient.Client
-	version           string
-	clusterSemVer     *semver.Version
-	cache             cache.Cache
-	namespace         string
-	clusterURL        *url.URL
-	clusterIsPaused   userclustercontrollermanager.IsPausedChecker
-	openvpnServerPort uint32
-	kasSecurePort     uint32
-	tunnelingAgentIP  net.IP
-	dnsClusterIP      string
-	nodeLocalDNSCache bool
-	opaIntegration    bool
-	opaWebhookTimeout int
-	userSSHKeyAgent   bool
-	versions          kubermatic.Versions
-	caBundle          resources.CABundle
-	userClusterMLA    UserClusterMLA
-	cloudProvider     kubermaticv1.ProviderType
-	clusterName       string
+	seedClient            ctrlruntimeclient.Client
+	version               string
+	clusterSemVer         *semver.Version
+	cache                 cache.Cache
+	namespace             string
+	clusterURL            *url.URL
+	clusterIsPaused       userclustercontrollermanager.IsPausedChecker
+	openvpnServerPort     uint32
+	kasSecurePort         uint32
+	tunnelingAgentIP      net.IP
+	dnsClusterIP          string
+	nodeLocalDNSCache     bool
+	opaIntegration        bool
+	opaWebhookTimeout     int
+	userSSHKeyAgent       bool
+	versions              kubermatic.Versions
+	caBundle              resources.CABundle
+	userClusterMLA        UserClusterMLA
+	cloudProvider         kubermaticv1.ProviderType
+	clusterName           string
+	isKonnectivityEnabled bool
 
 	rLock                      *sync.Mutex
 	reconciledSuccessfullyOnce bool

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/clusterrolebinding.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRoleBindingCreator returns a func to create/update the ClusterRoleBinding for konnectivity
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return resources.KonnectivityClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.ObjectMeta.Labels = map[string]string{
+				"kubernetes.io/cluster-service":   "true",
+				"addonmanager.kubernetes.io/mode": "Reconcile",
+			}
+
+			crb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "system:auth-delegator",
+			}
+
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:     rbacv1.UserKind,
+					APIGroup: rbacv1.GroupName,
+					Name:     resources.KonnectivityClusterRoleBindingUsername,
+				},
+			}
+
+			return crb, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// DeploymentCreator returns function to create/update deployment for konnectivity agents in user cluster.
+func DeploymentCreator(clusterHostname string) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		const (
+			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
+			version = "v0.0.24"
+		)
+
+		return resources.KonnectivityDeploymentName, func(ds *appsv1.Deployment) (*appsv1.Deployment, error) {
+			labels := resources.BaseAppLabels(resources.KonnectivityDeploymentName, nil)
+			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			ds.Spec.Template.ObjectMeta.Labels = labels
+			replicas := int32(1)
+			ds.Spec.Replicas = &replicas
+			ds.Spec.Template.Spec.ServiceAccountName = resources.KonnectivityServiceAccountName
+			ds.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            resources.KonnectivityAgentContainer,
+					Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryUSGCR, name, version),
+					ImagePullPolicy: corev1.PullAlways,
+					Command:         []string{"/proxy-agent"},
+					Args: []string{
+						"--logtostderr=true",
+						"-v=100",
+						"--agent-identifiers=default-route=true",
+						"--ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+						fmt.Sprintf("--proxy-server-host=konnectivity-server.%s", clusterHostname),
+						"--proxy-server-port=6443",
+						"--admin-server-port=8133",
+						"--health-server-port=8134",
+						fmt.Sprintf("--service-account-token-path=/var/run/secrets/tokens/%s", resources.KonnectivityAgentToken),
+					},
+					Resources: corev1.ResourceRequirements{},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.KonnectivityAgentToken,
+							MountPath: "/var/run/secrets/tokens",
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.IntOrString{
+									Type:   intstr.Int,
+									IntVal: 8134,
+								},
+							},
+						},
+						InitialDelaySeconds: 15,
+						TimeoutSeconds:      15,
+					},
+				},
+			}
+			ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: resources.KonnectivityAgentToken,
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Audience: resources.KonnectivityClusterRoleBindingUsername, // TODO(pratik): what?
+										Path:     resources.KonnectivityAgentToken,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return ds, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/serviceaccount.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceAccountCreator returns a func to create/update the ServiceAccount used by konnectivity agents.
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return resources.KonnectivityServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			// TODO(pratik): these labels, why?
+			sa.Labels = map[string]string{
+				"kubernetes.io/cluster-service":   "true",
+				"addonmanager.kubernetes.io/mode": "Reconcile",
+			}
+			return sa, nil
+		}
+	}
+}

--- a/pkg/resources/apiserver/egressselectorconfigmap.go
+++ b/pkg/resources/apiserver/egressselectorconfigmap.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"sigs.k8s.io/yaml"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/apis/apiserver"
+)
+
+// EgressSelectorConfigCreator returns function to create cm that contains egress selection configuration for apiserver
+// to work with konnectivity proxy.
+func EgressSelectorConfigCreator() reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.KonnectivityKubeApiserverEgress, func(c *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			egressConfig := apiserver.EgressSelectorConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "EgressSelectorConfiguration",
+					APIVersion: "apiserver.k8s.io/v1beta1",
+				},
+				EgressSelections: []apiserver.EgressSelection{
+					{
+						Name: "cluster",
+						Connection: apiserver.Connection{
+							ProxyProtocol: "GRPC",
+							Transport: &apiserver.Transport{
+								TCP: nil,
+								UDS: &apiserver.UDSTransport{
+									UDSName: "/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			data, err := yaml.Marshal(egressConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			c.Data = map[string]string{
+				"egress-selector-configuration.yaml": string(data),
+			}
+
+			return c, nil
+		}
+	}
+}

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -88,6 +88,7 @@ type TemplateData struct {
 	inClusterPrometheusScrapingConfigsFile           string
 
 	userClusterMLAEnabled bool
+	isKonnectivityEnabled bool
 }
 
 type TemplateDataBuilder struct {
@@ -170,6 +171,11 @@ func (td *TemplateDataBuilder) WithInClusterPrometheusScrapingConfigsFile(file s
 
 func (td *TemplateDataBuilder) WithUserClusterMLAEnabled(enabled bool) *TemplateDataBuilder {
 	td.data.userClusterMLAEnabled = enabled
+	return td
+}
+
+func (td *TemplateDataBuilder) WithKonnectivityEnabled(enabled bool) *TemplateDataBuilder {
+	td.data.isKonnectivityEnabled = enabled
 	return td
 }
 
@@ -318,6 +324,11 @@ func (d *TemplateData) InClusterPrometheusScrapingConfigsFile() string {
 // UserClusterMLAEnabled returns userClusterMLAEnabled
 func (d *TemplateData) UserClusterMLAEnabled() bool {
 	return d.userClusterMLAEnabled
+}
+
+// IsKonnectivityEnabled returns isKonnectivityEnabled
+func (d *TemplateData) IsKonnectivityEnabled() bool {
+	return d.isKonnectivityEnabled
 }
 
 // NodeAccessNetwork returns the node access network

--- a/pkg/resources/konnectivity/proxyservice.go
+++ b/pkg/resources/konnectivity/proxyservice.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"fmt"
+	"strings"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ServiceCreator returns function to create konnectivity proxy service.
+func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, externalURL string) reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
+		return resources.KonnectivityProxyServiceName, func(se *corev1.Service) (*corev1.Service, error) {
+
+			se.Spec.Selector = map[string]string{
+				resources.AppLabelKey: "apiserver", // because konnectivity proxy runs in sidecar in apiserver pod
+			}
+
+			if se.Annotations == nil {
+				se.Annotations = make(map[string]string)
+			}
+
+			switch exposeStrategy {
+			case kubermaticv1.ExposeStrategyNodePort:
+				se.Spec.Type = corev1.ServiceTypeNodePort
+				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = nodeportproxy.NodePortType.String()
+				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
+			case kubermaticv1.ExposeStrategyLoadBalancer:
+				se.Spec.Type = corev1.ServiceTypeNodePort
+				se.Annotations[nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey] = "true"
+				delete(se.Annotations, nodeportproxy.DefaultExposeAnnotationKey)
+			case kubermaticv1.ExposeStrategyTunneling:
+				se.Spec.Type = corev1.ServiceTypeClusterIP
+				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = strings.Join([]string{nodeportproxy.SNIType.String(), nodeportproxy.TunnelingType.String()}, ",")
+				se.Annotations[nodeportproxy.PortHostMappingAnnotationKey] = fmt.Sprintf(`{"secure": %q}`, "konnectivity-server."+externalURL)
+				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
+			default:
+				return nil, fmt.Errorf("unsupported expose strategy: %q", exposeStrategy)
+			}
+
+			if len(se.Spec.Ports) == 0 {
+				se.Spec.Ports = make([]corev1.ServicePort, 1)
+			}
+
+			const port = 8132
+
+			se.Spec.Ports[0].Name = "secure"
+			se.Spec.Ports[0].Port = 443
+			se.Spec.Ports[0].Protocol = corev1.ProtocolTCP
+			se.Spec.Ports[0].TargetPort = intstr.FromInt(port)
+
+			if exposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+				se.Spec.Ports[0].NodePort = 0
+			}
+
+			return se, nil
+		}
+	}
+}

--- a/pkg/resources/konnectivity/secrets.go
+++ b/pkg/resources/konnectivity/secrets.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+// AgentTokenCreator steals the service account token from konnectivity agent in user-cluster to be used in seed-cluster
+// by the konnectivity agent in the seed-cluster.
+func AgentTokenCreator(userClusterClient ctrlruntimeclient.Client) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return resources.KonnectivityStolenAgentTokenSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
+
+			sa := new(corev1.ServiceAccount)
+			err := userClusterClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{
+				Namespace: "kube-system",
+				Name:      resources.KonnectivityServiceAccountName,
+			}, sa)
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to get konnectivity-service-account: %v", err)
+			}
+
+			if len(sa.Secrets) == 0 {
+				return nil, fmt.Errorf("konnectivity-service-account has no secrets")
+			}
+
+			tokenName := sa.Secrets[0].Name
+			s := new(corev1.Secret)
+			err = userClusterClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{
+				Namespace: "kube-system",
+				Name:      tokenName,
+			}, s)
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to get konnectivity-service-account secret token: %v", err)
+			}
+
+			caCrt, ok := s.Data["ca.crt"]
+			if !ok {
+				return nil, fmt.Errorf("failed to get konnectivity-service-account secret token doesn't have ca.crt: %v", err)
+			}
+
+			token, ok := s.Data["token"]
+			if !ok {
+				return nil, fmt.Errorf("failed to get konnectivity-service-account secret token doesn't have token: %v", err)
+			}
+
+			cm.Data = map[string][]byte{
+				resources.KonnectivityStolenAgentTokenNameCert:  caCrt,
+				resources.KonnectivityStolenAgentTokenNameToken: token,
+			}
+			return cm, nil
+		}
+	}
+}
+
+// ProxyKubeconfig returns kubeconfig for konnectivity proxy server.
+func ProxyKubeconfig(data *resources.TemplateData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return resources.KonnectivityKubeconfigSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
+			if _, exists := se.Data[resources.KonnectivityServerConf]; exists {
+				return se, nil
+			}
+
+			ca, err := data.GetRootCA()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get cluster CA: %v", err)
+			}
+
+			clientKeyPair, err := triple.NewClientKeyPair(ca, "system:konnectivity-server", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create client key pair: %v", err)
+			}
+
+			konnectivityServerConf := v1.Config{
+				Kind:       "Config",
+				APIVersion: "v1",
+				Clusters: []v1.NamedCluster{
+					{
+						Name: "kubernetes",
+						Cluster: v1.Cluster{
+							CertificateAuthorityData: triple.EncodeCertPEM(ca.Cert),
+							Server:                   data.Cluster().Address.URL,
+						},
+					},
+				},
+				AuthInfos: []v1.NamedAuthInfo{
+					{
+						Name: "system:konnectivity-server",
+						AuthInfo: v1.AuthInfo{
+							ClientCertificateData: triple.EncodeCertPEM(clientKeyPair.Cert),
+							ClientKeyData:         triple.EncodePrivateKeyPEM(clientKeyPair.Key),
+						},
+					},
+				},
+				Contexts: []v1.NamedContext{
+					{
+						Name: "system:konnectivity-server@kubernetes",
+						Context: v1.Context{
+							Cluster:  "kubernetes",
+							AuthInfo: "system:konnectivity-server",
+						},
+					},
+				},
+				CurrentContext: "system:konnectivity-server@kubernetes",
+			}
+
+			data, err := json.Marshal(konnectivityServerConf)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshall konnectivity-server config: %v", err)
+			}
+
+			se.Data = map[string][]byte{
+				resources.KonnectivityServerConf: data,
+			}
+
+			return se, nil
+		}
+	}
+}

--- a/pkg/resources/konnectivity/seedagent.go
+++ b/pkg/resources/konnectivity/seedagent.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// DeploymentCreator returns the function to create and update konnectivity agent deployment in seed-cluster.
+func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		const (
+			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
+			version = "v0.0.24"
+		)
+
+		return resources.KonnectivityDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			labels := map[string]string{"app": resources.KonnectivityDeploymentName}
+			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			dep.Spec.Template.ObjectMeta.Labels = labels
+			dep.Spec.Replicas = intPtr(1)
+
+			metricServerAddr := fmt.Sprintf("metrics-server.cluster-%s.svc.cluster.local", data.Cluster().Name)
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            resources.KonnectivityAgentContainer,
+					Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryUSGCR), name, version),
+					ImagePullPolicy: corev1.PullAlways,
+					Command:         []string{"/proxy-agent"},
+					Args: []string{
+						"--logtostderr=true",
+						"-v=100",
+						fmt.Sprintf("--agent-id=metrics-server.cluster-%s.svc.cluster.local", data.Cluster().Name),
+						fmt.Sprintf("--agent-identifiers=host=%s&host=%s:443", metricServerAddr, metricServerAddr),
+						fmt.Sprintf("--ca-cert=/var/run/secrets/certs/%s", resources.KonnectivityStolenAgentTokenNameCert),
+						fmt.Sprintf("--proxy-server-host=konnectivity-server.%s", data.Cluster().Address.ExternalName),
+						"--proxy-server-port=6443",
+						"--admin-server-port=8133",
+						"--health-server-port=8134",
+						fmt.Sprintf("--service-account-token-path=/var/run/secrets/tokens/%s", resources.KonnectivityStolenAgentTokenNameToken),
+					},
+					Resources: corev1.ResourceRequirements{},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							MountPath: "/var/run/secrets/certs/",
+							Name:      "konnectivity-agent-ca",
+						},
+						{
+							MountPath: "/var/run/secrets/tokens",
+							Name:      "konnectivity-agent-ca",
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.IntOrString{
+									Type:   intstr.Int,
+									IntVal: 8134,
+								},
+							},
+						},
+						InitialDelaySeconds: 15,
+						TimeoutSeconds:      15,
+					},
+				},
+			}
+
+			dep.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "konnectivity-agent-ca",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  resources.KonnectivityStolenAgentTokenSecretName,
+							DefaultMode: intPtr(420),
+						},
+					},
+				},
+			}
+
+			return dep, nil
+		}
+	}
+}
+
+func intPtr(i int32) *int32 {
+	return &i
+}

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ProxySidecar returns container that runs konnectivity proxy server as a sidecar in apiserver pods.
+func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Container, error) {
+	const (
+		name    = "k8s-artifacts-prod/kas-network-proxy/proxy-server"
+		version = "v0.0.24"
+	)
+
+	return &corev1.Container{
+		Name:            "konnectivity-server-container",
+		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryUSGCR), name, version),
+		ImagePullPolicy: corev1.PullAlways,
+		Command: []string{
+			"/proxy-server",
+		},
+		Args: []string{
+			"--logtostderr=true",
+			"-v=100",
+			fmt.Sprintf("--cluster-key=/etc/kubernetes/pki/%s.key", resources.KonnectivityProxyTLSSecretName),
+			fmt.Sprintf("--cluster-cert=/etc/kubernetes/pki/%s.crt", resources.KonnectivityProxyTLSSecretName),
+			"--uds-name=/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+			fmt.Sprintf("--kubeconfig=/etc/kubernetes/kubeconfig/%s", resources.KonnectivityServerConf),
+			fmt.Sprintf("--server-count=%d", serverCount),
+			"--mode=grpc",
+			"--server-port=0",
+			"--agent-port=8132",
+			"--admin-port=8133",
+			"--health-port=8134",
+			"--agent-namespace=kube-system",
+			fmt.Sprintf("--agent-service-account=%s", resources.KonnectivityServiceAccountName),
+			"--delete-existing-uds-file=true",
+			"--authentication-audience=system:konnectivity-server",
+			"--proxy-strategies=destHost,defaultRoute",
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "agentport",
+				ContainerPort: 8132,
+			},
+			{
+				Name:          "adminport",
+				ContainerPort: 8133,
+			},
+			{
+				Name:          "healthport",
+				ContainerPort: 8134,
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      resources.KonnectivityUDS,
+				MountPath: "/etc/kubernetes/konnectivity-server",
+			},
+			{
+				Name:      resources.KonnectivityKubeconfigSecretName,
+				ReadOnly:  true,
+				MountPath: "/etc/kubernetes/kubeconfig",
+			},
+			{
+				Name:      resources.KonnectivityProxyTLSSecretName,
+				ReadOnly:  true,
+				MountPath: "/etc/kubernetes/pki/",
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: nil,
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/healthz",
+					Port:   intstr.IntOrString{IntVal: 8134},
+					Scheme: "HTTP",
+				},
+				TCPSocket: nil,
+			},
+			InitialDelaySeconds: 30,
+			TimeoutSeconds:      60,
+		},
+	}, nil
+}

--- a/pkg/resources/konnectivity/tls-cert.go
+++ b/pkg/resources/konnectivity/tls-cert.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+type tlsServingCertCreatorData interface {
+	Cluster() *kubermaticv1.Cluster
+	GetRootCA() (*triple.KeyPair, error)
+}
+
+// TLSServingCertificateCreator returns a function to create/update the secret with the konnectivity proxy server tls certificate used to serve https.
+func TLSServingCertificateCreator(data tlsServingCertCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return resources.KonnectivityProxyTLSSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
+			if se.Data == nil {
+				se.Data = map[string][]byte{}
+			}
+
+			ca, err := data.GetRootCA()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get cluster ca: %v", err)
+			}
+
+			inClusterIP, err := resources.InClusterApiserverIP(data.Cluster())
+			if err != nil {
+				return nil, fmt.Errorf("failed to get the in-cluster ClusterIP for the apiserver: %v", err)
+			}
+
+			altNames := certutil.AltNames{
+				DNSNames: []string{
+					fmt.Sprintf("konnectivity-server.%s", data.Cluster().Address.ExternalName),
+				},
+				IPs: []net.IP{
+					*inClusterIP,
+					net.ParseIP("127.0.0.1"),
+				},
+			}
+
+			if b, exists := se.Data[resources.KonnectivityProxyTLSSecretName+".crt"]; exists {
+				certs, err := certutil.ParseCertsPEM(b)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse certificate (key=%s) from existing secret: %v", resources.KonnectivityProxyTLSSecretName+".crt", err)
+				}
+
+				if resources.IsServerCertificateValidForAllOf(certs[0], "konnectivity-proxy", altNames, ca.Cert) {
+					return se, nil
+				}
+			}
+
+			if data.Cluster().Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
+				externalIP := data.Cluster().Address.IP
+				if externalIP == "" {
+					return nil, errors.New("externalIP is unset")
+				}
+
+				externalIPParsed := net.ParseIP(externalIP)
+				if externalIPParsed == nil {
+					return nil, errors.New("no external IP")
+				}
+				altNames.IPs = append(altNames.IPs, externalIPParsed)
+			}
+
+			key, err := triple.NewPrivateKey()
+			if err != nil {
+				return nil, fmt.Errorf("unable to create a server private key: %v", err)
+			}
+
+			config := certutil.Config{
+				CommonName: "konnectivity-proxy",
+				AltNames:   altNames,
+				Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			}
+
+			cert, err := triple.NewSignedCert(config, key, ca.Cert, ca.Key)
+			if err != nil {
+				return nil, fmt.Errorf("unable to sign the server certificate: %v", err)
+			}
+
+			se.Data[resources.KonnectivityProxyTLSSecretName+".key"] = triple.EncodePrivateKeyPEM(key)
+			se.Data[resources.KonnectivityProxyTLSSecretName+".crt"] = triple.EncodeCertPEM(cert)
+
+			return se, nil
+		}
+	}
+}

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -40,7 +40,7 @@ const (
 	imageName          = "kubermatic/nodeport-proxy"
 	envoyAppLabelValue = name + "-envoy"
 
-	// NodePortPRoxyExposeNamespacedAnnotationKey is the annotation key used to indicate that
+	// NodePortProxyExposeNamespacedAnnotationKey is the annotation key used to indicate that
 	// a service should be exposed by the namespaced NodeportProxy instance.
 	// We use it when clusters get exposed via a LoadBalancer, to allow re-using that LoadBalancer
 	// for both the kube-apiserver and the openVPN server

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -355,6 +355,8 @@ const (
 
 	// RegistryK8SGCR defines the kubernetes specific docker registry at google
 	RegistryK8SGCR = "k8s.gcr.io"
+	// RegistryUSGCR defines the docker registry at google US
+	RegistryUSGCR = "us.gcr.io"
 	// RegistryGCR defines the kubernetes docker registry at google
 	RegistryGCR = "gcr.io"
 	// RegistryDocker defines the default docker.io registry
@@ -644,6 +646,23 @@ alertmanager_config: |
 
 	// MLAAdminSettingsName specifies a fixed name of the MLA admin settings custom resource in the cluster namespace
 	MLAAdminSettingsName = "mla-admin-settings"
+
+	// Konnectivity
+	KonnectivityDeploymentName             = "konnectivity-agent"
+	KonnectivityClusterRoleBindingName     = "system:konnectivity-server"
+	KonnectivityClusterRoleBindingUsername = "system:konnectivity-server"
+	KonnectivityServiceAccountName         = "system-konnectivity-agent"
+	KonnectivityAgentContainer             = "konnectivity-agent"
+	KonnectivityAgentToken                 = "system-konnectivity-agent-token"
+	KonnectivityProxyServiceName           = "konnectivity-server"
+	KonnectivityProxyTLSSecretName         = "konnectivityproxy-tls"
+	KonnectivityKubeconfigSecretName       = "konnectivity-kubeconfig"
+	KonnectivityServerConf                 = "konnectivity-server.conf"
+	KonnectivityStolenAgentTokenSecretName = "stolen-agent-ca"
+	KonnectivityStolenAgentTokenNameCert   = "agentca.crt"
+	KonnectivityStolenAgentTokenNameToken  = "agenttoken.txt"
+	KonnectivityKubeApiserverEgress        = "kube-apiserver-egress"
+	KonnectivityUDS                        = "konnectivity-uds"
 )
 
 // ECDSAKeyPair is a ECDSA x509 certificate and private key


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements part of 
-  Epic https://github.com/kubermatic/kubermatic/issues/6188
-  Proposal [Exposing control-plane services using SNI and HTTP tunneling
](https://github.com/kubermatic/kubermatic/blob/master/docs/proposals/konnectivity-openvpn.md)

It deploys konnectivity-proxy-server in sidecar in the KAS pods. 
It also deploys two agents one in user-cluster and one in seed-cluster. 
- User-cluster agent 
   This agent handles traffic going from KAS to user-cluster. 
- Seed-cluster agent 

   This agent handles traffic going to `metric-server` allowing us to avoid moving `metric-server` to user-cluster. 
   PR deviates here from the original proposal. We had planned to move `metric-server` to user cluster. 
  
   This agent uses token stolen from user-cluster.  This will be made more efficient in future PRs. See https://github.com/kubermatic/kubermatic-installer/issues/139. 

References: 
- [Set up Konnectivity service
](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/ )

**Does this PR introduce a user-facing change?**:
```release-note
Add konnectivity option for controlplane to cluster communication
```
