### PR TITLE
Remove Gatekeeper from default accessible addon list

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.49
+version: 1.1.50
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/kubermatic/static/master/accessible-addons.yaml
+++ b/charts/kubermatic/static/master/accessible-addons.yaml
@@ -4,4 +4,3 @@ addons:
 - cluster-autoscaler
 - node-exporter
 - multus
-- gatekeeper

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -11,7 +11,6 @@ spec:
       - cluster-autoscaler
       - node-exporter
       - multus
-      - gatekeeper
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -69,7 +69,6 @@ var (
 		"cluster-autoscaler",
 		"node-exporter",
 		"multus",
-		"gatekeeper",
 	}
 
 	DefaultUIResources = corev1.ResourceRequirements{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes Gatekeeper from the default accessible addon list since it is already deprecated, and now it is installed by OPA integration.
This will need to be cherry-picked for 2.17 and 2.16.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #7508 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Remove Gatekeeper from default accessible addon list
```
