### PR TITLE
Add support of Kubernetes 1.20 and 1.21 in cluster-autoscaler addon

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -19,6 +19,12 @@
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
 {{ $version = "v1.19.0 "}}
 {{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.20" }}
+{{ $version = "v1.20.0 "}}
+{{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.21" }}
+{{ $version = "v1.21.0 "}}
+{{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support of Kubernetes 1.20 and 1.21 in cluster-autoscaler addon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support of Kubernetes 1.20 and 1.21 in cluster-autoscaler addon
```
