### PR TITLE
Extend CCM migration E2E tests to cleanup MachineDeployments and wait for resources to be deleted

### DIFF
--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("CCM migration", func() {
 		})
 
 		ginkgo.AfterEach(func() {
-			gomega.Expect(clusterJig.SeedClient.Delete(context.TODO(), clusterJig.Cluster)).NotTo(gomega.HaveOccurred())
+			gomega.Expect(clusterJig.CleanUp()).NotTo(gomega.HaveOccurred())
 		})
 
 		ginkgo.It("migrating cluster to external CCM", func() {

--- a/pkg/test/e2e/ccm-migration/cluster.go
+++ b/pkg/test/e2e/ccm-migration/cluster.go
@@ -46,7 +46,7 @@ const (
 	clusterReadinessCheckPeriod = 10 * time.Second
 	clusterReadinessTimeout     = 10 * time.Minute
 
-	machineDeploymentName      = "ccm-test-machine"
+	machineDeploymentName      = "ccm-migration-e2e"
 	machineDeploymentNamespace = "kube-system"
 )
 
@@ -106,13 +106,13 @@ func (c *ClusterJig) CreateMachineDeployment(userClient ctrlruntimeclient.Client
 		Spec: clusterv1alpha1.MachineDeploymentSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "test-machine",
+					"name": machineDeploymentName,
 				},
 			},
 			Template: clusterv1alpha1.MachineTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name": "test-machine",
+						"name": machineDeploymentName,
 					},
 				},
 				Spec: clusterv1alpha1.MachineSpec{

--- a/pkg/test/e2e/ccm-migration/cluster.go
+++ b/pkg/test/e2e/ccm-migration/cluster.go
@@ -292,7 +292,7 @@ func (c *ClusterJig) CleanUp() error {
 				return false, errors.Wrap(err, "failed to delete user cluster")
 			}
 		}
-		
+
 		return false, nil
 	})
 }

--- a/pkg/test/e2e/ccm-migration/cluster.go
+++ b/pkg/test/e2e/ccm-migration/cluster.go
@@ -28,13 +28,16 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -42,6 +45,9 @@ import (
 const (
 	clusterReadinessCheckPeriod = 10 * time.Second
 	clusterReadinessTimeout     = 10 * time.Minute
+
+	machineDeploymentName      = "ccm-test-machine"
+	machineDeploymentNamespace = "kube-system"
 )
 
 // ClusterJig helps setting up a user cluster for testing.
@@ -94,8 +100,8 @@ func (c *ClusterJig) CreateMachineDeployment(userClient ctrlruntimeclient.Client
 
 	machineDeployment := &clusterv1alpha1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-machine",
-			Namespace: "kube-system",
+			Name:      machineDeploymentName,
+			Namespace: machineDeploymentNamespace,
 		},
 		Spec: clusterv1alpha1.MachineDeploymentSpec{
 			Selector: metav1.LabelSelector{
@@ -211,7 +217,84 @@ func (c *ClusterJig) createCluster(cloudSpec kubermaticv1.CloudSpec) error {
 
 // CleanUp deletes the cluster.
 func (c *ClusterJig) CleanUp() error {
-	return c.SeedClient.Delete(context.TODO(), c.Cluster)
+	clusterClientProvider, err := clusterclient.NewExternal(c.SeedClient)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user cluster client provider")
+	}
+
+	userClient, err := clusterClientProvider.GetClient(context.TODO(), c.Cluster)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user cluster client")
+	}
+
+	// Skip eviction to speed up the clean up process
+	nodes := &corev1.NodeList{}
+	if err := userClient.List(context.TODO(), nodes); err != nil {
+		return errors.Wrap(err, "failed to list user cluster nodes")
+	}
+
+	for _, node := range nodes.Items {
+		nodeKey := ctrlruntimeclient.ObjectKey{Name: node.Name}
+
+		retErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			n := corev1.Node{}
+			if err := userClient.Get(context.TODO(), nodeKey, &n); err != nil {
+				return err
+			}
+
+			if n.Annotations == nil {
+				n.Annotations = map[string]string{}
+			}
+			n.Annotations["kubermatic.io/skip-eviction"] = "true"
+			return userClient.Update(context.TODO(), &n)
+		})
+		if retErr != nil {
+			return errors.Wrapf(retErr, "failed to annotate node %s", node.Name)
+		}
+	}
+
+	// Delete MachineDeployment and Cluster
+	deleteTimeout := 15 * time.Minute
+	return wait.PollImmediate(5*time.Second, deleteTimeout, func() (bool, error) {
+		mdKey := ctrlruntimeclient.ObjectKey{Name: machineDeploymentName, Namespace: machineDeploymentNamespace}
+
+		md := &clusterv1alpha1.MachineDeployment{}
+		err := userClient.Get(context.TODO(), mdKey, md)
+		if err == nil {
+			if md.DeletionTimestamp != nil {
+				return false, nil
+			}
+			err := userClient.Delete(context.TODO(), md)
+			if err != nil {
+				return false, errors.Wrap(err, "failed to delete user cluster machinedeployment")
+			}
+			return false, nil
+		} else if err != nil && !k8serrors.IsNotFound(err) {
+			return false, errors.Wrap(err, "failed to get user cluster machinedeployment")
+		}
+
+		clusters := &kubermaticv1.ClusterList{}
+		err = c.SeedClient.List(context.TODO(), clusters)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to list user clusters")
+		}
+
+		if len(clusters.Items) == 0 {
+			return true, nil
+		}
+		if len(clusters.Items) > 1 {
+			return false, errors.Wrap(err, "there is more than one user cluster, expected one or zero cluster")
+		}
+
+		if clusters.Items[0].DeletionTimestamp == nil {
+			err := c.SeedClient.Delete(context.TODO(), c.Cluster)
+			if err != nil {
+				return false, errors.Wrap(err, "failed to delete user cluster")
+			}
+		}
+		
+		return false, nil
+	})
 }
 
 func (c *ClusterJig) waitForClusterControlPlaneReady(cl *kubermaticv1.Cluster) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

The CCM migration tests are currently not properly cleaning up cloud resources:

* The MachineDeployment object is not explicitly removed, so we leak one OpenStack instance per test run
* We don't wait for cluster deletion to be complete, so it happens that we also leak SecurityGroups, networks, and other resources

This is causing us to reach OpenStack limits very frequently, causing all other OpenStack tests to fail.

This PR addresses this problem by explicitly deleting MachineDeployment and waiting for MachineDeployment and the user cluster to get deleted.

This PR also renames machines from `test-machine` to `ccm-migration-e2e`, so that we're sure machines are related to the CCM migration tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```