### PR TITLE
Integrate node-exporter addon with user cluster MLA

### DIFF
--- a/addons/node-exporter/scrape-config.yaml
+++ b/addons/node-exporter/scrape-config.yaml
@@ -1,0 +1,42 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Cluster.MLA.MonitoringEnabled }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-custom-scrape-configs-node-exporter
+  namespace: mla-system
+data:
+  custom-scrape-configs.yaml: |+
+    - job_name: node-exporter
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app_kubernetes_io_name]
+          regex: kube-system;node-exporter
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          action: replace
+          regex: (.+)
+          replacement: $1
+          target_label: node_name
+
+{{ end }}

--- a/addons/node-exporter/scrape-config.yaml
+++ b/addons/node-exporter/scrape-config.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-custom-scrape-configs-node-exporter
+  name: prometheus-scraping-node-exporter
   namespace: mla-system
 data:
   custom-scrape-configs.yaml: |+


### PR DESCRIPTION
**What this PR does / why we need it**:
Integrates the node-exporter addon with the [User Cluster MLA Stack](https://docs.kubermatic.com/kubermatic/master/architecture/monitoring_logging_alerting/user_cluster/) by adding the node-exporter scrape config for the user cluster Prometheus.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
