### PR TITLE
remove webhooks when preparing a ginkgo conformance test

### DIFF
--- a/cmd/conformance-tests/cleanup.go
+++ b/cmd/conformance-tests/cleanup.go
@@ -21,6 +21,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"k8c.io/kubermatic/v2/pkg/resources"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/resources/kubernetes-dashboard"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -37,7 +38,9 @@ var (
 		metav1.NamespaceSystem,
 		metav1.NamespacePublic,
 		corev1.NamespaceNodeLease,
-		kubernetesdashboard.Namespace)
+		kubernetesdashboard.Namespace,
+		resources.CloudInitSettingsNamespace,
+	)
 )
 
 func (r *testRunner) cleanupBeforeGinkgo(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {

--- a/cmd/conformance-tests/cleanup.go
+++ b/cmd/conformance-tests/cleanup.go
@@ -23,6 +23,7 @@ import (
 
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/resources/kubernetes-dashboard"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -39,7 +40,37 @@ var (
 		kubernetesdashboard.Namespace)
 )
 
-func (r *testRunner) deleteAllNonDefaultNamespaces(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {
+func (r *testRunner) cleanupBeforeGinkgo(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {
+	log.Info("Removing webhooks...")
+
+	if err := wait.Poll(r.userClusterPollInterval, r.customTestTimeout, func() (done bool, err error) {
+		webhookList := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+		if err := client.List(ctx, webhookList); err != nil {
+			log.Errorw("Failed to list webhooks", zap.Error(err))
+			return false, nil
+		}
+
+		if len(webhookList.Items) == 0 {
+			return true, nil
+		}
+
+		for _, webhook := range webhookList.Items {
+			if webhook.DeletionTimestamp == nil {
+				wlog := log.With("webhook", webhook.Name)
+
+				if err := client.Delete(ctx, &webhook); err != nil {
+					wlog.Errorw("Failed to delete webhook", zap.Error(err))
+				} else {
+					wlog.Debug("Deleted webhook.")
+				}
+			}
+		}
+
+		return false, nil
+	}); err != nil {
+		return err
+	}
+
 	log.Info("Removing non-default namespaces...")
 
 	return wait.Poll(r.userClusterPollInterval, r.customTestTimeout, func() (done bool, err error) {
@@ -61,14 +92,12 @@ func (r *testRunner) deleteAllNonDefaultNamespaces(ctx context.Context, log *zap
 
 			// If it's not gone & the DeletionTimestamp is nil, delete it
 			if namespace.DeletionTimestamp == nil {
-				// make sure to create a new variable, or else subsequent With() calls will
-				// *add* new attributes instead of overriding the existing namespace value
-				log := log.With("namespace", namespace.Name)
+				nslog := log.With("namespace", namespace.Name)
 
 				if err := client.Delete(ctx, &namespace); err != nil {
-					log.Errorw("Failed to delete namespace", zap.Error(err))
+					nslog.Errorw("Failed to delete namespace", zap.Error(err))
 				} else {
-					log.Debug("Deleted namespace.")
+					nslog.Debug("Deleted namespace.")
 				}
 			}
 		}

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1240,8 +1240,8 @@ func (r *testRunner) getGinkgoRuns(
 func (r *testRunner) executeGinkgoRun(ctx context.Context, parentLog *zap.SugaredLogger, run *ginkgoRun, client ctrlruntimeclient.Client) (*ginkgoResult, error) {
 	log := parentLog.With("reports-dir", run.reportsDir)
 
-	if err := r.deleteAllNonDefaultNamespaces(ctx, log, client); err != nil {
-		return nil, fmt.Errorf("failed to cleanup namespaces before the Ginkgo run: %v", err)
+	if err := r.cleanupBeforeGinkgo(ctx, log, client); err != nil {
+		return nil, fmt.Errorf("failed to cleanup before the Ginkgo run: %v", err)
 	}
 
 	timedCtx, cancel := context.WithTimeout(ctx, run.timeout)

--- a/pkg/provider/datacenter.go
+++ b/pkg/provider/datacenter.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
 
 	corev1 "k8s.io/api/core/v1"
@@ -145,7 +144,6 @@ func SeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.C
 		if err != nil {
 			return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
 		}
-		kubermaticlog.Logger.With("seed", seed.Name).Debug("Successfully got kubeconfig")
 		return cfg, nil
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
To ensure that Ginkgo runs are consistent, we cleanup the usercluster between GInkgo runs. This just included deleting all non-default namespaces, but this can sometimes break the usercluster even more, when webhooks are preventing the namespaces from being deleted.

This PR improves that by deleting all webhooks first.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
