### PR TITLE
Remove kubermatic from user cluster MLA name prefix

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -587,15 +587,15 @@ const (
 const (
 	UserClusterMLANamespace        = "mla-system"
 	PromtailServiceAccountName     = "promtail"
-	PromtailClusterRoleName        = "system:kubermatic:mla:promtail"
-	PromtailClusterRoleBindingName = "system:kubermatic:mla:promtail"
+	PromtailClusterRoleName        = "system:mla:promtail"
+	PromtailClusterRoleBindingName = "system:mla:promtail"
 	PromtailSecretName             = "promtail"
 	PromtailDaemonSetName          = "promtail"
 
 	UserClusterPrometheusConfigMapName          = "prometheus"
 	UserClusterPrometheusServiceAccountName     = "prometheus"
-	UserClusterPrometheusClusterRoleName        = "system:kubermatic:mla:prometheus"
-	UserClusterPrometheusClusterRoleBindingName = "system:kubermatic:mla:prometheus"
+	UserClusterPrometheusClusterRoleName        = "system:mla:prometheus"
+	UserClusterPrometheusClusterRoleBindingName = "system:mla:prometheus"
 	UserClusterPrometheusDeploymentName         = "prometheus"
 
 	// MLAGatewayExternalServiceName is the name for the MLA Gateway external service


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes `kubermatic` from the user cluster MLA name prefix and tries to make Kubermatic a white-label product.
Ref: https://github.com/kubermatic/kubermatic/pull/7504#discussion_r689641930
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
