### PR TITLE
improve test-helm-charts.sh for batch jobs

### DIFF
--- a/hack/ci/test-helm-charts.sh
+++ b/hack/ci/test-helm-charts.sh
@@ -27,7 +27,7 @@ source hack/lib.sh
 
 # find all changed charts (the pre-kubermatic-verify-charts job ensures
 # that all updated charts also change their Chart.yaml)
-changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
+changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA:-}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
 
 for chartDirectory in $changedCharts; do
   chartName="$(basename "$chartDirectory")"


### PR DESCRIPTION
**What this PR does / why we need it**:
In a batch process of Prow the `PULL_PULL_SHA` var is not set. It can be omitted and will than be treated as `HEAD`

```release-note
NONE
```
