### PR TITLE
do not let gocache grow over time

### DIFF
--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -51,6 +51,12 @@ echodate "Building binaries"
 
 (
   TEST_NAME="Build Kubermatic"
+
+  # prevent the Makefile from downloading the old Gocache. This ensures that
+  # our cache does not grow over time, as packages are added and removed,
+  # but makes creating the cache a tiny bit slower
+  touch download-gocache
+
   retry 2 make build
 )
 (


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently I noticed that after the ctrl-runtime upgrade (#7462) our gocache archive reached an astonishing 4.7GB. I then, just for testing, created a fresh one without re-using the gocache from the previous revision, and we ended up with 1.7GB.

The original runtime of this job was somewhere between 5 and 15 minutes. With my "cold start" above it took 9 minutes. So we do not really lose performance/time if we ignore previous caches, but we gain the fact that the caches won't grow over time.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
