### PR TITLE
Add kube-state-metrics into default accessible addons

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.60
+version: 1.1.61
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/kubermatic/static/master/accessible-addons.yaml
+++ b/charts/kubermatic/static/master/accessible-addons.yaml
@@ -3,4 +3,5 @@
 addons:
 - cluster-autoscaler
 - node-exporter
+- kube-state-metrics
 - multus

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -10,6 +10,7 @@ spec:
     accessibleAddons:
       - cluster-autoscaler
       - node-exporter
+      - kube-state-metrics
       - multus
     # DebugLog enables more verbose logging.
     debugLog: false

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -68,6 +68,7 @@ var (
 	DefaultAccessibleAddons = []string{
 		"cluster-autoscaler",
 		"node-exporter",
+		"kube-state-metrics",
 		"multus",
 	}
 


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Add kube-state-metrics into default accessible addons, so that can be easily used with the [user cluster MLA stack](https://docs.kubermatic.com/kubermatic/master/architecture/monitoring_logging_alerting/user_cluster/).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
