### PR TITLE
Lower scrape interval for user cluster Prometheus, do not scrape apiserver

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/configmap.go
@@ -58,8 +58,8 @@ func ConfigMapCreator(config Config) reconciling.NamedConfigMapCreatorGetter {
 const (
 	configTemplate = `
 global:
-  evaluation_interval: 1m
-  scrape_interval: 1m
+  evaluation_interval: 30s
+  scrape_interval: 30s
   scrape_timeout: 10s
 remote_write:
 - url: {{ .MLAGatewayURL }}
@@ -77,20 +77,6 @@ scrape_configs:
   static_configs:
   - targets:
     - localhost:9090
-- bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  job_name: kubernetes-apiservers
-  kubernetes_sd_configs:
-  - role: endpoints
-  relabel_configs:
-  - action: keep
-    regex: default;kubernetes;https
-    source_labels:
-    - __meta_kubernetes_namespace
-    - __meta_kubernetes_service_name
-    - __meta_kubernetes_endpoint_port_name
-  scheme: https
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   job_name: kubernetes-nodes
   kubernetes_sd_configs:


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Enhancements for user cluster Prometheus scraping:
 - lower scrape interval for user cluster Prometheus
 - do not scrape apiserver

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
