### PR TITLE
Add Anexia CCM to controlplane 

### DIFF
--- a/hack/ci/test-helm-charts.sh
+++ b/hack/ci/test-helm-charts.sh
@@ -27,7 +27,7 @@ source hack/lib.sh
 
 # find all changed charts (the pre-kubermatic-verify-charts job ensures
 # that all updated charts also change their Chart.yaml)
-changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
+changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA:-}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
 
 for chartDirectory in $changedCharts; do
   chartName="$(basename "$chartDirectory")"

--- a/hack/ci/test-helm-charts.sh
+++ b/hack/ci/test-helm-charts.sh
@@ -27,7 +27,7 @@ source hack/lib.sh
 
 # find all changed charts (the pre-kubermatic-verify-charts job ensures
 # that all updated charts also change their Chart.yaml)
-changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA:-}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
+changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
 
 for chartDirectory in $changedCharts; do
   chartName="$(basename "$chartDirectory")"

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -1,109 +1,128 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cloudcontroller
 
 import (
-  "fmt"
-  "k8c.io/kubermatic/v2/pkg/resources"
-  "k8c.io/kubermatic/v2/pkg/resources/reconciling"
-  "k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
-  appsv1 "k8s.io/api/apps/v1"
-  corev1 "k8s.io/api/core/v1"
-  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/util/intstr"
+	"fmt"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const AnexiaCCMDeploymentName = "anx-cloud-controller-manager"
 
 func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
 
-  return func() (name string, create reconciling.DeploymentCreator) {
-    return AnexiaCCMDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-      deployment.Labels = resources.BaseAppLabels(AnexiaCCMDeploymentName, nil)
-      deployment.Spec.Replicas = resources.Int32(1)
+	return func() (name string, create reconciling.DeploymentCreator) {
+		return AnexiaCCMDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+			deployment.Labels = resources.BaseAppLabels(AnexiaCCMDeploymentName, nil)
+			deployment.Spec.Replicas = resources.Int32(1)
 
-      deployment.Spec.Selector = &metav1.LabelSelector{
-        MatchLabels: resources.BaseAppLabels(AnexiaCCMDeploymentName, nil),
-      }
+			deployment.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabels(AnexiaCCMDeploymentName, nil),
+			}
 
-      podLabels, err := data.GetPodTemplateLabels(AnexiaCCMDeploymentName, deployment.Spec.Template.Spec.Volumes, nil)
+			podLabels, err := data.GetPodTemplateLabels(AnexiaCCMDeploymentName, deployment.Spec.Template.Spec.Volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("unable to get pod template labels: %w", err)
+			}
 
-      deployment.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-        Labels: podLabels,
-      }
+			deployment.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+			}
 
-      f := false
-      deployment.Spec.Template.Spec.AutomountServiceAccountToken = &f
+			f := false
+			deployment.Spec.Template.Spec.AutomountServiceAccountToken = &f
 
-      openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, openvpnClientContainerName)
-      if err != nil {
-        return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
-      }
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, openvpnClientContainerName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+			}
 
-      credentials, err := resources.GetCredentials(data)
-      if err != nil {
-        return nil, fmt.Errorf("failed to get credentials: %v", err)
-      }
+			credentials, err := resources.GetCredentials(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get credentials: %v", err)
+			}
 
-      deployment.Spec.Template.Spec.Volumes = append(getVolumes())
+			deployment.Spec.Template.Spec.Volumes = getVolumes()
 
-      deployment.Spec.Template.Spec.Containers = []corev1.Container{
-        *openvpnSidecar,
-        {
-          Name:            ccmContainerName,
-          Image:           data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:0.1.0",
-          Command: []string{
-            "/app/ccm",
-            "--cloud-provider=anexia",
-            "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
-          },
-          Env: []corev1.EnvVar{
-            {
-              Name:  "ANEXIA_TOKEN",
-              Value: credentials.Anexia.Token,
-            },
-          },
-          Ports: []corev1.ContainerPort{
-            {
-              Name:          "http",
-              ContainerPort: 8080,
-              Protocol:      "TCP",
-            },
-          },
-          LivenessProbe: &corev1.Probe{
-            Handler: corev1.Handler{
-              HTTPGet: &corev1.HTTPGetAction{
-                Path:   "/healthz",
-                Port:   intstr.FromString("http"),
-                Scheme: "HTTPS",
-              },
-            },
-            InitialDelaySeconds: 5,
-            TimeoutSeconds:      10,
-            PeriodSeconds:       20,
-            SuccessThreshold:    1,
-            FailureThreshold:    3,
-          },
-          ReadinessProbe: &corev1.Probe{
-           Handler: corev1.Handler{
-             HTTPGet: &corev1.HTTPGetAction{
-               Path:   "/healthz",
-               Port:   intstr.FromString("http"),
-               Scheme: "HTTPS",
-             },
-           },
-            InitialDelaySeconds: 5,
-            TimeoutSeconds:      10,
-            PeriodSeconds:       20,
-            SuccessThreshold:    1,
-            FailureThreshold:    3,
-          },
-          VolumeMounts: getVolumeMounts(),
-        },
-      }
+			deployment.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				{
+					Name:  ccmContainerName,
+					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:0.1.0",
+					Command: []string{
+						"/app/ccm",
+						"--cloud-provider=anexia",
+						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ANEXIA_TOKEN",
+							Value: credentials.Anexia.Token,
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      "TCP",
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromString("http"),
+								Scheme: "HTTPS",
+							},
+						},
+						InitialDelaySeconds: 5,
+						TimeoutSeconds:      10,
+						PeriodSeconds:       20,
+						SuccessThreshold:    1,
+						FailureThreshold:    3,
+					},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromString("http"),
+								Scheme: "HTTPS",
+							},
+						},
+						InitialDelaySeconds: 5,
+						TimeoutSeconds:      10,
+						PeriodSeconds:       20,
+						SuccessThreshold:    1,
+						FailureThreshold:    3,
+					},
+					VolumeMounts: getVolumeMounts(),
+				},
+			}
 
-      if err != nil {
-        return nil, err
-      }
-      return deployment, nil
-    }
-  }
+			if err != nil {
+				return nil, err
+			}
+			return deployment, nil
+		}
+	}
 }

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -18,9 +18,11 @@ package cloudcontroller
 
 import (
 	"fmt"
+
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -1,0 +1,109 @@
+package cloudcontroller
+
+import (
+  "fmt"
+  "k8c.io/kubermatic/v2/pkg/resources"
+  "k8c.io/kubermatic/v2/pkg/resources/reconciling"
+  "k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
+  appsv1 "k8s.io/api/apps/v1"
+  corev1 "k8s.io/api/core/v1"
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const AnexiaCCMDeploymentName = "anx-cloud-controller-manager"
+
+func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
+
+  return func() (name string, create reconciling.DeploymentCreator) {
+    return AnexiaCCMDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+      deployment.Labels = resources.BaseAppLabels(AnexiaCCMDeploymentName, nil)
+      deployment.Spec.Replicas = resources.Int32(1)
+
+      deployment.Spec.Selector = &metav1.LabelSelector{
+        MatchLabels: resources.BaseAppLabels(AnexiaCCMDeploymentName, nil),
+      }
+
+      podLabels, err := data.GetPodTemplateLabels(AnexiaCCMDeploymentName, deployment.Spec.Template.Spec.Volumes, nil)
+
+      deployment.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+        Labels: podLabels,
+      }
+
+      f := false
+      deployment.Spec.Template.Spec.AutomountServiceAccountToken = &f
+
+      openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, openvpnClientContainerName)
+      if err != nil {
+        return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+      }
+
+      credentials, err := resources.GetCredentials(data)
+      if err != nil {
+        return nil, fmt.Errorf("failed to get credentials: %v", err)
+      }
+
+      deployment.Spec.Template.Spec.Volumes = append(getVolumes())
+
+      deployment.Spec.Template.Spec.Containers = []corev1.Container{
+        *openvpnSidecar,
+        {
+          Name:            ccmContainerName,
+          Image:           data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:0.1.0",
+          Command: []string{
+            "/app/ccm",
+            "--cloud-provider=anexia",
+            "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+          },
+          Env: []corev1.EnvVar{
+            {
+              Name:  "ANEXIA_TOKEN",
+              Value: credentials.Anexia.Token,
+            },
+          },
+          Ports: []corev1.ContainerPort{
+            {
+              Name:          "http",
+              ContainerPort: 8080,
+              Protocol:      "TCP",
+            },
+          },
+          LivenessProbe: &corev1.Probe{
+            Handler: corev1.Handler{
+              HTTPGet: &corev1.HTTPGetAction{
+                Path:   "/healthz",
+                Port:   intstr.FromString("http"),
+                Scheme: "HTTPS",
+              },
+            },
+            InitialDelaySeconds: 5,
+            TimeoutSeconds:      10,
+            PeriodSeconds:       20,
+            SuccessThreshold:    1,
+            FailureThreshold:    3,
+          },
+          ReadinessProbe: &corev1.Probe{
+           Handler: corev1.Handler{
+             HTTPGet: &corev1.HTTPGetAction{
+               Path:   "/healthz",
+               Port:   intstr.FromString("http"),
+               Scheme: "HTTPS",
+             },
+           },
+            InitialDelaySeconds: 5,
+            TimeoutSeconds:      10,
+            PeriodSeconds:       20,
+            SuccessThreshold:    1,
+            FailureThreshold:    3,
+          },
+          VolumeMounts: getVolumeMounts(),
+        },
+      }
+
+      if err != nil {
+        return nil, err
+      }
+      return deployment, nil
+    }
+  }
+}

--- a/pkg/resources/cloudcontroller/deployment.go
+++ b/pkg/resources/cloudcontroller/deployment.go
@@ -45,6 +45,9 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 	case data.Cluster().Spec.Cloud.Hetzner != nil:
 		creatorGetter = hetznerDeploymentCreator(data)
 
+	case data.Cluster().Spec.Cloud.Anexia != nil:
+		creatorGetter = anexiaDeploymentCreator(data)
+
 	case data.Cluster().Spec.Cloud.VSphere != nil:
 		creatorGetter = vsphereDeploymentCreator(data)
 	}

--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -50,9 +50,8 @@ func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluste
 	case cluster.Spec.Cloud.VSphere != nil:
 		return VsphereCloudControllerSupported(cluster.Spec.Version)
 
-	case dc.Spec.Anexia != nil: {
+	case dc.Spec.Anexia != nil:
 		return true
-	}
 
 	default:
 		return false

--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -50,6 +50,10 @@ func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluste
 	case cluster.Spec.Cloud.VSphere != nil:
 		return VsphereCloudControllerSupported(cluster.Spec.Version)
 
+	case dc.Spec.Anexia != nil: {
+		return true
+	}
+
 	default:
 		return false
 	}

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -150,7 +150,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 					Name:    Name,
 					Image:   repository + ":" + tag,
 					Command: []string{"/usr/local/bin/machine-controller"},
-					Args:   getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime, isExternal),
+					Args:    getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime, isExternal),
 					Env: append(envVars, corev1.EnvVar{
 						Name:  "KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
@@ -286,7 +286,7 @@ func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri 
 		}
 
 		if isExternal {
-			flags = append(flags, "-node-external-cloud-provider", "true")
+			flags = append(flags, "-node-external-cloud-provider")
 		}
 
 		// TODO(kron4eg): deprecate and remove this

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -90,7 +90,7 @@ func DeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCr
 	}
 }
 
-// DeploymentCreator returns the function to create and update the machine controller deployment without the
+// DeploymentCreatorWithoutInitWrapper returns the function to create and update the machine controller deployment without the
 // wrapper that checks for apiserver availabiltiy. This allows to adjust the command.
 func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
@@ -144,13 +144,12 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 			if t := data.MachineControllerImageTag(); t != "" {
 				tag = t
 			}
-			isExternal := isExternalCloudProvider(data)
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,
 					Image:   repository + ":" + tag,
 					Command: []string{"/usr/local/bin/machine-controller"},
-					Args:    getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime, isExternal),
+					Args:    getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime),
 					Env: append(envVars, corev1.EnvVar{
 						Name:  "KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
@@ -191,10 +190,6 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 			return dep, nil
 		}
 	}
-}
-
-func isExternalCloudProvider(data machinecontrollerData) bool {
-	return data.Cluster().Spec.Cloud.Anexia != nil
 }
 
 func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
@@ -256,7 +251,7 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 	return vars, nil
 }
 
-func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri string, isExternal bool) []string {
+func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri string) []string {
 	flags := []string{
 		"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 		"-logtostderr",
@@ -284,11 +279,6 @@ func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri 
 		if nodeSettings.PauseImage != "" {
 			flags = append(flags, "-node-pause-image", nodeSettings.PauseImage)
 		}
-
-		if isExternal {
-			flags = append(flags, "-node-external-cloud-provider")
-		}
-
 		// TODO(kron4eg): deprecate and remove this
 		if nodeSettings.HyperkubeImage != "" {
 			flags = append(flags, "-node-hyperkube-image", nodeSettings.HyperkubeImage)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -357,6 +357,8 @@ const (
 	RegistryDocker = "docker.io"
 	// RegistryQuay defines the image registry from coreos/redhat - quay
 	RegistryQuay = "quay.io"
+	// RegistryAnexia defines the anexia specific docker registry
+	RegistryAnexia = "anx-cr.io"
 
 	// TopologyKeyHostname defines the topology key for the node hostname
 	TopologyKeyHostname = "kubernetes.io/hostname"

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -225,6 +225,10 @@ func (h *AdmissionHandler) defaultClusterComponentSettings(c *kubermaticv1.Clust
 	if c.Spec.ComponentsOverride.Prometheus.Resources == nil {
 		c.Spec.ComponentsOverride.Prometheus.Resources = h.defaultComponentSettings.Prometheus.Resources
 	}
+	if c.Spec.Cloud.Anexia != nil {
+		// Always enable external CCM for Anexia clusters
+		c.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] = true
+	}
 }
 
 func (h *AdmissionHandler) mutateUpdate(ctx context.Context, oldCluster, newCluster *kubermaticv1.Cluster) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Anexia has developed an own kubernetes cloud controller manager. This change adds it to the control plane and makes sure that the machine controller is started with the correct flags.


**Does this PR introduce a user-facing change?**:
```release-note
* Anexia CCM is now added to the control plane 
```
