### PR TITLE
Watch network policies in seed kubernetes controller

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -37,6 +37,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -207,6 +208,7 @@ func Add(
 		&autoscalingv1beta2.VerticalPodAutoscaler{},
 		&rbacv1.Role{},
 		&rbacv1.RoleBinding{},
+		&networkingv1.NetworkPolicy{},
 	}
 
 	for _, t := range typesToWatch {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug introduced in #7396, making sure that network policies are watched so that the seed controller manager reacts to changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
