### PR TITLE
Sync KubermaticConfiguration into seed clusters

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -83,7 +83,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
 		return fmt.Errorf("failed to create serviceaccount controller: %v", err)
 	}
-	if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
+	if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter, ctrlCtx.seedsGetter); err != nil {
 		return fmt.Errorf("failed to create seedsync controller: %v", err)
 	}
 	if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/features"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/metrics"
@@ -150,6 +151,10 @@ func main() {
 
 	if err := mgr.Add(pprofOpts); err != nil {
 		log.Fatalw("failed to add pprof endpoint", zap.Error(err))
+	}
+
+	if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatalw("Failed to register scheme", zap.Stringer("api", operatorv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
 
 	// these two getters rely on the ctrlruntime manager being started; they

--- a/cmd/nodeport-proxy/Makefile
+++ b/cmd/nodeport-proxy/Makefile
@@ -17,11 +17,11 @@ GOOS ?= $(shell go env GOOS)
 
 .PHONY: lb-updater
 lb-updater:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/lb-updater k8c.io/kubermatic/v2/cmd/nodeport-proxy/lb-updater
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/lb-updater -v k8c.io/kubermatic/v2/cmd/nodeport-proxy/lb-updater
 
 .PHONY: envoy-manager
 envoy-manager:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/envoy-manager k8c.io/kubermatic/v2/cmd/nodeport-proxy/envoy-manager
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/envoy-manager -v k8c.io/kubermatic/v2/cmd/nodeport-proxy/envoy-manager
 
 .PHONY: build
 build: envoy-manager lb-updater

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -142,6 +142,11 @@ func main() {
 				ResourceImportPath: "k8s.io/api/networking/v1",
 			},
 			{
+				ResourceName:       "KubermaticConfiguration",
+				ImportAlias:        "operatorv1alpha1",
+				ResourceImportPath: "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1",
+			},
+			{
 				ResourceName:       "Seed",
 				ImportAlias:        "kubermaticv1",
 				ResourceImportPath: "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1",

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -70,6 +70,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get config: %w", err)
 	}
 
+	// not having a config at all should never really happen
+	if config == nil {
+		return reconcile.Result{}, nil
+	}
+
 	// cleanup once a Seed was deleted in the master cluster
 	if seed.DeletionTimestamp != nil {
 		result, err := r.cleanupDeletedSeed(ctx, config, seed, client, logger)

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
@@ -25,18 +25,26 @@ import (
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+func init() {
+	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme.Scheme))
+}
+
 func TestReconcilingSeed(t *testing.T) {
+
 	existingSeeds := []ctrlruntimeclient.Object{
 		&kubermaticv1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
@@ -57,13 +65,14 @@ func TestReconcilingSeed(t *testing.T) {
 	tests := []struct {
 		name          string
 		shouldFail    bool
-		input         *kubermaticv1.Seed
+		seed          *kubermaticv1.Seed
+		config        *operatorv1alpha1.KubermaticConfiguration
 		existingSeeds []ctrlruntimeclient.Object
-		validate      func(input, result *kubermaticv1.Seed) error
+		validate      func(input, result *kubermaticv1.Seed, masterClient, seedClient ctrlruntimeclient.Client) error
 	}{
 		{
-			name: "Happy path",
-			input: &kubermaticv1.Seed{
+			name: "happy path",
+			seed: &kubermaticv1.Seed{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-seed",
 					Namespace: "kubermatic",
@@ -73,8 +82,14 @@ func TestReconcilingSeed(t *testing.T) {
 					ExposeStrategy: kubermaticv1.ExposeStrategyNodePort,
 				},
 			},
+			config: &operatorv1alpha1.KubermaticConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubermatic",
+					Namespace: "kubermatic",
+				},
+			},
 			existingSeeds: existingSeeds,
-			validate: func(input, result *kubermaticv1.Seed) error {
+			validate: func(input, result *kubermaticv1.Seed, _, _ ctrlruntimeclient.Client) error {
 				if result == nil {
 					return errors.New("seed CR should exist in seed cluster, but does not")
 				}
@@ -99,8 +114,8 @@ func TestReconcilingSeed(t *testing.T) {
 			},
 		},
 		{
-			name: "Empty Expose Strategy",
-			input: &kubermaticv1.Seed{
+			name: "empty expose strategy",
+			seed: &kubermaticv1.Seed{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-seed",
 					Namespace: "kubermatic",
@@ -109,8 +124,14 @@ func TestReconcilingSeed(t *testing.T) {
 					Country: "Germany",
 				},
 			},
+			config: &operatorv1alpha1.KubermaticConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubermatic",
+					Namespace: "kubermatic",
+				},
+			},
 			existingSeeds: existingSeeds,
-			validate: func(input, result *kubermaticv1.Seed) error {
+			validate: func(input, result *kubermaticv1.Seed, _, _ ctrlruntimeclient.Client) error {
 				if result == nil {
 					return errors.New("seed CR should exist in seed cluster, but does not")
 				}
@@ -135,9 +156,9 @@ func TestReconcilingSeed(t *testing.T) {
 			},
 		},
 		{
-			name:       "Invalid Expose Strategy",
+			name:       "invalid expose strategy",
 			shouldFail: true,
-			input: &kubermaticv1.Seed{
+			seed: &kubermaticv1.Seed{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-seed",
 					Namespace: "kubermatic",
@@ -147,9 +168,55 @@ func TestReconcilingSeed(t *testing.T) {
 					ExposeStrategy: kubermaticv1.ExposeStrategy("wtf"),
 				},
 			},
+			config: &operatorv1alpha1.KubermaticConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubermatic",
+					Namespace: "kubermatic",
+				},
+			},
 			existingSeeds: existingSeeds,
 			// actual check is done in the reconciler, nothing to validate here
 			validate: nil,
+		},
+		{
+			name: "sync config into seed",
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-seed",
+					Namespace: "kubermatic",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Country:        "Germany",
+					ExposeStrategy: kubermaticv1.ExposeStrategyNodePort,
+				},
+			},
+			config: &operatorv1alpha1.KubermaticConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubermatic",
+					Namespace: "kubermatic",
+				},
+				Spec: operatorv1alpha1.KubermaticConfigurationSpec{
+					ImagePullSecret: "hello world",
+				},
+			},
+			existingSeeds: existingSeeds,
+			validate: func(_, _ *kubermaticv1.Seed, masterClient, seedClient ctrlruntimeclient.Client) error {
+				cfg := &operatorv1alpha1.KubermaticConfiguration{}
+				err := seedClient.Get(context.TODO(), types.NamespacedName{
+					Namespace: "kubermatic",
+					Name:      "kubermatic",
+				}, cfg)
+
+				if err != nil {
+					return fmt.Errorf("failed to get config: %w", err)
+				}
+
+				if cfg.Spec.ImagePullSecret == "" {
+					return fmt.Errorf("ImagePullSecret should be set on the config copy in the seed cluster, but is empty")
+				}
+
+				return nil
+			},
 		},
 	}
 
@@ -160,7 +227,7 @@ func TestReconcilingSeed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			masterClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(test.input).Build()
+			masterClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(test.seed).Build()
 			seedClient := fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
@@ -178,7 +245,7 @@ func TestReconcilingSeed(t *testing.T) {
 				},
 			}
 
-			err := reconciler.reconcile(ctx, test.input, seedClient, log)
+			err := reconciler.reconcile(ctx, test.config, test.seed, seedClient, log)
 			if test.shouldFail && err == nil {
 				t.Fatalf("check for %s failed", test.name)
 			}
@@ -186,14 +253,14 @@ func TestReconcilingSeed(t *testing.T) {
 				t.Fatalf("reconciling failed: %v", err)
 			}
 
-			key := ctrlruntimeclient.ObjectKeyFromObject(test.input)
+			key := ctrlruntimeclient.ObjectKeyFromObject(test.seed)
 
 			result := &kubermaticv1.Seed{}
 			if err := seedClient.Get(ctx, key, result); err != nil && kerrors.IsNotFound(err) {
 				t.Fatalf("could not find seed CR in seed cluster: %v", err)
 			}
 			if test.validate != nil {
-				if err := test.validate(test.input, result); err != nil {
+				if err := test.validate(test.seed, result, masterClient, seedClient); err != nil {
 					t.Fatalf("reconciling did not lead to a valid end state: %v", err)
 				}
 			}

--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -18,6 +18,7 @@ package seedsync
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 )
 
@@ -34,6 +35,23 @@ func seedCreator(seed *kubermaticv1.Seed) reconciling.NamedSeedCreatorGetter {
 			s.Spec = seed.Spec
 
 			return s, nil
+		}
+	}
+}
+
+func configCreator(config *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedKubermaticConfigurationCreatorGetter {
+	return func() (string, reconciling.KubermaticConfigurationCreator) {
+		return config.Name, func(c *operatorv1alpha1.KubermaticConfiguration) (*operatorv1alpha1.KubermaticConfiguration, error) {
+			c.Labels = config.Labels
+			if c.Labels == nil {
+				c.Labels = make(map[string]string)
+			}
+			c.Labels[ManagedByLabel] = ControllerName
+
+			c.Annotations = config.Annotations
+			c.Spec = config.Spec
+
+			return c, nil
 		}
 	}
 }

--- a/pkg/controller/operator/seed/controller.go
+++ b/pkg/controller/operator/seed/controller.go
@@ -23,7 +23,6 @@ import (
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
-	"k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
@@ -64,6 +63,7 @@ func Add(
 	workerName string,
 ) error {
 	namespacePredicate := predicateutil.ByNamespace(namespace)
+	versionChangedPredicate := predicate.ResourceVersionChangedPredicate{}
 
 	reconciler := &Reconciler{
 		log:            log.Named(ControllerName),
@@ -88,7 +88,7 @@ func Add(
 	}
 
 	// watch for changes to KubermaticConfigurations in the master cluster and reconcile all seeds
-	configEventHandler := handler.EnqueueRequestsFromMapFunc(func(_ ctrlruntimeclient.Object) []reconcile.Request {
+	configEventHandler := handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
 		seeds, err := seedsGetter()
 		if err != nil {
 			log.Errorw("Failed to handle request", zap.Error(err))
@@ -100,7 +100,8 @@ func Add(
 		for _, seed := range seeds {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name: seed.Name,
+					Name:      seed.Name,
+					Namespace: seed.Namespace,
 				},
 			})
 		}
@@ -109,19 +110,66 @@ func Add(
 	})
 
 	config := &operatorv1alpha1.KubermaticConfiguration{}
-	if err := c.Watch(&source.Kind{Type: config}, configEventHandler, namespacePredicate); err != nil {
+	if err := c.Watch(&source.Kind{Type: config}, configEventHandler, namespacePredicate, predicate.ResourceVersionChangedPredicate{}); err != nil {
 		return fmt.Errorf("failed to create watcher for %T: %v", config, err)
 	}
 
 	// watch for changes to the global CA bundle ConfigMap and replicate it into each Seed
+	configMapEventHandler := handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		// find the owning KubermaticConfiguration
+		config, err := getKubermaticConfigurationForNamespace(ctx, reconciler.masterClient, namespace, reconciler.log)
+		if err != nil {
+			log.Errorw("Failed to retrieve config", zap.Error(err))
+			utilruntime.HandleError(err)
+			return nil
+		}
+		if config == nil {
+			return nil
+		}
+
+		defaulted, err := common.DefaultConfiguration(config, zap.NewNop().Sugar())
+		if err != nil {
+			log.Errorw("Failed to default config", zap.Error(err))
+			utilruntime.HandleError(err)
+			return nil
+		}
+
+		// we only care for one specific ConfigMap, but its name is dynamic so we cannot have
+		// a static watch setup for it
+		if a.GetName() != defaulted.Spec.CABundle.Name {
+			return nil
+		}
+
+		fmt.Println("Configmap!")
+
+		seeds, err := seedsGetter()
+		if err != nil {
+			log.Errorw("Failed to handle request", zap.Error(err))
+			utilruntime.HandleError(err)
+			return nil
+		}
+
+		requests := []reconcile.Request{}
+		for _, seed := range seeds {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      seed.Name,
+					Namespace: seed.Namespace,
+				},
+			})
+		}
+
+		return requests
+	})
+
 	configMap := &corev1.ConfigMap{}
-	if err := c.Watch(&source.Kind{Type: configMap}, configEventHandler, namespacePredicate); err != nil {
+	if err := c.Watch(&source.Kind{Type: configMap}, configMapEventHandler, namespacePredicate, versionChangedPredicate); err != nil {
 		return fmt.Errorf("failed to create watcher for %T: %v", configMap, err)
 	}
 
 	// watch for changes to Seed CRs inside the master cluster and reconcile the seed itself only
 	seed := &kubermaticv1.Seed{}
-	if err := c.Watch(&source.Kind{Type: seed}, &handler.EnqueueRequestForObject{}, namespacePredicate); err != nil {
+	if err := c.Watch(&source.Kind{Type: seed}, &handler.EnqueueRequestForObject{}, namespacePredicate, versionChangedPredicate); err != nil {
 		return fmt.Errorf("failed to create watcher for %T: %v", seed, err)
 	}
 
@@ -140,7 +188,14 @@ func Add(
 
 func createSeedWatches(controller controller.Controller, seedName string, seedManager manager.Manager, namespace string) error {
 	cache := seedManager.GetCache()
-	eventHandler := util.EnqueueConst(seedName)
+	eventHandler := handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Name:      seedName,
+				Namespace: namespace,
+			},
+		}}
+	})
 
 	watch := func(t ctrlruntimeclient.Object, preds ...predicate.Predicate) error {
 		seedTypeWatch := &source.Kind{Type: t}
@@ -220,4 +275,28 @@ func createSeedWatches(controller controller.Controller, seedName string, seedMa
 	}
 
 	return nil
+}
+
+func getKubermaticConfigurationForNamespace(ctx context.Context, client ctrlruntimeclient.Client, namespace string, log *zap.SugaredLogger) (*operatorv1alpha1.KubermaticConfiguration, error) {
+	// find the owning KubermaticConfiguration
+	configList := &operatorv1alpha1.KubermaticConfigurationList{}
+	listOpts := &ctrlruntimeclient.ListOptions{
+		Namespace: namespace,
+	}
+
+	if err := client.List(ctx, configList, listOpts); err != nil {
+		return nil, fmt.Errorf("failed to find KubermaticConfigurations: %v", err)
+	}
+
+	if len(configList.Items) == 0 {
+		log.Debug("ignoring request for namespace without KubermaticConfiguration")
+		return nil, nil
+	}
+
+	if len(configList.Items) > 1 {
+		log.Infow("there are multiple KubermaticConfiguration objects, cannot reconcile", "namespace", namespace)
+		return nil, nil
+	}
+
+	return &configList.Items[0], nil
 }

--- a/pkg/controller/operator/seed/controller.go
+++ b/pkg/controller/operator/seed/controller.go
@@ -140,8 +140,6 @@ func Add(
 			return nil
 		}
 
-		fmt.Println("Configmap!")
-
 		seeds, err := seedsGetter()
 		if err != nil {
 			log.Errorw("Failed to handle request", zap.Error(err))

--- a/pkg/crd/equality/semantic.go
+++ b/pkg/crd/equality/semantic.go
@@ -32,7 +32,15 @@ var Semantic = conversion.EqualitiesOrDie(
 		return a.Cmp(b) == 0
 	},
 	func(a, b *semverlib.Version) bool {
-		return a.Compare(b) == 0
+		if a == nil && b == nil {
+			return true
+		}
+
+		if a != nil && b != nil {
+			return a.Equal(b)
+		}
+
+		return false
 	},
 	func(a, b time.Time) bool {
 		return a.UTC() == b.UTC()

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -57,7 +57,7 @@ func DeepEqual(a, b metav1.Object) bool {
 		diff = deep.Equal(b, a)
 	}
 
-	kubermaticlog.Logger.Infow("Object differs from generated one", "type", fmt.Sprintf("%T", a), "namespace", a.GetNamespace(), "name", a.GetName(), "diff", diff)
+	kubermaticlog.Logger.Debugw("Object differs from generated one", "type", fmt.Sprintf("%T", a), "namespace", a.GetNamespace(), "name", a.GetName(), "diff", diff)
 	return false
 }
 

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -57,7 +57,7 @@ func DeepEqual(a, b metav1.Object) bool {
 		diff = deep.Equal(b, a)
 	}
 
-	kubermaticlog.Logger.Debugw("Object differs from generated one", "type", fmt.Sprintf("%T", a), "namespace", a.GetNamespace(), "name", a.GetName(), "diff", diff)
+	kubermaticlog.Logger.Infow("Object differs from generated one", "type", fmt.Sprintf("%T", a), "namespace", a.GetNamespace(), "name", a.GetName(), "diff", diff)
 	return false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the seed-ctrlmgr is still using ancient file formats, like the `versions.yaml` and `addons.ỳaml` and whatnot. These files have long been deprecated in favor of the KubermaticConfiguration CRD.

To finally get rid of the `kubermatic` Helm chart, we need to migrate the seed-ctrlmgr to use this new CRD instead of our homegrown files. And the first step to achieve this is to make the KubermaticConfiguration available on seed clusters. This PR does exactly that.

This PR also contains a few tweaks to the KKP operator in order to significantly reduce its reconciliations. When updating to controller-runtime 0.9, the behaviour of Patch() seemingly also changed, so the defaulting the operator did had no real effect.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
