### PR TITLE
workaround for Helm deployment errors

### DIFF
--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -101,7 +101,10 @@ function deploy3 {
     echodate "Deployment has been manually disabled on this cluster. Skipping this chart."
   else
     echodate "Upgrading $name..."
-    retry 5 helm3 --namespace "$namespace" upgrade --install --force --atomic --timeout "$timeout" --values "$VALUES_FILE" "$name" "$path"
+
+    # Do not set --force, as this will cause problems when upgrading a Helm release.
+    # See Helm issue #7956 and the upstream k8s bug #91459, which was fixed in 1.22+.
+    retry 5 helm3 --namespace "$namespace" upgrade --install --atomic --timeout "$timeout" --values "$VALUES_FILE" "$name" "$path"
   fi
 
   unset TEST_NAME


### PR DESCRIPTION
**What this PR does / why we need it**:
My latest patch to use Helm 3 caused us to experience https://github.com/helm/helm/issues/7956, which is triggered by https://github.com/kubernetes/kubernetes/issues/91459, which is fixed in 1.22+ only. So this PR removes the `--force` option.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
