### PR TITLE
Fix OpenStack CCM version for 1.20+ clusters

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -141,20 +141,18 @@ func getOSFlags(data *resources.TemplateData) []string {
 	return flags
 }
 
-const latestOpenstackCCMVersion = "1.21.1"
-
 func getOSVersion(version semver.Semver) (string, error) {
 	switch version.Minor() {
 	case 19:
 		return "1.19.2", nil
 	case 20:
-		return latestOpenstackCCMVersion, nil
+		return "1.20.2", nil
 	case 21:
-		return latestOpenstackCCMVersion, nil
+		return "1.21.0", nil
 	case 22:
-		return latestOpenstackCCMVersion, nil
+		fallthrough
 	default:
-		return latestOpenstackCCMVersion, nil
+		return "1.22.0", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.1
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.1
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.1
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses the following problems related to the OpenStack CCM versioning:

* The v1.21.1 image doesn't actually exist, even though the GitHub tag exists. The latest available image is v1.21.0
* The OpenStack CCM team recommends matching the CCM minor version with the Kubernetes minor version. Therefore:
    * Kubernetes 1.20 clusters will use OpenStack CCM v1.20.2
    * Kubernetes 1.21 clusters will use OpenStack CCM v1.21.0 (upgraded from 1.20.2)
    * Kubernetes 1.22 clusters will use OpenStack CCM v1.22.0

**Does this PR introduce a user-facing change?**:
```release-note
Use OpenStack CCM v1.21.0 for Kubernetes v1.21 clusters, and CCM v1.22.0 for Kubernetes v1.22 clusters
```