### PR TITLE
remove priorityClassName from metric-server deployment

### DIFF
--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -162,7 +162,6 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			}
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
-			dep.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -164,7 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      priorityClassName: system-cluster-critical
       volumes:
       - name: metrics-server
         secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
This was added by mistake and now creating pods fail with following error. 

> Warning  FailedCreate  5m37s (x18 over 16m)  replicaset-controller  Error creating: insufficient quota to match these scopes: [{PriorityClass In [system-node-critical system-cluster-critical]}]

The priority class doesn't make sense for us either way, as the metrics-server runs on the seed. Its existence however is certainly not critical for the _seed_ cluster.

**Documentation**:

Discussion https://kubermatic.slack.com/archives/C01FJ10TBM2/p1629965851002700

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
