### PR TITLE
Fix cluster template instance creation by implementing missing method

### DIFF
--- a/pkg/provider/kubernetes/cluster_template_instance.go
+++ b/pkg/provider/kubernetes/cluster_template_instance.go
@@ -118,6 +118,24 @@ func (r ClusterTemplateInstanceProvider) GetUnsecured(name string) (*kubermaticv
 	return instance, nil
 }
 
+func (r ClusterTemplateInstanceProvider) ListUnsecured(options provider.ClusterTemplateInstanceListOptions) (*kubermaticv1.ClusterTemplateInstanceList, error) {
+	instanceList := &kubermaticv1.ClusterTemplateInstanceList{}
+
+	labelSelector := ctrlruntimeclient.MatchingLabels{}
+
+	if options.ProjectID != "" {
+		labelSelector[kubermaticv1.ClusterTemplateProjectLabelKey] = options.ProjectID
+	}
+	if options.TemplateID != "" {
+		labelSelector[ClusterTemplateLabelKey] = options.TemplateID
+	}
+
+	if err := r.privilegedClient.List(context.Background(), instanceList, labelSelector); err != nil {
+		return nil, err
+	}
+	return instanceList, nil
+}
+
 func (r ClusterTemplateInstanceProvider) Get(userInfo *provider.UserInfo, name string) (*kubermaticv1.ClusterTemplateInstance, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, r.createSeedImpersonatedClient)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/kubermatic/issues/7587

**Special notes for your reviewer**: Missing method caused panic for admin users because of the cast that couldn't be completed.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
