### PR TITLE
Filter etcd backup config

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -14285,6 +14285,12 @@
             "name": "project_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Type",
+            "name": "type",
+            "in": "query"
           }
         ],
         "responses": {

--- a/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
+++ b/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
@@ -56,10 +56,6 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			return nil, err
 		}
 
-		if err := req.validate(); err != nil {
-			return nil, err
-		}
-
 		ebc, err := convertAPIToInternalEtcdBackupConfig(req.Body.Name, &req.Body.Spec, c)
 		if err != nil {
 			return nil, err
@@ -92,14 +88,6 @@ type ebcBody struct {
 	Name string `json:"name"`
 	// EtcdBackupConfigSpec Spec of the etcd backup config
 	Spec apiv2.EtcdBackupConfigSpec `json:"spec"`
-}
-
-func (r *createEtcdBackupConfigReq) validate() error {
-	// schedule and keep have to either be both set, or both absent
-	if (r.Body.Spec.Keep == nil && r.Body.Spec.Schedule != "") || (r.Body.Spec.Keep != nil && r.Body.Spec.Schedule == "") {
-		return errors.NewBadRequest("EtcdBackupConfig has to have both Schedule and Keep options set or both empty")
-	}
-	return nil
 }
 
 func DecodeCreateEtcdBackupConfigReq(c context.Context, r *http.Request) (interface{}, error) {
@@ -224,9 +212,6 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provi
 	privilegedProjectProvider provider.PrivilegedProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(patchEtcdBackupConfigReq)
-		if err := req.validate(); err != nil {
-			return nil, err
-		}
 
 		c, err := handlercommon.GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, req.ProjectID, req.ClusterID, nil)
 		if err != nil {
@@ -282,14 +267,6 @@ func DecodePatchEtcdBackupConfigReq(c context.Context, r *http.Request) (interfa
 	}
 
 	return req, nil
-}
-
-func (r *patchEtcdBackupConfigReq) validate() error {
-	// schedule and keep have to either be both set, or both absent
-	if (r.Body.Keep == nil && r.Body.Schedule != "") || (r.Body.Keep != nil && r.Body.Schedule == "") {
-		return errors.NewBadRequest("EtcdBackupConfig has to have both Schedule and Keep options set or both empty")
-	}
-	return nil
 }
 
 func ProjectListEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {

--- a/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig_test.go
+++ b/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig_test.go
@@ -91,23 +91,6 @@ func TestCreateEndpoint(t *testing.T) {
 			ExpectedHTTPStatusCode: http.StatusCreated,
 			ExpectedResponse:       test.GenAPIEtcdBackupConfig("test-ebc", test.GenDefaultCluster().Name),
 		},
-		{
-			Name:      "validation fails when schedule is set and keep is not",
-			ProjectID: test.GenDefaultProject().Name,
-			ClusterID: test.GenDefaultCluster().Name,
-			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
-				test.GenTestSeed(),
-				test.GenDefaultCluster(),
-			),
-			ExistingAPIUser: test.GenDefaultAPIUser(),
-			EtcdBackupConfig: func() *apiv2.EtcdBackupConfig {
-				ebc := test.GenAPIEtcdBackupConfig("test-ebc", test.GenDefaultCluster().Name)
-				ebc.Spec.Keep = nil
-				return ebc
-			}(),
-			ExpectedHTTPStatusCode: http.StatusBadRequest,
-			ExpectedResponse:       nil,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -508,25 +491,6 @@ func TestPatchEndpoint(t *testing.T) {
 				ebc.Spec.Schedule = modifiedSchedule
 				return ebc
 			}(),
-		},
-		{
-			Name:                 "patch etcdbackupconfig validation fail",
-			EtcdBackupConfigName: "test-1",
-			PatchSpec: func() *apiv2.EtcdBackupConfigSpec {
-				spec := test.GenAPIEtcdBackupConfig("test-1", test.GenDefaultCluster().Name).Spec
-				spec.Schedule = modifiedSchedule
-				spec.Keep = nil
-				return &spec
-			}(),
-			ProjectID: test.GenDefaultProject().Name,
-			ClusterID: test.GenDefaultCluster().Name,
-			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
-				test.GenTestSeed(),
-				test.GenDefaultCluster(),
-				test.GenEtcdBackupConfig("test-1", test.GenDefaultCluster(), test.GenDefaultProject().Name),
-			),
-			ExistingAPIUser:        test.GenDefaultAPIUser(),
-			ExpectedHTTPStatusCode: http.StatusBadRequest,
 		},
 	}
 

--- a/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig_test.go
+++ b/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig_test.go
@@ -27,6 +27,7 @@ import (
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 
@@ -566,6 +567,7 @@ func TestProjectListEndpoint(t *testing.T) {
 	testCases := []struct {
 		Name                      string
 		ProjectID                 string
+		Type                      string
 		ExistingKubermaticObjects []ctrlruntimeclient.Object
 		ExistingAPIUser           *apiv1.User
 		ExpectedResponse          []*apiv2.EtcdBackupConfig
@@ -580,12 +582,22 @@ func TestProjectListEndpoint(t *testing.T) {
 				test.GenEtcdBackupConfig("test-1", test.GenDefaultCluster(), test.GenDefaultProject().Name),
 				test.GenEtcdBackupConfig("test-2", test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)), test.GenDefaultProject().Name),
 				test.GenEtcdBackupConfig("test-3", test.GenDefaultCluster(), "some-different-project"),
+				func() *kubermaticv1.EtcdBackupConfig {
+					ebc := test.GenEtcdBackupConfig("test-4", test.GenDefaultCluster(), test.GenDefaultProject().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
 			ExpectedResponse: []*apiv2.EtcdBackupConfig{
 				test.GenAPIEtcdBackupConfig("test-1", test.GenDefaultCluster().Name),
 				test.GenAPIEtcdBackupConfig("test-2", "clusterAbcID"),
+				func() *apiv2.EtcdBackupConfig {
+					ebc := test.GenAPIEtcdBackupConfig("test-4", test.GenDefaultCluster().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
 			},
 		},
 		{
@@ -611,19 +623,92 @@ func TestProjectListEndpoint(t *testing.T) {
 				test.GenEtcdBackupConfig("test-1", test.GenDefaultCluster(), test.GenDefaultProject().Name),
 				test.GenEtcdBackupConfig("test-2", test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)), test.GenDefaultProject().Name),
 				test.GenEtcdBackupConfig("test-3", test.GenDefaultCluster(), "some-different-project"),
+				func() *kubermaticv1.EtcdBackupConfig {
+					ebc := test.GenEtcdBackupConfig("test-4", test.GenDefaultCluster(), test.GenDefaultProject().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
 			),
 			ExistingAPIUser:        test.GenAPIUser("John", "john@acme.com"),
 			ExpectedHTTPStatusCode: http.StatusOK,
 			ExpectedResponse: []*apiv2.EtcdBackupConfig{
 				test.GenAPIEtcdBackupConfig("test-1", test.GenDefaultCluster().Name),
 				test.GenAPIEtcdBackupConfig("test-2", "clusterAbcID"),
+				func() *apiv2.EtcdBackupConfig {
+					ebc := test.GenAPIEtcdBackupConfig("test-4", test.GenDefaultCluster().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
 			},
+		},
+		{
+			Name:      "filter by type snapshot",
+			ProjectID: test.GenDefaultProject().Name,
+			Type:      "snapshot",
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+				test.GenEtcdBackupConfig("test-1", test.GenDefaultCluster(), test.GenDefaultProject().Name),
+				test.GenEtcdBackupConfig("test-2", test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)), test.GenDefaultProject().Name),
+				test.GenEtcdBackupConfig("test-3", test.GenDefaultCluster(), "some-different-project"),
+				func() *kubermaticv1.EtcdBackupConfig {
+					ebc := test.GenEtcdBackupConfig("test-4", test.GenDefaultCluster(), test.GenDefaultProject().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
+			),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: []*apiv2.EtcdBackupConfig{
+				func() *apiv2.EtcdBackupConfig {
+					ebc := test.GenAPIEtcdBackupConfig("test-4", test.GenDefaultCluster().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
+			},
+		},
+		{
+			Name:      "filter by type automatic",
+			ProjectID: test.GenDefaultProject().Name,
+			Type:      "automatic",
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+				test.GenEtcdBackupConfig("test-1", test.GenDefaultCluster(), test.GenDefaultProject().Name),
+				test.GenEtcdBackupConfig("test-2", test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)), test.GenDefaultProject().Name),
+				test.GenEtcdBackupConfig("test-3", test.GenDefaultCluster(), "some-different-project"),
+				func() *kubermaticv1.EtcdBackupConfig {
+					ebc := test.GenEtcdBackupConfig("test-4", test.GenDefaultCluster(), test.GenDefaultProject().Name)
+					ebc.Spec.Schedule = ""
+					return ebc
+				}(),
+			),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: []*apiv2.EtcdBackupConfig{
+				test.GenAPIEtcdBackupConfig("test-1", test.GenDefaultCluster().Name),
+				test.GenAPIEtcdBackupConfig("test-2", "clusterAbcID"),
+			},
+		},
+		{
+			Name:      "fail filtering by unknown type",
+			Type:      "unknown",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+				test.GenAdminUser("John", "john@acme.com", false),
+				test.GenEtcdBackupConfig("test-1", test.GenDefaultCluster(), test.GenDefaultProject().Name),
+				test.GenEtcdBackupConfig("test-2", test.GenDefaultCluster(), test.GenDefaultProject().Name),
+			),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExpectedHTTPStatusCode: http.StatusBadRequest,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			requestURL := fmt.Sprintf("/api/v2/projects/%s/etcdbackupconfigs", tc.ProjectID)
+			requestURL := fmt.Sprintf("/api/v2/projects/%s/etcdbackupconfigs?type=%s", tc.ProjectID, tc.Type)
 			req := httptest.NewRequest(http.MethodGet, requestURL, nil)
 			resp := httptest.NewRecorder()
 

--- a/pkg/test/e2e/utils/apiclient/client/etcdbackupconfig/list_project_etcd_backup_config_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/etcdbackupconfig/list_project_etcd_backup_config_parameters.go
@@ -62,6 +62,9 @@ type ListProjectEtcdBackupConfigParams struct {
 	// ProjectID.
 	ProjectID string
 
+	// Type.
+	Type *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -126,6 +129,17 @@ func (o *ListProjectEtcdBackupConfigParams) SetProjectID(projectID string) {
 	o.ProjectID = projectID
 }
 
+// WithType adds the typeVar to the list project etcd backup config params
+func (o *ListProjectEtcdBackupConfigParams) WithType(typeVar *string) *ListProjectEtcdBackupConfigParams {
+	o.SetType(typeVar)
+	return o
+}
+
+// SetType adds the type to the list project etcd backup config params
+func (o *ListProjectEtcdBackupConfigParams) SetType(typeVar *string) {
+	o.Type = typeVar
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListProjectEtcdBackupConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -137,6 +151,23 @@ func (o *ListProjectEtcdBackupConfigParams) WriteToRequest(r runtime.ClientReque
 	// path param project_id
 	if err := r.SetPathParam("project_id", o.ProjectID); err != nil {
 		return err
+	}
+
+	if o.Type != nil {
+
+		// query param type
+		var qrType string
+
+		if o.Type != nil {
+			qrType = *o.Type
+		}
+		qType := qrType
+		if qType != "" {
+
+			if err := r.SetQueryParam("type", qType); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds filtering option to etcd backup config project list endpoint. Also removed validation in create and patch endpoints for automatic backups as `keep` is defaulted when empty, so no need to enforce it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7582 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
