### PR TITLE
update clusterrole for kube-state-metrics

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics/clusterrole.go
@@ -53,16 +53,6 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					Verbs: []string{"list", "watch"},
 				},
 				{
-					APIGroups: []string{"extensions"},
-					Resources: []string{
-						"daemonsets",
-						"deployments",
-						"replicasets",
-						"ingresses",
-					},
-					Verbs: []string{"list", "watch"},
-				},
-				{
 					APIGroups: []string{"apps"},
 					Resources: []string{
 						"daemonsets",
@@ -127,6 +117,7 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					APIGroups: []string{"networking.k8s.io"},
 					Resources: []string{
 						"networkpolicies",
+						"ingresses",
 					},
 					Verbs: []string{"list", "watch"},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Update clusterrole for kube-state-metrics deployment for user clusters

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
