### PR TITLE
Velero backuptoolong alert

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.2
+version: 2.4.3
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-velero.yaml
+++ b/charts/monitoring/prometheus/rules/general-velero.yaml
@@ -19,9 +19,9 @@ groups:
     rules:
       - alert: VeleroBackupTakesTooLong
         annotations:
-          message: Backup schedule {{ $labels.schedule }} has been taking more than 60min already.
+          message: Last backup with schedule {{ $labels.schedule }} has not finished successfully within 60min.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-velerobackuptakestoolong
-        expr: (velero_backup_attempt_total - velero_backup_success_total) > 0
+        expr: (increase(velero_backup_attempt_total[60m]) - increase(velero_backup_failure_total[60m])) > 0
         for: 60m
         labels:
           severity: warning

--- a/charts/monitoring/prometheus/rules/src/general/velero.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/velero.yaml
@@ -17,9 +17,9 @@ groups:
   rules:
   - alert: VeleroBackupTakesTooLong
     annotations:
-      message: Backup schedule {{ $labels.schedule }} has been taking more than 60min already.
+      message: Last backup with schedule {{ $labels.schedule }} has not finished successfully within 60min.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-velerobackuptakestoolong
-    expr: (velero_backup_attempt_total - velero_backup_success_total) > 0
+    expr: (increase(velero_backup_attempt_total[60m]) - increase(velero_backup_failure_total[60m])) > 0
     for: 60m
     labels:
       severity: warning


### PR DESCRIPTION
**What this PR does / why we need it**:
`velero_backup_*_total` metrics are counters and as such never decrease their values.
Effectively, this alert checked if any backup has (partially-)failed ever since velero was restarted.

This change "resets" the alert each 60 minutes, if there was a backup that actually successfully finished within the last 60 minutes period.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Documentation**:


**Does this PR introduce a user-facing change?**:
```release-note
Alert VeleroBackupTakesTooLong will now reset if the next backup of the same schedule finished successfully.

```
