### PR TITLE
Etcd restore optional name

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -22172,7 +22172,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the etcd backup restore",
+          "description": "Name of the etcd backup restore. If not set, it will be generated",
           "type": "string",
           "x-go-name": "Name"
         },

--- a/pkg/handler/v2/etcdrestore/etcdrestore.go
+++ b/pkg/handler/v2/etcdrestore/etcdrestore.go
@@ -36,6 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/reference"
 )
@@ -52,6 +53,11 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 
 		if err := req.validate(); err != nil {
 			return nil, err
+		}
+
+		// generate name if not set
+		if req.Body.Name == "" {
+			req.Body.Name = rand.String(10)
 		}
 
 		er, err := convertAPIToInternalEtcdRestore(req.Body.Name, &req.Body.Spec, c)
@@ -82,8 +88,8 @@ type createEtcdRestoreReq struct {
 }
 
 type erBody struct {
-	// Name of the etcd backup restore
-	Name string `json:"name"`
+	// Name of the etcd backup restore. If not set, it will be generated
+	Name string `json:"name,omitempty"`
 	// EtcdRestoreSpec Spec of the etcd backup restore
 	Spec apiv2.EtcdRestoreSpec `json:"spec"`
 }

--- a/pkg/handler/v2/etcdrestore/etcdrestore_test.go
+++ b/pkg/handler/v2/etcdrestore/etcdrestore_test.go
@@ -104,6 +104,18 @@ func TestCreateEndpoint(t *testing.T) {
 			ExpectedHTTPStatusCode: http.StatusBadRequest,
 			ExpectedResponse:       nil,
 		},
+		{
+			Name:      "create etcd restore with generated name",
+			ProjectID: test.GenDefaultProject().Name,
+			ClusterID: test.GenDefaultCluster().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			EtcdRestore:            test.GenAPIEtcdRestore("", test.GenDefaultCluster().Name),
+			ExpectedHTTPStatusCode: http.StatusCreated,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -125,7 +137,8 @@ func TestCreateEndpoint(t *testing.T) {
 			if resp.Code != tc.ExpectedHTTPStatusCode {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatusCode, resp.Code, resp.Body.String())
 			}
-			if resp.Code == http.StatusCreated {
+			// skip the comparison for error codes and when the name is generated
+			if resp.Code == http.StatusCreated && tc.EtcdRestore.Name != "" {
 				b, err := json.Marshal(tc.ExpectedResponse)
 				if err != nil {
 					t.Fatalf("failed to marshal expected response %v", err)

--- a/pkg/test/e2e/utils/apiclient/models/er_body.go
+++ b/pkg/test/e2e/utils/apiclient/models/er_body.go
@@ -18,7 +18,7 @@ import (
 // swagger:model erBody
 type ErBody struct {
 
-	// Name of the etcd backup restore
+	// Name of the etcd backup restore. If not set, it will be generated
 	Name string `json:"name,omitempty"`
 
 	// spec


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows for optional names when creating EtcdRestores through API, as users will want to focus on picking the backup and cluster, instead of needing to chose a name. If not set, name will be randomly generated. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7620 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
