### PR TITLE
Update hcloud-go dependency

### DIFF
--- a/addons/csi/hetzner/hcloud-csi-1.5.1.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.5.1.yaml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # This is based on
-# https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.5.1/deploy/kubernetes/hcloud-csi.yml
-# and compatible with Kubernetes 1.16+; the only difference between
-# 1.4.0 and 1.5.1 is the NODE_NAME env variable.
+# 1.19: https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.5.1/deploy/kubernetes/hcloud-csi.yml
+# and is applicable for k8s 1.19 clusters.
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "hetzner" }}
+{{ if eq .Cluster.MajorMinorVersion "1.19" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -358,5 +358,6 @@ spec:
     - port: 9189
       name: metrics
       targetPort: metrics
+{{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/hetzner/hcloud-csi-1.5.1.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.5.1.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This is based on
-# 1.19: https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.5.1/deploy/kubernetes/hcloud-csi.yml
+# https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.5.1/deploy/kubernetes/hcloud-csi.yml
 # and is applicable for k8s 1.19 clusters.
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -1,0 +1,369 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is based on
+# https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml
+# and is applicable for k8s 1.20+ clusters.
+
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if eq .Cluster.CloudProviderName "hetzner" }}
+{{ if gt .Cluster.Version.Minor 19 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+data:
+  token: {{ .Credentials.Hetzner.Token | b64enc }}
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.hetzner.cloud
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+---
+# storage class is defined in the default-storage-class addon
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi
+rules:
+  # attacher
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  # provisioner
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  # resizer
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # node
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi
+subjects:
+  - kind: ServiceAccount
+    name: hcloud-csi
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: hcloud-csi
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: hcloud-csi-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: hcloud-csi-controller
+  serviceName: hcloud-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hcloud-csi-controller
+    spec:
+      serviceAccount: hcloud-csi
+      containers:
+        - name: csi-attacher
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.2.1'
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /run/csi
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: csi-resizer
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.2.0'
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /run/csi
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: csi-provisioner
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.2.2'
+          args:
+            - --feature-gates=Topology=true
+            - --default-fstype=ext4
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /run/csi
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: hcloud-csi-driver
+          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.6.0'
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///run/csi/socket
+            - name: METRICS_ENDPOINT
+              value: 0.0.0.0:9189
+            - name: ENABLE_METRICS
+              value: "true"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-csi
+                  key: token
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /run/csi
+          ports:
+            - containerPort: 9189
+              name: metrics
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: liveness-probe
+          imagePullPolicy: Always
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0'
+          volumeMounts:
+            - mountPath: /run/csi
+              name: socket-dir
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: hcloud-csi-node
+  namespace: kube-system
+  labels:
+    app: hcloud-csi
+spec:
+  selector:
+    matchLabels:
+      app: hcloud-csi
+  template:
+    metadata:
+      labels:
+        app: hcloud-csi
+    spec:
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "instance.hetzner.cloud/is-root-server"
+                    operator: NotIn
+                    values:
+                      - "true"
+      serviceAccount: hcloud-csi
+      containers:
+        - name: csi-node-driver-registrar
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'
+          args:
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /run/csi
+            - name: registration-dir
+              mountPath: /registration
+          securityContext:
+            privileged: true
+        - name: hcloud-csi-driver
+          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.6.0'
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///run/csi/socket
+            - name: METRICS_ENDPOINT
+              value: 0.0.0.0:9189
+            - name: ENABLE_METRICS
+              value: "true"
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-csi
+                  key: token
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /run/csi
+            - name: device-dir
+              mountPath: /dev
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9189
+              name: metrics
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+        - name: liveness-probe
+          imagePullPolicy: Always
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0'
+          volumeMounts:
+            - mountPath: /run/csi
+              name: plugin-dir
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hcloud-csi-controller-metrics
+  namespace: kube-system
+  labels:
+    app: hcloud-csi
+spec:
+  selector:
+    app: hcloud-csi-controller
+  ports:
+    - port: 9189
+      name: metrics
+      targetPort: metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hcloud-csi-node-metrics
+  namespace: kube-system
+  labels:
+    app: hcloud-csi
+spec:
+  selector:
+    app: hcloud-csi
+  ports:
+    - port: 9189
+      name: metrics
+      targetPort: metrics
+{{ end }}
+{{ end }}
+{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grafana/grafana v6.1.6+incompatible
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hetznercloud/hcloud-go v1.25.0
+	github.com/hetznercloud/hcloud-go v1.32.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac // indirect
 	github.com/jetstack/cert-manager v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1093,8 +1093,9 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
-github.com/hetznercloud/hcloud-go v1.25.0 h1:QAaFKtGKWRxjwjKJWBGMxGYUxVEQmIkb35j/WXrsazY=
 github.com/hetznercloud/hcloud-go v1.25.0/go.mod h1:2C5uMtBiMoFr3m7lBFPf7wXTdh33CevmZpQIIDPGYJI=
+github.com/hetznercloud/hcloud-go v1.32.0 h1:7zyN2V7hMlhm3HZdxOarmOtvzKvkcYKjM0hcwYMQZz0=
+github.com/hetznercloud/hcloud-go v1.32.0/go.mod h1:XX/TQub3ge0yWR2yHWmnDVIrB+MQbda1pHxkUmDlUME=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a PR to ensure that Hetzner support for 1.22 works as expected.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
