### PR TITLE
fix wrong cert-manager API in installer

### DIFF
--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/sirupsen/logrus"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
@kron4eg found it, but I take credit for it! #management

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
