### PR TITLE
Enable etcd-launcher and etcd backup an restore

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.64
+version: 1.1.65
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.65
+version: 1.1.68
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/kubermatic/values.yaml
+++ b/charts/kubermatic/values.yaml
@@ -266,11 +266,10 @@ kubermatic:
   storeContainer: null
   deleteContainer: null
   cleanupContainer: null
-  # Settings for the the controllers for EtcdBackupConfig and EtcdRestore CRDs,
-  # which allow dynamically creating multiple arbitrary backup schedules for each
-  # cluster, as well as restoring a cluster's etcd from any of the created backups
+  # DEPRECATED: use the BackupRestore field to configure the etcd backup and restore
+  # feature in the seed object.
   etcdBackupsRestores:
-    enabled: true
+    enabled: false
     s3:
       endpoint: minio.minio.svc.cluster.local:9000
       bucket: kubermatic-etcd-backups

--- a/charts/kubermatic/values.yaml
+++ b/charts/kubermatic/values.yaml
@@ -99,7 +99,7 @@ kubermatic:
     #   If enabled will apply the cluster level etcd-launcher feature flag on all clusters, unless it's explicitly disabled at the cluster level
     # For example:
     # featureGates: "OpenIDAuthPlugin=true,VerticalPodAutoscaler=true"
-    featureGates: ""
+    featureGates: "EtcdLauncher=true"
     datacenterName: ""
     # Specifies the NodePort range for customer clusters - this must match the NodePort range of the seed cluster.
     nodeportRange: "30000-32767"
@@ -270,7 +270,7 @@ kubermatic:
   # which allow dynamically creating multiple arbitrary backup schedules for each
   # cluster, as well as restoring a cluster's etcd from any of the created backups
   etcdBackupsRestores:
-    enabled: false
+    enabled: true
     s3:
       endpoint: minio.minio.svc.cluster.local:9000
       bucket: kubermatic-etcd-backups

--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -75,6 +75,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
@@ -116,7 +117,19 @@ func main() {
 		kubermaticlog.Logger.Fatalw("failed to register scheme", zap.Stringer("api", gatekeeperconfigv1alpha1.GroupVersion), zap.Error(err))
 	}
 
-	providers, err := createInitProviders(ctx, options)
+	masterCfg, err := ctrlruntime.GetConfig()
+	if err != nil {
+		kubermaticlog.Logger.Fatalw("unable to build client configuration from kubeconfig due to %v", err)
+	}
+
+	// We use the manager only to get a lister-backed ctrlruntimeclient.Client. We can not use it for most
+	// other actions, because it doesn't support impersonation (and can't be changed to do that as that would mean it has to replicate the apiservers RBAC for the lister)
+	mgr, err := manager.New(masterCfg, manager.Options{MetricsBindAddress: "0"})
+	if err != nil {
+		kubermaticlog.Logger.Fatalw("failed to construct manager: %v", err)
+	}
+
+	providers, err := createInitProviders(ctx, options, masterCfg, mgr)
 	if err != nil {
 		log.Fatalw("failed to create and initialize providers", "error", err)
 	}
@@ -132,7 +145,7 @@ func main() {
 	if err != nil {
 		log.Fatalw("failed to create update manager", "error", err)
 	}
-	apiHandler, err := createAPIHandler(options, providers, oidcIssuerVerifier, tokenVerifiers, tokenExtractors, updateManager)
+	apiHandler, err := createAPIHandler(options, providers, oidcIssuerVerifier, tokenVerifiers, tokenExtractors, updateManager, mgr)
 	if err != nil {
 		log.Fatalw("failed to create API Handler", "error", err)
 	}
@@ -148,24 +161,12 @@ func main() {
 	log.Fatalw("failed to start API server", "error", http.ListenAndServe(options.listenAddress, handlers.CombinedLoggingHandler(os.Stdout, apiHandler)))
 }
 
-func createInitProviders(ctx context.Context, options serverRunOptions) (providers, error) {
-	masterCfg, err := ctrlruntime.GetConfig()
-	if err != nil {
-		return providers{}, fmt.Errorf("unable to build client configuration from kubeconfig due to %v", err)
-	}
-
+func createInitProviders(ctx context.Context, options serverRunOptions, masterCfg *rest.Config, mgr manager.Manager) (providers, error) {
 	// create other providers
 	kubeMasterClient := kubernetes.NewForConfigOrDie(masterCfg)
 	kubeMasterInformerFactory := informers.NewSharedInformerFactory(kubeMasterClient, 30*time.Minute)
 	kubermaticMasterClient := kubermaticclientset.NewForConfigOrDie(masterCfg)
 	kubermaticMasterInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticMasterClient, 30*time.Minute)
-
-	// We use the manager only to get a lister-backed ctrlruntimeclient.Client. We can not use it for most
-	// other actions, because it doesn't support impersonation (and can't be changed to do that as that would mean it has to replicate the apiservers RBAC for the lister)
-	mgr, err := manager.New(masterCfg, manager.Options{MetricsBindAddress: "0"})
-	if err != nil {
-		return providers{}, fmt.Errorf("failed to construct manager: %v", err)
-	}
 
 	client := mgr.GetClient()
 
@@ -398,7 +399,8 @@ func createAuthClients(options serverRunOptions, prov providers) (auth.TokenVeri
 	return tokenVerifiers, tokenExtractors, nil
 }
 
-func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifier auth.OIDCIssuerVerifier, tokenVerifiers auth.TokenVerifier, tokenExtractors auth.TokenExtractor, updateManager common.UpdateManager) (http.HandlerFunc, error) {
+func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifier auth.OIDCIssuerVerifier, tokenVerifiers auth.TokenVerifier,
+	tokenExtractors auth.TokenExtractor, updateManager common.UpdateManager, mgr manager.Manager) (http.HandlerFunc, error) {
 	var prometheusClient prometheusapi.Client
 	if options.featureGates.Enabled(features.PrometheusEndpoint) {
 		var err error
@@ -469,7 +471,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		CABundle:                              options.caBundle.CertPool(),
 	}
 
-	r := handler.NewRouting(routingParams)
+	r := handler.NewRouting(routingParams, mgr.GetClient())
 	rv2 := v2.NewV2Routing(routingParams)
 
 	registerMetrics()

--- a/pkg/handler/routes_v1_admin.go
+++ b/pkg/handler/routes_v1_admin.go
@@ -466,7 +466,7 @@ func (r Routing) createOrUpdateMeteringConfigurations() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.CreateOrUpdateMeteringConfigurations(r.userInfoGetter, r.seedsGetter, r.seedsClientGetter)),
+		)(admin.CreateOrUpdateMeteringConfigurations(r.userInfoGetter, r.masterClient)),
 		metering.DecodeMeteringConfigurationsReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/handler/routing.go
+++ b/pkg/handler/routing.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Routing represents an object which binds endpoints to http handlers.
@@ -43,6 +44,7 @@ type Routing struct {
 	logger                                log.Logger
 	versions                              kubermatic.Versions
 	presetsProvider                       provider.PresetProvider
+	masterClient                          client.Client
 	seedsGetter                           provider.SeedsGetter
 	seedsClientGetter                     provider.SeedClientGetter
 	sshKeyProvider                        provider.SSHKeyProvider
@@ -80,11 +82,12 @@ type Routing struct {
 }
 
 // NewRouting creates a new Routing.
-func NewRouting(routingParams RoutingParams) Routing {
+func NewRouting(routingParams RoutingParams, masterClient client.Client) Routing {
 	return Routing{
 		log:                                   routingParams.Log,
 		logger:                                log.NewLogfmtLogger(os.Stderr),
 		presetsProvider:                       routingParams.PresetsProvider,
+		masterClient:                          masterClient,
 		seedsGetter:                           routingParams.SeedsGetter,
 		seedsClientGetter:                     routingParams.SeedsClientGetter,
 		clusterProviderGetter:                 routingParams.ClusterProviderGetter,

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -148,7 +148,7 @@ func NewTestRouting(
 		CABundle:                              certificates.NewFakeCABundle().CertPool(),
 	}
 
-	r := handler.NewRouting(routingParams)
+	r := handler.NewRouting(routingParams, nil)
 	rv2 := v2.NewV2Routing(routingParams)
 
 	mainRouter := mux.NewRouter()

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 
 	"github.com/go-kit/kit/endpoint"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8c.io/kubermatic/v2/pkg/handler/v1/metering"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateOrUpdateMeteringCredentials creates or updates metrering tool SecretReq.
@@ -59,7 +61,7 @@ func CreateOrUpdateMeteringCredentials(userInfoGetter provider.UserInfoGetter, s
 }
 
 // CreateOrUpdateMeteringConfigurations configures kkp metering tool.
-func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) endpoint.Endpoint {
+func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter, masterClient client.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -79,7 +81,7 @@ func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter
 			return "", err
 		}
 
-		if err := createOrUpdateMeteringConfigurations(ctx, request, seedsGetter, seedClientGetter); err != nil {
+		if err := createOrUpdateMeteringConfigurations(ctx, request, masterClient); err != nil {
 			return nil, fmt.Errorf("failed to create/update metering SecretReq: %v", err)
 		}
 

--- a/pkg/handler/v1/admin/wrappers_ce.go
+++ b/pkg/handler/v1/admin/wrappers_ce.go
@@ -24,13 +24,15 @@ import (
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	meteringApi "k8c.io/kubermatic/v2/pkg/handler/v1/metering"
 	"k8c.io/kubermatic/v2/pkg/provider"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func createOrUpdateMeteringCredentials(ctx context.Context, request meteringApi.SecretReq, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) error {
 	return nil
 }
 
-func createOrUpdateMeteringConfigurations(ctx context.Context, request meteringApi.ConfigurationReq, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) error {
+func createOrUpdateMeteringConfigurations(ctx context.Context, request meteringApi.ConfigurationReq, masterClient client.Client) error {
 	return nil
 }
 

--- a/pkg/handler/v1/admin/wrappers_ee.go
+++ b/pkg/handler/v1/admin/wrappers_ee.go
@@ -20,6 +20,7 @@ package admin
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/ee/metering"
@@ -31,8 +32,8 @@ func createOrUpdateMeteringCredentials(ctx context.Context, request meteringApi.
 	return metering.CreateOrUpdateCredentials(ctx, request, seedsGetter, seedClientGetter)
 }
 
-func createOrUpdateMeteringConfigurations(ctx context.Context, request meteringApi.ConfigurationReq, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) error {
-	return metering.CreateOrUpdateConfigurations(ctx, request, seedsGetter, seedClientGetter)
+func createOrUpdateMeteringConfigurations(ctx context.Context, request meteringApi.ConfigurationReq, masterClient client.Client) error {
+	return metering.CreateOrUpdateConfigurations(ctx, request, masterClient)
 }
 
 func listMeteringReports(ctx context.Context, request meteringApi.ListMeteringReportReq, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) ([]v1.MeteringReport, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This update would activate the etcd launcher for all seeds and user clusters. In addition to running the new backup and restore feature by default. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7567

**Special notes for your reviewer**:

**Documentation**:
Important: this is a breaking change, old backups from LegacyBackup are not supported by the restore controller. If a user would like to restore an old backup they have to do it manually 

**Does this PR introduce a user-facing change?**:
No
```release-note
Enable etcd launcher and it's backup and restore feature by default for all seeds and user clusters 
```
