### PR TITLE
Deprecated vsphere and openstack Feature Gates removal

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
-
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/metering"
 
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common/vpa"
 	kubermaticseed "k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/kubermatic"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/metering"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
@@ -26,11 +26,13 @@ import (
 	"testing"
 	"time"
 
-	grafanasdk "github.com/kubermatic/grafanasdk"
 	"github.com/stretchr/testify/assert"
+
+	grafanasdk "github.com/kubermatic/grafanasdk"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 
 	"github.com/go-kit/kit/endpoint"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8c.io/kubermatic/v2/pkg/handler/v1/metering"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // CreateOrUpdateMeteringCredentials creates or updates metrering tool SecretReq.

--- a/pkg/handler/v1/metering/metering.go
+++ b/pkg/handler/v1/metering/metering.go
@@ -25,9 +25,10 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // swagger:parameters listMeteringReports


### PR DESCRIPTION
**What this PR does / why we need it**:
The Feature gate `CSIMigrationvSphereComplete` has been replaced by `InTreePluginvSphereUnregister` starting from Kubernetes 1.22 and `CSIMigrationOpenStackComplete` by `InTreePluginOpenStackUnregister` from Kubernetes 1.21.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
