### PR TITLE
Resolving KubeControllerManagerDown and KubeSchedulerDown alerts in kube-state-metrics 2.1.0+

### DIFF
--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kube-state-metrics
-version: 1.2.0
+version: 1.2.1
 appVersion: v2.2.0
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
       containers:
       - name: kube-state-metrics
         image: '{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}'
+        # Ref: https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/#what-is-new-in-v2-0
+        # Issue and solutions: https://github.com/kubernetes/kube-state-metrics/issues/1501#issuecomment-863020915
+        # and https://github.com/kubernetes/kube-state-metrics/issues/1489#issuecomment-851970288
+        args:
+        - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
with kube-state-metrics v2.0+, kube-pod-labels needs explicit whitelisting of labels as noted in [release notes](https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/#what-is-new-in-v2-0) This causes continuous firing of alerts KubeSchedulerDown and KubeControllerManagerDown in our seed monitoring.

Solution is to add whitelisting for some common labels as suggested by few others in couple of issues [Ref1](https://github.com/kubernetes/kube-state-metrics/issues/1501#issuecomment-863020915) [Ref2](https://github.com/kubernetes/kube-state-metrics/issues/1489#issuecomment-851970288)

I have confirmed that this solution works fine by updating local cluster with updated chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
