### PR TITLE
[release/v2.15] Update the datasource name for Grafana dashboards (#7640)

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.4.7
+version: 1.4.8
 appVersion: 7.1.5
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/dashboards/prometheus-exporter/overview.json
+++ b/charts/monitoring/grafana/dashboards/prometheus-exporter/overview.json
@@ -24,7 +24,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -111,7 +111,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -211,7 +211,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -299,7 +299,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -387,7 +387,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -475,7 +475,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -575,7 +575,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -663,7 +663,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -750,7 +750,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -838,7 +838,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus xrstf",
+      "datasource": "prometheus",
       "editable": true,
       "fill": 1,
       "gridPos": {
@@ -930,7 +930,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus xrstf",
+        "datasource": "prometheus",
         "definition": "label_values(prom_exporter_pod_cpu_usage, pod)",
         "hide": 0,
         "includeAll": true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #7640.

**Does this PR introduce a user-facing change?**:
```release-note
Fix dashboard source in the Prometheus Exporter dashboard
```
