### PR TITLE
Use release version for metering images and fix cronjob name

### DIFF
--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -114,8 +114,9 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 
 			job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:  "kubermatic-metering-report",
-					Image: "quay.io/kubermatic/metering:v0.5",
+					Name:            "kubermatic-metering-report",
+					Image:           "quay.io/kubermatic/metering:v0.5",
+					ImagePullPolicy: corev1.PullAlways,
 					Command: []string{
 						"/bin/sh",
 					},

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -36,7 +36,7 @@ import (
 // cronJobCreator returns the func to create/update the etcd defragger cronjob
 func cronJobCreator(seedName string) reconciling.NamedCronJobCreatorGetter {
 	return func() (string, reconciling.CronJobCreator) {
-		return meteringCronJobMonthly, func(job *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
+		return meteringCronJobWeeklyName, func(job *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
 
 			job.Spec.Schedule = "0 6 * * 1"
 			job.Spec.JobTemplate.Spec.Parallelism = pointer.Int32Ptr(1)

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -115,7 +115,7 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 			job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  "kubermatic-metering-report",
-					Image: "quay.io/kubermatic/metering:7a12117",
+					Image: "quay.io/kubermatic/metering:v0.5.0",
 					Command: []string{
 						"/bin/sh",
 					},

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -115,7 +115,7 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 			job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  "kubermatic-metering-report",
-					Image: "quay.io/kubermatic/metering:v0.5.0",
+					Image: "quay.io/kubermatic/metering:v0.5",
 					Command: []string{
 						"/bin/sh",
 					},

--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -38,9 +38,9 @@ import (
 )
 
 const (
-	meteringToolName       = "kubermatic-metering"
-	meteringDataName       = "metering-data"
-	meteringCronJobMonthly = "kubermatic-metering-report-monthly"
+	meteringToolName          = "kubermatic-metering"
+	meteringDataName          = "metering-data"
+	meteringCronJobWeeklyName = "kubermatic-metering-report-weekly"
 )
 
 // deploymentCreator creates a new metering tool deployment per seed cluster.

--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -145,7 +145,7 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 						"--seed",
 						seed.Name,
 					},
-					Image:           "quay.io/kubermatic/metering:v0.5.0",
+					Image:           "quay.io/kubermatic/metering:v0.5",
 					ImagePullPolicy: corev1.PullAlways,
 					Ports: []corev1.ContainerPort{
 						{

--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -145,7 +145,7 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 						"--seed",
 						seed.Name,
 					},
-					Image:           "quay.io/kubermatic/metering:7a12117",
+					Image:           "quay.io/kubermatic/metering:v0.5.0",
 					ImagePullPolicy: corev1.PullAlways,
 					Ports: []corev1.ContainerPort{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**: Use minor version v0.5 instead of development tag for metering images.
Also the schedule for the metering reports has been changed from monthly to weekly in https://github.com/kubermatic/kubermatic/pull/7612, but the CronJob name is still called monthly.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
