### PR TITLE
Use port number in scrape annotations for logging

### DIFF
--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: "v1"
 name: loki
-version: 0.1.2
+version: 0.1.3
 appVersion: v2.1.0
 description: "Loki: like Prometheus, but for logs."
 keywords:

--- a/charts/logging/loki/templates/statefulset.yaml
+++ b/charts/logging/loki/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "http-metrics"
+        prometheus.io/port: "7946"
         kubermatic.io/chart: loki
     spec:
       serviceAccountName: {{ template "loki.serviceAccountName" . }}

--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: promtail
-version: 0.2.4
+version: 0.2.5
 appVersion: v2.1.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:

--- a/charts/logging/promtail/templates/daemonset.yaml
+++ b/charts/logging/promtail/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "http-metrics"
+        prometheus.io/port: "7946"
         kubermatic.io/chart: promtail
     spec:
       serviceAccountName: {{ template "promtail.serviceAccountName" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
`prometheus.io/port` annotation should contain port number instead of port name, since our Prometheus configuration cannot use it that way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
