### PR TITLE
set apiserver egress config for konnectivity

### DIFF
--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -440,6 +440,11 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		flags = append(flags, strings.Join(fg, ","))
 	}
 
+	if data.IsKonnectivityEnabled() {
+		flags = append(flags, "--egress-selector-config-file",
+			"/etc/kubernetes/konnectivity/egress-selector-configuration.yaml")
+	}
+
 	return flags, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

#7504 removed egress selector config for apiserver by mistake. This adds it. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
