### PR TITLE
Enable optional tls support for minio chart

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.65
+version: 1.1.66
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.23
+version: 1.0.24
 appVersion: RELEASE.2021-08-20T18-32-01Z
 description: minio
 keywords:

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
         ports:
         - containerPort: 9000
         volumeMounts:
+        {{- if .Values.minio.certificatesSecret }}
+        - name: certificates-volume
+          mountPath: /root/.minio/certs
+        {{- end }}
         - name: storage
           mountPath: "/storage"
         resources:
@@ -78,7 +82,11 @@ spec:
         args:
         - /bin/sh
         - -c
+        {{- if .Values.minio.certificatesSecret }}
+        - mc --insecure config host add src https://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        {{- else }}
         - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        {{- end }}
         env:
         - name: MINIO_ACCESS_KEY
           valueFrom:
@@ -107,6 +115,18 @@ spec:
       {{- if .Values.minio.backup.enabled }}
       - name: minio-backup
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.minio.certificatesSecret }}
+      - name: certificates-volume
+        secret:
+          secretName: {{ .Values.minio.certificatesSecret }}
+          items:
+          - key: tls.crt
+            path: public.crt
+          - key: tls.key
+            path: private.key
+          - key: tls.crt
+            path: CAs/public.crt
       {{- end }}
       nodeSelector:
 {{ toYaml .Values.minio.nodeSelector | indent 8 }}

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -19,7 +19,8 @@ minio:
   storeSize: 100Gi
   
   # The is required to enable the BackupRestore controller so it can backup
-  # and restore from the local minio deployment
+  # and restore from the local minio deployment. The TLS certificates should be 
+  # signed by the global KKP CA.
   certificateSecret: minio-certificates # tls secret used by minio.
   
   # These settings are required. Keys must be alphanumeric.

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -17,7 +17,11 @@ minio:
     repository: docker.io/minio/minio
     tag: RELEASE.2021-08-20T18-32-01Z
   storeSize: 100Gi
-
+  
+  # The is required to enable the BackupRestore controller so it can backup
+  # and restore from the local minio deployment
+  certificateSecret: minio-certificates # tls secret used by minio.
+  
   # These settings are required. Keys must be alphanumeric.
   credentials:
     accessKey: '' # 32 byte long


### PR DESCRIPTION
**What this PR does / why we need it**:
The new BackupRestore controller requires an s3-compatible storage backend that works over TLS. Our current minio deployment works in-cluster and doesn't have TLS enabled. This PR provide optional support for TLS. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
- Adds  optional TLS support for minio chart. The user can define a TLS secret that minio will use for its server. The TLS certificates should be signed by the global Kubermatic CA documented in https://github.com/kubermatic/docs/pull/524/files
```
