### PR TITLE
Telemetry chart: add missing ClusterRole for listing KubermaticConfiguration

### DIFF
--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: telemetry
 description: A Helm chart to install agents
-version: v0.1.1
+version: v0.1.2
 appVersion: v0.1.0
 keywords:
 - telemetry

--- a/charts/telemetry/templates/kubermatic-role.yaml
+++ b/charts/telemetry/templates/kubermatic-role.yaml
@@ -18,7 +18,7 @@ metadata:
   name: {{ .Release.Name }}-kubermatic-agent-role
 rules:
 - apiGroups:
-  - "kubermatic.k8s.io"
+  - kubermatic.k8s.io
   resources:
   - seeds
   - clusters
@@ -35,3 +35,9 @@ rules:
   - secrets
   verbs:
   - get
+- apiGroups:
+  - operator.kubermatic.io
+  resources:
+  - kubermaticconfigurations
+  verbs:
+  - list


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the missing ClusterRole for listing KubermaticConfiguration objects for telemetry chart

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
