### PR TITLE
add option to enable konnectivity by user-cluster

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17353,6 +17353,11 @@
         "ipvs": {
           "$ref": "#/definitions/IPVSConfiguration"
         },
+        "konnectivityEnabled": {
+          "description": "KonnectivityEnabled enables konnectivity for controlplane to node network communication.",
+          "type": "boolean",
+          "x-go-name": "KonnectivityEnabled"
+        },
         "nodeLocalDNSCacheEnabled": {
           "description": "NodeLocalDNSCacheEnabled controls whether the NodeLocal DNS Cache feature is enabled.\nDefaults to true.",
           "type": "boolean",

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -190,7 +190,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithInClusterPrometheusDefaultScrapingConfigsDisabled(r.inClusterPrometheusDisableDefaultScrapingConfigs).
 		WithInClusterPrometheusScrapingConfigsFile(r.inClusterPrometheusScrapingConfigsFile).
 		WithUserClusterMLAEnabled(r.userClusterMLAEnabled).
-		WithKonnectivityEnabled(r.features.Konnectivity).
+		WithKonnectivityEnabled(r.features.Konnectivity && cluster.Spec.ClusterNetwork.KonnectivityEnabled).
 		WithCABundle(r.caBundle).
 		WithOIDCIssuerURL(r.oidcIssuerURL).
 		WithOIDCIssuerClientID(r.oidcIssuerClientID).

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -481,6 +481,9 @@ type ClusterNetworkingConfig struct {
 	// NodeLocalDNSCacheEnabled controls whether the NodeLocal DNS Cache feature is enabled.
 	// Defaults to true.
 	NodeLocalDNSCacheEnabled *bool `json:"nodeLocalDNSCacheEnabled,omitempty"`
+
+	// KonnectivityEnabled enables konnectivity for controlplane to node network communication.
+	KonnectivityEnabled bool `json:"konnectivityEnabled,omitempty"`
 }
 
 // MachineNetworkingConfig specifies the networking parameters used for IPAM.

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -68,6 +68,7 @@ type userclusterControllerData interface {
 	KubermaticDockerTag() string
 	GetCloudProviderName() (string, error)
 	UserClusterMLAEnabled() bool
+	IsKonnectivityEnabled() bool
 }
 
 // DeploymentCreator returns the function to create and update the user cluster controller deployment
@@ -145,6 +146,10 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				fmt.Sprintf("-ca-bundle=/opt/ca-bundle/%s", resources.CABundleConfigMapKey),
 				fmt.Sprintf("-node-local-dns-cache=%t", data.NodeLocalDNSCacheEnabled()),
 			}, getNetworkArgs(data)...)
+
+			if data.IsKonnectivityEnabled() {
+				args = append(args, "--konnectivity-enabled", "true")
+			}
 
 			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
 				args = append(args, "-tunneling-agent-ip", data.Cluster().Address.IP)

--- a/pkg/test/e2e/utils/apiclient/models/cluster_networking_config.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster_networking_config.go
@@ -22,6 +22,9 @@ type ClusterNetworkingConfig struct {
 	// Domain name for services.
 	DNSDomain string `json:"dnsDomain,omitempty"`
 
+	// KonnectivityEnabled enables konnectivity for controlplane to node network communication.
+	KonnectivityEnabled bool `json:"konnectivityEnabled,omitempty"`
+
 	// NodeLocalDNSCacheEnabled controls whether the NodeLocal DNS Cache feature is enabled.
 	// Defaults to true.
 	NodeLocalDNSCacheEnabled bool `json:"nodeLocalDNSCacheEnabled,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds option to enable/disable konnectivity by user-cluster. 

Ref #7504 

**Does this PR introduce a user-facing change?**:
```release-note
Users can now enble/disable konnectivity on their clusters. 
```
