### PR TITLE
Deploy OPA Mutating webhook only when enabled and add exempt for kube-system

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -82,6 +82,7 @@ type controllerRunOptions struct {
 	dnsClusterIP                 string
 	nodeLocalDNSCache            bool
 	opaIntegration               bool
+	opaEnableMutation            bool
 	opaWebhookTimeout            int
 	useSSHKeyAgent               bool
 	caBundleFile                 string
@@ -121,7 +122,8 @@ func main() {
 	flag.StringVar(&runOp.updateWindowStart, "update-window-start", "", "The start time of the update window, e.g. 02:00")
 	flag.StringVar(&runOp.updateWindowLength, "update-window-length", "", "The length of the update window, e.g. 1h")
 	flag.BoolVar(&runOp.opaIntegration, "opa-integration", false, "Enable OPA integration in user cluster")
-	flag.IntVar(&runOp.opaWebhookTimeout, "opa-webhook-timeout", 3, "Timeout for OPA Integration validating webhook, in seconds")
+	flag.BoolVar(&runOp.opaEnableMutation, "enable-mutation", false, "Enable OPA experimental mutation in user cluster")
+	flag.IntVar(&runOp.opaWebhookTimeout, "opa-webhook-timeout", 1, "Timeout for OPA Integration validating webhook, in seconds")
 	flag.BoolVar(&runOp.useSSHKeyAgent, "enable-ssh-key-agent", false, "Enable UserSSHKeyAgent integration in user cluster")
 	flag.StringVar(&runOp.caBundleFile, "ca-bundle", "", "The path to the cluster's CA bundle (PEM-encoded).")
 	flag.StringVar(&runOp.mlaGatewayURL, "mla-gateway-url", "", "The URL of MLA (Monitoring, Logging, and Alerting) gateway endpoint.")
@@ -257,6 +259,7 @@ func main() {
 		runOp.dnsClusterIP,
 		runOp.nodeLocalDNSCache,
 		runOp.opaIntegration,
+		runOp.opaEnableMutation,
 		versions,
 		runOp.useSSHKeyAgent,
 		runOp.opaWebhookTimeout,

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -84,6 +84,7 @@ func Add(
 	dnsClusterIP string,
 	nodeLocalDNSCache bool,
 	opaIntegration bool,
+	opaEnableMutation bool,
 	versions kubermatic.Versions,
 	userSSHKeyAgent bool,
 	opaWebhookTimeout int,
@@ -105,6 +106,7 @@ func Add(
 		dnsClusterIP:          dnsClusterIP,
 		nodeLocalDNSCache:     nodeLocalDNSCache,
 		opaIntegration:        opaIntegration,
+		opaEnableMutation:     opaEnableMutation,
 		opaWebhookTimeout:     opaWebhookTimeout,
 		userSSHKeyAgent:       userSSHKeyAgent,
 		versions:              versions,
@@ -244,6 +246,7 @@ type reconciler struct {
 	dnsClusterIP          string
 	nodeLocalDNSCache     bool
 	opaIntegration        bool
+	opaEnableMutation     bool
 	opaWebhookTimeout     int
 	userSSHKeyAgent       bool
 	versions              kubermatic.Versions

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
@@ -21,11 +21,27 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NamespaceCreator creates the namespace for Gatekeeper
 func NamespaceCreator() (string, reconciling.NamespaceCreator) {
 	return resources.GatekeeperNamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels[resources.GatekeeperExemptNamespaceLabel] = "true"
+		return ns, nil
+	}
+}
+
+// KubeSystemLabeler labels the kube-system namespace to be exempt from Gatekeeper
+func KubeSystemLabeler() (string, reconciling.NamespaceCreator) {
+	return metav1.NamespaceSystem, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels[resources.GatekeeperExemptNamespaceLabel] = "true"
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/webhook.go
@@ -56,7 +56,7 @@ func ValidatingWebhookConfigurationCreator(timeout int) reconciling.NamedValidat
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
 							{
-								Key:      "admission.gatekeeper.sh/ignore",
+								Key:      resources.GatekeeperExemptNamespaceLabel,
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
 						},
@@ -101,7 +101,7 @@ func ValidatingWebhookConfigurationCreator(timeout int) reconciling.NamedValidat
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
 							{
-								Key:      "admission.gatekeeper.sh/ignore",
+								Key:      resources.GatekeeperExemptNamespaceLabel,
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
 						},
@@ -170,7 +170,7 @@ func MutatingWebhookConfigurationCreator(timeout int) reconciling.NamedMutatingW
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
 							{
-								Key:      "admission.gatekeeper.sh/ignore",
+								Key:      resources.GatekeeperExemptNamespaceLabel,
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
 						},

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -341,6 +341,8 @@ const (
 	AuditMatchKindOnly = false
 	// ConstraintViolationsLimit defines the maximum number of audit violations reported on a constraint
 	ConstraintViolationsLimit = 20
+	// GatekeeperExemptNamespaceLabel label key for exempting namespaces from Gatekeeper checks
+	GatekeeperExemptNamespaceLabel = "admission.gatekeeper.sh/ignore"
 
 	// CloudInitSettingsNamespace are used in order to reach, authenticate and be authorized by the api server, to fetch
 	// the machine  provisioning cloud-init


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce Mutation timeout from 3 to 1 sec
Exempt kube-system namespace from both the Validation and Mutation
Install Mutation Webhook only On Demand using experimentalEnableMutation in Cluster OPA settings

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7673 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Reduce default OPA webhooks timeout to 1s, exempt kube-system namespace from OPA and deploy OPA mutating webhook only when enabled
```
