### PR TITLE
Fix s3 secret name for metering cronjobs

### DIFF
--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -69,9 +69,9 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "endpoint",
+									Key: Endpoint,
 								},
 							},
 						},
@@ -80,9 +80,9 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "bucket",
+									Key: Bucket,
 								},
 							},
 						},
@@ -91,9 +91,9 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "accessKey",
+									Key: AccessKey,
 								},
 							},
 						},
@@ -102,9 +102,9 @@ mc mirror --newer-than "65d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "secretKey",
+									Key: SecretKey,
 								},
 							},
 						},
@@ -164,9 +164,9 @@ mc mirror /report s3/$S3_BUCKET`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "endpoint",
+									Key: Endpoint,
 								},
 							},
 						},
@@ -175,9 +175,9 @@ mc mirror /report s3/$S3_BUCKET`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "bucket",
+									Key: Bucket,
 								},
 							},
 						},
@@ -186,9 +186,9 @@ mc mirror /report s3/$S3_BUCKET`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "accessKey",
+									Key: AccessKey,
 								},
 							},
 						},
@@ -197,9 +197,9 @@ mc mirror /report s3/$S3_BUCKET`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "s3",
+										Name: SecretName,
 									},
-									Key: "secretKey",
+									Key: SecretKey,
 								},
 							},
 						},

--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -90,9 +90,9 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "endpoint",
+									Key: Endpoint,
 								},
 							},
 						},
@@ -101,9 +101,9 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "bucket",
+									Key: Bucket,
 								},
 							},
 						},
@@ -112,9 +112,9 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "accessKey",
+									Key: AccessKey,
 								},
 							},
 						},
@@ -123,9 +123,9 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "secretKey",
+									Key: SecretKey,
 								},
 							},
 						},
@@ -219,9 +219,9 @@ while true; do mc mirror --overwrite /metering-data s3/$S3_BUCKET; sleep 300; do
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "endpoint",
+									Key: Endpoint,
 								},
 							},
 						},
@@ -230,9 +230,9 @@ while true; do mc mirror --overwrite /metering-data s3/$S3_BUCKET; sleep 300; do
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "bucket",
+									Key: Bucket,
 								},
 							},
 						},
@@ -241,9 +241,9 @@ while true; do mc mirror --overwrite /metering-data s3/$S3_BUCKET; sleep 300; do
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "accessKey",
+									Key: AccessKey,
 								},
 							},
 						},
@@ -252,9 +252,9 @@ while true; do mc mirror --overwrite /metering-data s3/$S3_BUCKET; sleep 300; do
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "metering-s3",
+										Name: SecretName,
 									},
-									Key: "secretKey",
+									Key: SecretKey,
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**: The secret for the S3 credentials used by the metering cronjobs was introduced as "s3", but was then later changed to "metering-s3". The cronjobs still refer to the old secret, resulting in:

```
$ k get events -n kubermatic
LAST SEEN   TYPE      REASON   OBJECT                                                    MESSAGE
12m         Warning   Failed   pod/kubermatic-metering-report-monthly-xxx-xxx   Error: secret "s3" not found
```

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
