### PR TITLE
fix dev deployment

### DIFF
--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -121,11 +121,13 @@ kubermatic)
   if [[ "${1}" = "master" ]]; then
     echodate "Running Kubermatic Installer..."
 
+    # --force must be given because the Chart versions have not necessarily changed.
     ./_build/kubermatic-installer deploy \
       --storageclass copy-default \
       --config "$KUBERMATIC_CONFIG" \
       --helm-values "$VALUES_FILE" \
-      --helm-binary "helm3"
+      --helm-binary "helm3" \
+      --force
 
     # We might have not configured IAP which results in nothing being deployed. This triggers https://github.com/helm/helm/issues/4295 and marks this as failed
     # We hack around this by grepping for a string that is mandatory in the values file of IAP


### PR DESCRIPTION
**What this PR does / why we need it**:
The installer was smarter than me:

```
time="09:12:59" level=info msg="   📦 Deploying Kubermatic Operator…"
time="09:12:59" level=info msg="      Deploying Custom Resource Definitions…"
time="09:13:00" level=info msg="      Deploying Helm chart…"
time="09:13:01" level=info msg="      Release is up-to-date, nothing to do. Set --force to re-install anyway."
```

For a dev system, this is no good and the reason why we have `--force`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
