### PR TITLE
Fix for seed API using seed clients instead of master

### DIFF
--- a/pkg/handler/routes_v1.go
+++ b/pkg/handler/routes_v1.go
@@ -1560,7 +1560,7 @@ func (r Routing) createDC() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(dc.CreateEndpoint(r.seedsGetter, r.userInfoGetter, r.seedsClientGetter)),
+		)(dc.CreateEndpoint(r.seedsGetter, r.userInfoGetter, r.masterClient)),
 		dc.DecodeCreateDCReq,
 		SetStatusCreatedHeader(EncodeJSON),
 		r.defaultServerOptions()...,
@@ -1587,7 +1587,7 @@ func (r Routing) updateDC() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(dc.UpdateEndpoint(r.seedsGetter, r.userInfoGetter, r.seedsClientGetter)),
+		)(dc.UpdateEndpoint(r.seedsGetter, r.userInfoGetter, r.masterClient)),
 		dc.DecodeUpdateDCReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
@@ -1614,7 +1614,7 @@ func (r Routing) patchDC() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(dc.PatchEndpoint(r.seedsGetter, r.userInfoGetter, r.seedsClientGetter)),
+		)(dc.PatchEndpoint(r.seedsGetter, r.userInfoGetter, r.masterClient)),
 		dc.DecodePatchDCReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
@@ -1638,7 +1638,7 @@ func (r Routing) deleteDC() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(dc.DeleteEndpoint(r.seedsGetter, r.userInfoGetter, r.seedsClientGetter)),
+		)(dc.DeleteEndpoint(r.seedsGetter, r.userInfoGetter, r.masterClient)),
 		dc.DecodeDeleteDCReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/handler/routes_v1_admin.go
+++ b/pkg/handler/routes_v1_admin.go
@@ -394,7 +394,7 @@ func (r Routing) updateSeed() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.UpdateSeedEndpoint(r.userInfoGetter, r.seedsGetter, r.seedsClientGetter)),
+		)(admin.UpdateSeedEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeUpdateSeedReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
@@ -418,7 +418,7 @@ func (r Routing) deleteSeed() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.DeleteSeedEndpoint(r.userInfoGetter, r.seedsGetter, r.seedsClientGetter)),
+		)(admin.DeleteSeedEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeSeedReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -39,6 +39,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewTestRouting is a hack that helps us avoid circular imports
@@ -93,7 +94,8 @@ func NewTestRouting(
 	etcdBackupConfigProjectProviderGetter provider.EtcdBackupConfigProjectProviderGetter,
 	etcdRestoreProjectProviderGetter provider.EtcdRestoreProjectProviderGetter,
 	backupCredentialsProviderGetter provider.BackupCredentialsProviderGetter,
-	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter) http.Handler {
+	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter,
+	masterClient client.Client) http.Handler {
 
 	updateManager := version.New(versions, updates, providerIncompatibilities)
 
@@ -153,7 +155,7 @@ func NewTestRouting(
 		CABundle:                                certificates.NewFakeCABundle().CertPool(),
 	}
 
-	r := handler.NewRouting(routingParams, nil)
+	r := handler.NewRouting(routingParams, masterClient)
 	rv2 := v2.NewV2Routing(routingParams)
 
 	mainRouter := mux.NewRouter()

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -71,6 +71,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -202,6 +203,7 @@ type newRoutingFunc func(
 	etcdRestoreProjectProviderGetter provider.EtcdRestoreProjectProviderGetter,
 	backupCredentialsProviderGetter provider.BackupCredentialsProviderGetter,
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter,
+	masterClient client.Client,
 ) http.Handler
 
 func getRuntimeObjects(objs ...ctrlruntimeclient.Object) []runtime.Object {
@@ -534,6 +536,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		etcdRestoreProjectProviderGetter,
 		backupCredentialsProviderGetter,
 		privilegedMLAAdminSettingProviderGetter,
+		fakeClient,
 	)
 
 	return mainRouter, &ClientsSets{kubermaticClient, fakeClient, kubernetesClient, tokenAuth, tokenGenerator}, nil

--- a/pkg/handler/v1/admin/seed_test.go
+++ b/pkg/handler/v1/admin/seed_test.go
@@ -194,6 +194,7 @@ func TestUpdateSeedEndpoint(t *testing.T) {
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true), test.GenTestSeed()},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
+		// scenario 5
 		{
 			name:                   "scenario 5: authorized user updates seed - just backup",
 			body:                   `{"name":"us-central1","spec":{"country":"NL","kubeconfig":{},"backupRestore":{"s3BucketName":"bucket"}}}`,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the issue where Seed API was using seed clients to update the Seeds on master cluster instead of using the master client. This was causing Seed API not to work on Seeds which were not also the master clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7667 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixes the issue where Seed API was using seed clients to update the Seeds on master cluster instead of using the master client. This was causing Seed API not to work on Seeds which were not also the master clusters.
```
