### PR TITLE
update kubermatic/util image to 2.0 and remove Helm 2 from it

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.6.0
+      - image: quay.io/kubermatic/util:2.0.0
         command:
         - "./hack/ci/verify-chart-versions.sh"
         resources:
@@ -145,7 +145,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.6.0
+      - image: quay.io/kubermatic/util:2.0.0
         command:
         - "./hack/verify-grafana-dashboards.sh"
         resources:
@@ -298,14 +298,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.6.0
+      - image: quay.io/kubermatic/util:2.0.0
         command:
         - ./hack/verify-prometheus-rules.sh
         env:
         - name: KUBERMATIC_EDITION
           value: ee
-      imagePullSecrets:
-      - name: quay
 
   - name: pre-kubermatic-user-cluster-prometheus-config-validation
     run_if_changed: "pkg/resources/prometheus"

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.24
+version: 1.0.25
 appVersion: RELEASE.2021-08-20T18-32-01Z
 description: minio
 keywords:

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -17,12 +17,12 @@ minio:
     repository: docker.io/minio/minio
     tag: RELEASE.2021-08-20T18-32-01Z
   storeSize: 100Gi
-  
+
   # The is required to enable the BackupRestore controller so it can backup
-  # and restore from the local minio deployment. The TLS certificates should be 
+  # and restore from the local minio deployment. The TLS certificates should be
   # signed by the global KKP CA.
   certificateSecret: minio-certificates # tls secret used by minio.
-  
+
   # These settings are required. Keys must be alphanumeric.
   credentials:
     accessKey: '' # 32 byte long
@@ -50,7 +50,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.5.0
+      tag: 2.0.0
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.5.1
+version: 1.5.2
 appVersion: 8.1.2
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -25,7 +25,7 @@ grafana:
     tag: 8.1.2
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 1.5.0
+    tag: 2.0.0
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
     tag: 1.3.1

--- a/charts/monitoring/karma/Chart.yaml
+++ b/charts/monitoring/karma/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: karma
-version: 0.0.16
+version: 0.0.17
 appVersion: v0.89
 description: Dashboard for Prometheus Alertmanager
 keywords:

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -41,7 +41,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 1.5.0
+      tag: 2.0.0
       pullPolicy: IfNotPresent
   resources:
     karma:

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -1,3 +1,4 @@
+
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.6
+version: 2.4.7
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -42,7 +42,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.5.0
+      tag: 2.0.0
     timeout: 60m
 
   # Specify additional external labels which will be added to all

--- a/hack/ci/test-helm-charts.sh
+++ b/hack/ci/test-helm-charts.sh
@@ -25,9 +25,8 @@ set -euo pipefail
 cd $(dirname $0)/../..
 source hack/lib.sh
 
-# find all changed charts (the pre-kubermatic-verify-charts job ensures
-# that all updated charts also change their Chart.yaml)
-changedCharts=$(git diff --name-status "${PULL_BASE_SHA}..${PULL_PULL_SHA:-}" 'charts/**/Chart.yaml' | awk '{ print $2 }' | xargs dirname | sort -u)
+# find all changed charts
+changedCharts=$(git diff --name-only "${PULL_BASE_SHA}..${PULL_PULL_SHA:-}" 'charts/**' | xargs -r dirname | sort -u)
 
 for chartDirectory in $changedCharts; do
   chartName="$(basename "$chartDirectory")"

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -17,9 +17,8 @@ LABEL maintainer="support@kubermatic.com"
 
 ENV MC_VERSION=RELEASE.2021-07-27T06-46-19Z \
     KUBECTL_VERSION=v1.21.4 \
-    HELM2_VERSION=v2.17.0 \
-    HELM3_VERSION=v3.6.3 \
-    VAULT_VERSION=1.8.0 \
+    HELM_VERSION=v3.6.3 \
+    VAULT_VERSION=1.8.1 \
     YQ_VERSION=3.4.1
 
 RUN apk add --no-cache -U \
@@ -50,13 +49,9 @@ RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/
     chmod +x /usr/bin/kubectl && \
     kubectl version --short --client
 
-RUN curl --fail -L https://get.helm.sh/helm-${HELM2_VERSION}-linux-amd64.tar.gz | tar -xzO linux-amd64/helm > helm2 && \
-    curl --fail -L https://get.helm.sh/helm-${HELM3_VERSION}-linux-amd64.tar.gz | tar -xzO linux-amd64/helm > helm3 && \
-    mv helm2 helm3 /usr/local/bin/ && \
-    chmod +x /usr/local/bin/helm* && \
-    helm2 version --client --short && \
-    helm3 version --short && \
-    ln -s /usr/local/bin/helm2 /usr/local/bin/helm
+RUN curl --fail -L https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
+    chmod +x /usr/local/bin/helm && \
+    helm version --short
 
 RUN curl -Lo vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
     unzip vault.zip && \

--- a/hack/images/util/release.sh
+++ b/hack/images/util/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/util
-VERSION=1.6.0
+VERSION=2.0.0
 SUFFIX=""
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}${SUFFIX}" .

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -93,7 +93,7 @@ EOF
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:1.6.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.0.0}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
 
   if ! [ -f /.dockerenv ]; then

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -228,7 +228,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret) rec
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   "quay.io/kubermatic/util:1.6.0",
+					Image:   "quay.io/kubermatic/util:2.0.0",
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that our last test system was migrated to Helm 3 and KKP 2.18 is practically out the door, we can finally pull the plug and remove Helm 2 usage/support entirely. This PR is the first small step towards that. Note that the kubermatic/build image is still shipping both binaries, but is next on my agenda.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
