### PR TITLE
Remove gatekeeper v3.5.2 crds on OPA disabled

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/removal.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/removal.go
@@ -22,6 +22,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,17 @@ func GetResourcesToRemoveOnDelete() []ctrlruntimeclient.Object {
 	toRemove = append(toRemove, &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resources.GatekeeperValidatingWebhookConfigurationName,
+		}})
+	toRemove = append(toRemove, &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperMutatingWebhookConfigurationName,
+		}})
+
+	// Pod Disruption Budget
+	toRemove = append(toRemove, &policyv1beta1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.GatekeeperPodDisruptionBudgetName,
+			Namespace: resources.GatekeeperNamespace,
 		}})
 
 	// Deployment
@@ -95,6 +107,26 @@ func GetResourcesToRemoveOnDelete() []ctrlruntimeclient.Object {
 	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resources.GatekeeperConfigCRDName,
+		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperConstraintPodStatusCRDName,
+		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperConstraintTemplatePodStatusCRDName,
+		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperMutatorPodStatusCRDName,
+		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperAssignCRDName,
+		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperAssignMetadataCRDName,
 		}})
 	// Namespace
 	toRemove = append(toRemove, &corev1.Namespace{


### PR DESCRIPTION
Signed-off-by: Harshita <harshita.sharma6174@gmail.com>
**What this PR does / why we need it**:
- Removes Crds added in new gatekeeper v3.5.2  when OPA is disabled
-  Removes Mutation Webhook when `-enable-mutation` is `false`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7767

**Special notes for your reviewer**:
Removed constraintpodstatuses.status.gatekeeper.sh   and constrainttemplatepodstatuses.status.gatekeeper.sh too when OPA disabled


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
