### PR TITLE
Fix metering namespace

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -263,7 +263,7 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *operatorv1alph
 	}
 
 	if seed.Spec.Metering != nil && seed.Spec.Metering.Enabled {
-		if err := metering.ReconcileMeteringResources(ctx, client, r.namespace, cfg, seed, log); err != nil {
+		if err := metering.ReconcileMeteringResources(ctx, client, seed); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
@@ -21,17 +21,13 @@ package metering
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ReconcileMeteringResources reconciles the metering related resources.
-func ReconcileMeteringResources(_ context.Context, _ ctrlruntimeclient.Client, _ string,
-	_ *operatorv1alpha1.KubermaticConfiguration, _ *kubermaticv1.Seed, _ *zap.SugaredLogger) error {
+func ReconcileMeteringResources(_ context.Context, _ ctrlruntimeclient.Client, _ *kubermaticv1.Seed) error {
 
 	return nil
 }

--- a/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
@@ -21,18 +21,14 @@ package metering
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/ee/metering"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ReconcileMeteringResources reconciles the metering related resources.
-func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, namespace string,
-	cfg *operatorv1alpha1.KubermaticConfiguration, seed *kubermaticv1.Seed, log *zap.SugaredLogger) error {
+func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) error {
 
-	return metering.ReconcileMeteringResources(ctx, client, namespace, cfg, seed, log)
+	return metering.ReconcileMeteringResources(ctx, client, seed)
 }

--- a/pkg/ee/metering/handler.go
+++ b/pkg/ee/metering/handler.go
@@ -47,15 +47,14 @@ import (
 )
 
 const (
-	AccessKey       = "accessKey"
-	SecretKey       = "secretKey"
-	Bucket          = "bucket"
-	Endpoint        = "endpoint"
-	SecretName      = "metering-s3"
-	SecretNamespace = "kubermatic"
+	AccessKey  = "accessKey"
+	SecretKey  = "secretKey"
+	Bucket     = "bucket"
+	Endpoint   = "endpoint"
+	SecretName = "metering-s3"
 )
 
-var secretNamespacedName = types.NamespacedName{Name: SecretName, Namespace: SecretNamespace}
+var secretNamespacedName = types.NamespacedName{Name: SecretName, Namespace: resources.KubermaticNamespace}
 
 type configurationReq struct {
 	Enabled          bool   `json:"enabled"`

--- a/pkg/ee/metering/pvc.go
+++ b/pkg/ee/metering/pvc.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +47,7 @@ func persistentVolumeClaimCreator(ctx context.Context, client ctrlruntimeclient.
 	if err := client.Get(ctx, types.NamespacedName{Namespace: seed.Namespace, Name: meteringDataName}, pvc); err != nil {
 		if kerrors.IsNotFound(err) {
 			pvc.ObjectMeta.Name = meteringDataName
-			pvc.ObjectMeta.Namespace = seed.Namespace
+			pvc.ObjectMeta.Namespace = resources.KubermaticNamespace
 			pvc.ObjectMeta.Labels = map[string]string{
 				"app": meteringToolName,
 			}

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,25 +44,25 @@ func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Cl
 
 	if err := reconciling.ReconcileServiceAccounts(ctx, []reconciling.NamedServiceAccountCreatorGetter{
 		serviceAccountCreator(),
-	}, seed.Namespace, client); err != nil {
+	}, resources.KubermaticNamespace, client); err != nil {
 		return fmt.Errorf("failed to reconcile metering ServiceAccounts: %v", err)
 	}
 
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, []reconciling.NamedClusterRoleBindingCreatorGetter{
-		clusterRoleBindingCreator(seed.Namespace),
+		clusterRoleBindingCreator(resources.KubermaticNamespace),
 	}, "", client); err != nil {
 		return fmt.Errorf("failed to reconcile metering ClusterRoleBindings: %v", err)
 	}
 
 	if err := reconciling.ReconcileCronJobs(ctx, []reconciling.NamedCronJobCreatorGetter{
 		cronJobCreator(seed.Name),
-	}, seed.Namespace, client); err != nil {
+	}, resources.KubermaticNamespace, client); err != nil {
 		return fmt.Errorf("failed to reconcile metering CronJob: %v", err)
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, []reconciling.NamedDeploymentCreatorGetter{
 		deploymentCreator(seed),
-	}, seed.Namespace, client); err != nil {
+	}, resources.KubermaticNamespace, client); err != nil {
 		return fmt.Errorf("failed to reconcile metering Deployment: %v", err)
 	}
 

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -28,46 +28,41 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ReconcileMeteringResources reconciles the metering related resources.
-func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, namespace string,
-	cfg *operatorv1alpha1.KubermaticConfiguration, seed *kubermaticv1.Seed, log *zap.SugaredLogger) error {
+func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) error {
 
 	if err := persistentVolumeClaimCreator(ctx, client, seed); err != nil {
-		return fmt.Errorf("failed to reconcile metering pvc: %v", err)
+		return fmt.Errorf("failed to reconcile metering PVC: %v", err)
 	}
 
 	if err := reconciling.ReconcileServiceAccounts(ctx, []reconciling.NamedServiceAccountCreatorGetter{
 		serviceAccountCreator(),
-	}, metav1.NamespaceSystem, client); err != nil {
+	}, seed.Namespace, client); err != nil {
 		return fmt.Errorf("failed to reconcile metering ServiceAccounts: %v", err)
 	}
 
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, []reconciling.NamedClusterRoleBindingCreatorGetter{
-		clusterRoleBindingCreator(cfg.Namespace),
+		clusterRoleBindingCreator(seed.Namespace),
 	}, "", client); err != nil {
 		return fmt.Errorf("failed to reconcile metering ClusterRoleBindings: %v", err)
 	}
 
 	if err := reconciling.ReconcileCronJobs(ctx, []reconciling.NamedCronJobCreatorGetter{
 		cronJobCreator(seed.Name),
-	}, namespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile cronjpbs: %v", err)
+	}, seed.Namespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile metering CronJob: %v", err)
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, []reconciling.NamedDeploymentCreatorGetter{
 		deploymentCreator(seed),
-	}, metav1.NamespaceSystem, client); err != nil {
-		return fmt.Errorf("failed to reconcile VPA Deployments: %v", err)
+	}, seed.Namespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile metering Deployment: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Set metering resources namespace to equal seed namespace

```release-note
NONE
```
