### PR TITLE
fix for allowedregistry patch endpoint

### DIFF
--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -281,8 +281,8 @@ func (p *FakePrivilegedAllowedRegistryProvider) ListUnsecured() (*kubermaticapiv
 	return p.Provider.ListUnsecured()
 }
 
-func (p *FakePrivilegedAllowedRegistryProvider) PatchUnsecured(wr *kubermaticapiv1.AllowedRegistry) (*kubermaticapiv1.AllowedRegistry, error) {
-	return p.Provider.PatchUnsecured(wr)
+func (p *FakePrivilegedAllowedRegistryProvider) UpdateUnsecured(wr *kubermaticapiv1.AllowedRegistry) (*kubermaticapiv1.AllowedRegistry, error) {
+	return p.Provider.UpdateUnsecured(wr)
 }
 
 func (p *FakePrivilegedAllowedRegistryProvider) DeleteUnsecured(name string) error {

--- a/pkg/provider/kubernetes/allowed_registry.go
+++ b/pkg/provider/kubernetes/allowed_registry.go
@@ -63,20 +63,13 @@ func (p *PrivilegedAllowedRegistryProvider) ListUnsecured() (*kubermaticv1.Allow
 	return wrList, err
 }
 
-// PatchUnsecured patches a allowed registry
-func (p *PrivilegedAllowedRegistryProvider) PatchUnsecured(wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
-
-	oldWR, err := p.GetUnsecured(wr.Name)
-	if err != nil {
-		return nil, err
-	}
-	oldWR = oldWR.DeepCopy()
-
-	if err := p.clientPrivileged.Patch(context.Background(), wr, ctrlruntimeclient.MergeFrom(oldWR)); err != nil {
+// UpdateUnsecured updates the allowed registry
+func (p *PrivilegedAllowedRegistryProvider) UpdateUnsecured(ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
+	if err := p.clientPrivileged.Update(context.Background(), ar); err != nil {
 		return nil, err
 	}
 
-	return wr, nil
+	return ar, nil
 }
 
 // DeleteUnsecured deletes a allowed registry

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1073,7 +1073,7 @@ type PrivilegedAllowedRegistryProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
+	CreateUnsecured(ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
 
 	// GetUnsecured gets the given allowed registry
 	//
@@ -1087,11 +1087,11 @@ type PrivilegedAllowedRegistryProvider interface {
 	// is unsafe in a sense that it uses privileged account to get the resources
 	ListUnsecured() (*kubermaticv1.AllowedRegistryList, error)
 
-	// PatchUnsecured patches a allowed registry
+	// UpdateUnsecured updates the allowed registry
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	PatchUnsecured(wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
+	UpdateUnsecured(ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
 
 	// DeleteUnsecured deletes the allowed registry with the given name
 	//


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes failing allowedRegistry PATCH endpoint which was failing with:
`Object 'Kind' is missing in...` because the Kind was not set. 

Now using a simpler patch method, as anyway the data is patched before, by simply updating the resource 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7756 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
