### PR TITLE
Do not log every request on MLA Gateway

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -59,10 +59,6 @@ http {
   scgi_temp_path        /tmp/scgi_temp;
 
   default_type application/octet-stream;
-  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-	'"$request" $body_bytes_sent "$http_referer" '
-	'"$http_user_agent" "$http_x_forwarded_for" $http_x_scope_orgid';
-  access_log   /dev/stderr  main;
   sendfile     on;
   tcp_nopush   on;
   resolver kube-dns.kube-system.svc.cluster.local;


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Logging every request on MLA gateway is unnecessary and produces too many logs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
(Error logs are still logged, as `error_log  /dev/stderr;` remains in the config)

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
