### PR TITLE
Set project label on default backup config

### DIFF
--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1868,7 +1868,7 @@ func GenEtcdBackupConfig(id, name string, cluster *kubermaticv1.Cluster, project
 			Name:      id,
 			Namespace: cluster.Status.NamespaceName,
 			Labels: map[string]string{
-				provider.ProjectLabelKey: projectID,
+				kubermaticv1.ProjectIDLabelKey: projectID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cluster, kubermaticv1.SchemeGroupVersion.WithKind("Cluster")),
@@ -1902,7 +1902,7 @@ func GenEtcdRestore(name string, cluster *kubermaticv1.Cluster, projectID string
 			Name:      name,
 			Namespace: cluster.Status.NamespaceName,
 			Labels: map[string]string{
-				provider.ProjectLabelKey: projectID,
+				kubermaticv1.ProjectIDLabelKey: projectID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cluster, kubermaticv1.SchemeGroupVersion.WithKind("Cluster")),

--- a/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
+++ b/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
@@ -64,7 +64,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 
 		// set projectID label
 		ebc.Labels = map[string]string{
-			provider.ProjectLabelKey: req.ProjectID,
+			kubermaticv1.ProjectIDLabelKey: req.ProjectID,
 		}
 
 		ebc, err = createEtcdBackupConfig(ctx, userInfoGetter, req.ProjectID, ebc)

--- a/pkg/handler/v2/etcdrestore/etcdrestore.go
+++ b/pkg/handler/v2/etcdrestore/etcdrestore.go
@@ -67,7 +67,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 
 		// set projectID label
 		er.Labels = map[string]string{
-			provider.ProjectLabelKey: req.ProjectID,
+			kubermaticv1.ProjectIDLabelKey: req.ProjectID,
 		}
 
 		er, err = createEtcdRestore(ctx, userInfoGetter, req.ProjectID, er)

--- a/pkg/provider/kubernetes/etcdbackupconfig.go
+++ b/pkg/provider/kubernetes/etcdbackupconfig.go
@@ -206,7 +206,7 @@ func (p *EtcdBackupConfigProjectProvider) List(userInfo *provider.UserInfo, proj
 		}
 
 		ebcList := &kubermaticv1.EtcdBackupConfigList{}
-		err = impersonationClient.List(context.Background(), ebcList, ctrlruntimeclient.MatchingLabels{provider.ProjectLabelKey: projectID})
+		err = impersonationClient.List(context.Background(), ebcList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func (p *EtcdBackupConfigProjectProvider) ListUnsecured(projectID string) ([]*ku
 	var etcdBackupConfigLists []*kubermaticv1.EtcdBackupConfigList
 	for _, clientPrivileged := range p.clientsPrivileged {
 		ebcList := &kubermaticv1.EtcdBackupConfigList{}
-		err := clientPrivileged.List(context.Background(), ebcList, ctrlruntimeclient.MatchingLabels{provider.ProjectLabelKey: projectID})
+		err := clientPrivileged.List(context.Background(), ebcList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/kubernetes/etcdrestore.go
+++ b/pkg/provider/kubernetes/etcdrestore.go
@@ -189,7 +189,7 @@ func (p *EtcdRestoreProjectProvider) List(userInfo *provider.UserInfo, projectID
 		}
 
 		erList := &kubermaticv1.EtcdRestoreList{}
-		err = impersonationClient.List(context.Background(), erList, ctrlruntimeclient.MatchingLabels{provider.ProjectLabelKey: projectID})
+		err = impersonationClient.List(context.Background(), erList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (p *EtcdRestoreProjectProvider) ListUnsecured(projectID string) ([]*kuberma
 	var etcdRestoreLists []*kubermaticv1.EtcdRestoreList
 	for _, clientPrivileged := range p.clientsPrivileged {
 		erList := &kubermaticv1.EtcdRestoreList{}
-		err := clientPrivileged.List(context.Background(), erList, ctrlruntimeclient.MatchingLabels{provider.ProjectLabelKey: projectID})
+		err := clientPrivileged.List(context.Background(), erList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -65,9 +65,6 @@ const (
 	DefaultKubeletPort = 10250
 
 	DefaultKubeconfigFieldPath = "kubeconfig"
-
-	// ProjectLabelKey is the key under which resources can be project labelled
-	ProjectLabelKey = "project"
 )
 
 func supportedProviders() []string {

--- a/pkg/resources/etcd/backupconfig.go
+++ b/pkg/resources/etcd/backupconfig.go
@@ -38,6 +38,13 @@ type etcdBackupConfigCreatorData interface {
 func BackupConfigCreator(data etcdBackupConfigCreatorData) reconciling.NamedEtcdBackupConfigCreatorGetter {
 	return func() (string, reconciling.EtcdBackupConfigCreator) {
 		return resources.EtcdDefaultBackupConfigName, func(config *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+			if config.Labels == nil {
+				config.Labels = make(map[string]string)
+			}
+			if data.Cluster().Labels != nil {
+				config.Labels[kubermaticv1.ProjectIDLabelKey] = data.Cluster().Labels[kubermaticv1.ProjectIDLabelKey]
+			}
+
 			backupScheduleString, err := parseDuration(data.BackupSchedule())
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse backup duration: %v", err)

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.19.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.19.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.20.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.20.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.21.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.21.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.22.1-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.22.1-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.19.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.19.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.20.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.20.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.21.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.21.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.22.1-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.22.1-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.19.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.19.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.20.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.20.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.21.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.21.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.22.1-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.22.1-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.19.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.19.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.20.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.20.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.21.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.21.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.22.1-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.22.1-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.19.0--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.19.0--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.19.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.19.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.20.0--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.20.0--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.20.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.20.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.21.0--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.21.0--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.21.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.21.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.19.0--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.19.0--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.19.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.19.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.20.0--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.20.0--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.20.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.20.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.21.0--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.21.0--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.21.0-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.21.0-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1--externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1--externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1-.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1-.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    project-id: ""
 spec:
   cluster:
     apiVersion: kubermatic.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the project ID label to the default backup config so that the Project-wide LIST API can pick it up.

Also changes the project id key EtcdBackupConfigs use so its the same as other KKP resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7771 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
