### PR TITLE
Add "resource" and "service" labels to prometheus alerts

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.3
+version: 2.4.4
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-blackbox-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-blackbox-exporter.yaml
@@ -25,6 +25,8 @@ groups:
         for: 5m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: blackbox-exporter
       - alert: HttpProbeSlow
         annotations:
           message: '{{ $labels.instance }} takes {{ $value }} seconds to respond.'
@@ -33,6 +35,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: blackbox-exporter
       - alert: HttpCertExpiresSoon
         annotations:
           message: The certificate for {{ $labels.instance }} expires in less than 3 days.
@@ -40,6 +44,8 @@ groups:
         expr: probe_ssl_earliest_cert_expiry - time() < 3*24*3600
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: blackbox-exporter
       - alert: HttpCertExpiresVerySoon
         annotations:
           message: The certificate for {{ $labels.instance }} expires in less than 24 hours.
@@ -47,3 +53,5 @@ groups:
         expr: probe_ssl_earliest_cert_expiry - time() < 24*3600
         labels:
           severity: critical
+          resource: '{{ $labels.instance }}'
+          service: blackbox-exporter

--- a/charts/monitoring/prometheus/rules/general-cadvisor.yaml
+++ b/charts/monitoring/prometheus/rules/general-cadvisor.yaml
@@ -25,6 +25,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: cadvisor
+          service: cadvisor
       - record: namespace:container_memory_usage_bytes:sum
         expr: |
           sum by (namespace) (

--- a/charts/monitoring/prometheus/rules/general-cert-manager.yaml
+++ b/charts/monitoring/prometheus/rules/general-cert-manager.yaml
@@ -24,6 +24,8 @@ groups:
         expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3*24*3600
         labels:
           severity: warning
+          resource: '{{ $labels.name }}'
+          service: cert-manager
       - alert: CertManagerCertExpiresVerySoon
         annotations:
           message: The certificate {{ $labels.name }} expires in less than 24 hours.
@@ -31,3 +33,5 @@ groups:
         expr: certmanager_certificate_expiration_timestamp_seconds - time() < 24*3600
         labels:
           severity: critical
+          resource: '{{ $labels.name }}'
+          service: cert-manager

--- a/charts/monitoring/prometheus/rules/general-helm-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-helm-exporter.yaml
@@ -25,3 +25,5 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.release }}'
+          service: helm-exporter

--- a/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
@@ -43,6 +43,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: apiserver
+          service: kubernetes
       - alert: KubeAPILatencyHigh
         annotations:
           message: The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
@@ -51,6 +53,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: apiserver
+          service: kubernetes
       - alert: KubeAPILatencyHigh
         annotations:
           message: The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
@@ -59,6 +63,8 @@ groups:
         for: 10m
         labels:
           severity: critical
+          resource: apiserver
+          service: kubernetes
       - alert: KubeAPIErrorsHigh
         annotations:
           message: API server is returning errors for {{ $value }}% of requests.
@@ -70,6 +76,8 @@ groups:
         for: 10m
         labels:
           severity: critical
+          resource: apiserver
+          service: kubernetes
       - alert: KubeAPIErrorsHigh
         annotations:
           message: API server is returning errors for {{ $value }}% of requests.
@@ -81,6 +89,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: apiserver
+          service: kubernetes
       - alert: KubeClientCertificateExpiration
         annotations:
           message: A client certificate used to authenticate to the apiserver is expiring in less than 7 days.
@@ -91,6 +101,8 @@ groups:
           histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
         labels:
           severity: warning
+          resource: apiserver
+          service: kubernetes
       - alert: KubeClientCertificateExpiration
         annotations:
           message: A client certificate used to authenticate to the apiserver is expiring in less than 24 hours.
@@ -101,3 +113,5 @@ groups:
           histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
         labels:
           severity: critical
+          resource: apiserver
+          service: kubernetes

--- a/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
@@ -25,6 +25,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.instance }}'
+          service: kubelet
       - alert: KubePersistentVolumeUsageCritical
         annotations:
           message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is only {{ printf "%0.0f" $value }}% free.
@@ -37,6 +39,8 @@ groups:
         for: 1m
         labels:
           severity: critical
+          service: kubelet
+          resource: '{{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}'
       - alert: KubePersistentVolumeFullInFourDays
         annotations:
           message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value }} bytes are available.
@@ -52,6 +56,8 @@ groups:
         for: 5m
         labels:
           severity: critical
+          service: kubelet
+          resource: '{{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}'
       - alert: KubeletTooManyPods
         annotations:
           message: Kubelet {{ $labels.instance }} is running {{ $value }} pods, close to the limit of 110.
@@ -60,6 +66,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: kubelet
       - alert: KubeClientErrors
         annotations:
           message: The kubelet on {{ $labels.instance }} is experiencing {{ printf "%0.0f" $value }}% errors.
@@ -72,6 +80,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: kubelet
       # a dedicated rule for pods to include more helpful labels in the message like the instance and job name
       - alert: KubeClientErrors
         annotations:
@@ -85,6 +95,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: kubelet
       - alert: KubeletRuntimeErrors
         annotations:
           message: The kubelet on {{ $labels.instance }} is having an elevated error rate for container runtime oprations.
@@ -94,6 +106,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}'
+          service: kubelet
       - alert: KubeletCGroupManagerDurationHigh
         annotations:
           message: The kubelet's cgroup manager duration on {{ $labels.instance }} has been elevated ({{ printf "%0.2f" $value }}ms) for more than 15 minutes.
@@ -102,6 +116,8 @@ groups:
           sum(rate(kubelet_cgroup_manager_duration_seconds{quantile="0.9"}[5m])) by (instance) * 1000 > 1
         for: 15m
         labels:
+          resource: '{{ $labels.instance }}'
+          service: kubelet
           severity: warning
       - alert: KubeletPodWorkerDurationHigh
         annotations:
@@ -112,6 +128,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.instance }}/{{ $labels.operation_type }}'
+          service: kubelet
       - alert: KubeVersionMismatch
         annotations:
           message: There are {{ $value }} different versions of Kubernetes components running.

--- a/charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml
@@ -70,6 +70,7 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.pod }}"
       - alert: KubePodNotReady
         annotations:
           message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than an hour.
@@ -78,6 +79,7 @@ groups:
         for: 30m
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.pod }}"
       - alert: KubeDeploymentGenerationMismatch
         annotations:
           message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.
@@ -89,6 +91,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.deployment }}"
       - alert: KubeDeploymentReplicasMismatch
         annotations:
           message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than an hour.
@@ -100,6 +103,7 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.deployment }}"
       - alert: KubeStatefulSetReplicasMismatch
         annotations:
           message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.
@@ -111,6 +115,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.statefulset }}"
       - alert: KubeStatefulSetGenerationMismatch
         annotations:
           message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back.
@@ -122,6 +127,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.statefulset }}"
       - alert: KubeStatefulSetUpdateNotRolledOut
         annotations:
           message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.
@@ -141,6 +147,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.statefulset }}"
       - alert: KubeDaemonSetRolloutStuck
         annotations:
           message: Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.
@@ -152,6 +159,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: "{{ $labels.namespace }}/{{ $labels.daemonset }}"
       - alert: KubeDaemonSetNotScheduled
         annotations:
           message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.'
@@ -163,6 +171,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: "{{ $labels.namespace }}/{{ $labels.daemonset }}"
       - alert: KubeDaemonSetMisScheduled
         annotations:
           message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.'
@@ -171,6 +180,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: "{{ $labels.namespace }}/{{ $labels.daemonset }}"
       - alert: KubeCronJobRunning
         annotations:
           message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
@@ -179,6 +189,7 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: "{{ $labels.namespace }}/{{ $labels.cronjob }}"
       - alert: KubeJobCompletion
         annotations:
           message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.
@@ -187,6 +198,7 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: "{{ $labels.namespace }}/{{ $labels.job_name }}"
       - alert: KubeJobFailed
         annotations:
           message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
@@ -195,6 +207,7 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: "{{ $labels.namespace }}/{{ $labels.job_name }}"
       - alert: KubeCPUOvercommit
         annotations:
           message: Cluster has overcommitted CPU resource requests for namespaces.
@@ -270,6 +283,7 @@ groups:
         for: 0m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}'
       - alert: KubeNodeNotReady
         annotations:
           message: '{{ $labels.node }} has been unready for more than an hour.'
@@ -278,3 +292,4 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: '{{ $labels.node }}'

--- a/charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml
@@ -62,6 +62,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: kube-state-metrics
       - alert: KubePodCrashLooping
         annotations:
           message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
@@ -220,6 +222,8 @@ groups:
         for: 5m
         labels:
           severity: warning
+          resource: cluster
+          service: kube-state-metrics
       - alert: KubeCPUOvercommit
         annotations:
           message: Cluster has overcommitted CPU resource requests for pods and cannot tolerate node failure.
@@ -233,6 +237,8 @@ groups:
         for: 5m
         labels:
           severity: warning
+          resource: cluster
+          service: kube-state-metrics
       - alert: KubeMemOvercommit
         annotations:
           message: Cluster has overcommitted memory resource requests for namespaces.
@@ -245,6 +251,8 @@ groups:
         for: 5m
         labels:
           severity: warning
+          resource: cluster
+          service: kube-state-metrics
       - alert: KubeMemOvercommit
         annotations:
           message: Cluster has overcommitted memory resource requests for pods and cannot tolerate node failure.
@@ -260,6 +268,8 @@ groups:
         for: 5m
         labels:
           severity: warning
+          resource: cluster
+          service: kube-state-metrics
       - alert: KubeQuotaExceeded
         annotations:
           message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
@@ -272,6 +282,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: cluster
+          service: kube-state-metrics
       - alert: KubePodOOMKilled
         annotations:
           message: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has been OOMKilled {{ $value }} times in the last 30 minutes.

--- a/charts/monitoring/prometheus/rules/general-node-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-node-exporter.yaml
@@ -183,6 +183,8 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemSpaceFillingUp
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted to run out of space within the next 4 hours.
@@ -196,6 +198,8 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemOutOfSpace
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available space left.
@@ -207,6 +211,8 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemOutOfSpace
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available space left.
@@ -218,6 +224,8 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemFilesFillingUp
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted to run out of files within the next 24 hours.
@@ -231,6 +239,8 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemFilesFillingUp
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted to run out of files within the next 4 hours.
@@ -244,6 +254,8 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemOutOfFiles
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available inodes left.
@@ -255,6 +267,8 @@ groups:
         for: 1h
         labels:
           severity: warning
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeFilesystemOutOfSpace
         annotations:
           message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available space left.
@@ -266,6 +280,8 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeNetworkReceiveErrs
         annotations:
           message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors while receiving packets ({{ $value }} errors in two minutes).'
@@ -274,6 +290,8 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'
       - alert: NodeNetworkTransmitErrs
         annotations:
           message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors while transmitting packets ({{ $value }} errors in two minutes).'
@@ -282,3 +300,5 @@ groups:
         for: 1h
         labels:
           severity: critical
+          resource: '{{ $labels.instance }} {{ $labels.device }}'
+          service: 'node-exporter'

--- a/charts/monitoring/prometheus/rules/general-prometheus.yaml
+++ b/charts/monitoring/prometheus/rules/general-prometheus.yaml
@@ -25,6 +25,8 @@ groups:
         for: 15m
         labels:
           severity: warning
+          resource: '{{ $labels.job }}/{{ $labels.instance }}'
+          service: prometheus
       - alert: PromBadConfig
         annotations:
           message: Prometheus failed to reload config.
@@ -33,6 +35,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.job }}/{{ $labels.instance }}'
+          service: prometheus
       - alert: PromAlertmanagerBadConfig
         annotations:
           message: Alertmanager failed to reload config.
@@ -41,6 +45,8 @@ groups:
         for: 10m
         labels:
           severity: critical
+          resource: '{{ $labels.job }}/{{ $labels.instance }}'
+          service: prometheus
       - alert: PromAlertsFailed
         annotations:
           message: Alertmanager failed to send an alert.
@@ -49,6 +55,8 @@ groups:
         for: 5m
         labels:
           severity: critical
+          resource: '{{ $labels.job }}/{{ $labels.instance }}'
+          service: prometheus
       - alert: PromRemoteStorageFailures
         annotations:
           message: Prometheus failed to send {{ printf "%.1f" $value }}% samples.
@@ -61,6 +69,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.job }}/{{ $labels.instance }}'
+          service: prometheus
       - alert: PromRuleFailures
         annotations:
           message: Prometheus failed to evaluate {{ printf "%.1f" $value }} rules/sec.
@@ -69,3 +79,5 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.job }}/{{ $labels.instance }}'
+          service: prometheus

--- a/charts/monitoring/prometheus/rules/general-thanos.yaml
+++ b/charts/monitoring/prometheus/rules/general-thanos.yaml
@@ -25,6 +25,8 @@ groups:
         for: 5m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos
       - alert: ThanosSidecarNoHeartbeat
         annotations:
           message: The Thanos sidecar in `{{ $labels.namespace }}/{{ $labels.pod }}` didn't send a heartbeat in {{ $value }} seconds.
@@ -33,6 +35,8 @@ groups:
         for: 3m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos
       - alert: ThanosCompactorManyRetries
         annotations:
           message: The Thanos compactor in `{{ $labels.namespace }}` is experiencing a high retry rate.
@@ -41,6 +45,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos
       - alert: ThanosShipperManyDirSyncFailures
         annotations:
           message: The Thanos shipper in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a high dir-sync failure rate.
@@ -49,6 +55,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos
       - alert: ThanosManyPanicRecoveries
         annotations:
           message: The Thanos component in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a panic recovery rate.
@@ -57,6 +65,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos
       - alert: ThanosManyBlockLoadFailures
         annotations:
           message: The Thanos store in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a many failed block loads.
@@ -65,6 +75,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos
       - alert: ThanosManyBlockDropFailures
         annotations:
           message: The Thanos store in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a many failed block drops.
@@ -73,3 +85,5 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+          service: thanos

--- a/charts/monitoring/prometheus/rules/general-velero.yaml
+++ b/charts/monitoring/prometheus/rules/general-velero.yaml
@@ -25,10 +25,14 @@ groups:
         for: 60m
         labels:
           severity: warning
+          resource: '{{ $labels.schedule }}'
+          service: 'velero'
       - alert: VeleroNoRecentBackup
         annotations:
           message: There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-veleronorecentbackup
         expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600*25
         labels:
-          severity: warning
+          severity: critical
+          resource: '{{ $labels.schedule }}'
+          service: 'velero'

--- a/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -25,6 +25,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          service: kubermatic-master
       - alert: KubermaticAPITooManyErrors
         annotations:
           message: Kubermatic API is returning a high rate of HTTP 5xx responses.
@@ -33,6 +34,7 @@ groups:
         for: 15m
         labels:
           severity: warning
+          service: kubermatic-master
       - alert: KubermaticAPITooManyInitNodeDeloymentFailures
         annotations:
           message: Kubermatic API is failing to create too many initial node deployments.
@@ -48,3 +50,4 @@ groups:
         for: 15m
         labels:
           severity: critical
+          service: kubermatic-master

--- a/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -25,6 +25,8 @@ groups:
         for: 10m
         labels:
           severity: warning
+          resource: '{{ $labels.namespace }}'
+          service: kubermatic-seed
       - alert: KubermaticClusterDeletionTakesTooLong
         annotations:
           message: Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
@@ -33,6 +35,8 @@ groups:
         for: 0m
         labels:
           severity: warning
+          resource: '{{ $labels.cluster }}'
+          service: kubermatic-seed
       - alert: KubermaticAddonDeletionTakesTooLong
         annotations:
           message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
@@ -41,6 +45,8 @@ groups:
         for: 0m
         labels:
           severity: warning
+          resource: '{{ $labels.cluster }}/{{ $labels.addon }}'
+          service: kubermatic-seed
       - alert: KubermaticAddonTakesTooLongToReconcile
         annotations:
           message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} has no related resources created for more than 30min.
@@ -49,6 +55,8 @@ groups:
         for: 30m
         labels:
           severity: warning
+          resource: '{{ $labels.cluster }}/{{ $labels.addon }}'
+          service: kubermatic-seed
       - alert: KubermaticSeedControllerManagerDown
         annotations:
           message: Kubermatic Seed Controller Manager has disappeared from Prometheus target discovery.
@@ -57,6 +65,7 @@ groups:
         for: 15m
         labels:
           severity: critical
+          service: kubermatic-seed
       - alert: OpenVPNServerDown
         annotations:
           message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
@@ -65,6 +74,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.cluster }}'
+          service: kubermatic-seed
       - alert: UserClusterPrometheusAbsent
         annotations:
           message: There is no Prometheus in cluster {{ $labels.name }}.
@@ -79,6 +90,8 @@ groups:
         for: 15m
         labels:
           severity: critical
+          resource: '{{ $labels.name }}'
+          service: kubermatic-seed
       # This is a dummy alert that is triggered for paused clusters to inhibit all other alerts from such clusters.
       # The label_replace() is used to create a new "cluster" label that will be used for the inhibitions as well.
       - alert: KubermaticClusterPaused
@@ -86,4 +99,6 @@ groups:
           message: Cluster {{ $labels.name }} has been paused and will not be reconciled until the pause flag is reset.
         expr: label_replace(kubermatic_cluster_info{pause="true"}, "cluster", "$0", "name", ".+")
         labels:
-          severity: none
+          severity: informational
+          resource: '{{ $labels.name }}'
+          service: kubermatic-seed

--- a/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -51,7 +51,10 @@ groups:
         annotations:
           message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} has no related resources created for more than 30min.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticaddonreconciliationtakestoolong
-        expr: kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_created - kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_deleted > 0
+        expr: |
+          kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_created
+          - kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_deleted
+          > 0
         for: 30m
         labels:
           severity: warning

--- a/charts/monitoring/prometheus/rules/managed-kube-controller-manager.yaml
+++ b/charts/monitoring/prometheus/rules/managed-kube-controller-manager.yaml
@@ -32,3 +32,5 @@ groups:
         for: 10m
         labels:
           severity: critical
+          resource: kube-controller-manager
+          service: kubernetes

--- a/charts/monitoring/prometheus/rules/managed-kube-scheduler.yaml
+++ b/charts/monitoring/prometheus/rules/managed-kube-scheduler.yaml
@@ -32,3 +32,5 @@ groups:
         for: 10m
         labels:
           severity: critical
+          resource: kube-scheduler
+          service: kubernetes

--- a/charts/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml
@@ -23,6 +23,8 @@ groups:
     for: 5m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: blackbox-exporter
 
   - alert: HttpProbeSlow
     annotations:
@@ -32,6 +34,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: blackbox-exporter
     runbook:
       steps:
       - Check the target system's resource usage for anomalias.
@@ -44,6 +48,8 @@ groups:
     expr: probe_ssl_earliest_cert_expiry - time() < 3*24*3600
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: blackbox-exporter
 
   - alert: HttpCertExpiresVerySoon
     annotations:
@@ -52,3 +58,5 @@ groups:
     expr: probe_ssl_earliest_cert_expiry - time() < 24*3600
     labels:
       severity: critical
+      resource: '{{ $labels.instance }}'
+      service: blackbox-exporter

--- a/charts/monitoring/prometheus/rules/src/general/cadvisor.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/cadvisor.yaml
@@ -23,6 +23,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: cadvisor
+      service: cadvisor
 
   - record: namespace:container_memory_usage_bytes:sum
     expr: |

--- a/charts/monitoring/prometheus/rules/src/general/cert-manager.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/cert-manager.yaml
@@ -22,6 +22,8 @@ groups:
     expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3*24*3600
     labels:
       severity: warning
+      resource: '{{ $labels.name }}'
+      service: cert-manager
 
   - alert: CertManagerCertExpiresVerySoon
     annotations:
@@ -30,3 +32,5 @@ groups:
     expr: certmanager_certificate_expiration_timestamp_seconds - time() < 24*3600
     labels:
       severity: critical
+      resource: '{{ $labels.name }}'
+      service: cert-manager

--- a/charts/monitoring/prometheus/rules/src/general/helm-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/helm-exporter.yaml
@@ -25,6 +25,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.release }}'
+      service: helm-exporter
     runbook:
       steps:
       - Check the installed Helm releases via `helm --tiller-namespace kubermtic-installer ls`.

--- a/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -45,6 +45,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeAPILatencyHigh
     annotations:
@@ -56,6 +58,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeAPILatencyHigh
     annotations:
@@ -67,6 +71,8 @@ groups:
     for: 10m
     labels:
       severity: critical
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeAPIErrorsHigh
     annotations:
@@ -79,6 +85,8 @@ groups:
     for: 10m
     labels:
       severity: critical
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeAPIErrorsHigh
     annotations:
@@ -91,6 +99,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeClientCertificateExpiration
     annotations:
@@ -102,6 +112,8 @@ groups:
       histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
     labels:
       severity: warning
+      resource: apiserver
+      service: kubernetes
     runbook:
       steps:
       - Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/) on how to renew certificates.
@@ -118,6 +130,8 @@ groups:
       histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
     labels:
       severity: critical
+      resource: apiserver
+      service: kubernetes
     runbook:
       steps:
       - Urgently renew your certificates. Expired certificates can make fixing the cluster difficult to begin with.

--- a/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
@@ -23,6 +23,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.instance }}'
+      service: kubelet
 
   - alert: KubePersistentVolumeUsageCritical
     annotations:
@@ -38,6 +40,8 @@ groups:
     for: 1m
     labels:
       severity: critical
+      service: kubelet
+      resource: '{{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}'
 
   - alert: KubePersistentVolumeFullInFourDays
     annotations:
@@ -57,6 +61,8 @@ groups:
     for: 5m
     labels:
       severity: critical
+      service: kubelet
+      resource: '{{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}'
 
   - alert: KubeletTooManyPods
     annotations:
@@ -66,6 +72,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: kubelet
 
   - alert: KubeClientErrors
     annotations:
@@ -80,6 +88,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: kubelet
 
   # a dedicated rule for pods to include more helpful labels in the message like the instance and job name
   - alert: KubeClientErrors
@@ -95,6 +105,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: kubelet
 
   - alert: KubeletRuntimeErrors
     annotations:
@@ -106,6 +118,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}'
+      service: kubelet
 
   - alert: KubeletCGroupManagerDurationHigh
     annotations:
@@ -116,6 +130,8 @@ groups:
       sum(rate(kubelet_cgroup_manager_duration_seconds{quantile="0.9"}[5m])) by (instance) * 1000 > 1
     for: 15m
     labels:
+      resource: '{{ $labels.instance }}'
+      service: kubelet
       severity: warning
 
   - alert: KubeletPodWorkerDurationHigh
@@ -128,6 +144,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.instance }}/{{ $labels.operation_type }}'
+      service: kubelet
 
   - alert: KubeVersionMismatch
     annotations:

--- a/charts/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
@@ -78,6 +78,7 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.pod }}"
     runbook:
       steps:
       - Check the pod's logs.
@@ -90,6 +91,7 @@ groups:
     for: 30m
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.pod }}"
     runbook:
       steps:
       - Check the pod via `kubectl describe pod [POD]` to find out about scheduling issues.
@@ -107,6 +109,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.deployment }}"
 
   - alert: KubeDeploymentReplicasMismatch
     annotations:
@@ -121,6 +124,7 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.deployment }}"
 
   - alert: KubeStatefulSetReplicasMismatch
     annotations:
@@ -135,6 +139,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.statefulset }}"
 
   - alert: KubeStatefulSetGenerationMismatch
     annotations:
@@ -149,6 +154,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.statefulset }}"
 
   - alert: KubeStatefulSetUpdateNotRolledOut
     annotations:
@@ -169,6 +175,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.statefulset }}"
 
   - alert: KubeDaemonSetRolloutStuck
     annotations:
@@ -183,6 +190,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: "{{ $labels.namespace }}/{{ $labels.daemonset }}"
 
   - alert: KubeDaemonSetNotScheduled
     annotations:
@@ -195,6 +203,7 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: "{{ $labels.namespace }}/{{ $labels.daemonset }}"
 
   - alert: KubeDaemonSetMisScheduled
     annotations:
@@ -204,6 +213,7 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: "{{ $labels.namespace }}/{{ $labels.daemonset }}"
 
   - alert: KubeCronJobRunning
     annotations:
@@ -213,6 +223,7 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: "{{ $labels.namespace }}/{{ $labels.cronjob }}"
 
   - alert: KubeJobCompletion
     annotations:
@@ -222,6 +233,7 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: "{{ $labels.namespace }}/{{ $labels.job_name }}"
 
   - alert: KubeJobFailed
     annotations:
@@ -231,6 +243,7 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: "{{ $labels.namespace }}/{{ $labels.job_name }}"
 
   - alert: KubeCPUOvercommit
     annotations:
@@ -314,6 +327,7 @@ groups:
     for: 0m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}'
 
   - alert: KubeNodeNotReady
     annotations:
@@ -323,3 +337,4 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: '{{ $labels.node }}'

--- a/charts/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
@@ -67,6 +67,9 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: kube-state-metrics
+
 
   - alert: KubePodCrashLooping
     annotations:
@@ -257,6 +260,8 @@ groups:
     for: 5m
     labels:
       severity: warning
+      resource: cluster
+      service: kube-state-metrics
 
   - alert: KubeCPUOvercommit
     annotations:
@@ -271,6 +276,8 @@ groups:
     for: 5m
     labels:
       severity: warning
+      resource: cluster
+      service: kube-state-metrics
 
   - alert: KubeMemOvercommit
     annotations:
@@ -284,6 +291,8 @@ groups:
     for: 5m
     labels:
       severity: warning
+      resource: cluster
+      service: kube-state-metrics
 
   - alert: KubeMemOvercommit
     annotations:
@@ -300,6 +309,8 @@ groups:
     for: 5m
     labels:
       severity: warning
+      resource: cluster
+      service: kube-state-metrics
 
   - alert: KubeQuotaExceeded
     annotations:
@@ -313,6 +324,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: cluster
+      service: kube-state-metrics
 
   - alert: KubePodOOMKilled
     annotations:

--- a/charts/monitoring/prometheus/rules/src/general/node-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/node-exporter.yaml
@@ -209,6 +209,8 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemSpaceFillingUp
     annotations:
@@ -225,6 +227,8 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemOutOfSpace
     annotations:
@@ -239,6 +243,8 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemOutOfSpace
     annotations:
@@ -253,6 +259,8 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemFilesFillingUp
     annotations:
@@ -269,6 +277,8 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemFilesFillingUp
     annotations:
@@ -285,6 +295,8 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemOutOfFiles
     annotations:
@@ -299,6 +311,8 @@ groups:
     for: 1h
     labels:
       severity: warning
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeFilesystemOutOfSpace
     annotations:
@@ -313,6 +327,8 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeNetworkReceiveErrs
     annotations:
@@ -324,6 +340,8 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'
 
   - alert: NodeNetworkTransmitErrs
     annotations:
@@ -335,3 +353,5 @@ groups:
     for: 1h
     labels:
       severity: critical
+      resource: '{{ $labels.instance }} {{ $labels.device }}'
+      service: 'node-exporter'

--- a/charts/monitoring/prometheus/rules/src/general/prometheus.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/prometheus.yaml
@@ -23,6 +23,8 @@ groups:
     for: 15m
     labels:
       severity: warning
+      resource: '{{ $labels.job }}/{{ $labels.instance }}'
+      service: prometheus
     runbook:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
@@ -35,6 +37,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.job }}/{{ $labels.instance }}'
+      service: prometheus
     runbook:
       steps:
       - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.
@@ -48,6 +52,8 @@ groups:
     for: 10m
     labels:
       severity: critical
+      resource: '{{ $labels.job }}/{{ $labels.instance }}'
+      service: prometheus
     runbook:
       steps:
       - Check Alertmanager pod's logs via `kubectl -n monitoring logs alertmanager-0`, `-1` and `-2`.
@@ -61,6 +67,8 @@ groups:
     for: 5m
     labels:
       severity: critical
+      resource: '{{ $labels.job }}/{{ $labels.instance }}'
+      service: prometheus
     runbook:
       steps:
       - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.
@@ -78,6 +86,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.job }}/{{ $labels.instance }}'
+      service: prometheus
     runbook:
       steps:
       - Ensure that the Prometheus volume has not reached capacity.
@@ -91,6 +101,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.job }}/{{ $labels.instance }}'
+      service: prometheus
     runbook:
       steps:
       - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.

--- a/charts/monitoring/prometheus/rules/src/general/thanos.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/thanos.yaml
@@ -23,6 +23,8 @@ groups:
     for: 5m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos
 
   - alert: ThanosSidecarNoHeartbeat
     annotations:
@@ -32,6 +34,8 @@ groups:
     for: 3m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos
 
   - alert: ThanosCompactorManyRetries
     annotations:
@@ -41,6 +45,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos
     runbook:
       steps:
       - Check the `thanos-compact` pod's logs.
@@ -53,6 +59,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos
     runbook:
       steps:
       - Check the `thanos` containers's logs inside the Prometheus pod.
@@ -65,6 +73,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos
 
   - alert: ThanosManyBlockLoadFailures
     annotations:
@@ -74,6 +84,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos
 
   - alert: ThanosManyBlockDropFailures
     annotations:
@@ -83,3 +95,5 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}/{{ $labels.pod }}'
+      service: thanos

--- a/charts/monitoring/prometheus/rules/src/general/velero.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/velero.yaml
@@ -23,6 +23,8 @@ groups:
     for: 60m
     labels:
       severity: warning
+      resource: '{{ $labels.schedule }}'
+      service: 'velero'
     runbook:
       steps:
       - Check if a backup is really in "InProgress" state via `velero -n velero backup get`.
@@ -35,7 +37,9 @@ groups:
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-veleronorecentbackup
     expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600*25
     labels:
-      severity: warning
+      severity: critical
+      resource: '{{ $labels.schedule }}'
+      service: 'velero'
     runbook:
       steps:
       - Check if really no backups happened via `velero -n velero backup get`.

--- a/charts/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
@@ -23,6 +23,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      service: kubermatic-master
     runbook:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
@@ -36,6 +37,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      service: kubermatic-master
     runbook:
       steps:
       - Check the API pod's logs.
@@ -56,6 +58,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      service: kubermatic-master
     runbook:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.

--- a/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -23,6 +23,8 @@ groups:
     for: 10m
     labels:
       severity: warning
+      resource: '{{ $labels.namespace }}'
+      service: kubermatic-seed
     runbook:
       steps:
       - Check the controller-manager pod's logs.
@@ -35,6 +37,8 @@ groups:
     for: 0m
     labels:
       severity: warning
+      resource: '{{ $labels.cluster }}'
+      service: kubermatic-seed
     runbook:
       steps:
       - Check the machine-controller's logs via `kubectl -n cluster-XYZ logs -l 'app=machine-controller'` for errors related to cloud provider integrations.
@@ -51,6 +55,8 @@ groups:
     for: 0m
     labels:
       severity: warning
+      resource: '{{ $labels.cluster }}/{{ $labels.addon }}'
+      service: kubermatic-seed
     runbook:
       steps:
         - Check the kubermatic controller-manager's logs via `kubectl -n kubermatic logs -l 'app.kubernetes.io/name=kubermatic-seed-controller-manager'` for errors related to deletion of the addon.
@@ -68,6 +74,8 @@ groups:
     for: 30m
     labels:
       severity: warning
+      resource: '{{ $labels.cluster }}/{{ $labels.addon }}'
+      service: kubermatic-seed
     runbook:
       steps:
         - Check the kubermatic seed controller-manager's logs via `kubectl -n kubermatic logs -l 'app.kubernetes.io/name=kubermatic-seed-controller-manager'` for errors related to reconciliation of the addon.
@@ -80,6 +88,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+      service: kubermatic-seed
     runbook:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
@@ -93,6 +102,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.cluster }}'
+      service: kubermatic-seed
 
   - alert: UserClusterPrometheusAbsent
     annotations:
@@ -108,6 +119,8 @@ groups:
     for: 15m
     labels:
       severity: critical
+      resource: '{{ $labels.name }}'
+      service: kubermatic-seed
 
   # This is a dummy alert that is triggered for paused clusters to inhibit all other alerts from such clusters.
   # The label_replace() is used to create a new "cluster" label that will be used for the inhibitions as well.
@@ -116,4 +129,6 @@ groups:
       message: Cluster {{ $labels.name }} has been paused and will not be reconciled until the pause flag is reset.
     expr: label_replace(kubermatic_cluster_info{pause="true"}, "cluster", "$0", "name", ".+")
     labels:
-      severity: none
+      severity: informational
+      resource: '{{ $labels.name }}'
+      service: kubermatic-seed

--- a/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -68,7 +68,8 @@ groups:
       message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} has no related
         resources created for more than 30min.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticaddonreconciliationtakestoolong
-    expr: kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_created
+    expr: |
+      kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_created
       - kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_deleted
       > 0
     for: 30m

--- a/charts/monitoring/prometheus/rules/src/managed/kube-controller-manager.yaml
+++ b/charts/monitoring/prometheus/rules/src/managed/kube-controller-manager.yaml
@@ -31,3 +31,5 @@ groups:
     for: 10m
     labels:
       severity: critical
+      resource: kube-controller-manager
+      service: kubernetes

--- a/charts/monitoring/prometheus/rules/src/managed/kube-scheduler.yaml
+++ b/charts/monitoring/prometheus/rules/src/managed/kube-scheduler.yaml
@@ -31,3 +31,5 @@ groups:
     for: 10m
     labels:
       severity: critical
+      resource: kube-scheduler
+      service: kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:
To improve usability of the predefined alerts, this PR introduces a common set of labels to them (where applicable).
The labels are:
* resource - defining what object is the subject of this alert (e.g. which pod, which pvc, which usercluster)
* service - general description of the area covered by the alert (e.g. kubernetes, kube-state-metrics, velero...)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
Please make sure that none of platform features actually depend on labels in the alerts, because in rare cases `resource` and `service` might overwrite labels coming from Prometheus's service discovery.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
