### PR TITLE
separate gocache from other projects

### DIFF
--- a/hack/ci/download-gocache.sh
+++ b/hack/ci/download-gocache.sh
@@ -67,7 +67,7 @@ if [ -z "${PULL_NUMBER:-}" ]; then
 fi
 
 ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
-URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
+URL="${GOCACHE_MINIO_ADDRESS}/kkp/${ARCHIVE_NAME}"
 
 # Do not go through the retry loop when there is nothing, but do try the
 # first parent if no cache was found. This is helpful for retests happening
@@ -79,7 +79,7 @@ if ! curl --head --silent --fail "${URL}" > /dev/null; then
 
   CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
   ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
-  URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
+  URL="${GOCACHE_MINIO_ADDRESS}/kkp/${ARCHIVE_NAME}"
 
   if ! curl --head --silent --fail "${URL}" > /dev/null; then
     echodate "Remote has no gocache ${ARCHIVE_NAME}, giving up."

--- a/hack/ci/download-gocache.sh
+++ b/hack/ci/download-gocache.sh
@@ -75,7 +75,7 @@ fi
 GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
 
 ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
-URL="${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_BRANCH}/${ARCHIVE_NAME}"
+URL="${GOCACHE_MINIO_ADDRESS}/kubermatic/${GIT_BRANCH}/${ARCHIVE_NAME}"
 
 # Do not go through the retry loop when there is nothing, but do try the
 # first parent if no cache was found. This is helpful for retests happening
@@ -87,7 +87,7 @@ if ! curl --head --silent --fail "${URL}" > /dev/null; then
 
   CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
   ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
-  URL="${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_BRANCH}/${ARCHIVE_NAME}"
+  URL="${GOCACHE_MINIO_ADDRESS}/kubermatic/${GIT_BRANCH}/${ARCHIVE_NAME}"
 
   if ! curl --head --silent --fail "${URL}" > /dev/null; then
     echodate "Remote has no gocache ${ARCHIVE_NAME}, giving up."

--- a/hack/ci/download-gocache.sh
+++ b/hack/ci/download-gocache.sh
@@ -32,6 +32,7 @@ set -o monitor
 
 # The gocache needs a matching go version to work, so append that to the name
 GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+GOARCH="$(go env GOARCH)"
 
 # Make sure we never error, this is always best-effort only
 exit_gracefully() {
@@ -53,11 +54,15 @@ GOCACHE="$(go env GOCACHE)"
 # Make sure it actually exists
 mkdir -p "${GOCACHE}"
 
-export CACHE_VERSION="${PULL_BASE_SHA:-}"
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-}"
+CACHE_VERSION="${PULL_BASE_SHA:-}"
 
 # Periodics just use their head ref
 if [[ -z "${CACHE_VERSION}" ]]; then
   CACHE_VERSION="$(git rev-parse HEAD)"
+  GIT_BRANCH="master"
 fi
 
 if [ -z "${PULL_NUMBER:-}" ]; then
@@ -66,8 +71,11 @@ if [ -z "${PULL_NUMBER:-}" ]; then
   CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
 fi
 
-ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
-URL="${GOCACHE_MINIO_ADDRESS}/kkp/${ARCHIVE_NAME}"
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
+
+ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
+URL="${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_BRANCH}/${ARCHIVE_NAME}"
 
 # Do not go through the retry loop when there is nothing, but do try the
 # first parent if no cache was found. This is helpful for retests happening
@@ -78,8 +86,8 @@ if ! curl --head --silent --fail "${URL}" > /dev/null; then
   echodate "Remote has no gocache ${ARCHIVE_NAME}, trying previous commit as a fallback..."
 
   CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
-  ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
-  URL="${GOCACHE_MINIO_ADDRESS}/kkp/${ARCHIVE_NAME}"
+  ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
+  URL="${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_BRANCH}/${ARCHIVE_NAME}"
 
   if ! curl --head --silent --fail "${URL}" > /dev/null; then
     echodate "Remote has no gocache ${ARCHIVE_NAME}, giving up."

--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -88,6 +88,6 @@ echodate "Uploading gocache archive"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
+retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
 
 echodate "Upload complete."

--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -35,13 +35,21 @@ fi
 
 # The gocache needs a matching go version to work, so append that to the name
 GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+GOARCH="$(go env GOARCH)"
 
 GOCACHE_DIR="$(mktemp -d)"
 export GOCACHE="${GOCACHE_DIR}"
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 export CGO_ENABLED=0
 
-echodate "Creating cache for revision ${GIT_HEAD_HASH} / Go ${GO_VERSION} ..."
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-}"
+
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
+
+echodate "Creating cache for revision ${GIT_BRANCH}/${GIT_HEAD_HASH} / Go ${GO_VERSION}/${GOARCH} ..."
 
 # Go does not distinguish compiled files based on
 # tags, so we cannot cache CE *and* EE.
@@ -57,17 +65,20 @@ echodate "Building binaries"
   # but makes creating the cache a tiny bit slower
   touch download-gocache
 
-  retry 2 make build
+  make build
 )
 (
   TEST_NAME="Building Nodeport proxy"
-  cd cmd/nodeport-proxy
-  retry 2 make build
+  make -C cmd/nodeport-proxy build
 )
 (
   TEST_NAME="Building kubeletdnat controller"
-  cd cmd/kubeletdnat-controller
-  retry 2 make build
+  make -C cmd/kubeletdnat-controller build
+)
+(
+  TEST_NAME="Building clusterexposer"
+  cd pkg/test/clusterexposer/cmd
+  go build --tags "$KUBERMATIC_EDITION" -v .
 )
 
 TEST_NAME="Build tests"
@@ -88,6 +99,6 @@ echodate "Uploading gocache archive"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
+retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_BRANCH}/${GIT_HEAD_HASH}-${GO_VERSION}-${GOARCH}.tar"
 
 echodate "Upload complete."

--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -99,6 +99,6 @@ echodate "Uploading gocache archive"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kkp/${GIT_BRANCH}/${GIT_HEAD_HASH}-${GO_VERSION}-${GOARCH}.tar"
+retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kubermatic/${GIT_BRANCH}/${GIT_HEAD_HASH}-${GO_VERSION}-${GOARCH}.tar"
 
 echodate "Upload complete."


### PR DESCRIPTION
**What this PR does / why we need it**:
Putting each project into its own directory will make cleanup scripts easier to write.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
