### PR TITLE
[release/v2.15] separate gocache from other projects (#7780)

### DIFF
--- a/hack/ci/ci-download-gocache.sh
+++ b/hack/ci/ci-download-gocache.sh
@@ -22,7 +22,8 @@ set -euo pipefail
 set -o monitor
 
 # The gocache needs a matching go version to work, so append that to the name
-GO_VERSION="$(go version|awk '{ print $3 }'|sed 's/go//g')"
+GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+GOARCH="$(go env GOARCH)"
 
 # Make sure we never error, this is always best-effort only
 exit_gracefully() {
@@ -44,26 +45,45 @@ GOCACHE="$(go env GOCACHE)"
 # Make sure it actually exists
 mkdir -p "${GOCACHE}"
 
-export CACHE_VERSION="${PULL_BASE_SHA:-}"
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-}"
+CACHE_VERSION="${PULL_BASE_SHA:-}"
 
 # Periodics just use their head ref
 if [[ -z "${CACHE_VERSION}" ]]; then
   CACHE_VERSION="$(git rev-parse HEAD)"
+  GIT_BRANCH="master"
 fi
 
 if [ -z "${PULL_NUMBER:-}" ]; then
-  # Special case: This is called in a Postubmit. Go one revision back,
+  # Special case: This is called in a Postsubmit. Go one revision back,
   # as there can't be a cache for the current revision
   CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
 fi
 
-ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
-URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
 
-# Do not go through the retry loop when there is nothing
-if curl --head "${URL}" | grep -q 404; then
-  echodate "Remote has no gocache ${ARCHIVE_NAME}, exiting"
-  exit 0
+ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
+URL="${GOCACHE_MINIO_ADDRESS}/kubermatic/${GIT_BRANCH}/${ARCHIVE_NAME}"
+
+# Do not go through the retry loop when there is nothing, but do try the
+# first parent if no cache was found. This is helpful for retests happening
+# quickly after something got merged to master and no gocache for the most
+# recent commit exists yet. In this case, taking the previous commit's
+# cache is better than nothing.
+if ! curl --head --silent --fail "${URL}" > /dev/null; then
+  echodate "Remote has no gocache ${ARCHIVE_NAME}, trying previous commit as a fallback..."
+
+  CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
+  ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
+  URL="${GOCACHE_MINIO_ADDRESS}/kubermatic/${GIT_BRANCH}/${ARCHIVE_NAME}"
+
+  if ! curl --head --silent --fail "${URL}" > /dev/null; then
+    echodate "Remote has no gocache ${ARCHIVE_NAME}, giving up."
+    exit 0
+  fi
 fi
 
 echodate "Downloading and extracting gocache"

--- a/hack/ci/ci-upload-gocache.sh
+++ b/hack/ci/ci-upload-gocache.sh
@@ -29,10 +29,23 @@ if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
   exit 1
 fi
 
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+GOARCH="$(go env GOARCH)"
+
 GOCACHE_DIR="$(mktemp -d)"
 export GOCACHE="${GOCACHE_DIR}"
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 export CGO_ENABLED=0
+
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-}"
+
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
+
+echodate "Creating cache for revision ${GIT_BRANCH}/${GIT_HEAD_HASH} / Go ${GO_VERSION}/${GOARCH} ..."
 
 # Go does not distinguish compiled files based on
 # tags, so we cannot cache CE *and* EE.
@@ -42,17 +55,26 @@ echodate "Building binaries"
 
 (
   TEST_NAME="Build Kubermatic"
-  retry 2 make build
+
+  # prevent the Makefile from downloading the old Gocache. This ensures that
+  # our cache does not grow over time, as packages are added and removed,
+  # but makes creating the cache a tiny bit slower
+  touch download-gocache
+
+  make build
 )
 (
   TEST_NAME="Building Nodeport proxy"
-  cd cmd/nodeport-proxy
-  retry 2 make build
+  make -C cmd/nodeport-proxy build
 )
 (
   TEST_NAME="Building kubeletdnat controller"
-  cd cmd/kubeletdnat-controller
-  retry 2 make build
+  make -C cmd/kubeletdnat-controller build
+)
+(
+  TEST_NAME="Building clusterexposer"
+  cd pkg/test/clusterexposer/cmd
+  go build --tags "$KUBERMATIC_EDITION" -v .
 )
 
 TEST_NAME="Build tests"
@@ -70,10 +92,9 @@ retry 2 tar -C "$GOCACHE" -cf "$ARCHIVE_FILE" .
 TEST_NAME="Uploading gocache archive"
 echodate "Uploading gocache archive"
 
-# The gocache needs a matching go version to work, so append that to the name
-GO_VERSION="$(go version|awk '{ print $3 }'|sed 's/go//g')"
-
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
+retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kubermatic/${GIT_BRANCH}/${GIT_HEAD_HASH}-${GO_VERSION}-${GOARCH}.tar"
+
+echodate "Upload complete."


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #7780.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
