### PR TITLE
defaulting backup/restore containers templates

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -398,7 +398,7 @@ func (r *Reconciler) reconcileConfigMaps(ctx context.Context, cfg *operatorv1alp
 	log.Debug("reconciling ConfigMaps")
 
 	creators := []reconciling.NamedConfigMapCreatorGetter{
-		kubermaticseed.BackupContainersConfigMapCreator(cfg),
+		kubermaticseed.BackupContainersConfigMapCreator(cfg, seed, log),
 		kubermaticseed.CABundleConfigMapCreator(caBundle),
 	}
 

--- a/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
@@ -92,14 +92,18 @@ func BackupContainersConfigMapCreator(cfg *operatorv1alpha1.KubermaticConfigurat
 			if cfg.Spec.SeedController.BackupStoreContainer == strings.TrimSpace(common.DefaultBackupStoreContainer) &&
 				seed.Spec.BackupRestore != nil {
 				c.Data[storeContainerKey] = strings.TrimSpace(common.DefaultNewBackupStoreContainer)
+				log.Debugw("Defaulting field", "field", "seedController.backupRestoreContainer")
 			}
 
-			if cfg.Spec.SeedController.BackupDeleteContainer == "" {
-				cfg.Spec.SeedController.BackupDeleteContainer = strings.TrimSpace(common.DefaultNewBackupDeleteContainer)
-				log.Debugw("Defaulting field", "field", "seedController.backupDeleteContainer")
+			if seed.Spec.BackupRestore != nil {
+				if cfg.Spec.SeedController.BackupDeleteContainer == "" {
+					cfg.Spec.SeedController.BackupDeleteContainer = strings.TrimSpace(common.DefaultNewBackupDeleteContainer)
+					log.Debugw("Defaulting field", "field", "seedController.backupDeleteContainer")
+				}
+
+				c.Data[deleteContainerKey] = cfg.Spec.SeedController.BackupDeleteContainer
 			}
 
-			c.Data[deleteContainerKey] = cfg.Spec.SeedController.BackupDeleteContainer
 			return c, nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabling the backup and restore containers for Etcd in the new seed configurations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7778

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
