### PR TITLE
fix extra args support to prometheus chart

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.4
+version: 2.4.5
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -84,10 +84,10 @@ spec:
             {{- end }}
             --web.enable-lifecycle \
             --web.external-url=https://{{ .Values.prometheus.host | trim }} \
-            --web.enable-admin-api
+            --web.enable-admin-api \
           {{- range $key, $value := .Values.prometheus.extraArgs }}
-            - --{{ $key }}={{ $value }}
-          {{- end }}
+            --{{ $key }}={{ $value }} \
+          {{ end }}
           {{- else }}
           echo "Starting Prometheus..."
           exec /bin/prometheus \
@@ -102,10 +102,10 @@ spec:
             {{- if .Values.prometheus.backup.enabled }}
             --web.enable-admin-api \
             {{- end }}
-            --web.external-url=https://{{ .Values.prometheus.host | trim }}
+            --web.external-url=https://{{ .Values.prometheus.host | trim }} \
             {{- range $key, $value := .Values.prometheus.extraArgs }}
-            --{{ $key }}={{ $value }}
-            {{- end }}
+            --{{ $key }}={{ $value }} \
+            {{ end }}
           {{- end }}
         ports:
         - containerPort: 9090


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes extraArgs support for prometheus chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Additional line continuation is required for the command to use additional flags. Empty line is there as a failsafe if there are no extraArgs.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
