### PR TITLE
reorder konnectivity resources to reconcile after dependencies

### DIFF
--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -84,6 +84,7 @@ set -x
   -version=${CLUSTER_VERSION} \
   -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
+  -tunneling-agent-ip=192.168.30.10\
   -logtostderr \
   -v=4 \
   -seed-kubeconfig=${SEED_KUBECONFIG} \

--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -84,8 +84,8 @@ set -x
   -version=${CLUSTER_VERSION} \
   -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
-  -tunneling-agent-ip=192.168.30.10\
   -logtostderr \
+  -tunneling-agent-ip=192.168.30.10 \
   -v=4 \
   -seed-kubeconfig=${SEED_KUBECONFIG} \
   -owner-email=${OWNER_EMAIL} \

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -197,6 +197,12 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
+	if r.isKonnectivityEnabled {
+		if err := r.reconcileKonnectivityDeployments(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -760,10 +766,6 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		coredns.DeploymentCreator(r.clusterSemVer),
 	}
 
-	if r.isKonnectivityEnabled {
-		kubeSystemCreators = append(kubeSystemCreators, konnectivity.DeploymentCreator(r.clusterURL.Hostname()))
-	}
-
 	if err := reconciling.ReconcileDeployments(ctx, kubeSystemCreators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", metav1.NamespaceSystem, err)
 	}
@@ -789,6 +791,13 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		}
 	}
 
+	return nil
+}
+
+func (r *reconciler) reconcileKonnectivityDeployments(ctx context.Context) error {
+	if err := reconciling.ReconcileDeployments(ctx, []reconciling.NamedDeploymentCreatorGetter{konnectivity.DeploymentCreator(r.clusterURL.Hostname())}, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", metav1.NamespaceSystem, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Deployment of Konnectivity resources failed because we tried to deploy them before 
their dependencies were deployed. This PR carefully orders the Konnectivity resources to be deployed. 

PR also  fixes  `hack/run-user-cluster-controller-manager.sh`. If `-tunneling-agent-ip` is not set `envoy-agent` doesn't 
deploy. This makes call from `calico/node` to KAS fail preventing setup of pod networking. This shouldn't be an issue 
on the actual clusters (only during  the development) because on real clusters the flag is set.  


**Which issue(s) this PR fixes**: 
Fixes 
https://github.com/kubermatic/kubermatic/issues/7759
https://github.com/kubermatic/kubermatic/issues/7760


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
