### PR TITLE
migration webhook deployed only when migrating

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -91,6 +91,7 @@ type controllerRunOptions struct {
 	userClusterMonitoring        bool
 	prometheusScrapeConfigPrefix string
 	ccmMigration                 bool
+	ccmMigrationCompleted        bool
 	isKonnectivityEnabled        bool
 }
 
@@ -131,6 +132,7 @@ func main() {
 	flag.BoolVar(&runOp.userClusterMonitoring, "user-cluster-monitoring", false, "Enable monitoring in user cluster.")
 	flag.StringVar(&runOp.prometheusScrapeConfigPrefix, "prometheus-scrape-config-prefix", "prometheus-scraping", fmt.Sprintf("The name prefix of ConfigMaps in namespace %s, which will be used to add customized scrape configs for user cluster Prometheus.", resources.UserClusterMLANamespace))
 	flag.BoolVar(&runOp.ccmMigration, "ccm-migration", false, "Enable ccm migration in user cluster.")
+	flag.BoolVar(&runOp.ccmMigrationCompleted, "ccm-migration-completed", false, "cluster has been successfully migrated.")
 	flag.BoolVar(&runOp.isKonnectivityEnabled, "konnectivity-enabled", false, "Enable Konnectivity.")
 
 	flag.Parse()
@@ -272,6 +274,8 @@ func main() {
 		},
 		runOp.clusterName,
 		runOp.isKonnectivityEnabled,
+		runOp.ccmMigration,
+		runOp.ccmMigrationCompleted,
 		log,
 	); err != nil {
 		log.Fatalw("Failed to register user cluster controller", zap.Error(err))

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -92,6 +92,8 @@ func Add(
 	userClusterMLA UserClusterMLA,
 	clusterName string,
 	konnectivity bool,
+	ccmMigration bool,
+	ccmMigrationCompleted bool,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
 		version:               version,
@@ -115,6 +117,8 @@ func Add(
 		cloudProvider:         kubermaticv1.ProviderType(cloudProviderName),
 		clusterName:           clusterName,
 		isKonnectivityEnabled: konnectivity,
+		ccmMigration:          ccmMigration,
+		ccmMigrationCompleted: ccmMigrationCompleted,
 	}
 
 	var err error
@@ -255,6 +259,8 @@ type reconciler struct {
 	cloudProvider         kubermaticv1.ProviderType
 	clusterName           string
 	isKonnectivityEnabled bool
+	ccmMigration          bool
+	ccmMigrationCompleted bool
 
 	rLock                      *sync.Mutex
 	reconciledSuccessfullyOnce bool

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -92,6 +92,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		userSSHKeys:    userSSHKeys,
 		cloudConfig:    cloudConfig,
 		csiCloudConfig: CSICloudConfig,
+		ccmMigration:   r.ccmMigration || r.ccmMigrationCompleted,
 	}
 
 	if r.userClusterMLA.Monitoring || r.userClusterMLA.Logging {
@@ -535,7 +536,7 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 		creators = append(creators, gatekeeper.ValidatingWebhookConfigurationCreator(r.opaWebhookTimeout))
 	}
 
-	if data.csiCloudConfig != nil {
+	if data.ccmMigration && data.csiCloudConfig != nil {
 		creators = append(creators, csimigration.ValidatingwebhookConfigurationCreator(data.caCert.Cert, metav1.NamespaceSystem, resources.VsphereCSIMigrationWebhookConfigurationWebhookName))
 	}
 
@@ -653,7 +654,9 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 
 	if data.csiCloudConfig != nil {
 		creators = append(creators, cloudcontroller.CloudConfig(data.csiCloudConfig, resources.CSICloudConfigSecretName))
-		creators = append(creators, csimigration.TLSServingCertificateCreator(data.caCert))
+		if data.ccmMigration {
+			creators = append(creators, csimigration.TLSServingCertificateCreator(data.caCert))
+		}
 	}
 
 	if r.userSSHKeyAgent {
@@ -831,6 +834,7 @@ type reconcileData struct {
 	cloudConfig      []byte
 	// csiCloudConfig is currently used only by vSphere, whose needs it to properly configure the external CSI driver
 	csiCloudConfig         []byte
+	ccmMigration           bool
 	monitoringRequirements *corev1.ResourceRequirements
 	loggingRequirements    *corev1.ResourceRequirements
 }

--- a/pkg/crd/kubermatic/v1/helper/helper.go
+++ b/pkg/crd/kubermatic/v1/helper/helper.go
@@ -218,3 +218,7 @@ func NeedCCMMigration(cluster *kubermaticv1.Cluster) bool {
 
 	return ccmOk && csiOk && !migrated
 }
+
+func CCMMigrationCompleted(cluster *kubermaticv1.Cluster) bool {
+	return ClusterConditionHasStatus(cluster, kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted, corev1.ConditionTrue)
+}

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -195,6 +195,10 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				args = append(args, "-ccm-migration")
 			}
 
+			if helper.CCMMigrationCompleted(data.Cluster()) {
+				args = append(args, "-ccm-migration-completed")
+			}
+
 			labelArgsValue, err := getLabelsArgValue(data.Cluster())
 			if err != nil {
 				return nil, fmt.Errorf("failed to get label args value: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
The vSphere CSI `validatingWebhookConfiguration` has to be deployed only when performing the CCM/CSI migration. We didn't check the migration condition but deployed it in every condition when the external CCM was used. This PR ensures that it is deployed only when migrating the cluster, or once the migration has been completed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
