### PR TITLE
Fix incorrect konnectivity-enabled arg syntax

### DIFF
--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -148,7 +148,7 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 			}, getNetworkArgs(data)...)
 
 			if data.IsKonnectivityEnabled() {
-				args = append(args, "--konnectivity-enabled", "true")
+				args = append(args, "-konnectivity-enabled", "true")
 			}
 
 			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Fixes incorrect `konnectivity-enabled` arg syntax in user-cluster-controller-manager, which causes issues when Konnectivity is enabled (makes the following args ignored).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7802

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
