### PR TITLE
Include the vnet resource group on user cluster deletion

### DIFF
--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -119,7 +119,11 @@ func deleteSubnet(ctx context.Context, cloud kubermaticv1.CloudSpec, credentials
 		return err
 	}
 
-	deleteSubnetFuture, err := subnetsClient.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.VNetName, cloud.Azure.SubnetName)
+	var resourceGroup = cloud.Azure.ResourceGroup
+	if cloud.Azure.VNetResourceGroup != "" {
+		resourceGroup = cloud.Azure.VNetResourceGroup
+	}
+	deleteSubnetFuture, err := subnetsClient.Delete(ctx, resourceGroup, cloud.Azure.VNetName, cloud.Azure.SubnetName)
 	if err != nil {
 		return err
 	}
@@ -147,7 +151,11 @@ func deleteVNet(ctx context.Context, cloud kubermaticv1.CloudSpec, credentials C
 		return err
 	}
 
-	deleteVNetFuture, err := networksClient.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.VNetName)
+	var resourceGroup = cloud.Azure.ResourceGroup
+	if cloud.Azure.VNetResourceGroup != "" {
+		resourceGroup = cloud.Azure.VNetResourceGroup
+	}
+	deleteVNetFuture, err := networksClient.Delete(ctx, resourceGroup, cloud.Azure.VNetName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Looking for the right subnet and vnet when vnetResourceGroup is selected for the created user cluster, otherwise the cluster some of the user cluster resources will be stuck in deletion phase

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7816 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
