### PR TITLE
Fix query for VeleroBackupTakesTooLong

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.5
+version: 2.4.6
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-velero.yaml
+++ b/charts/monitoring/prometheus/rules/general-velero.yaml
@@ -21,8 +21,8 @@ groups:
         annotations:
           message: Last backup with schedule {{ $labels.schedule }} has not finished successfully within 60min.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-velerobackuptakestoolong
-        expr: (increase(velero_backup_attempt_total[60m]) - increase(velero_backup_failure_total[60m])) > 0
-        for: 60m
+        expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600
+        for: 5m
         labels:
           severity: warning
           resource: '{{ $labels.schedule }}'

--- a/charts/monitoring/prometheus/rules/src/general/velero.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/velero.yaml
@@ -19,8 +19,8 @@ groups:
     annotations:
       message: Last backup with schedule {{ $labels.schedule }} has not finished successfully within 60min.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-velerobackuptakestoolong
-    expr: (increase(velero_backup_attempt_total[60m]) - increase(velero_backup_failure_total[60m])) > 0
-    for: 60m
+    expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600
+    for: 5m
     labels:
       severity: warning
       resource: '{{ $labels.schedule }}'


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the query for VeleroBackupTakesTooLong to be based on last successful time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
using metrics for finished jobs is too flaky and can lead to false positives if the backup job takes longer/shorter time than expected... if backup wasn't successful within the last hour, alert.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
