### PR TITLE
Fixed EtcdBackupConfig resource name typo

### DIFF
--- a/pkg/crd/kubermatic/v1/etcd_backup_config.go
+++ b/pkg/crd/kubermatic/v1/etcd_backup_config.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// EtcdBackupConfigResourceName represents "Resource" defined in Kubernetes
-	EtcdBackupConfigResourceName = "etcdbackupconfig"
+	EtcdBackupConfigResourceName = "etcdbackupconfigs"
 
 	// EtcdBackupConfigKindName represents "Kind" defined in Kubernetes
 	EtcdBackupConfigKindName = "EtcdBackupConfig"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo in the EtcdBackupConfig resource name, which was causing RBAC issues


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
