### PR TITLE
[release/v2.15] Update Kubernetes Versions

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -404,7 +404,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,flatcar,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -447,7 +447,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,flatcar,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -493,7 +493,7 @@ presubmits:
         - name: USE_LEGACY_HELM_CHART
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,flatcar,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -538,7 +538,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,coreos,flatcar,rhel"
         - name: PROVIDER
@@ -584,7 +584,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -627,7 +627,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -675,7 +675,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "ubuntu,coreos,flatcar,rhel"
         - name: PROVIDER
@@ -718,7 +718,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "packet"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -761,7 +761,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "kubevirt"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -804,7 +804,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "hetzner"
         # Hetzner doesn't support coreos
@@ -850,7 +850,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "openstack"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -895,7 +895,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -940,7 +940,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -984,7 +984,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -1030,7 +1030,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.25
+version: 1.1.26
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -38,6 +38,10 @@ updates:
 - from: 1.19.*
   to: 1.19.*
   type: kubernetes
+- automatic: true
+  from: '>= 1.19.0, < 1.19.15'
+  to: 1.19.15
+  type: kubernetes
 - from: 4.1.*
   to: 4.1.*
   type: openshift

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -17,11 +17,7 @@ versions:
   type: kubernetes
   version: 1.18.10
 - type: kubernetes
-  version: 1.19.0
-- type: kubernetes
-  version: 1.19.2
-- type: kubernetes
-  version: 1.19.3
+  version: 1.19.15
 - type: openshift
   version: 4.1.9
 - default: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -448,6 +448,9 @@ spec:
           to: 1.19.*
         - from: 1.19.*
           to: 1.19.*
+        - automatic: true
+          from: '>= 1.19.0, < 1.19.15'
+          to: 1.19.15
       # Versions lists the available versions.
       versions:
         - 1.17.9
@@ -457,9 +460,7 @@ spec:
         - 1.18.6
         - 1.18.8
         - 1.18.10
-        - 1.19.0
-        - 1.19.2
-        - 1.19.3
+        - 1.19.15
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -199,9 +199,7 @@ var (
 			semver.MustParse("v1.18.8"),
 			semver.MustParse("v1.18.10"),
 			// Kubernetes 1.19
-			semver.MustParse("v1.19.0"),
-			semver.MustParse("v1.19.2"),
-			semver.MustParse("v1.19.3"),
+			semver.MustParse("v1.19.15"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			{
@@ -272,6 +270,12 @@ var (
 				// Allow to change to any patch version
 				From: "1.19.*",
 				To:   "1.19.*",
+			},
+			{
+				// Auto-upgrade because of CVE-2021-25741
+				From:      ">= 1.19.0, < 1.19.15",
+				To:        "1.19.15",
+				Automatic: pointer.BoolPtr(true),
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the supported Kubernetes versions one last time before sunsetting the 2.15 branch.

**Does this PR introduce a user-facing change?**:
```release-note
Add Kubernetes 1.19.15 to the list of supported versions, including an automated update rule for all 1.19.x userclusters.
```
