### PR TITLE
[release/v2.16] Update Kubernetes Versions

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -421,7 +421,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.15"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -462,7 +462,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -505,7 +505,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -551,7 +551,7 @@ presubmits:
         - name: USE_LEGACY_HELM_CHART
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -596,7 +596,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: PROVIDER
@@ -642,7 +642,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -685,7 +685,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -733,7 +733,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: DISTRIBUTIONS
           value: centos
         - name: PROVIDER
@@ -776,7 +776,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "packet"
         - name: DISTRIBUTIONS
@@ -819,7 +819,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -862,7 +862,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "hetzner"
         - name: DISTRIBUTIONS
@@ -907,7 +907,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "openstack"
         - name: DISTRIBUTIONS
@@ -952,7 +952,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -997,7 +997,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1041,7 +1041,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1087,7 +1087,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.2"
+          value: "v1.20.11"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1226,7 +1226,7 @@ presubmits:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.20.2
+          value: v1.20.11
         - name: KUBERMATIC_EDITION
           value: ee
         - name: SERVICE_ACCOUNT_KEY

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.50
+version: 1.1.51
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -28,11 +28,19 @@ updates:
 - from: 1.19.*
   to: 1.19.*
   type: kubernetes
+- automatic: true
+  from: '>= 1.19.0, < 1.19.15'
+  to: 1.19.15
+  type: kubernetes
 - from: 1.19.*
   to: 1.20.*
   type: kubernetes
 - from: 1.20.*
   to: 1.20.*
+  type: kubernetes
+- automatic: true
+  from: '>= 1.20.0, < 1.20.11'
+  to: 1.20.11
   type: kubernetes
 - from: 4.1.*
   to: 4.1.*

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -20,14 +20,9 @@ versions:
 - type: kubernetes
   version: 1.18.14
 - type: kubernetes
-  version: 1.19.0
+  version: 1.19.15
 - type: kubernetes
-  version: 1.19.2
-- default: true
-  type: kubernetes
-  version: 1.19.3
-- type: kubernetes
-  version: 1.20.2
+  version: 1.20.11
 - type: openshift
   version: 4.1.9
 - default: true

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -19,7 +19,8 @@ versions:
   version: 1.18.10
 - type: kubernetes
   version: 1.18.14
-- type: kubernetes
+- default: true
+  type: kubernetes
   version: 1.19.15
 - type: kubernetes
   version: 1.20.11

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -445,10 +445,16 @@ spec:
           to: 1.19.*
         - from: 1.19.*
           to: 1.19.*
+        - automatic: true
+          from: '>= 1.19.0, < 1.19.15'
+          to: 1.19.15
         - from: 1.19.*
           to: 1.20.*
         - from: 1.20.*
           to: 1.20.*
+        - automatic: true
+          from: '>= 1.20.0, < 1.20.11'
+          to: 1.20.11
       # Versions lists the available versions.
       versions:
         - 1.17.9
@@ -460,10 +466,8 @@ spec:
         - 1.18.8
         - 1.18.10
         - 1.18.14
-        - 1.19.0
-        - 1.19.2
-        - 1.19.3
-        - 1.20.2
+        - 1.19.15
+        - 1.20.11
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -408,7 +408,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.19.3
+      default: 1.19.15
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -201,11 +201,9 @@ var (
 			semver.MustParse("v1.18.10"),
 			semver.MustParse("v1.18.14"),
 			// Kubernetes 1.19
-			semver.MustParse("v1.19.0"),
-			semver.MustParse("v1.19.2"),
-			semver.MustParse("v1.19.3"),
+			semver.MustParse("v1.19.15"),
 			// Kubernetes 1.20
-			semver.MustParse("v1.20.2"),
+			semver.MustParse("v1.20.11"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			{
@@ -260,6 +258,12 @@ var (
 				To:   "1.19.*",
 			},
 			{
+				// Auto-upgrade because of CVE-2021-25741
+				From:      ">= 1.19.0, < 1.19.15",
+				To:        "1.19.15",
+				Automatic: pointer.BoolPtr(true),
+			},
+			{
 				// Allow to next minor release
 				From: "1.19.*",
 				To:   "1.20.*",
@@ -270,6 +274,12 @@ var (
 				// Allow to change to any patch version
 				From: "1.20.*",
 				To:   "1.20.*",
+			},
+			{
+				// Auto-upgrade because of CVE-2021-25741
+				From:      ">= 1.20.0, < 1.20.11",
+				To:        "1.20.11",
+				Automatic: pointer.BoolPtr(true),
 			},
 		},
 	}

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -187,7 +187,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.19.3"),
+		Default: semver.MustParse("v1.19.15"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the list of supported Kubernetes versions and adds automatic update rules for all 1.19 and 1.20 clusters, each to their latest patch releases that were just released.

**Does this PR introduce a user-facing change?**:
```release-note
Add Kubernetes 1.19.15 to the list of supported versions, including an automated update rule for all 1.19.x userclusters.
Add Kubernetes 1.20.11 to the list of supported versions, including an automated update rule for all 1.20.x userclusters.
```
