### PR TITLE
[release/v2.17] Update Kubernetes Versions

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -432,7 +432,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.9"
+          value: "v1.19.15"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -473,7 +473,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.20.5"
+          value: "v1.20.11"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -514,7 +514,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -557,7 +557,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -603,7 +603,7 @@ presubmits:
         - name: USE_LEGACY_HELM_CHART
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -648,7 +648,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: PROVIDER
@@ -694,7 +694,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -737,7 +737,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -785,7 +785,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: DISTRIBUTIONS
           value: centos
         - name: PROVIDER
@@ -828,7 +828,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "packet"
         - name: DISTRIBUTIONS
@@ -871,7 +871,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -914,7 +914,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "hetzner"
         - name: DISTRIBUTIONS
@@ -959,7 +959,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "openstack"
         - name: DISTRIBUTIONS
@@ -1004,7 +1004,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -1049,7 +1049,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1093,7 +1093,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1139,7 +1139,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.21.0"
+          value: "v1.21.5"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1231,7 +1231,7 @@ presubmits:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.21.0
+          value: v1.21.5
         - name: KUBERMATIC_EDITION
           value: ee
         - name: SERVICE_ACCOUNT_KEY
@@ -1304,7 +1304,7 @@ presubmits:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.21.0
+              value: v1.21.5
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.50
+version: 1.1.51
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -18,15 +18,27 @@ updates:
 - from: 1.19.*
   to: 1.19.*
   type: kubernetes
+- automatic: true
+  from: '>= 1.19.0, < 1.19.15'
+  to: 1.19.15
+  type: kubernetes
 - from: 1.19.*
   to: 1.20.*
   type: kubernetes
 - from: 1.20.*
   to: 1.20.*
   type: kubernetes
+- automatic: true
+  from: '>= 1.20.0, < 1.20.11'
+  to: 1.20.11
+  type: kubernetes
 - from: 1.20.*
   to: 1.21.*
   type: kubernetes
 - from: 1.21.*
   to: 1.21.*
+  type: kubernetes
+- automatic: true
+  from: '>= 1.21.0, < 1.21.5'
+  to: 1.21.5
   type: kubernetes

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -13,7 +13,8 @@ versions:
   version: 1.18.17
 - type: kubernetes
   version: 1.19.15
-- type: kubernetes
+- default: true
+  type: kubernetes
   version: 1.20.11
 - type: kubernetes
   version: 1.21.5

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -12,19 +12,8 @@ versions:
 - type: kubernetes
   version: 1.18.17
 - type: kubernetes
-  version: 1.19.0
+  version: 1.19.15
 - type: kubernetes
-  version: 1.19.2
+  version: 1.20.11
 - type: kubernetes
-  version: 1.19.3
-- type: kubernetes
-  version: 1.19.8
-- default: true
-  type: kubernetes
-  version: 1.19.9
-- type: kubernetes
-  version: 1.20.2
-- type: kubernetes
-  version: 1.20.5
-- type: kubernetes
-  version: 1.21.0
+  version: 1.21.5

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -426,14 +426,23 @@ spec:
           to: 1.19.*
         - from: 1.19.*
           to: 1.19.*
+        - automatic: true
+          from: '>= 1.19.0, < 1.19.15'
+          to: 1.19.15
         - from: 1.19.*
           to: 1.20.*
         - from: 1.20.*
           to: 1.20.*
+        - automatic: true
+          from: '>= 1.20.0, < 1.20.11'
+          to: 1.20.11
         - from: 1.20.*
           to: 1.21.*
         - from: 1.21.*
           to: 1.21.*
+        - automatic: true
+          from: '>= 1.21.0, < 1.21.5'
+          to: 1.21.5
       # Versions lists the available versions.
       versions:
         - 1.18.6
@@ -441,14 +450,9 @@ spec:
         - 1.18.10
         - 1.18.14
         - 1.18.17
-        - 1.19.0
-        - 1.19.2
-        - 1.19.3
-        - 1.19.8
-        - 1.19.9
-        - 1.20.2
-        - 1.20.5
-        - 1.21.0
+        - 1.19.15
+        - 1.20.11
+        - 1.21.5
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -396,7 +396,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.19.9
+      default: 1.20.11
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -199,16 +199,11 @@ var (
 			semver.MustParse("v1.18.14"),
 			semver.MustParse("v1.18.17"),
 			// Kubernetes 1.19
-			semver.MustParse("v1.19.0"),
-			semver.MustParse("v1.19.2"),
-			semver.MustParse("v1.19.3"),
-			semver.MustParse("v1.19.8"),
-			semver.MustParse("v1.19.9"),
+			semver.MustParse("v1.19.15"),
 			// Kubernetes 1.20
-			semver.MustParse("v1.20.2"),
-			semver.MustParse("v1.20.5"),
+			semver.MustParse("v1.20.11"),
 			// Kubernetes 1.21
-			semver.MustParse("v1.21.0"),
+			semver.MustParse("v1.21.5"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			// ======= 1.17 =======
@@ -246,6 +241,12 @@ var (
 				To:   "1.19.*",
 			},
 			{
+				// Auto-upgrade because of CVE-2021-25741
+				From:      ">= 1.19.0, < 1.19.15",
+				To:        "1.19.15",
+				Automatic: pointer.BoolPtr(true),
+			},
+			{
 				// Allow to next minor release
 				From: "1.19.*",
 				To:   "1.20.*",
@@ -258,6 +259,12 @@ var (
 				To:   "1.20.*",
 			},
 			{
+				// Auto-upgrade because of CVE-2021-25741
+				From:      ">= 1.20.0, < 1.20.11",
+				To:        "1.20.11",
+				Automatic: pointer.BoolPtr(true),
+			},
+			{
 				// Allow to next minor release
 				From: "1.20.*",
 				To:   "1.21.*",
@@ -268,6 +275,12 @@ var (
 				// Allow to change to any patch version
 				From: "1.21.*",
 				To:   "1.21.*",
+			},
+			{
+				// Auto-upgrade because of CVE-2021-25741
+				From:      ">= 1.21.0, < 1.21.5",
+				To:        "1.21.5",
+				Automatic: pointer.BoolPtr(true),
 			},
 		},
 	}

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -190,7 +190,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.19.9"),
+		Default: semver.MustParse("v1.20.11"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.6"),

--- a/pkg/test/e2e/expose-strategy/expose_strategy_suite_test.go
+++ b/pkg/test/e2e/expose-strategy/expose_strategy_suite_test.go
@@ -38,7 +38,7 @@ type testOptions struct {
 }
 
 var options = testOptions{
-	kubernetesVersion: *semver.NewSemverOrDie("v1.20.2"),
+	kubernetesVersion: *semver.NewSemverOrDie("v1.20.11"),
 }
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the list of supported Kubernetes versions and adds automatic update rules for all 1.19, 1.20 and 1.21 clusters, each to their latest patch releases that were just released.

**Does this PR introduce a user-facing change?**:
```release-note
Add Kubernetes 1.19.15 to the list of supported versions, including an automated update rule for all 1.19.x userclusters.
Add Kubernetes 1.20.11 to the list of supported versions, including an automated update rule for all 1.20.x userclusters.
Add Kubernetes 1.21.5 to the list of supported versions, including an automated update rule for all 1.21.x userclusters.
```
