### PR TITLE
Invalidate metering deployment on secrets changes

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -54,15 +55,18 @@ func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Cl
 		return fmt.Errorf("failed to reconcile metering ClusterRoleBindings: %v", err)
 	}
 
+	modifiers := []reconciling.ObjectModifier{
+		common.VolumeRevisionLabelsModifierFactory(ctx, client),
+	}
 	if err := reconciling.ReconcileCronJobs(ctx, []reconciling.NamedCronJobCreatorGetter{
 		cronJobCreator(seed.Name),
-	}, resources.KubermaticNamespace, client); err != nil {
+	}, resources.KubermaticNamespace, client, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile metering CronJob: %v", err)
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, []reconciling.NamedDeploymentCreatorGetter{
 		deploymentCreator(seed),
-	}, resources.KubermaticNamespace, client); err != nil {
+	}, resources.KubermaticNamespace, client, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile metering Deployment: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Invalidates the metering pods in case of credentials update.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7827

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
