### PR TITLE
revert updating metering configs

### DIFF
--- a/pkg/ee/metering/pvc.go
+++ b/pkg/ee/metering/pvc.go
@@ -65,11 +65,7 @@ func persistentVolumeClaimCreator(ctx context.Context, client ctrlruntimeclient.
 		return err
 	}
 
-	if err := updatePVCStorageSizeAndName(pvc, seed); err != nil {
-		return fmt.Errorf("failed to update pvc storage class name or size: %v", err)
-	}
-
-	return client.Update(ctx, pvc)
+	return nil
 }
 
 func updatePVCStorageSizeAndName(pvc *corev1.PersistentVolumeClaim, seed *kubermaticv1.Seed) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a quick fix to prevent attempting to update the PVC size. PVCs cannot simply be resized by changing a field, as they are (generally) immutable. Some CSI's might support it, but it's certainly not supported everywhere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
