### PR TITLE
Add CABundle for ccm

### DIFF
--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,6 +65,9 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.19.2
         name: cloud-controller-manager
         resources:
@@ -80,6 +83,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
           readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,6 +65,9 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2
         name: cloud-controller-manager
         resources:
@@ -80,6 +83,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
           readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,6 +65,9 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0
         name: cloud-controller-manager
         resources:
@@ -80,6 +83,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
           readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -65,6 +65,9 @@ spec:
         - '{"command":"/bin/openstack-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=1","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=openstack"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0
         name: cloud-controller-manager
         resources:
@@ -80,6 +83,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
           readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -35,6 +35,9 @@ spec:
         - '{"command":"/bin/vsphere-cloud-controller-manager","args":["--v=2","--cloud-provider=vsphere","--cloud-config=/etc/cloud/config","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.19.1
         name: cloud-controller-manager
         resources:
@@ -50,6 +53,9 @@ spec:
           readOnly: true
         - mountPath: /etc/cloud
           name: cloud-config
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       - args:
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -35,6 +35,9 @@ spec:
         - '{"command":"/bin/vsphere-cloud-controller-manager","args":["--v=2","--cloud-provider=vsphere","--cloud-config=/etc/cloud/config","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.20.0
         name: cloud-controller-manager
         resources:
@@ -50,6 +53,9 @@ spec:
           readOnly: true
         - mountPath: /etc/cloud
           name: cloud-config
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       - args:
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -35,6 +35,9 @@ spec:
         - '{"command":"/bin/vsphere-cloud-controller-manager","args":["--v=2","--cloud-provider=vsphere","--cloud-config=/etc/cloud/config","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.21.0
         name: cloud-controller-manager
         resources:
@@ -50,6 +53,9 @@ spec:
           readOnly: true
         - mountPath: /etc/cloud
           name: cloud-config
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       - args:
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -35,6 +35,9 @@ spec:
         - '{"command":"/bin/vsphere-cloud-controller-manager","args":["--v=2","--cloud-provider=vsphere","--cloud-config=/etc/cloud/config","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/kubermatic/certs/ca-bundle.pem
         image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.21.0
         name: cloud-controller-manager
         resources:
@@ -50,6 +53,9 @@ spec:
           readOnly: true
         - mountPath: /etc/cloud
           name: cloud-config
+        - mountPath: /etc/kubermatic/certs
+          name: ca-bundle
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       - args:
@@ -115,6 +121,9 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
       - emptyDir: {}
         name: http-prober-bin
 status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ca-bundle to vsphere and openstack ccm deployment

I adjusted the deployments based on the templates used in KubeOne

Fixes #7835

```release-note
NONE
```
