### PR TITLE
update nginx-ingress-controller to 1.0.0

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.1.11
-appVersion: 0.49.0
+version: 1.2.0
+appVersion: 1.0.0
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/charts/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/charts/nginx-ingress-controller/templates/clusterrole.yaml
@@ -46,10 +46,8 @@ rules:
   verbs:
   - get
   - list
-  - update
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -65,9 +63,16 @@ rules:
   - create
   - patch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
   verbs:
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/charts/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -82,6 +82,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: LD_PRELOAD
+          value: /usr/local/lib/libmimalloc.so
         ports:
         - name: http
           containerPort: 80

--- a/charts/nginx-ingress-controller/templates/role.yaml
+++ b/charts/nginx-ingress-controller/templates/role.yaml
@@ -46,11 +46,9 @@ rules:
   verbs:
   - get
   - list
-  - update
   - watch
 - apiGroups:
-  - extensions
-  - "networking.k8s.io" # k8s 1.14+
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:
@@ -58,18 +56,25 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
-  - "networking.k8s.io" # k8s 1.14+
+  - networking.k8s.io
   resources:
   - ingresses/status
   verbs:
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps
   resourceNames:
-  - "ingress-controller-leader-nginx"
+  - ingress-controller-leader-nginx
   verbs:
   - get
   - update

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -18,7 +18,7 @@ nginx:
   replicas: 3
   image:
     repository: k8s.gcr.io/ingress-nginx/controller
-    tag: v0.49.0
+    tag: v1.0.0
   config: {}
 #   load-balance: "least_conn"
   extraArgs: []


### PR DESCRIPTION
**What this PR does / why we need it**:
nginx-ingress-controller 0.x does not support Kubernetes 1.22. I forgot to update nginx before the 2.18 release, this PR fixes that.

_Technically_ this is a breaking change, but we document that master/seeds need to be 1.19-1.22, so it should not actually be a break.

I assume that during the hackathon, we will most likely deprecate this chart and recommend using the upstream chart instead. For this reason I am not adding any support for IngressClass to this chart.

**Does this PR introduce a user-facing change?**:
```release-note
update nginx-ingress-controller to 1.0.0 to support Kubernetes 1.22 master/seed clusters
```
