### PR TITLE
update Dex to 2.30.0

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: oauth
-version: 1.5.8
-appVersion: v2.27.0
+version: 1.6.0
+appVersion: v2.30.0
 description: Dex
 keywords:
 - kubermatic

--- a/charts/oauth/templates/configmap.yaml
+++ b/charts/oauth/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
     web:
       http: 0.0.0.0:5556
     frontend:
+      dir: /srv/dex/web
       logoURL: theme/logo.svg
     telemetry:
       http: 0.0.0.0:5558

--- a/charts/oauth/templates/deployment.yaml
+++ b/charts/oauth/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - name: config
           mountPath: /etc/dex/cfg
         - name: themes
-          mountPath: /web/themes/coreos
+          mountPath: /srv/dex/web/themes/light
           readOnly: true
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.certMount | trim | indent 8 }}
 {{- end }}

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -15,7 +15,7 @@
 dex:
   image:
     repository: "docker.io/dexidp/dex"
-    tag: "v2.27.0"
+    tag: "v2.30.0"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec

--- a/pkg/test/e2e/utils/dex/client.go
+++ b/pkg/test/e2e/utils/dex/client.go
@@ -116,14 +116,15 @@ func (c *Client) fetchLoginURL(ctx context.Context) (*url.URL, error) {
 		return nil, fmt.Errorf("invalid provider URL %q: %v", c.ProviderURI, err)
 	}
 
+	// make sure we are seeing the email login form immediately
+	loginURL.Path += "/local"
+
 	params := loginURL.Query()
 	params.Set("client_id", c.ClientID)
 	params.Set("redirect_uri", c.RedirectURI)
 	params.Set("response_type", "id_token")
 	params.Set("scope", "openid profile email")
 	params.Set("nonce", "not-actually-a-nonce")
-	// make sure we are redirected and not greeted with a "choose your login method page"
-	params.Set("connector_id", "local")
 	loginURL.RawQuery = params.Encode()
 
 	c.log.Debugw("Fetching OIDC login page", "url", loginURL.String())


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings Kubernetes 1.22 compatibility.

**Does this PR introduce a user-facing change?**:
```release-note
update Dex to 2.30.0
```
