### PR TITLE
Allow cilium as CNI plugin

### DIFF
--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -193,6 +193,9 @@ const (
 	// CNIPluginTypeCanal corresponds to Canal CNI plugin (i.e. Flannel +
 	// Calico for policy enforcement).
 	CNIPluginTypeCanal CNIPluginType = "canal"
+
+	// CNIPluginTypeCilium corresponds to Cilium CNI plugin
+	CNIPluginTypeCilium CNIPluginType = "cilium"
 )
 
 const (

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -37,9 +37,10 @@ import (
 )
 
 var (
-	supportedCNIPlugins        = sets.NewString(kubermaticv1.CNIPluginTypeCanal.String())
+	supportedCNIPlugins        = sets.NewString(kubermaticv1.CNIPluginTypeCanal.String(), kubermaticv1.CNIPluginTypeCilium.String())
 	supportedCNIPluginVersions = map[kubermaticv1.CNIPluginType]sets.String{
-		kubermaticv1.CNIPluginTypeCanal: sets.NewString("v3.8", "v3.19"),
+		kubermaticv1.CNIPluginTypeCanal:  sets.NewString("v3.8", "v3.19"),
+		kubermaticv1.CNIPluginTypeCilium: sets.NewString("v1.10"),
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we support only canal as a CNI plugin. This allows to specify different cluster CNI and is a first initial step of adding cilium as an alternative CNI addon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
