### PR TITLE
Default CNI plugin version for each supported type

### DIFF
--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -34,6 +34,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+var (
+	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
+		kubermaticv1.CNIPluginTypeCanal:  "v3.19",
+		kubermaticv1.CNIPluginTypeCilium: "v1.10",
+	}
+)
+
 // AdmissionHandler for mutating Kubermatic Cluster CRD.
 type AdmissionHandler struct {
 	log     logr.Logger
@@ -100,8 +107,10 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) {
 	if c.Spec.CNIPlugin == nil {
 		c.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
 			Type:    kubermaticv1.CNIPluginTypeCanal,
-			Version: "v3.19",
+			Version: defaultCNIPluginVersion[kubermaticv1.CNIPluginTypeCanal],
 		}
+	} else if c.Spec.CNIPlugin.Version == "" {
+		c.Spec.CNIPlugin.Version = defaultCNIPluginVersion[c.Spec.CNIPlugin.Type]
 	}
 
 	if len(c.Spec.ClusterNetwork.Services.CIDRBlocks) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
It was decided we don't want to expose CNI plugin versions in the UI for https://github.com/kubermatic/dashboard/pull/3709, so we would like to default the versions for each plugin on the backend side.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
