### PR TITLE
update nginx-ingress-controller to 1.0.2

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.2.0
-appVersion: 1.0.0
+version: 1.2.1
+appVersion: 1.0.2
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -18,7 +18,7 @@ nginx:
   replicas: 3
   image:
     repository: k8s.gcr.io/ingress-nginx/controller
-    tag: v1.0.0
+    tag: v1.0.2
   config: {}
 #   load-balance: "least_conn"
   extraArgs: []


### PR DESCRIPTION
**What this PR does / why we need it**:
v1.0.1 and 1.0.2 have a bunch of important bugfixes: https://github.com/kubernetes/ingress-nginx/releases

**Does this PR introduce a user-facing change?**:
```release-note
update nginx-ingress-controller to 1.0.2
```
