### PR TITLE
Fix MLA certificate issue by LB expose strategy

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 	"text/template"
 
@@ -471,6 +472,10 @@ func GatewayCertificateCreator(c *kubermaticv1.Cluster, mlaGatewayCAGetter func(
 					commonName,
 					c.Address.ExternalName, // required for NodePort expose strategy
 				},
+			}
+			cIP := net.ParseIP(c.Address.IP)
+			if cIP != nil {
+				altNames.IPs = []net.IP{cIP} // required for LoadBalancer expose strategy
 			}
 			if b, exists := se.Data[resources.MLAGatewayCertSecretKey]; exists {
 				certs, err := certutil.ParseCertsPEM(b)


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Fixes user cluster MLA certificate issue by LoadBalancer expose strategy, when LB IP address is used for exposing MLA Gateway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7843

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed user cluster MLA certificate issue by LoadBalancer expose strategy.
```
