### PR TITLE
Update build image from go-1.17-node-14-0 to go-1.17-node-14-1

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - make
         args:
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - "./hack/verify-kubermatic-chart.sh"
         resources:
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - "./hack/verify-docs.sh"
         resources:
@@ -199,7 +199,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - make
         args:
@@ -217,7 +217,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - make
         args:
@@ -260,7 +260,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - ./hack/verify-licenses.sh
         resources:
@@ -307,7 +307,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - "./hack/ci/verify-user-cluster-prometheus-configs.sh"
         env:
@@ -324,7 +324,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-1
         command:
         - ./hack/ci/test-github-release.sh
         resources:
@@ -343,7 +343,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -367,7 +367,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -404,7 +404,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -445,7 +445,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -486,7 +486,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -527,7 +527,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -568,7 +568,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -615,7 +615,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -661,7 +661,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -704,7 +704,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -752,7 +752,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -795,7 +795,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -838,7 +838,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -881,7 +881,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -926,7 +926,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -971,7 +971,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1016,7 +1016,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1060,7 +1060,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1106,7 +1106,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1156,7 +1156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         imagePullPolicy: Always
         command:
         - "./hack/ci/run-api-e2e.sh"
@@ -1198,7 +1198,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
@@ -1235,7 +1235,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         imagePullPolicy: Always
         command:
         - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -1266,7 +1266,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -1303,7 +1303,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         imagePullPolicy: Always
         command:
         - ./hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -1332,7 +1332,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -1363,7 +1363,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+      - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.17-node-14-0 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.17-node-14-1 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -e
 cd $(dirname $0)/..
 . hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.17-node-14-0 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.17-node-14-1 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This update includes fixes required to make building and pushing the user-ssh-keys-agent work.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
