### PR TITLE
stop publishing Docker images to quay.io/kubermatic/api

### DIFF
--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -84,11 +84,6 @@ for ARCH in ${ARCHITECTURES}; do
   buildah manifest add "${DOCKER_REPO}/user-ssh-keys-agent:${PRIMARY_TAG}" "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${PRIMARY_TAG}"
 done
 
-# keep a mirror of the EE version in the old repo
-if [ "$KUBERMATIC_EDITION" == "ee" ]; then
-  docker tag "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${PRIMARY_TAG}" "${DOCKER_REPO}/api:${PRIMARY_TAG}"
-fi
-
 # for each given tag, tag and push the image
 for TAG in "$@"; do
   if [ -z "$TAG" ]; then
@@ -110,9 +105,4 @@ for TAG in "$@"; do
   docker push "${DOCKER_REPO}/addons:${TAG}"
   docker push "${DOCKER_REPO}/etcd-launcher:${TAG}"
   buildah manifest push --all "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" "docker://${DOCKER_REPO}/user-ssh-keys-agent:${TAG}"
-
-  if [ "$KUBERMATIC_EDITION" == "ee" ]; then
-    docker tag "${DOCKER_REPO}/api:${PRIMARY_TAG}" "${DOCKER_REPO}/api:${TAG}"
-    docker push "${DOCKER_REPO}/api:${TAG}"
-  fi
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
With KKP 2.14, we switched to the new repo at `quay.io/kubermatic/kubermatic` and only kept the old repo around for users of the legacy Helm chart. This is now over so we can stop updating the `api` repo.

**Does this PR introduce a user-facing change?**:
```release-note
The old Docker repository at `quay.io/kubermatic/api` will not receive new images anymore, please use `quay.io/kubermatic/kubermatic` (CE) or `quay.io/kubermatic/kubermatic-ee` (EE) instead. This should only affect EE users who were still using the deprecated Helm chart.
```
