### PR TITLE
Add configurable root_url for grafana

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.5.2
+version: 1.5.3
 appVersion: 8.1.2
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/config/grafana.ini
+++ b/charts/monitoring/grafana/config/grafana.ini
@@ -17,3 +17,7 @@ auto_sign_up = true
 [users]
 viewers_can_edit = {{ .Values.grafana.provisioning.configuration.viewers_can_edit }}
 auto_assign_org_role = {{ .Values.grafana.provisioning.configuration.auto_assign_org_role }}
+{{ if .Values.grafana.provisioning.configuration.root_url }}
+[server]
+root_url = {{ .Values.grafana.provisioning.configuration.root_url | quote }}
+{{- end }}

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -119,6 +119,12 @@ grafana:
       # the dashboards.
       viewers_can_edit: false
 
+      # Change this to the URL that will be used to expose 
+      # your Grafana installation. This is needed for Grafana to be aware
+      # where it is hosted. This address is used in some redirects 
+      # or for sharing dashboards. 
+      root_url: ""
+
   # If you manage your dashboards via your own configmaps,
   # you can add them here to have them automatically be
   # mounted in Grafana. For each volume, specify either a


### PR DESCRIPTION


**What this PR does / why we need it**:
Starting with v. 8.0, grafana is using webhooks for continuous connection. They fail to upgrade if there is no correct value for root_url.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7915

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added configurable root_url option for grafana.
```
