### PR TITLE
Fix flaky dc e2e

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -136,3 +136,21 @@ spec:
             minimum_memory: 0
             minimum_vcpus: 0
           region: dbl
+    dc-to-delete:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    dc-to-update:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    dc-to-patch:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -1251,7 +1251,11 @@ func (r *TestClient) ListDCForProvider(provider string) ([]*models.Datacenter, e
 	params := &datacenter.ListDCForProviderParams{
 		Provider: provider,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	list, err := r.client.Datacenter.ListDCForProvider(params, r.bearerToken)
 	if err != nil {
@@ -1266,7 +1270,11 @@ func (r *TestClient) GetDCForProvider(provider, dc string) (*models.Datacenter, 
 		Provider:   provider,
 		Datacenter: dc,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	receivedDC, err := r.client.Datacenter.GetDCForProvider(params, r.bearerToken)
 	if err != nil {
@@ -1284,7 +1292,11 @@ func (r *TestClient) CreateDC(seed string, dc *models.Datacenter) (*models.Datac
 		},
 		Seed: seed,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	createdDC, err := r.client.Datacenter.CreateDC(params, r.bearerToken)
 	if err != nil {
@@ -1300,7 +1312,11 @@ func (r *TestClient) DeleteDC(seed, dc string) error {
 		DC:   dc,
 	}
 	// HTTP400 is returned when the DC is not yet available in the Seed
-	SetupParams(r.test, params, 1*time.Second, 5*time.Minute, http.StatusBadRequest)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	}, http.StatusBadRequest)
 
 	_, err := r.client.Datacenter.DeleteDC(params, r.bearerToken)
 	return err
@@ -1335,7 +1351,11 @@ func (r *TestClient) PatchDC(seed, dcToPatch, patch string) (*models.Datacenter,
 		DCToPatch: dcToPatch,
 		Seed:      seed,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	patchedDC, err := r.client.Datacenter.PatchDC(params, r.bearerToken)
 	if err != nil {
@@ -1350,7 +1370,11 @@ func (r *TestClient) GetDCForSeed(seed, dc string) (*models.Datacenter, error) {
 		Seed: seed,
 		DC:   dc,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute, http.StatusNotFound)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	}, http.StatusNotFound)
 
 	receivedDC, err := r.client.Datacenter.GetDCForSeed(params, r.bearerToken)
 	if err != nil {
@@ -1364,7 +1388,11 @@ func (r *TestClient) ListDCForSeed(seed string) ([]*models.Datacenter, error) {
 	params := &datacenter.ListDCForSeedParams{
 		Seed: seed,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	list, err := r.client.Datacenter.ListDCForSeed(params, r.bearerToken)
 	if err != nil {
@@ -1378,7 +1406,11 @@ func (r *TestClient) GetDC(dc string) (*models.Datacenter, error) {
 	params := &datacenter.GetDatacenterParams{
 		DC: dc,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	receivedDC, err := r.client.Datacenter.GetDatacenter(params, r.bearerToken)
 	if err != nil {
@@ -1390,7 +1422,11 @@ func (r *TestClient) GetDC(dc string) (*models.Datacenter, error) {
 
 func (r *TestClient) ListDC() ([]*models.Datacenter, error) {
 	params := &datacenter.ListDatacentersParams{}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	list, err := r.client.Datacenter.ListDatacenters(params, r.bearerToken)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
looking for a fix for the flaky dc e2e tests. They were mostly failing because in the Delete/Patch/Update tests, the DC that was being created, was missing, even though the create succeeded. I couldnt determine if the reason for that is some cache issue or a race.

But creating the needed DCs in the Seed beforehand stabilizes the tests, as they dont depend on Create anymore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7928

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
