### PR TITLE
Fix LB expose strategy for LBs with external DNS names instead of IPs

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -53,8 +53,12 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 	}
 
 	// Deploy & Update master components for Kubernetes
-	if err := r.ensureResourcesAreDeployed(ctx, cluster); err != nil {
+	res, err := r.ensureResourcesAreDeployed(ctx, cluster)
+	if err != nil {
 		return nil, err
+	}
+	if !res.IsZero() {
+		return res, nil
 	}
 
 	var finalizers []string

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -73,7 +73,7 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	// strategy is used. Its required for all Kubeconfigs & triggers errors
 	// otherwise.
 	if cluster.Address.IP == "" && cluster.Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
-		return nil
+		return fmt.Errorf("cluster IP address is not set")
 	}
 
 	// check that all secrets are available // New way of handling secrets
@@ -263,7 +263,7 @@ func GetServiceCreators(data *resources.TemplateData) []reconciling.NamedService
 	}
 
 	if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
-		creators = append(creators, nodeportproxy.FrontLoadBalancerServiceCreator())
+		creators = append(creators, nodeportproxy.FrontLoadBalancerServiceCreator(data))
 	}
 
 	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureRancherIntegration]; flag {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -19,6 +19,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"time"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -47,71 +48,79 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+const (
+	clusterIPUnknownRetryTimeout = 5 * time.Second
+)
+
+func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	seed, err := r.seedGetter()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	data, err := r.getClusterTemplateData(ctx, cluster, seed)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all services are available
 	if err := r.ensureServices(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Set the hostname & url
 	if err := r.syncAddress(ctx, r.log.With("cluster", cluster.Name), cluster, seed); err != nil {
-		return fmt.Errorf("failed to sync address: %v", err)
+		return nil, fmt.Errorf("failed to sync address: %v", err)
 	}
 
 	// We should not proceed without having an IP address unless tunneling
 	// strategy is used. Its required for all Kubeconfigs & triggers errors
 	// otherwise.
 	if cluster.Address.IP == "" && cluster.Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
-		return fmt.Errorf("cluster IP address is not set")
+		// This can happen e.g. if a LB external IP address has not yet been allocated by a CCM.
+		// Try to reconcile after some time and do not return an error.
+		r.log.Debugf("Cluster IP address not known, retry after %.0f s", clusterIPUnknownRetryTimeout.Seconds())
+		return &reconcile.Result{RequeueAfter: clusterIPUnknownRetryTimeout}, nil
 	}
 
 	// check that all secrets are available // New way of handling secrets
 	if err := r.ensureSecrets(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureServiceAccounts(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureRoles(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureRoleBindings(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureClusterRoles(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureClusterRoleBindings(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureNetworkPolicies(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all StatefulSets are created
 	if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureEtcdBackupConfigs(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Wait until the cloud provider infra is ready before attempting
@@ -121,59 +130,59 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	// isn't working correctly"
 	// https://github.com/kubermatic/kubermatic/issues/2948
 	if kubermaticv1.HealthStatusUp != cluster.Status.ExtendedHealth.CloudProviderInfrastructure {
-		return nil
+		return nil, nil
 	}
 
 	// check that all ConfigMaps are available
 	if err := r.ensureConfigMaps(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all Deployments are available
 	if err := r.ensureDeployments(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// This needs to happen after other secrets are created
 	// because it uses some secrets created in previous steps.
 	if data.IsKonnectivityEnabled() {
 		if err := r.ensureKonnectivitySecrets(ctx, cluster, data); err != nil {
-			return err
+			return nil, err
 		}
 
 		// check that all Deployments are available
 		if err := r.ensureKonnectivityDeployments(ctx, cluster, data); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	// check that all CronJobs are created
 	if err := r.ensureCronJobs(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all PodDisruptionBudgets are created
 	if err := r.ensurePodDisruptionBudgets(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all VerticalPodAutoscalers are created
 	if err := r.ensureVerticalPodAutoscalers(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
 		if err := nodeportproxy.EnsureResources(ctx, r.Client, data); err != nil {
-			return fmt.Errorf("failed to ensure NodePortProxy resources: %v", err)
+			return nil, fmt.Errorf("failed to ensure NodePortProxy resources: %v", err)
 		}
 	}
 
 	// Remove possible leftovers of older version of Gatekeeper, remove this in 1.19
 	if err := r.ensureOldOPAIntegrationIsRemoved(ctx, data); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &reconcile.Result{}, nil
 }
 
 func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) (*resources.TemplateData, error) {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -210,11 +210,11 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		userClusterConnProvider: new(testUserClusterConnectionProvider),
 	}
 
-	if err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
+	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
 		t.Fatalf("Initial resource deployment failed, this indicates that some resources are invalid. Error: %v", err)
 	}
 
-	if err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
+	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
 		t.Fatalf("The second resource reconciliation failed, indicating we don't properly default some fields. Check the `Object differs from generated one` error for the object for which we timed out. Original error: %v", err)
 	}
 

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -161,7 +161,7 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 			ip = frontProxyLBServiceIP
 		} else {
 			var err error
-			// Always lookup IP address, in case it changes (IP's on AWS LB's change)
+			// Always lookup IP address, in case it changes
 			ip, err = m.getExternalIPv4(frontProxyLBServiceHostname)
 			if err != nil {
 				return nil, err

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -136,7 +136,7 @@ func TestSyncClusterAddress(t *testing.T) {
 			frontproxyService: corev1.Service{
 				Status: corev1.ServiceStatus{
 					LoadBalancer: corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{{Hostname: "xyz.eu-central-1.cloudprovider.test"}},
+						Ingress: []corev1.LoadBalancerIngress{{Hostname: loadbBalancerHostName}},
 					},
 				},
 			},

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -38,6 +38,7 @@ const (
 	fakeExternalURL          = "dev.kubermatic.io"
 	fakeClusterNamespaceName = "cluster-ns"
 	externalIP               = "34.89.181.151"
+	loadbBalancerHostName    = "xyz.eu-central-1.cloudprovider.test"
 	testDomain               = "dns-test.kubermatic.io"
 )
 
@@ -48,6 +49,8 @@ func testLookupFunction(host string) ([]net.IP, error) {
 	case "fake-cluster.europe-west3-c.dev.kubermatic.io":
 		fallthrough
 	case "fake-cluster.alias-europe-west3-c.dev.kubermatic.io":
+		return []net.IP{net.IPv4(34, 89, 181, 151)}, nil
+	case loadbBalancerHostName:
 		return []net.IP{net.IPv4(34, 89, 181, 151)}, nil
 	default:
 		return []net.IP{}, nil
@@ -121,6 +124,27 @@ func TestSyncClusterAddress(t *testing.T) {
 			expectedIP:           "1.2.3.4",
 			expectedPort:         int32(443),
 			expectedURL:          "https://1.2.3.4:443",
+		},
+		{
+			name: "Verify properties for service type LoadBalancer with LB hostname instead of IP",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{NodePort: int32(443)},
+					},
+				}},
+			frontproxyService: corev1.Service{
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{Hostname: "xyz.eu-central-1.cloudprovider.test"}},
+					},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyLoadBalancer,
+			expectedExternalName: loadbBalancerHostName,
+			expectedIP:           externalIP,
+			expectedPort:         int32(443),
+			expectedURL:          fmt.Sprintf("https://%s:443", loadbBalancerHostName),
 		},
 		{
 			name: "Verify properties for service type NodePort",

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -437,8 +437,14 @@ func FrontLoadBalancerServiceCreator(data *resources.TemplateData) reconciling.N
 				if s.Annotations == nil {
 					s.Annotations = make(map[string]string)
 				}
+				// NOTE: While KKP uses in-tree cloud provider for AWS, we use annotations defined in
+				// https://github.com/kubernetes/kubernetes/blob/v1.22.2/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+
+				// Make sure to use Network Load Balancer with fixed IPs instead of Classic Load Balancer
 				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+				// Extend the default idle timeout (60s), e.g. to not timeout "kubectl logs -f"
 				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"] = "3600"
+				// Load-balance across nodes in all zones to ensure HA if nodes in a DNS-selected zone are not available
 				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
 			}
 			s.Spec.Selector = resources.BaseAppLabels(envoyAppLabelValue, nil)

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -416,7 +416,7 @@ func podDisruptionBudget() reconciling.NamedPodDisruptionBudgetCreatorGetter {
 
 // FrontLoadBalancerServiceCreator returns the creator for the LoadBalancer that fronts apiserver
 // and openVPN when using exposeStrategy=LoadBalancer
-func FrontLoadBalancerServiceCreator() reconciling.NamedServiceCreatorGetter {
+func FrontLoadBalancerServiceCreator(data *resources.TemplateData) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.FrontLoadBalancerServiceName, func(s *corev1.Service) (*corev1.Service, error) {
 			// We don't actually manage this service, that is done by the nodeport proxy, we just
@@ -433,7 +433,14 @@ func FrontLoadBalancerServiceCreator() reconciling.NamedServiceCreatorGetter {
 					},
 				}
 			}
-
+			if data.Cluster().Spec.Cloud.AWS != nil {
+				if s.Annotations == nil {
+					s.Annotations = make(map[string]string)
+				}
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"] = "3600"
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+			}
 			s.Spec.Selector = resources.BaseAppLabels(envoyAppLabelValue, nil)
 			return s, nil
 		}

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -437,7 +437,7 @@ func FrontLoadBalancerServiceCreator(data *resources.TemplateData) reconciling.N
 				if s.Annotations == nil {
 					s.Annotations = make(map[string]string)
 				}
-				// NOTE: While KKP uses in-tree cloud provider for AWS, we use annotations defined in
+				// NOTE: While KKP uses in-tree CCM for AWS, we use annotations defined in
 				// https://github.com/kubernetes/kubernetes/blob/v1.22.2/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
 
 				// Make sure to use Network Load Balancer with fixed IPs instead of Classic Load Balancer

--- a/pkg/resources/test/fixtures/service-aws-1.19.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.19.0-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.21.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.21.0-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes LoadBalancer expose strategy for cases where load-balancers provide an external DNS name instead of an external IP, such as in AWS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7108

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix LoadBalancer expose strategy for LBs with external DNS names instead of IPs
```
