### PR TITLE
CaBundle for csi

### DIFF
--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -142,6 +142,8 @@ spec:
               value: /etc/config/config
             - name: CLUSTER_NAME
               value: {{ .Cluster.Name }}
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 9808
@@ -162,11 +164,17 @@ spec:
             - name: cloud-config
               mountPath: /etc/config
               readOnly: true
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
+              readOnly: true
       volumes:
         - name: socket-dir
           emptyDir:
         - name: cloud-config
           secret:
             secretName: cloud-config
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
 {{ end }}
 {{ end }}

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -101,6 +101,8 @@ spec:
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/config
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 9808
@@ -127,6 +129,9 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
+              readOnly: true
       volumes:
         - name: socket-dir
           hostPath:
@@ -147,5 +152,8 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
 {{ end }}
 {{ end }}

--- a/addons/csi/vsphere/csiAdmissionWebhook.yaml
+++ b/addons/csi/vsphere/csiAdmissionWebhook.yaml
@@ -94,9 +94,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           volumeMounts:
             - mountPath: /etc/webhook
               name: webhook-certs
+              readOnly: true
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
               readOnly: true
       volumes:
         - name: socket-dir
@@ -104,6 +109,9 @@ spec:
         - name: webhook-certs
           secret:
             secretName: csi-migration-webhook-certs
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
 {{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/vsphere/csiController.yaml
+++ b/addons/csi/vsphere/csiController.yaml
@@ -100,12 +100,17 @@ spec:
                   fieldPath: metadata.namespace
             - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
               value: 3m
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
             - mountPath: /csi
               name: socket-dir
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
+              readOnly: true
           ports:
             - name: healthz
               containerPort: 9808
@@ -155,9 +160,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
               readOnly: true
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v2.1.0
@@ -184,6 +194,9 @@ spec:
             secretName: cloud-config-csi
         - name: socket-dir
           emptyDir: {}
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
 ---
 apiVersion: v1
 data:

--- a/addons/csi/vsphere/csiNode-ds.yaml
+++ b/addons/csi/vsphere/csiNode-ds.yaml
@@ -103,6 +103,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           securityContext:
             privileged: true
             capabilities:
@@ -126,6 +128,9 @@ spec:
               mountPath: /sys/block
             - name: sys-devices-dir
               mountPath: /sys/devices
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
+              readOnly: true
           ports:
             - containerPort: 9808
               name: healthz
@@ -173,6 +178,9 @@ spec:
           hostPath:
             path: /sys/devices
             type: Directory
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
       tolerations:
         - effect: NoExecute
           operator: Exists


### PR DESCRIPTION
**What this PR does / why we need it**:
Usage of KKP provided CA-Bundle in csi controllers for Vsphere and Openstack


Fixes #7855



```release-note
NONE
```
