### PR TITLE
Update nginx-ingress role with proper name of configmap (electionID)

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.0.2
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/templates/role.yaml
+++ b/charts/nginx-ingress-controller/templates/role.yaml
@@ -74,7 +74,7 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - ingress-controller-leader-nginx
+  - ingress-controller-leader
   verbs:
   - get
   - update


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit is fixing the role definition for nginx helm chart as the current version fails on following error (in controller pods):
```
Failed to update lock: configmaps "ingress-controller-leader" is forbidden: User "system:serviceaccount:nginx-ingress-controller:nginx-ingress-controller" cannot update resource "configmaps" in API group "" in the namespace "nginx-ingress-controller"
```

Most likely caused by incomplete sync of upgraded helm chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7941 

**Special notes for your reviewer**: 
I am not sure how many parts of the nginx-ingress chart are customized in kkp repository but in general the switch to use upstream helm chart may resolve this kind of issues.

**Documentation**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Fix nginx-ingress role to allow update of leader configmap
```