### PR TITLE
Use PublishNotReadyAddresses for etcd clusters

### DIFF
--- a/pkg/resources/etcd/etcdservices.go
+++ b/pkg/resources/etcd/etcdservices.go
@@ -39,10 +39,8 @@ func ServiceCreator(data serviceCreatorData) reconciling.NamedServiceCreatorGett
 		return resources.EtcdServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.EtcdServiceName
 			se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-			se.Annotations = map[string]string{
-				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-			}
 			se.Spec.ClusterIP = "None"
+			se.Spec.PublishNotReadyAddresses = true
 			se.Spec.Selector = map[string]string{
 				resources.AppLabelKey: name,
 				"cluster":             data.Cluster().Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

The annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` was deprecated in Kubernetes v1.9, and replaced by `Service.spec.publishNotReadyAddresses` in [v1.11.0-beta.1](https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.11.md?plain=1#L2113).

While the annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` is [still implemented for `Endpoints`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpoint/endpoints_controller.go#L421-L430) on `master`, it is [not implemented for `EndpointSlices`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpointslice/utils.go#L43-L83). Therefore, any consumers that have updated to use `EndpointSlices` [(i.e. CoreDNS)](https://github.com/coredns/coredns/blob/9f72db12e73d6f1b7f69812baa4381fc7a1f04b3/plugin/kubernetes/README.md#monitoring-kubernetes-endpoints) in clusters v1.18-v1.21 that enable `EndpointSliceProxying` and by [default on versions ≥v1.22.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md?plain=1#L651) will not list unready pods.

Given that Kubermatic does not support versions before Kubernetes v1.17, it is safe to do a direct cut from the annotation to `publishNotReadyAddresses`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:

Please consider backporting as this causes all child clusters deployed on seed clusters with feature gate `EndpointSliceProxying` enabled ([Beta v1.19, GA v1.22](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)) to fail, as members of the etcd statefulset are unable to resolve their peers addresses

I have been unable to locate the code that generates the `pkg/resources/test/fixtures/service-*-{kubernetes-semver}-etcd*.yaml` test fixtures to make the correction in the generated code.

Additionally this is present in [kubermatic/kubermatic-installer](https://github.com/kubermatic/kubermatic-installer/search?q=tolerate-unready-endpoints), but given that has moved into `kubermatic/kubermatic` and the repo is archived I have not submitted a PR

Release note is quite verbose, consider alternative:
```
Child cluster etcd services now use `spec.publishNotReadyAddresses` to ensure compatibility with `EndpointSlice` consumers
```

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
None

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Child cluster etcd services now use `spec.publishNotReadyAddresses` instead of the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation (deprecated in Kubernetes v1.11) to ensure compatibility with `EndpointSlice` consumers
```
