### PR TITLE
Fix flaky logout API e2e test

### DIFF
--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -137,9 +137,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if !kuberneteshelper.HasFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer) {
-		oldUser := user.DeepCopy()
 		kuberneteshelper.AddFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer)
-		if err := r.masterClient.Patch(ctx, user, ctrlruntimeclient.MergeFrom(oldUser)); err != nil {
+		if err := r.masterClient.Update(ctx, user); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add user finalizer %s: %w", user.Name, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -105,8 +105,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if !kuberneteshelper.HasFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer) {
+		oldUser := user.DeepCopy()
 		kuberneteshelper.AddFinalizer(user, kubermaticapiv1.SeedUserCleanupFinalizer)
-		if err := r.masterClient.Update(ctx, user); err != nil {
+		if err := r.masterClient.Patch(ctx, user, ctrlruntimeclient.MergeFrom(oldUser)); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add user finalizer %s: %w", user.Name, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 
 	"go.uber.org/zap"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -124,7 +124,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	user := &kubermaticv1.User{}
 	// using the reader here to bypass the cache. It is necessary because we update the same object we are watching
 	// in the case when master and seed clusters are on the same cluster. Otherwise, the old cache state can overwrite
-	// the update.
+	// the update. Ideally, we would not reconcile the resource whose change caused the reconciliation.
 	if err := r.masterAPIReader.Get(ctx, request.NamespacedName, user); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
@@ -84,10 +84,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			r := &reconciler{
-				log:          kubermaticlog.Logger,
-				recorder:     &record.FakeRecorder{},
-				masterClient: tc.masterClient,
-				seedClients:  map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+				log:             kubermaticlog.Logger,
+				recorder:        &record.FakeRecorder{},
+				masterClient:    tc.masterClient,
+				seedClients:     map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+				masterAPIReader: tc.masterClient,
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/provider/kubernetes/user.go
+++ b/pkg/provider/kubernetes/user.go
@@ -250,14 +250,15 @@ func ensureTokenBlacklistSecret(ctx context.Context, client ctrlruntimeclient.Cl
 	}
 
 	if user.Spec.TokenBlackListReference == nil {
+		oldUser := user.DeepCopy()
 		user.Spec.TokenBlackListReference = &providerconfig.GlobalSecretKeySelector{
 			ObjectReference: corev1.ObjectReference{
 				Name:      name,
 				Namespace: resources.KubermaticNamespace,
 			},
 		}
-		if err := client.Update(ctx, user); err != nil {
-			return nil, fmt.Errorf("failed to update user: %v", err)
+		if err := client.Patch(ctx, user, ctrlruntimeclient.MergeFrom(oldUser)); err != nil {
+			return nil, fmt.Errorf("failed to patch user: %v", err)
 		}
 	}
 

--- a/pkg/provider/kubernetes/user.go
+++ b/pkg/provider/kubernetes/user.go
@@ -250,15 +250,14 @@ func ensureTokenBlacklistSecret(ctx context.Context, client ctrlruntimeclient.Cl
 	}
 
 	if user.Spec.TokenBlackListReference == nil {
-		oldUser := user.DeepCopy()
 		user.Spec.TokenBlackListReference = &providerconfig.GlobalSecretKeySelector{
 			ObjectReference: corev1.ObjectReference{
 				Name:      name,
 				Namespace: resources.KubermaticNamespace,
 			},
 		}
-		if err := client.Patch(ctx, user, ctrlruntimeclient.MergeFrom(oldUser)); err != nil {
-			return nil, fmt.Errorf("failed to patch user: %v", err)
+		if err := client.Update(ctx, user); err != nil {
+			return nil, fmt.Errorf("failed to update user: %v", err)
 		}
 	}
 

--- a/pkg/test/e2e/api/logout_test.go
+++ b/pkg/test/e2e/api/logout_test.go
@@ -61,8 +61,13 @@ func TestLogout(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get master token: %v", err)
 			}
-
 			testClient := utils.NewTestClient(masterToken, t)
+			// user gets create when we do a first API action
+			_, err = testClient.ListDC()
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			if err := testClient.Logout(); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/test/e2e/api/logout_test.go
+++ b/pkg/test/e2e/api/logout_test.go
@@ -62,7 +62,7 @@ func TestLogout(t *testing.T) {
 				t.Fatalf("failed to get master token: %v", err)
 			}
 			testClient := utils.NewTestClient(masterToken, t)
-			// user gets create when we do a first API action
+			// user gets created when we do a first API action
 			_, err = testClient.ListDC()
 			if err != nil {
 				t.Fatal(err)
@@ -72,7 +72,7 @@ func TestLogout(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// test projection creation, ignore created result, or other error codes other then Unauthorized
+			// test projection creation, ignore results that are not Unauthorized
 			_, err = testClient.CreateProject(rand.String(10), http.StatusCreated, http.StatusForbidden, http.StatusBadRequest, http.StatusConflict)
 			if err == nil {
 				t.Fatal("create project: expected error")

--- a/pkg/test/e2e/api/logout_test.go
+++ b/pkg/test/e2e/api/logout_test.go
@@ -23,14 +23,10 @@ import (
 	"net/http"
 	"testing"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/credentials"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/datacenter"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/project"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 )
@@ -71,8 +67,8 @@ func TestLogout(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// test projection creation
-			_, err = testClient.CreateProject(rand.String(10))
+			// test projection creation, ignore created result, or other error codes other then Unauthorized
+			_, err = testClient.CreateProject(rand.String(10), http.StatusCreated, http.StatusForbidden, http.StatusBadRequest, http.StatusConflict)
 			if err == nil {
 				t.Fatal("create project: expected error")
 			}

--- a/pkg/test/e2e/api/logout_test.go
+++ b/pkg/test/e2e/api/logout_test.go
@@ -23,10 +23,14 @@ import (
 	"net/http"
 	"testing"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/credentials"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/datacenter"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/project"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 )

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -84,7 +84,7 @@ func NewTestClient(token string, t *testing.T) *TestClient {
 }
 
 // CreateProject creates a new project and waits for it to become active (ready).
-func (r *TestClient) CreateProject(name string) (*apiv1.Project, error) {
+func (r *TestClient) CreateProject(name string, ignoredStatusCodes ...int) (*apiv1.Project, error) {
 	before := time.Now()
 	timeout := 30 * time.Second
 
@@ -93,7 +93,7 @@ func (r *TestClient) CreateProject(name string) (*apiv1.Project, error) {
 		Duration: 1 * time.Second,
 		Steps:    4,
 		Factor:   1.5,
-	})
+	}, ignoredStatusCodes...)
 
 	r.test.Logf("Creating project %s...", name)
 
@@ -1438,7 +1438,11 @@ func (r *TestClient) ListDC() ([]*models.Datacenter, error) {
 
 func (r *TestClient) Logout() error {
 	params := &users.LogoutCurrentUserParams{}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	})
 
 	_, err := r.client.Users.LogoutCurrentUser(params, r.bearerToken)
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Tries to fix the flaky logout API e2e test,

user-synchronizer reconciles users from the master to the seed clusters. When we have a master/seed KKP setup, it meas that every action on user in the master cluster, causes it to update itself. 

Logging out blacklists the user token by creating a secret in which the blacklist tokens are stored, and adding info to the User resource about said secret. As this causes an Update on the User resource, the user-sync gets triggered and it tries to reconcile all Users on all Seeds. 

There are 2 problems with this:
- user-sync uses the cached version of the User, which may not be the newest one (with the blacklist secret ref)
- user-sync reconciles also the master version of the User, because its also a Seed

So in the end there is a big chance that the user which just logged out, gets overwritten by the user-sync with the old version of User which doesnt have the blacklist token ref.

This PR fixes it by improving the user-sync, with the most important change being that it gets the User resource from the kube API server, instead of the cache, so we are sure we wont overwrite the master user. This solution is not ideal as it adds more overhead for the user reconciliation, but it fixes the issue for now, and we dont expect users resources to be changed so often.

Ideally, user-sync should recognize that it shouldnt update the master-seed resources, but we dont have such logic as of yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7555 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
