### PR TITLE
Add static dex users as KKP admin

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1163,6 +1163,13 @@ presubmits:
         env:
         - name: VERSION_TO_TEST
           value: v1.22.2
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
         securityContext:
           privileged: true
         resources:
@@ -1171,15 +1178,6 @@ presubmits:
             cpu: 2
           limits:
             memory: 6Gi
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-
   #########################################################
   # etcd-launcher e2e tests
   #########################################################

--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -105,17 +105,17 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-openstack.yaml
 
-echodate "Creating roxy2 user..."
+echodate "Creating roxy user..."
 cat << EOF > user.yaml
 apiVersion: kubermatic.k8s.io/v1
 kind: User
 metadata:
-  name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3
+  name: 2d8e8de30d44c46bb0641315ff7b60f05ae92ab0818872f78dc43ebff8ed4614
 spec:
-  email: roxy2@loodse.com
-  id: 1413636a43ddc27da27e47614faedff24b4ab19c9d9f2b45dd1b89d9_KUBE
+  email: roxy@loodse.com
+  id: 226655708b35be078a9302f3c79bd7f3982f8cb03ae32872da8e7b23_KUBE
   name: roxy2
-  admin: true
+  admin: false
 EOF
 retry 2 kubectl apply -f user.yaml
 

--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -114,7 +114,7 @@ metadata:
 spec:
   email: roxy@loodse.com
   id: 226655708b35be078a9302f3c79bd7f3982f8cb03ae32872da8e7b23_KUBE
-  name: roxy2
+  name: roxy
   admin: false
 EOF
 retry 2 kubectl apply -f user.yaml

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -47,7 +47,6 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-digitalocean.yaml
 
-
 echodate "Running etcd-launcher tests..."
 go test -timeout 30m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
 echodate "Tests completed successfully!"

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -47,19 +47,6 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-digitalocean.yaml
 
-echodate "Creating roxy2 user..."
-cat << EOF > user.yaml
-apiVersion: kubermatic.k8s.io/v1
-kind: User
-metadata:
-  name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3
-spec:
-  email: roxy2@loodse.com
-  id: 1413636a43ddc27da27e47614faedff24b4ab19c9d9f2b45dd1b89d9_KUBE
-  name: roxy2
-  admin: true
-EOF
-retry 2 kubectl apply -f user.yaml
 
 echodate "Running etcd-launcher tests..."
 go test -timeout 30m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -47,20 +47,6 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-digitalocean.yaml
 
-echodate "Creating roxy2 user..."
-cat << EOF > user.yaml
-apiVersion: kubermatic.k8s.io/v1
-kind: User
-metadata:
-  name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3
-spec:
-  email: roxy2@loodse.com
-  id: 1413636a43ddc27da27e47614faedff24b4ab19c9d9f2b45dd1b89d9_KUBE
-  name: roxy2
-  admin: true
-EOF
-retry 2 kubectl apply -f user.yaml
-
 echodate "Running opa tests..."
 go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
 echodate "Tests completed successfully!"

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -519,7 +519,7 @@ func createFirstUser(ctx context.Context, logger *logrus.Entry, kubeClient ctrlr
 
 	staticUsers, ok := opt.HelmValues.Get(yamled.Path{"dex", "staticPasswords"})
 
-	//No user provided, skipping
+	// no user provided, skipping
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add static dex users as KKP admin on installation

Fixes #6481

Based on: https://github.com/kubermatic/kubermatic/pull/7944

I left validation to the  dex chart as data is used there before hitting our customer installer code.

```release-note
NONE
```
