### PR TITLE
Open NodePort range in Azure network security group

### DIFF
--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -420,7 +420,7 @@ func (a *Azure) ensureSecurityGroup(cloud kubermaticv1.CloudSpec, location strin
 					Name: to.StringPtr("node_ports_ingress"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Direction:                network.SecurityRuleDirectionInbound,
-						Protocol:                 network.SecurityRuleProtocolTCP,
+						Protocol:                 network.SecurityRuleProtocolAsterisk,
 						SourceAddressPrefix:      to.StringPtr("*"),
 						SourcePortRange:          to.StringPtr("*"),
 						DestinationAddressPrefix: to.StringPtr("*"),


### PR DESCRIPTION
**What this PR does / why we need it**: Opens up the configured node port range in the Azure NSG created by seed-controller-manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7962

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Open Azure Network Security Group for external traffic to NodePort port ranges
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
