### PR TITLE
Added a correct prometheus annotation for custom path of metrics url

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.7
+version: 2.4.8
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/config/scraping/pods.yaml
+++ b/charts/monitoring/prometheus/config/scraping/pods.yaml
@@ -46,7 +46,8 @@ relabel_configs:
 - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]   # standard source label is prometheus.io/path
   action: replace
   target_label: __metrics_path__
-  regex: (.+)- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metrics_path] # deprecated
+  regex: (.+)
+- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metrics_path] # deprecated
   action: replace
   target_label: __metrics_path__
   regex: (.+)

--- a/charts/monitoring/prometheus/config/scraping/pods.yaml
+++ b/charts/monitoring/prometheus/config/scraping/pods.yaml
@@ -43,7 +43,10 @@ relabel_configs:
   action: replace
   target_label: __metrics_path__
   regex: (.+)
-- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metrics_path] # deprecated
+- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]   # standard source label is prometheus.io/path
+  action: replace
+  target_label: __metrics_path__
+  regex: (.+)- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metrics_path] # deprecated
   action: replace
   target_label: __metrics_path__
   regex: (.+)


### PR DESCRIPTION
**What this PR does / why we need it**:
Some apps specify `prometheus.io/path` annotation to customize the url endpoint where metrics will be available. Our scrape config was ignoring this annotation and was honoring only `prometheus.io/metrics_path` annotations in kubernetes_sd_config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NA

**Special notes for your reviewer**:
Some examples of this annotation in use. https://github.com/search?q=prometheus.io%2Fpath&type=code

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
