### PR TITLE
Use PublishNotReadyAddresses for etcd clusters 

### DIFF
--- a/pkg/resources/etcd/etcdservices.go
+++ b/pkg/resources/etcd/etcdservices.go
@@ -39,10 +39,8 @@ func ServiceCreator(data serviceCreatorData) reconciling.NamedServiceCreatorGett
 		return resources.EtcdServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.EtcdServiceName
 			se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-			se.Annotations = map[string]string{
-				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-			}
 			se.Spec.ClusterIP = "None"
+			se.Spec.PublishNotReadyAddresses = true
 			se.Spec.Selector = map[string]string{
 				resources.AppLabelKey: name,
 				"cluster":             data.Cluster().Name,

--- a/pkg/resources/test/fixtures/service-aws-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.19.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-aws-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.21.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.19.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.21.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.19.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.21.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.19.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.21.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.19.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.19.0-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.19.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.19.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.19.0-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.19.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd.yaml
@@ -1,8 +1,6 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   creationTimestamp: null
   name: etcd
   ownerReferences:
@@ -23,6 +21,7 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  publishNotReadyAddresses: true
   selector:
     app: etcd
     cluster: de-test-01


### PR DESCRIPTION
**What this PR does / why we need it**:
This is takeover of #7947

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Child cluster etcd services now use `spec.publishNotReadyAddresses` instead of the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation (deprecated in Kubernetes v1.11) to ensure compatibility with `EndpointSlice` consumers
```
