### PR TITLE
add vmware-exporter chart

### DIFF
--- a/charts/monitoring/vmware-exporter/Chart.yaml
+++ b/charts/monitoring/vmware-exporter/Chart.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+name: vmware-exporter
+appVersion: v0.18.2
+description: VMware vCenter Exporter for Prometheus Helm chart
+home: https://github.com/pryorda/vmware_exporter
+maintainers:
+- name: The Kubermatic Kubernetes Platform contributors
+  email: support@kubermatic.com
+sources:
+- https://github.com/pryorda/vmware_exporter
+version: 2.2.0

--- a/charts/monitoring/vmware-exporter/templates/_helpers.tpl
+++ b/charts/monitoring/vmware-exporter/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "vmware-exporter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.vmware-exporter.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,10 +12,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "vmware-exporter.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.vmware-exporter.fullnameOverride -}}
+{{- .Values.vmware-exporter.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.vmware-exporter.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/charts/monitoring/vmware-exporter/templates/_helpers.tpl
+++ b/charts/monitoring/vmware-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vmware-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vmware-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vmware-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/monitoring/vmware-exporter/templates/configmap.yaml
+++ b/charts/monitoring/vmware-exporter/templates/configmap.yaml
@@ -1,0 +1,58 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}-config
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  VSPHERE_USER: {{ .Values.vsphere.user | quote }}
+  VSPHERE_HOST: {{ .Values.vsphere.host | quote }}
+  VSPHERE_IGNORE_SSL: {{ .Values.vsphere.ignoressl | quote }}
+  VSPHERE_SPECS_SIZE: {{ .Values.vsphere.specsSize | quote }}
+  VSPHERE_FETCH_CUSTOM_ATTRIBUTES: {{ .Values.vsphere.fetchCustomAttributes | quote }}
+  VSPHERE_FETCH_TAGS: {{ .Values.vsphere.fetchTags | quote }}
+  VSPHERE_FETCH_ALARMS: {{ .Values.vsphere.fetchAlarms | quote }}
+  VSPHERE_COLLECT_HOSTS: {{ .Values.vsphere.collectors.hosts | quote }}
+  VSPHERE_COLLECT_DATASTORES: {{ default "True" .Values.vsphere.collectors.datastores | quote }}
+  VSPHERE_COLLECT_VMS: {{ .Values.vsphere.collectors.vms | quote }}
+  VSPHERE_COLLECT_VMGUESTS: {{ .Values.vsphere.collectors.vmguests | quote }}
+  VSPHERE_COLLECT_SNAPSHOTS: {{ .Values.vsphere.collectors.snapshots | quote }}
+{{- range $section := .Values.vsphere.sections }}
+{{- $key := $section.name }}
+  VSPHERE_{{ $key }}_USER: {{ $section.user | quote }}
+  VSPHERE_{{ $key }}_HOST: {{ $section.host | quote }}
+  VSPHERE_{{ $key }}_IGNORE_SSL: {{ $section.ignoressl | quote }}
+  {{- if $section.fetchCustomAttributes }}
+  VSPHERE_{{ $key }}_FETCH_CUSTOM_ATTRIBUTES: {{ $section.fetchCustomAttributes | quote }}
+  {{- end }}
+  {{- if $section.fetchTags }}
+  VSPHERE_{{ $key }}_FETCH_TAGS: {{ $section.fetchTags | quote }}
+  {{- end }}
+  {{- if $section.fetchAlarms }}
+  VSPHERE_{{ $key }}_FETCH_ALARMS: {{ $section.fetchAlarms | quote }}
+  {{- end }}
+{{- if $section.collectors }}
+  VSPHERE_{{ $key }}_COLLECT_HOSTS: {{ default $.Values.vsphere.collectors.hosts $section.collectors.hosts | quote }}
+  VSPHERE_{{ $key }}_COLLECT_DATASTORES: {{ default "True" $section.collectors.datastores | quote }}
+  VSPHERE_{{ $key }}_COLLECT_VMS: {{ default $.Values.vsphere.collectors.vms $section.collectors.vms | quote }}
+  VSPHERE_{{ $key }}_COLLECT_VMGUESTS: {{ default $.Values.vsphere.collectors.vmguests $section.collectors.vmguests | quote }}
+  VSPHERE_{{ $key }}_COLLECT_SNAPSHOTS: {{ default $.Values.vsphere.collectors.snapshots $section.collectors.snapshots | quote }}
+{{- end }}
+{{- end }}

--- a/charts/monitoring/vmware-exporter/templates/configmap.yaml
+++ b/charts/monitoring/vmware-exporter/templates/configmap.yaml
@@ -22,19 +22,19 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  VSPHERE_USER: {{ .Values.vsphere.user | quote }}
-  VSPHERE_HOST: {{ .Values.vsphere.host | quote }}
-  VSPHERE_IGNORE_SSL: {{ .Values.vsphere.ignoressl | quote }}
-  VSPHERE_SPECS_SIZE: {{ .Values.vsphere.specsSize | quote }}
-  VSPHERE_FETCH_CUSTOM_ATTRIBUTES: {{ .Values.vsphere.fetchCustomAttributes | quote }}
-  VSPHERE_FETCH_TAGS: {{ .Values.vsphere.fetchTags | quote }}
-  VSPHERE_FETCH_ALARMS: {{ .Values.vsphere.fetchAlarms | quote }}
-  VSPHERE_COLLECT_HOSTS: {{ .Values.vsphere.collectors.hosts | quote }}
-  VSPHERE_COLLECT_DATASTORES: {{ default "True" .Values.vsphere.collectors.datastores | quote }}
-  VSPHERE_COLLECT_VMS: {{ .Values.vsphere.collectors.vms | quote }}
-  VSPHERE_COLLECT_VMGUESTS: {{ .Values.vsphere.collectors.vmguests | quote }}
-  VSPHERE_COLLECT_SNAPSHOTS: {{ .Values.vsphere.collectors.snapshots | quote }}
-{{- range $section := .Values.vsphere.sections }}
+  VSPHERE_USER: {{ .Values.vmware-exporter.vsphere.user | quote }}
+  VSPHERE_HOST: {{ .Values.vmware-exporter.vsphere.host | quote }}
+  VSPHERE_IGNORE_SSL: {{ .Values.vmware-exporter.vsphere.ignoressl | quote }}
+  VSPHERE_SPECS_SIZE: {{ .Values.vmware-exporter.vsphere.specsSize | quote }}
+  VSPHERE_FETCH_CUSTOM_ATTRIBUTES: {{ .Values.vmware-exporter.vsphere.fetchCustomAttributes | quote }}
+  VSPHERE_FETCH_TAGS: {{ .Values.vmware-exporter.vsphere.fetchTags | quote }}
+  VSPHERE_FETCH_ALARMS: {{ .Values.vmware-exporter.vsphere.fetchAlarms | quote }}
+  VSPHERE_COLLECT_HOSTS: {{ .Values.vmware-exporter.vsphere.collectors.hosts | quote }}
+  VSPHERE_COLLECT_DATASTORES: {{ default "True" .Values.vmware-exporter.vsphere.collectors.datastores | quote }}
+  VSPHERE_COLLECT_VMS: {{ .Values.vmware-exporter.vsphere.collectors.vms | quote }}
+  VSPHERE_COLLECT_VMGUESTS: {{ .Values.vmware-exporter.vsphere.collectors.vmguests | quote }}
+  VSPHERE_COLLECT_SNAPSHOTS: {{ .Values.vmware-exporter.vsphere.collectors.snapshots | quote }}
+{{- range $section := .Values.vmware-exporter.vsphere.sections }}
 {{- $key := $section.name }}
   VSPHERE_{{ $key }}_USER: {{ $section.user | quote }}
   VSPHERE_{{ $key }}_HOST: {{ $section.host | quote }}
@@ -49,10 +49,10 @@ data:
   VSPHERE_{{ $key }}_FETCH_ALARMS: {{ $section.fetchAlarms | quote }}
   {{- end }}
 {{- if $section.collectors }}
-  VSPHERE_{{ $key }}_COLLECT_HOSTS: {{ default $.Values.vsphere.collectors.hosts $section.collectors.hosts | quote }}
+  VSPHERE_{{ $key }}_COLLECT_HOSTS: {{ default $.Values.vmware-exporter.vsphere.collectors.hosts $section.collectors.hosts | quote }}
   VSPHERE_{{ $key }}_COLLECT_DATASTORES: {{ default "True" $section.collectors.datastores | quote }}
-  VSPHERE_{{ $key }}_COLLECT_VMS: {{ default $.Values.vsphere.collectors.vms $section.collectors.vms | quote }}
-  VSPHERE_{{ $key }}_COLLECT_VMGUESTS: {{ default $.Values.vsphere.collectors.vmguests $section.collectors.vmguests | quote }}
-  VSPHERE_{{ $key }}_COLLECT_SNAPSHOTS: {{ default $.Values.vsphere.collectors.snapshots $section.collectors.snapshots | quote }}
+  VSPHERE_{{ $key }}_COLLECT_VMS: {{ default $.Values.vmware-exporter.vsphere.collectors.vms $section.collectors.vms | quote }}
+  VSPHERE_{{ $key }}_COLLECT_VMGUESTS: {{ default $.Values.vmware-exporter.vsphere.collectors.vmguests $section.collectors.vmguests | quote }}
+  VSPHERE_{{ $key }}_COLLECT_SNAPSHOTS: {{ default $.Values.vmware-exporter.vsphere.collectors.snapshots $section.collectors.snapshots | quote }}
 {{- end }}
 {{- end }}

--- a/charts/monitoring/vmware-exporter/templates/deployment.yaml
+++ b/charts/monitoring/vmware-exporter/templates/deployment.yaml
@@ -1,0 +1,78 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "vmware-exporter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "vmware-exporter.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+{{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9272
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ template "vmware-exporter.fullname" . }}-config
+            - secretRef:
+                name: {{ if not .Values.vsphere.existingSecret }}{{ template "vmware-exporter.fullname" . }}-secret{{ else }}{{ .Values.vsphere.existingSecret }}{{ end }}
+          livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 12 }}
+          readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 12 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        {{- with .Values.securityContext }}
+          securityContext:
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext:
+    {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/monitoring/vmware-exporter/templates/deployment.yaml
+++ b/charts/monitoring/vmware-exporter/templates/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.vmware-exporter.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "vmware-exporter.name" . }}
@@ -33,14 +33,14 @@ spec:
         app: {{ template "vmware-exporter.name" . }}
         release: {{ .Release.Name }}
       annotations:
-{{- with .Values.podAnnotations }}
+{{- with .Values.vmware-exporter.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.vmware-exporter.image.repository }}:{{ .Values.vmware-exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.vmware-exporter.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 9272
@@ -49,30 +49,30 @@ spec:
             - configMapRef:
                 name: {{ template "vmware-exporter.fullname" . }}-config
             - secretRef:
-                name: {{ if not .Values.vsphere.existingSecret }}{{ template "vmware-exporter.fullname" . }}-secret{{ else }}{{ .Values.vsphere.existingSecret }}{{ end }}
+                name: {{ if not .Values.vmware-exporter.vsphere.existingSecret }}{{ template "vmware-exporter.fullname" . }}-secret{{ else }}{{ .Values.vmware-exporter.vsphere.existingSecret }}{{ end }}
           livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 12 }}
+{{ toYaml .Values.vmware-exporter.livenessProbe | indent 12 }}
           readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 12 }}
+{{ toYaml .Values.vmware-exporter.readinessProbe | indent 12 }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-        {{- with .Values.securityContext }}
+{{ toYaml .Values.vmware-exporter.resources | indent 12 }}
+        {{- with .Values.vmware-exporter.securityContext }}
           securityContext:
         {{- toYaml . | nindent 12 }}
         {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with .Values.vmware-exporter.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.vmware-exporter.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with .Values.vmware-exporter.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.podSecurityContext }}
+    {{- with .Values.vmware-exporter.podSecurityContext }}
       securityContext:
     {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/monitoring/vmware-exporter/templates/ingress.yaml
+++ b/charts/monitoring/vmware-exporter/templates/ingress.yaml
@@ -1,0 +1,57 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "vmware-exporter.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/charts/monitoring/vmware-exporter/templates/ingress.yaml
+++ b/charts/monitoring/vmware-exporter/templates/ingress.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.vmware-exporter.ingress.enabled -}}
 {{- $fullName := include "vmware-exporter.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- $servicePort := .Values.vmware-exporter.service.port -}}
+{{- $ingressPath := .Values.vmware-exporter.ingress.path -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -29,14 +29,14 @@ metadata:
     chart: {{ template "vmware-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+{{- with .Values.vmware-exporter.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+{{- if .Values.vmware-exporter.ingress.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.vmware-exporter.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . }}
@@ -45,7 +45,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.vmware-exporter.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:

--- a/charts/monitoring/vmware-exporter/templates/secret.yaml
+++ b/charts/monitoring/vmware-exporter/templates/secret.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if not .Values.vsphere.existingSecret }}
+{{- if not .Values.vmware-exporter.vsphere.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,8 +24,8 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  VSPHERE_PASSWORD: {{ default "" .Values.vsphere.password | b64enc | quote }}
-{{- range $section := .Values.vsphere.sections }}
+  VSPHERE_PASSWORD: {{ default "" .Values.vmware-exporter.vsphere.password | b64enc | quote }}
+{{- range $section := .Values.vmware-exporter.vsphere.sections }}
 {{- $key := $section.name }}
   VSPHERE_{{ $key }}_PASSWORD: {{ $section.password | b64enc | quote }}
 {{- end }}

--- a/charts/monitoring/vmware-exporter/templates/secret.yaml
+++ b/charts/monitoring/vmware-exporter/templates/secret.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if not .Values.vsphere.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}-secret
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  VSPHERE_PASSWORD: {{ default "" .Values.vsphere.password | b64enc | quote }}
+{{- range $section := .Values.vsphere.sections }}
+{{- $key := $section.name }}
+  VSPHERE_{{ $key }}_PASSWORD: {{ $section.password | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/monitoring/vmware-exporter/templates/service.yaml
+++ b/charts/monitoring/vmware-exporter/templates/service.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vmware-exporter.fullname" . }}
+  labels:
+    app: {{ template "vmware-exporter.name" . }}
+    chart: {{ template "vmware-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.service.annotations }} 
+  annotations: 
+{{ toYaml . | indent 4 }} 
+{{- end }} 
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetport }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "vmware-exporter.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/monitoring/vmware-exporter/templates/service.yaml
+++ b/charts/monitoring/vmware-exporter/templates/service.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.service.enabled -}}
+{{- if .Values.vmware-exporter.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,15 +22,15 @@ metadata:
     chart: {{ template "vmware-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.service.annotations }} 
+{{- with .Values.vmware-exporter.service.annotations }} 
   annotations: 
 {{ toYaml . | indent 4 }} 
 {{- end }} 
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.vmware-exporter.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetport }}
+    - port: {{ .Values.vmware-exporter.service.port }}
+      targetPort: {{ .Values.vmware-exporter.service.targetport }}
       protocol: TCP
       name: http
   selector:

--- a/charts/monitoring/vmware-exporter/values.yaml
+++ b/charts/monitoring/vmware-exporter/values.yaml
@@ -1,0 +1,116 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+vmware-exporter:
+
+  replicaCount: 2
+  
+  vsphere:
+    user: user
+    password: na
+    existingSecret: {}
+    host: vcenter
+    ignoressl: true
+    fetchCustomAttributes: true
+    fetchTags: true
+    fetchAlarms: true
+    specsSize: 5000
+    sections: {}
+    collectors:
+      hosts: true
+      datastores: true
+      vms: true
+      vmguests: true
+      snapshots: true
+  
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9272"
+    prometheus.io/path: "/metrics"
+  
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: 9272
+  
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 9272
+    initialDelaySeconds: 30
+    failureThreshold: 10
+  
+  image:
+    repository: pryorda/vmware_exporter
+    tag: v0.18.2
+    pullPolicy: IfNotPresent
+  
+  service:
+    enabled: false
+    type: ClusterIP
+    ## Provide optional annotations to the service i.e. for external-dns
+    # annotations:
+    ##   external-dns.alpha.kubernetes.io/hostname: yourservicename.k8s.yourcompany.com
+    ##
+    port: 80
+    targetport: 9272
+  
+  ingress:
+    enabled: true
+    annotations:
+      {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - chart-example.local
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+  
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  
+  nodeSelector: {}
+  
+  tolerations: []
+  
+  affinity: {}
+  
+  # Set the container security context
+  securityContext:
+    {}
+    #  capabilities:
+    #    drop: [ALL]
+    #  readOnlyRootFilesystem: true
+    #  runAsGroup: 65532
+    #  runAsNonRoot: true
+    #  runAsUser: 65532
+  
+  # Set the Pod security context
+  podSecurityContext:
+    {}
+    #  fsGroup: 65532
+  

--- a/charts/monitoring/vmware-exporter/values.yaml
+++ b/charts/monitoring/vmware-exporter/values.yaml
@@ -113,4 +113,3 @@ vmware-exporter:
   podSecurityContext:
     {}
     #  fsGroup: 65532
-  


### PR DESCRIPTION
**What this PR does / why we need it**: To add basic monitoring of vsphere provider. This PR adds a chart named `vmware-exporter`, which adds metrics for Prometheus. According to the upstream chart below information will be get. 

- Basic VM and Host metrics
- Current number of active snapshots
- Datastore size and other stuff
- Snapshot Unix timestamp creation date


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: 

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```