### PR TITLE
Set first user as admin

### DIFF
--- a/pkg/handler/v1/admin/admission_plugin_test.go
+++ b/pkg/handler/v1/admin/admission_plugin_test.go
@@ -51,7 +51,7 @@ func TestListAdmissionPluginEndpoint(t *testing.T) {
 			name:                   "scenario 1: not authorized user gets plugins",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
@@ -133,7 +133,7 @@ func TestGetAdmissionPluginEndpoint(t *testing.T) {
 			plugin:                 "test",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
@@ -217,7 +217,7 @@ func TestDeleteAdmissionPluginEndpoint(t *testing.T) {
 			plugin:                 "test",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
@@ -303,7 +303,7 @@ func TestUpdateAdmissionPluginEndpoint(t *testing.T) {
 			body:                   `{"name":"eventRateLimit","plugin":"EventRateLimit","fromVersion":"1.13.0"}`,
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2

--- a/pkg/handler/v1/admin/seed_test.go
+++ b/pkg/handler/v1/admin/seed_test.go
@@ -44,7 +44,7 @@ func TestListSeedsEndpoint(t *testing.T) {
 			name:                   "scenario 1: not authorized user gets seeds",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{test.GenTestSeed()},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false), test.GenTestSeed()},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
@@ -97,7 +97,7 @@ func TestGetSeedEndpoint(t *testing.T) {
 			seedName:               "test",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{test.GenTestSeed()},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false), test.GenTestSeed()},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
@@ -161,7 +161,7 @@ func TestUpdateSeedEndpoint(t *testing.T) {
 			seedName:               "us-central1",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{test.GenTestSeed()},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false), test.GenTestSeed()},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
@@ -246,7 +246,7 @@ func TestDeleteSeedEndpoint(t *testing.T) {
 			seedName:               "test",
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: []ctrlruntimeclient.Object{test.GenTestSeed()},
+			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", false), test.GenTestSeed()},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2

--- a/pkg/handler/v1/user/user_test.go
+++ b/pkg/handler/v1/user/user_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -892,8 +893,8 @@ func TestNewUser(t *testing.T) {
 		ExistingAPIUser           *apiv1.User
 	}{
 		{
-			Name:             "scenario 1: successfully creates a new user resource",
-			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com"}`,
+			Name:             "scenario 1: successfully creates the initial new user resource",
+			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","isAdmin":true}`,
 			HTTPStatus:       http.StatusOK,
 			ExpectedKubermaticUser: func() *kubermaticapiv1.User {
 				expectedKubermaticUser := test.GenDefaultUser()


### PR DESCRIPTION
**What this PR does / why we need it**:

Elect the first authenticated user as an Admin.

Fixes #6481

**Documentation**:
https://github.com/kubermatic/docs/pull/824

```release-note
NONE
```
