### PR TITLE
Fix issue where `$$` in the password causes machine-controller fails to deploy machines

### DIFF
--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -134,8 +134,6 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 				return nil, err
 			}
 
-			envVars = sanatizeEnvVars(envVars)
-
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 
 			repository := data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller"
@@ -265,7 +263,8 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "ANEXIA_TOKEN", Value: credentials.Anexia.Token})
 	}
 	vars = append(vars, resources.GetHTTPProxyEnvVarsFromSeed(data.Seed(), data.Cluster().Address.InternalName)...)
-	return vars, nil
+
+	return sanatizeEnvVars(vars), nil
 }
 
 func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri string) []string {

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -134,6 +134,8 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 				return nil, err
 			}
 
+			envVars = sanatizeEnvVars(envVars)
+
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 
 			repository := data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller"
@@ -190,6 +192,21 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 			return dep, nil
 		}
 	}
+}
+
+// sanatizeEnvVar will take the value of a environment variable and sanatises it.
+// the need for this comes from github.com/kubermatic/kubermatic/issues/7960
+func sanatizeEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
+	sanatizedEnvVars := make([]corev1.EnvVar, len(envVars))
+
+	for idx, envVar := range envVars {
+		sanatizedEnvVars[idx] = corev1.EnvVar{
+			Name:  envVar.Name,
+			Value: strings.ReplaceAll(envVar.Value, "$", "$$"),
+		}
+	}
+
+	return sanatizedEnvVars
 }
 
 func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -192,19 +192,19 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 	}
 }
 
-// sanatizeEnvVar will take the value of a environment variable and sanatises it.
+// sanitizeEnvVar will take the value of a environment variable and sanatises it.
 // the need for this comes from github.com/kubermatic/kubermatic/issues/7960
-func sanatizeEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
-	sanatizedEnvVars := make([]corev1.EnvVar, len(envVars))
+func sanitizeEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
+	sanitizedEnvVars := make([]corev1.EnvVar, len(envVars))
 
 	for idx, envVar := range envVars {
-		sanatizedEnvVars[idx] = corev1.EnvVar{
+		sanitizedEnvVars[idx] = corev1.EnvVar{
 			Name:  envVar.Name,
 			Value: strings.ReplaceAll(envVar.Value, "$", "$$"),
 		}
 	}
 
-	return sanatizedEnvVars
+	return sanitizedEnvVars
 }
 
 func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
@@ -264,7 +264,7 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 	}
 	vars = append(vars, resources.GetHTTPProxyEnvVarsFromSeed(data.Seed(), data.Cluster().Address.InternalName)...)
 
-	return sanatizeEnvVars(vars), nil
+	return sanitizeEnvVars(vars), nil
 }
 
 func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri string) []string {


### PR DESCRIPTION
**What this PR does / why we need it**:

We discovered, if a passwords ends with or contains `$$` (two dollars
consecutive) the machine-controller fails to spin up machines in our
openstack environment with the following error message:

    Warning  ReconcilingError  13s                 kubermatic_initialmachinedeployment_controller  failed to create initial MachineDeployment: admission webhook "machine-controller.kubermatic.io-machinedeployments" denied the request: failed to default machineSpec: An error of type = InvalidConfiguration, with message = A request has been rejected due to invalid credentials which were taken from the MachineSpec: Authentication failed occurred

During debugging we validated, that the
* password is indeed valid in
OpenStack
* We where able to loginto OpenStack Horizon
* We where also able to log into the KKP Dashboard, since our KKP Dashboard is tied to
the OpenStack Keystone OIDC Provider.
* We where able to create a new KKP Cluster with the Password (the
Password is here used to retreive the tenants, etc. from OpenStack to be
displayed in the KKP UI
* The Password is saved correctly to secret `credential-openstack-<ACTUAL_ID>` in kubermatic

    $ k -n kubermatic get secret credential-openstack-<ACTUAL_ID> -ojsonpath='{.data.password}' | base64 -D

showed the correct password.

* We further validated if the password is exposed correctly to
machine-controller using

    $ kubectl exec --stdin --tty -n cluster-nwqm8tzj6w machine-controller-58c44fbbb7-zfnvt -- /bin/sh
    Defaulted container "machine-controller" out of: machine-controller, copy-http-prober (init)
    ~ $ echo $OS_PASSWORD
    <REDACTED>$

which showed that only one trailing dollar sign is exposed to
machine-controller.
Next step was verifying the machine-controller deployment, if the value
under `spec.containers[0].env` is set correctly:

    $ kubectl get deployments -n cluster-nwqm8tzj6w machine-controller -ojson | jq '.spec.template.spec.containers[0].env[] | select(.name == "OS_PASSWORD")'
    {
        "name": "OS_PASSWORD",
        "value": "<REDACTED>$$"
    }

which looks right on first glance.
However: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core says
> Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. “$$(VAR_NAME)” will produce the string literal “$(VAR_NAME)“. Escaped references will never be expanded, regardless of whether the variable exists or not.

That means we have to espace our `$` to make it work.

To validate this, we paused the cluster and used `kubectl edit` to
modify the deployment wo end with 4 dollar signs `$$$$`. After tthis
change, we can validate `spec.containers[0].env` again and it now looks
like this:

    $ kubectl get deployments -n cluster-nwqm8tzj6w machine-controller -ojson | jq '.spec.template.spec.containers[0].env[] | select(.name == "OS_PASSWORD")'
    {
        "name": "OS_PASSWORD",
        "value": "<REDACTED>$$$$"
    }

The after the machine-controller pods are re-started, we validate if
this change worked using:

    $ kubectl exec --stdin --tty -n cluster-nwqm8tzj6w machine-controller-75c486f475-4cz4h -- /bin/sh
    Defaulted container "machine-controller" out of: machine-controller, copy-http-prober (init)
    ~ $ echo $OS_PASSWORD
    <REDACTED>$$

which now is the correct password

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7960

**Special notes for your reviewer**:

**Documentation**:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core says

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a bug where `$$` in the environment-variables for machine-controller was interpreted in the Kubernetes Manifest and caused machine-controller to be unable to deploy resources, when for e.g. the password contains two consecutive `$` signs
```
