### PR TITLE
Set --kubelet-certificate-authority to validate kubelet serving certs

### DIFF
--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -315,6 +315,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--client-ca-file", "/etc/kubernetes/pki/ca/ca.crt",
 		"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
 		"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
+		"--kubelet-certificate-authority", "/etc/kubernetes/pki/ca/ca.crt",
 		"--requestheader-client-ca-file", "/etc/kubernetes/pki/front-proxy/ca/ca.crt",
 		"--requestheader-allowed-names", "apiserver-aggregator",
 		"--requestheader-extra-headers-prefix", "X-Remote-Extra-",

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -192,6 +192,8 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
+        - --kubelet-certificate-authority
+        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubelet exposes its own API that the Kubernetes API server uses to pull information from the kubelet (for example, accessing Pod logs when a user runs `kubectl logs`). In KKP, the TLS certificates for this kubelet API are generated from CSRs and thus are issued by the Kubernetes CA.

By default, `kube-apiserver` does not validate the TLS certificates that kubelets serve on this API. See https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet. This PR adds a flag to `kube-apiserver` to validate that kubelets only serve TLS certificates issued by the CA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/edgematic/issues/50

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
