### PR TITLE
use Recreate strategy for KKP operator deployment

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.7
+version: 0.3.8
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -21,6 +21,8 @@ metadata:
     app.kubernetes.io/version: '{{ .Values.kubermaticOperator.image.tag | default .Chart.AppVersion }}'
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: kubermatic-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
During KKP upgrades, we currently had the case that multiple operator pods could be alive at the same time. Since there is no leader election (because the operator is supposed to run with a single pod only, as a bit of downtime in the operator is absolutely harmless for a running KKP setup), these 2 operators would fight each other.

This PR changes the Deployment to use the Recreate strategy, ensuring that Kubernetes kills old pods before it creates new ones.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
