### PR TITLE
fix seed-proxy forbidding all incoming requests

### DIFF
--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -378,7 +378,7 @@ echo "Starting kubectl proxy for $KUBERNETES_CONTEXT on port $PROXY_PORT..."
 kubectl proxy \
   --address=0.0.0.0 \
   --port=$PROXY_PORT \
-  --accept-hosts=''
+  --accept-hosts='^.*'
 `
 
 const grafanaDatasource = `


### PR DESCRIPTION
**What this PR does / why we need it**:
Since https://github.com/kubernetes/kubernetes/pull/99617 (k8s 1.21), kubectl's `--accept-hosts` setting was silently changed (nothing is mentioned in any changelog) to treat an empty string differently. This broke our seed-proxy, because now _all_ hosts were rejected and clients just got a HTTP 403 Forbidden.

This PR fixes that. Only KKP 2.18 is affected, as previous versions shipped with an older kubectl binary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8008

**Does this PR introduce a user-facing change?**:
```release-note
Fix seed-proxy forbidding all traffic, breaking Karma dashboards.
```
