### PR TITLE
remove last traces of "Loodse" from the repository

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Kubermatic Kubernetes Platform
-Copyright 2020 Loodse GmbH
+Copyright 2020 Kubermatic GmbH
 
-This product includes software developed at Loodse GmbH.
+This product includes software developed at Kubermatic GmbH.
 (http://www.kubermatic.com/).

--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -14,11 +14,11 @@
 
 apiVersion: v1
 name: telemetry
-description: A Helm chart to install agents
-version: v0.1.3
+description: A Helm chart to install Kubermatic telemetry agents
+version: v0.1.4
 appVersion: v0.1.0
 keywords:
 - telemetry
 maintainers:
-- name: Loodse GmbH
+- name: Kubermatic GmbH
   email: support@kubermatic.com

--- a/docs/proposals/ceph-credentials-controller.md
+++ b/docs/proposals/ceph-credentials-controller.md
@@ -38,7 +38,7 @@ The controller will:
 
  * Prepare a Ceph cluster for testing
  * Exdend the datacenter definition with Ceph Credentials
- * Add Ceph test cluster admin credentials to Loodse VSphere datacenter
+ * Add Ceph test cluster admin credentials to Kubermatic VSphere datacenter
  * Write the `ceph-credentials-controller` as a part of `kubermatic-controller-manager`
  * Add e2e test runner that will:
    * create a cluster on dev in VSphere datacenter

--- a/docs/proposals/user-cluster-mla.md
+++ b/docs/proposals/user-cluster-mla.md
@@ -316,7 +316,7 @@ This proposal does not cover some advanced topics that are left for future enhan
 - High Availability Grafana setup.
 - Automated backups of data.
 
-## Alternatives Considered 
+## Alternatives Considered
 ### Decentralized Approach
 The Implementation section covers an alternative - “Decentralized” approach. Although it is very valid, it is left for
 the future.
@@ -336,16 +336,16 @@ spec:
     id: 92d86czsj5
     name: mla-project
   users:
-    - email: mla-user1@loodse.com
+    - email: mla-user1@kubermatic.com
       id: mla-user1-id
       name: User 1
-    - email: mla-user2@loodse.com
+    - email: mla-user2@kubermatic.com
       id: mla-user2-id
       name: User 2
 ```
 
 In this case, only `UserProjectMapping` objects will be propagated to Seed Cluster, which will reduce duplication of
-`UserProjectBinding` and `Project` in the Seed Cluster. However, in the scenario that Master Cluster and Seed 
+`UserProjectBinding` and `Project` in the Seed Cluster. However, in the scenario that Master Cluster and Seed
 Cluster are on the same Kubernetes cluster, `UserProejctMapping` will be redundant.
 
 In KKP, two synchronization controllers (master-constraint-template-controller, and seed-sync-controller) have been

--- a/hack/boilerplate/ee/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/ee/boilerplate.Dockerfile.txt
@@ -1,6 +1,6 @@
 #                Kubermatic Enterprise Read-Only License
 #                       Version 1.0 ("KERO-1.0”)
-#                   Copyright © YEAR Loodse GmbH
+#                   Copyright © YEAR Kubermatic GmbH
 #
 # 1.	You may only view, read and display for studying purposes the source
 #    code of the software licensed under this license, and, to the extent

--- a/hack/boilerplate/ee/boilerplate.go.txt
+++ b/hack/boilerplate/ee/boilerplate.go.txt
@@ -1,7 +1,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © YEAR Loodse GmbH
+                     Copyright © YEAR Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/hack/boilerplate/ee/boilerplate.sh.txt
+++ b/hack/boilerplate/ee/boilerplate.sh.txt
@@ -1,6 +1,6 @@
 #                Kubermatic Enterprise Read-Only License
 #                       Version 1.0 ("KERO-1.0”)
-#                   Copyright © YEAR Loodse GmbH
+#                   Copyright © YEAR Kubermatic GmbH
 #
 # 1.	You may only view, read and display for studying purposes the source
 #    code of the software licensed under this license, and, to the extent

--- a/hack/boilerplate/ee/boilerplate.yaml.txt
+++ b/hack/boilerplate/ee/boilerplate.yaml.txt
@@ -1,6 +1,6 @@
 #                Kubermatic Enterprise Read-Only License
 #                       Version 1.0 ("KERO-1.0”)
-#                   Copyright © YEAR Loodse GmbH
+#                   Copyright © YEAR Kubermatic GmbH
 #
 # 1.	You may only view, read and display for studying purposes the source
 #    code of the software licensed under this license, and, to the extent

--- a/hack/boilerplate/ee/boilerplate.yml.txt
+++ b/hack/boilerplate/ee/boilerplate.yml.txt
@@ -1,6 +1,6 @@
 #                Kubermatic Enterprise Read-Only License
 #                       Version 1.0 ("KERO-1.0”)
-#                   Copyright © YEAR Loodse GmbH
+#                   Copyright © YEAR Kubermatic GmbH
 #
 # 1.	You may only view, read and display for studying purposes the source
 #    code of the software licensed under this license, and, to the extent

--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -112,7 +112,7 @@ kind: User
 metadata:
   name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3
 spec:
-  email: roxy2@loodse.com
+  email: roxy2@kubermatic.com
   id: 1413636a43ddc27da27e47614faedff24b4ab19c9d9f2b45dd1b89d9_KUBE
   name: roxy2
   admin: true

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -54,7 +54,7 @@ kind: User
 metadata:
   name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3
 spec:
-  email: roxy2@loodse.com
+  email: roxy2@kubermatic.com
   id: 1413636a43ddc27da27e47614faedff24b4ab19c9d9f2b45dd1b89d9_KUBE
   name: roxy2
   admin: true

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -54,7 +54,7 @@ kind: User
 metadata:
   name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3
 spec:
-  email: roxy2@loodse.com
+  email: roxy2@kubermatic.com
   id: 1413636a43ddc27da27e47614faedff24b4ab19c9d9f2b45dd1b89d9_KUBE
   name: roxy2
   admin: true

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -46,7 +46,7 @@ export KUBERMATIC_API_ENDPOINT="http://localhost:8080"
 
 # Tell the conformance tester what dummy account we configure for the e2e tests.
 export KUBERMATIC_DEX_VALUES_FILE=$(realpath hack/ci/testdata/oauth_values.yaml)
-export KUBERMATIC_OIDC_LOGIN="roxy@loodse.com"
+export KUBERMATIC_OIDC_LOGIN="roxy@kubermatic.com"
 export KUBERMATIC_OIDC_PASSWORD="password"
 
 # Set docker config

--- a/hack/ci/testdata/oauth_values.yaml
+++ b/hack/ci/testdata/oauth_values.yaml
@@ -36,6 +36,16 @@ dex:
     # used by the dashboard
     - http://localhost:8000/projects
   staticPasswords:
+  - email: "roxy@kubermatic.com"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "roxy"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5468"
+  - email: "roxy2@kubermatic.com"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "roxy2"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5469"
+
+  # legacy dummy accounts, remove once we're sure no e2e test uses them anymore
   - email: "roxy@loodse.com"
     hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
     username: "roxy"

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -112,7 +112,7 @@ time retry 5 kind load docker-image "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" 
 export SEED_NAME=kubermatic
 
 # Tell the conformance tester what dummy account we configure for the e2e tests.
-export KUBERMATIC_OIDC_LOGIN="roxy@loodse.com"
+export KUBERMATIC_OIDC_LOGIN="roxy@kubermatic.com"
 export KUBERMATIC_OIDC_PASSWORD="password"
 
 # Build binaries and load the Docker images into the kind cluster

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -110,7 +110,7 @@ time retry 5 kind load docker-image "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" 
 export SEED_NAME=kubermatic
 
 # Tell the conformance tester what dummy account we configure for the e2e tests.
-export KUBERMATIC_OIDC_LOGIN="roxy@loodse.com"
+export KUBERMATIC_OIDC_LOGIN="roxy@kubermatic.com"
 export KUBERMATIC_OIDC_PASSWORD="password"
 
 # Build binaries and load the Docker images into the kind cluster

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/cmd/kubermatic-api/wrappers.go
+++ b/pkg/ee/cmd/kubermatic-api/wrappers.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2020 Loodse GmbH
+                     Copyright © 2020 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/cmd/master-controller-manager/wrappers.go
+++ b/pkg/ee/cmd/master-controller-manager/wrappers.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2020 Loodse GmbH
+                     Copyright © 2020 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/cmd/seed-controller-manager/wrappers.go
+++ b/pkg/ee/cmd/seed-controller-manager/wrappers.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2020 Loodse GmbH
+                     Copyright © 2020 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/constraint-controller/util.go
+++ b/pkg/ee/constraint-controller/util.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/constraint-controller/util_test.go
+++ b/pkg/ee/constraint-controller/util_test.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/constraint-template-controller/util.go
+++ b/pkg/ee/constraint-template-controller/util.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/constraint-template-controller/util_test.go
+++ b/pkg/ee/constraint-template-controller/util_test.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/clusterrolebinding.go
+++ b/pkg/ee/metering/clusterrolebinding.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/handler.go
+++ b/pkg/ee/metering/handler.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/pvc.go
+++ b/pkg/ee/metering/pvc.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/report_handler.go
+++ b/pkg/ee/metering/report_handler.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/metering/serviceaccount.go
+++ b/pkg/ee/metering/serviceaccount.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Loodse GmbH
+                     Copyright © 2021 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/provider/seed.go
+++ b/pkg/ee/provider/seed.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2020 Loodse GmbH
+                     Copyright © 2020 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/test/e2e/api/admin_test.go
+++ b/pkg/test/e2e/api/admin_test.go
@@ -246,7 +246,7 @@ func TestManageProjectMembersByAdmin(t *testing.T) {
 	}{
 		{
 			name:          "admin can manage project members for any project",
-			expectedUsers: sets.NewString("roxy@loodse.com"),
+			expectedUsers: sets.NewString("roxy@kubermatic.com"),
 		},
 	}
 

--- a/pkg/test/e2e/api/sa_test.go
+++ b/pkg/test/e2e/api/sa_test.go
@@ -135,7 +135,7 @@ func TestTokenAccessForProject(t *testing.T) {
 			}
 
 			// check if SA can add member to the project
-			_, err = apiRunnerWithSAToken.AddProjectUser(project.ID, "roxy2@loodse.com", "roxy2", "viewers")
+			_, err = apiRunnerWithSAToken.AddProjectUser(project.ID, "roxy2@kubermatic.com", "roxy2", "viewers")
 			switch tc.group {
 			case rbac.ViewerGroupNamePrefix:
 			case rbac.EditorGroupNamePrefix:
@@ -186,7 +186,7 @@ func TestTokenAccessForProject(t *testing.T) {
 					t.Fatalf("expected error status 403 Forbidden, but was: %v", err)
 				}
 			case rbac.ProjectManagerGroupNamePrefix:
-				newSAproject, err := apiRunnerWithSAToken.CreateProjectBySA(rand.String(10), []string{"roxy2@loodse.com", "roxy@loodse.com"})
+				newSAproject, err := apiRunnerWithSAToken.CreateProjectBySA(rand.String(10), []string{"roxy2@kubermatic.com", "roxy@kubermatic.com"})
 				if err != nil {
 					t.Fatalf("service account in projectmanagers should create a project %v", err)
 				}

--- a/pkg/test/e2e/api/user_test.go
+++ b/pkg/test/e2e/api/user_test.go
@@ -34,7 +34,7 @@ func TestDeleteProjectOwner(t *testing.T) {
 	}{
 		{
 			name:          "test, delete project owner",
-			expectedUsers: []string{"roxy@loodse.com"},
+			expectedUsers: []string{"roxy@kubermatic.com"},
 		},
 	}
 
@@ -87,10 +87,10 @@ func TestAddUserToProject(t *testing.T) {
 	}{
 		{
 			name:          "test, add user to project",
-			newUserEmail:  "roxy2@loodse.com",
+			newUserEmail:  "roxy2@kubermatic.com",
 			newUserName:   "roxy2",
 			newUserGroup:  "viewers",
-			expectedUsers: []string{"roxy@loodse.com", "roxy2@loodse.com"},
+			expectedUsers: []string{"roxy@kubermatic.com", "roxy2@kubermatic.com"},
 		},
 	}
 

--- a/pkg/test/e2e/utils/oidc.go
+++ b/pkg/test/e2e/utils/oidc.go
@@ -55,7 +55,7 @@ func OIDCAdminCredentials() (string, string, error) {
 		return "", "", fmt.Errorf("no OIDC password specified ($%s is unset)", PasswordEnvironmentVariable)
 	}
 
-	return "roxy2@loodse.com", password, nil
+	return "roxy2@kubermatic.com", password, nil
 }
 
 // these variables are runtime caches to not have to login to Dex


### PR DESCRIPTION
**What this PR does / why we need it**:
Legally everything has been done for ages, it's time that we finally update the KERO license and also being to get rid of loodse.com for the dummy e2e accounts. This PR does that.

I kept the old loodse.com accounts for now, because I think the dashboard tests assume that those exist. Once the dashboard has been adjusted, we can remove them for good.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
