### PR TITLE
bump kube-state-metrics to 2.2.3, raise memory limit

### DIFF
--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: kube-state-metrics
-version: 1.2.1
-appVersion: v2.2.0
+version: 1.2.2
+appVersion: v2.2.3
 description: Kube-State-Metrics for Kubermatic
 keywords:
 - kubermatic

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -15,14 +15,14 @@
 kubeStateMetrics:
   image:
     repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
-    tag: v2.2.0
+    tag: v2.2.3
   resources:
     requests:
       cpu: 250m
-      memory: 32Mi
-    limits:
-      cpu: 1
       memory: 128Mi
+    limits:
+      cpu: 2
+      memory: 384Mi
 
   resizer:
     image:

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -48,7 +48,7 @@ var (
 
 const (
 	name    = "kube-state-metrics"
-	version = "v2.2.0"
+	version = "v2.2.3"
 )
 
 // DeploymentCreator returns the function to create and update the kube-state-metrics deployment

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
On larger Seed clusters, ksm can easily be OOMKilled.

**Does this PR introduce a user-facing change?**:
```release-note
update kube-state-metrics to 2.2.3
```
