### PR TITLE
Respect userCluster.overwriteRegistry from k8c config in user cluster controllers and addon manifests

### DIFF
--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -207,7 +207,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: aws-node-termination-handler
-          image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.13.0
+          image: '{{ Registry "public.ecr.aws" }}/aws-ec2/aws-node-termination-handler:v1.13.0'
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true

--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -410,7 +410,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.8.0
+          image: '{{ Registry "docker.io" }}/calico/cni:v3.8.0'
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -441,7 +441,7 @@ spec:
         # host.
         - name: calico-node
           # FIXME: Remove FELIX_IGNORELOOSERPF from env when this is v3.12.0+
-          image: docker.io/calico/node:v3.8.0
+          image: '{{ Registry "docker.io" }}/calico/node:v3.8.0'
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -528,7 +528,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.11.0
+          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.11.0'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -3588,7 +3588,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.19.1
+          image: '{{ Registry "docker.io" }}/calico/cni:v3.19.1'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3631,7 +3631,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.19.1
+          image: '{{ Registry "docker.io" }}/calico/node:v3.19.1'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3732,7 +3732,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.13.0
+          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.13.0'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -3845,7 +3845,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.19.1
+          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.19.1'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/cilium/cilium.yaml
+++ b/addons/cilium/cilium.yaml
@@ -540,7 +540,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "{{ $apiServerPort }}"
 {{ end }}
-        image: "quay.io/cilium/cilium:v1.10.4@sha256:7d354052ccf2a7445101d78cebd14444c7c40129ce7889f2f04b89374dbf8a1d"
+        image: '{{ Registry "quay.io" }}/cilium/cilium:v1.10.4@sha256:7d354052ccf2a7445101d78cebd14444c7c40129ce7889f2f04b89374dbf8a1d'
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -603,7 +603,7 @@ spec:
           # same directory where we install cilium cni plugin so that exec permissions
           # are available.
           - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
-        image: "quay.io/cilium/cilium:v1.10.4@sha256:7d354052ccf2a7445101d78cebd14444c7c40129ce7889f2f04b89374dbf8a1d"
+        image: '{{ Registry "quay.io" }}/cilium/cilium:v1.10.4@sha256:7d354052ccf2a7445101d78cebd14444c7c40129ce7889f2f04b89374dbf8a1d'
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /hostproc
@@ -633,7 +633,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "{{ $apiServerPort }}"
 {{ end }}
-        image: "quay.io/cilium/cilium:v1.10.4@sha256:7d354052ccf2a7445101d78cebd14444c7c40129ce7889f2f04b89374dbf8a1d"
+        image: '{{ Registry "quay.io" }}/cilium/cilium:v1.10.4@sha256:7d354052ccf2a7445101d78cebd14444c7c40129ce7889f2f04b89374dbf8a1d'
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -795,7 +795,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "{{ $apiServerPort }}"
 {{ end }}
-        image: "quay.io/cilium/operator-generic:v1.10.4@sha256:c49a14e34634ff1a494c84b718641f27267fb3a0291ce3d74352b44f8a8d2f93"
+        image: '{{ Registry "quay.io" }}/cilium/operator-generic:v1.10.4@sha256:c49a14e34634ff1a494c84b718641f27267fb3a0291ce3d74352b44f8a8d2f93'
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -14,16 +14,16 @@
 
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
-{{ $version = "v1.19.0 "}}
+{{ $version = "v1.19.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v1.20.0 "}}
+{{ $version = "v1.20.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v1.21.0 "}}
+{{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0 "}}
+{{ $version = "v1.22.0"}}
 {{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -176,7 +176,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ $version }}
+      - image: '{{ Registry "k8s.gcr.io" }}/autoscaling/cluster-autoscaler:{{ $version }}'
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -64,7 +64,7 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -76,7 +76,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -89,7 +89,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v2.1.3'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -101,7 +101,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -114,7 +114,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0'
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -124,7 +124,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version }}
+          image: '{{ Registry "docker.io" }}/k8scloudprovider/cinder-csi-plugin:{{ $version }}'
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -17,16 +17,16 @@
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
-{{ $version = "v1.19.0 "}}
+{{ $version = "v1.19.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v1.20.3 "}}
+{{ $version = "v1.20.3"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v1.21.0 "}}
+{{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0 "}}
+{{ $version = "v1.22.0"}}
 {{ end }}
 
 ---

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -50,7 +50,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v1.3.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -74,7 +74,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0'
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -86,7 +86,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version }}
+          image: '{{ Registry "docker.io" }}/k8scloudprovider/cinder-csi-plugin:{{ $version }}'
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -17,16 +17,16 @@
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
-{{ $version = "v1.19.0 "}}
+{{ $version = "v1.19.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v1.20.3 "}}
+{{ $version = "v1.20.3"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v1.21.0 "}}
+{{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0 "}}
+{{ $version = "v1.22.0"}}
 {{ end }}
 
 ---

--- a/addons/csi/vsphere/csiAdmissionWebhook.yaml
+++ b/addons/csi/vsphere/csiAdmissionWebhook.yaml
@@ -80,7 +80,7 @@ spec:
       serviceAccountName: csi-migration-webhook
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.3.0
+          image: '{{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/syncer:v2.3.0'
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/addons/csi/vsphere/csiController.yaml
+++ b/addons/csi/vsphere/csiController.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.1.0
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-attacher:v3.1.0'
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -60,7 +60,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.1.0
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-resizer:v1.1.0'
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -76,7 +76,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:{{ $version }}
+          image: '{{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/driver:{{ $version }}'
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -127,7 +127,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.2.0
+          image: '{{ Registry "quay.io" }}/k8scsi/livenessprobe:v2.2.0'
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -135,7 +135,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:{{ $version }}
+          image: '{{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/syncer:{{ $version }}'
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -170,7 +170,7 @@ spec:
               name: ca-bundle
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.1.0
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-provisioner:v2.1.0'
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/addons/csi/vsphere/csiNode-ds.yaml
+++ b/addons/csi/vsphere/csiNode-ds.yaml
@@ -50,7 +50,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-node-driver-registrar:v2.1.0'
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -76,7 +76,7 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 5
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:{{ $version }}
+          image: '{{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/driver:{{ $version }}'
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -143,7 +143,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.2.0
+          image: '{{ Registry "quay.io" }}/k8scsi/livenessprobe:v2.2.0'
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/addons/multus/daemonset.yaml
+++ b/addons/multus/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: docker.io/nfvpe/multus:v3.6
+        image: '{{ Registry "docker.io" }}/nfvpe/multus:v3.6'
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=/tmp/multus-conf/00-multus.conflist"

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -254,6 +254,7 @@ func main() {
 		runOp.cloudProviderName,
 		clusterURL,
 		isPausedChecker,
+		runOp.overwriteRegistry,
 		uint32(runOp.openvpnServerPort),
 		uint32(runOp.kasSecurePort),
 		runOp.tunnelingAgentIP.IP,

--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -27,6 +27,7 @@ import (
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,23 +127,14 @@ func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error
 	return nil
 }
 
-func getRegistryDefaultFunc(overwriteRegistry string) func(defaultRegistry string) string {
-	return func(defaultRegistry string) string {
-		if overwriteRegistry != "" {
-			return overwriteRegistry
-		}
-		return defaultRegistry
-	}
-}
-
 func getDeploymentCreators(overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow) []reconciling.NamedDeploymentCreatorGetter {
 	return []reconciling.NamedDeploymentCreatorGetter{
-		resources.OperatorDeploymentCreator(getRegistryDefaultFunc(overwriteRegistry), updateWindow),
+		resources.OperatorDeploymentCreator(registry.GetOverwriteFunc(overwriteRegistry), updateWindow),
 	}
 }
 
 func getDaemonSetCreators(overwriteRegistry string) []reconciling.NamedDaemonSetCreatorGetter {
 	return []reconciling.NamedDaemonSetCreatorGetter{
-		resources.AgentDaemonSetCreator(getRegistryDefaultFunc(overwriteRegistry)),
+		resources.AgentDaemonSetCreator(registry.GetOverwriteFunc(overwriteRegistry)),
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -20,6 +20,7 @@ import (
 	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,7 @@ var (
 	hostPathType            = corev1.HostPathUnset
 )
 
-func AgentDaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCreatorGetter {
+func AgentDaemonSetCreator(getRegistry registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	var userCore int64 = 500 // UID of the flatcar admin user 'core'
 
 	return func() (string, reconciling.DaemonSetCreator) {

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -21,6 +21,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,9 +39,7 @@ var (
 	deploymentMaxUnavailable       = intstr.FromString("25%")
 )
 
-type GetImageRegistry func(reg string) string
-
-func OperatorDeploymentCreator(getRegistry GetImageRegistry, updateWindow kubermaticv1.UpdateWindow) reconciling.NamedDeploymentCreatorGetter {
+func OperatorDeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc, updateWindow kubermaticv1.UpdateWindow) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return OperatorDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Spec.Replicas = &deploymentReplicas
@@ -91,7 +90,7 @@ func OperatorDeploymentCreator(getRegistry GetImageRegistry, updateWindow kuberm
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "update-operator",
-					Image:   getRegistry(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
+					Image:   registryWithOverwrite(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
 					Command: []string{"/bin/update-operator"},
 					Env:     env,
 				},

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -33,6 +33,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -102,7 +103,7 @@ func Add(
 		namespace:             namespace,
 		clusterURL:            clusterURL,
 		clusterIsPaused:       clusterIsPaused,
-		overwriteRegistry:     overwriteRegistry,
+		overwriteRegistryFunc: registry.GetOverwriteFunc(overwriteRegistry),
 		openvpnServerPort:     openvpnServerPort,
 		kasSecurePort:         kasSecurePort,
 		tunnelingAgentIP:      tunnelingAgentIP,
@@ -246,7 +247,7 @@ type reconciler struct {
 	namespace             string
 	clusterURL            *url.URL
 	clusterIsPaused       userclustercontrollermanager.IsPausedChecker
-	overwriteRegistry     string
+	overwriteRegistryFunc registry.WithOverwriteFunc
 	openvpnServerPort     uint32
 	kasSecurePort         uint32
 	tunnelingAgentIP      net.IP
@@ -341,11 +342,4 @@ func (r *reconciler) mlaResourceRequirements(ctx context.Context) (monitoring, l
 		return nil, nil, fmt.Errorf("failed to get cluster: %w", err)
 	}
 	return cluster.Spec.MLA.MonitoringResources, cluster.Spec.MLA.LoggingResources, nil
-}
-
-func (r *reconciler) registryWithOverwrite(registry string) string {
-	if r.overwriteRegistry != "" {
-		return r.overwriteRegistry
-	}
-	return registry
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -77,6 +77,7 @@ func Add(
 	cloudProviderName string,
 	clusterURL *url.URL,
 	clusterIsPaused userclustercontrollermanager.IsPausedChecker,
+	overwriteRegistry string,
 	openvpnServerPort uint32,
 	kasSecurePort uint32,
 	tunnelingAgentIP net.IP,
@@ -101,6 +102,7 @@ func Add(
 		namespace:             namespace,
 		clusterURL:            clusterURL,
 		clusterIsPaused:       clusterIsPaused,
+		overwriteRegistry:     overwriteRegistry,
 		openvpnServerPort:     openvpnServerPort,
 		kasSecurePort:         kasSecurePort,
 		tunnelingAgentIP:      tunnelingAgentIP,
@@ -244,6 +246,7 @@ type reconciler struct {
 	namespace             string
 	clusterURL            *url.URL
 	clusterIsPaused       userclustercontrollermanager.IsPausedChecker
+	overwriteRegistry     string
 	openvpnServerPort     uint32
 	kasSecurePort         uint32
 	tunnelingAgentIP      net.IP

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -342,3 +342,10 @@ func (r *reconciler) mlaResourceRequirements(ctx context.Context) (monitoring, l
 	}
 	return cluster.Spec.MLA.MonitoringResources, cluster.Spec.MLA.LoggingResources, nil
 }
+
+func (r *reconciler) registryWithOverwrite(registry string) string {
+	if r.overwriteRegistry != "" {
+		return r.overwriteRegistry
+	}
+	return registry
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -731,7 +731,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context, data reconcileData)
 	}
 
 	if len(r.tunnelingAgentIP) > 0 {
-		dsCreators = append(dsCreators, envoyagent.DaemonSetCreator(r.tunnelingAgentIP, r.versions))
+		dsCreators = append(dsCreators, envoyagent.DaemonSetCreator(r.tunnelingAgentIP, r.versions, r.registryWithOverwrite))
 	}
 
 	if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, metav1.NamespaceSystem, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -778,7 +778,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 	}
 
 	kubeSystemCreators := []reconciling.NamedDeploymentCreatorGetter{
-		coredns.DeploymentCreator(r.clusterSemVer),
+		coredns.DeploymentCreator(r.clusterSemVer, r.registryWithOverwrite),
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, kubeSystemCreators, metav1.NamespaceSystem, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -810,7 +810,10 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 }
 
 func (r *reconciler) reconcileKonnectivityDeployments(ctx context.Context) error {
-	if err := reconciling.ReconcileDeployments(ctx, []reconciling.NamedDeploymentCreatorGetter{konnectivity.DeploymentCreator(r.clusterURL.Hostname())}, metav1.NamespaceSystem, r.Client); err != nil {
+	creators := []reconciling.NamedDeploymentCreatorGetter{
+		konnectivity.DeploymentCreator(r.clusterURL.Hostname(), r.registryWithOverwrite),
+	}
+	if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", metav1.NamespaceSystem, err)
 	}
 	return nil

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -788,8 +788,8 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 	// OPA related resources
 	if r.opaIntegration {
 		creators := []reconciling.NamedDeploymentCreatorGetter{
-			gatekeeper.ControllerDeploymentCreator(r.opaEnableMutation),
-			gatekeeper.AuditDeploymentCreator(),
+			gatekeeper.ControllerDeploymentCreator(r.opaEnableMutation, r.registryWithOverwrite),
+			gatekeeper.AuditDeploymentCreator(r.registryWithOverwrite),
 		}
 
 		if err := reconciling.ReconcileDeployments(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -799,7 +799,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 
 	if r.userClusterMLA.Monitoring {
 		creators := []reconciling.NamedDeploymentCreatorGetter{
-			userclusterprometheus.DeploymentCreator(data.monitoringRequirements),
+			userclusterprometheus.DeploymentCreator(data.monitoringRequirements, r.registryWithOverwrite),
 		}
 		if err := reconciling.ReconcileDeployments(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
 			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", resources.UserClusterMLANamespace, err)

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -771,7 +771,7 @@ func (r *reconciler) reconcileNamespaces(ctx context.Context) error {
 func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileData) error {
 	// Kubernetes Dashboard and related resources
 	creators := []reconciling.NamedDeploymentCreatorGetter{
-		kubernetesdashboard.DeploymentCreator(),
+		kubernetesdashboard.DeploymentCreator(r.registryWithOverwrite),
 	}
 	if err := reconciling.ReconcileDeployments(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", kubernetesdashboard.Namespace, err)

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -740,7 +740,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context, data reconcileData)
 
 	if r.userClusterMLA.Logging {
 		dsCreators = []reconciling.NamedDaemonSetCreatorGetter{
-			promtail.DaemonSetCreator(data.loggingRequirements),
+			promtail.DaemonSetCreator(data.loggingRequirements, r.registryWithOverwrite),
 		}
 		if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, resources.UserClusterMLANamespace, r.Client); err != nil {
 			return fmt.Errorf("failed to reconcile the DaemonSet: %v", err)

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -723,7 +723,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context, data reconcileData)
 	var dsCreators []reconciling.NamedDaemonSetCreatorGetter
 
 	if r.nodeLocalDNSCache {
-		dsCreators = append(dsCreators, nodelocaldns.DaemonSetCreator())
+		dsCreators = append(dsCreators, nodelocaldns.DaemonSetCreator(r.registryWithOverwrite))
 	}
 
 	if r.userSSHKeyAgent {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -24,6 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/dns"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,7 +51,7 @@ var (
 )
 
 // DeploymentCreator returns the function to create and update the CoreDNS deployment
-func DeploymentCreator(kubernetesVersion *semver.Version, registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(kubernetesVersion *semver.Version, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.CoreDNSDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.CoreDNSDeploymentName
@@ -117,7 +118,10 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 	}
 }
 
-func getContainers(clusterVersion *semver.Version, registryWithOverwrite func(string) string) []corev1.Container {
+func getContainers(
+	clusterVersion *semver.Version,
+	registryWithOverwrite registry.WithOverwriteFunc,
+) []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            resources.CoreDNSDeploymentName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -99,8 +99,7 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, registry string)
 	// interface in a loop.
 	return []corev1.Container{
 		{
-			Name: resources.EnvoyAgentCreateInterfaceInitContainerName,
-			// TODO: the registry should be overridable.
+			Name:    resources.EnvoyAgentCreateInterfaceInitContainerName,
 			Image:   fmt.Sprintf("%s/%s:%s", registry, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
 			Command: []string{"sh", "-c", "ip link add envoyagent type dummy || true"},
 			SecurityContext: &corev1.SecurityContext{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -22,6 +22,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,7 +52,7 @@ const (
 )
 
 // DaemonSetCreator returns the function to create and update the Envoy DaemonSet
-func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, registryWithOverwrite func(string) string) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.EnvoyAgentDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Name = resources.EnvoyAgentDaemonSetName

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -51,7 +51,7 @@ const (
 )
 
 // DaemonSetCreator returns the function to create and update the Envoy DaemonSet
-func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, registryWithOverwrite func(string) string) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.EnvoyAgentDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Name = resources.EnvoyAgentDaemonSetName
@@ -69,7 +69,19 @@ func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions) reconciling.
 					map[string]string{"app.kubernetes.io/name": "envoy-agent"}),
 			}
 
-			ds.Spec.Template.Spec = getAgentPodSpec(agentIP, versions)
+			ds.Spec.Template.Spec = corev1.PodSpec{
+				InitContainers: getInitContainers(agentIP, versions, registryWithOverwrite(resources.RegistryQuay)),
+				Containers:     getContainers(versions, registryWithOverwrite(resources.RegistryDocker)),
+				// TODO(youssefazrak) needed?
+				PriorityClassName:             "system-cluster-critical",
+				DNSPolicy:                     corev1.DNSClusterFirst,
+				HostNetwork:                   true,
+				Volumes:                       getVolumes(),
+				RestartPolicy:                 corev1.RestartPolicyAlways,
+				TerminationGracePeriodSeconds: utilpointer.Int64Ptr(30),
+				SecurityContext:               &corev1.PodSecurityContext{},
+				SchedulerName:                 corev1.DefaultSchedulerName,
+			}
 			if err := resources.SetResourceRequirements(ds.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, ds.Annotations); err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
@@ -79,23 +91,7 @@ func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions) reconciling.
 	}
 }
 
-func getAgentPodSpec(agentIP net.IP, versions kubermatic.Versions) corev1.PodSpec {
-	return corev1.PodSpec{
-		InitContainers: getInitContainers(agentIP, versions),
-		Containers:     getContainers(versions),
-		// TODO(youssefazrak) needed?
-		PriorityClassName:             "system-cluster-critical",
-		DNSPolicy:                     corev1.DNSClusterFirst,
-		HostNetwork:                   true,
-		Volumes:                       getVolumes(),
-		RestartPolicy:                 corev1.RestartPolicyAlways,
-		TerminationGracePeriodSeconds: utilpointer.Int64Ptr(30),
-		SecurityContext:               &corev1.PodSecurityContext{},
-		SchedulerName:                 corev1.DefaultSchedulerName,
-	}
-}
-
-func getInitContainers(ip net.IP, v kubermatic.Versions) []corev1.Container {
+func getInitContainers(ip net.IP, versions kubermatic.Versions, registry string) []corev1.Container {
 	// TODO: we are creating and configuring the a dummy interface
 	// using init containers. This approach is good enough for the tech preview
 	// but it is definitely not production ready. This should be replaced with
@@ -105,7 +101,7 @@ func getInitContainers(ip net.IP, v kubermatic.Versions) []corev1.Container {
 		{
 			Name: resources.EnvoyAgentCreateInterfaceInitContainerName,
 			// TODO: the registry should be overridable.
-			Image:   fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, v.Kubermatic),
+			Image:   fmt.Sprintf("%s/%s:%s", registry, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
 			Command: []string{"sh", "-c", "ip link add envoyagent type dummy || true"},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
@@ -120,7 +116,7 @@ func getInitContainers(ip net.IP, v kubermatic.Versions) []corev1.Container {
 		},
 		{
 			Name:    resources.EnvoyAgentAssignAddressInitContainerName,
-			Image:   fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, v.Kubermatic),
+			Image:   fmt.Sprintf("%s/%s:%s", registry, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
 			Command: []string{"sh", "-c", fmt.Sprintf("ip addr add %s/32 dev envoyagent scope host || true", ip.String())},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
@@ -136,11 +132,11 @@ func getInitContainers(ip net.IP, v kubermatic.Versions) []corev1.Container {
 	}
 }
 
-func getContainers(v kubermatic.Versions) []corev1.Container {
+func getContainers(versions kubermatic.Versions, registry string) []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            resources.EnvoyAgentDaemonSetName,
-			Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, envoyImageName, v.Envoy),
+			Image:           fmt.Sprintf("%s/%s:%s", registry, envoyImageName, versions.Envoy),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			// This amount of logs will be kept for the Tech Preview of

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -116,7 +116,7 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, registryWithOver
 		},
 		{
 			Name:    resources.EnvoyAgentAssignAddressInitContainerName,
-			Image:   fmt.Sprintf("%s/%s:%s", registry, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
+			Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
 			Command: []string{"sh", "-c", fmt.Sprintf("ip addr add %s/32 dev envoyagent scope host || true", ip.String())},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -80,7 +81,7 @@ var (
 )
 
 // ControllerDeploymentCreator returns the function to create and update the Gatekeeper controller deployment
-func ControllerDeploymentCreator(enableMutation bool, registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
+func ControllerDeploymentCreator(enableMutation bool, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return controllerName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = controllerName
@@ -127,7 +128,7 @@ func ControllerDeploymentCreator(enableMutation bool, registryWithOverwrite func
 }
 
 // AuditDeploymentCreator returns the function to create and update the Gatekeeper audit deployment
-func AuditDeploymentCreator(registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
+func AuditDeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return auditName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = auditName
@@ -164,7 +165,7 @@ func AuditDeploymentCreator(registryWithOverwrite func(string) string) reconcili
 	}
 }
 
-func getControllerContainers(enableMutation bool, registryWithOverwrite func(string) string) []corev1.Container {
+func getControllerContainers(enableMutation bool, registryWithOverwrite registry.WithOverwriteFunc) []corev1.Container {
 
 	return []corev1.Container{{
 		Name:            controllerName,
@@ -252,7 +253,7 @@ func getControllerContainers(enableMutation bool, registryWithOverwrite func(str
 	}}
 }
 
-func getAuditContainers(registryWithOverwrite func(string) string) []corev1.Container {
+func getAuditContainers(registryWithOverwrite registry.WithOverwriteFunc) []corev1.Container {
 
 	return []corev1.Container{{
 		Name:            auditName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -29,7 +29,7 @@ import (
 )
 
 // DeploymentCreator returns function to create/update deployment for konnectivity agents in user cluster.
-func DeploymentCreator(clusterHostname string) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(clusterHostname string, registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		const (
 			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
@@ -46,7 +46,7 @@ func DeploymentCreator(clusterHostname string) reconciling.NamedDeploymentCreato
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            resources.KonnectivityAgentContainer,
-					Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryUSGCR, name, version),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryUSGCR), name, version),
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"/proxy-agent"},
 					Args: []string{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 )
 
 // DeploymentCreator returns function to create/update deployment for konnectivity agents in user cluster.
-func DeploymentCreator(clusterHostname string, registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(clusterHostname string, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		const (
 			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -22,6 +22,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/resources/kubernetes-dashboard"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the dashboard-metrics-scraper deployment
-func DeploymentCreator(registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return scraperName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = scraperName
@@ -82,7 +83,7 @@ func DeploymentCreator(registryWithOverwrite func(string) string) reconciling.Na
 	}
 }
 
-func getContainers(registryWithOverwrite func(string) string) []corev1.Container {
+func getContainers(registryWithOverwrite registry.WithOverwriteFunc) []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            scraperName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
@@ -69,7 +69,7 @@ var (
 	}
 )
 
-func DeploymentCreator(overrides *corev1.ResourceRequirements) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(overrides *corev1.ResourceRequirements, registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterPrometheusDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
 			deployment.Labels = resources.BaseAppLabels(appName, nil)
@@ -89,7 +89,7 @@ func DeploymentCreator(overrides *corev1.ResourceRequirements) reconciling.Named
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            containerName,
-					Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, imageName, tag),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), imageName, tag),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						fmt.Sprintf("--config.file=%s/prometheus.yaml", configPath),
@@ -151,7 +151,7 @@ func DeploymentCreator(overrides *corev1.ResourceRequirements) reconciling.Named
 				},
 				{
 					Name:            "prometheus-config-reloader",
-					Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, reloaderImageName, reloaderTag),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), reloaderImageName, reloaderTag),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						// Full usage of prometheus-config-reloader:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ var (
 	}
 )
 
-func DeploymentCreator(overrides *corev1.ResourceRequirements, registryWithOverwrite func(string) string) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(overrides *corev1.ResourceRequirements, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterPrometheusDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
 			deployment.Labels = resources.BaseAppLabels(appName, nil)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
@@ -72,7 +72,7 @@ var (
 	}
 )
 
-func DaemonSetCreator(overrides *corev1.ResourceRequirements) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(overrides *corev1.ResourceRequirements, registryWithOverwrite func(string) string) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.PromtailDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Labels = resources.BaseAppLabels(appName, nil)
@@ -90,7 +90,7 @@ func DaemonSetCreator(overrides *corev1.ResourceRequirements) reconciling.NamedD
 			ds.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:            "init-inotify",
-					Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, initImageName, initImageTag),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryDocker), initImageName, initImageTag),
 					ImagePullPolicy: corev1.PullAlways,
 					Command: []string{
 						"sh",
@@ -105,7 +105,7 @@ func DaemonSetCreator(overrides *corev1.ResourceRequirements) reconciling.NamedD
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            containerName,
-					Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, imageName, imageTag),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryDocker), imageName, imageTag),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-config.file=/etc/promtail/promtail.yaml",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ var (
 	}
 )
 
-func DaemonSetCreator(overrides *corev1.ResourceRequirements, registryWithOverwrite func(string) string) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(overrides *corev1.ResourceRequirements, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.PromtailDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Labels = resources.BaseAppLabels(appName, nil)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func DaemonSetCreator(registryWithOverwrite func(string) string) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.NodeLocalDNSDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			maxUnvailable := intstr.FromString("10%")

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(registryWithOverwrite func(string) string) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.NodeLocalDNSDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			maxUnvailable := intstr.FromString("10%")
@@ -70,8 +70,8 @@ func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
+					Image:           fmt.Sprintf("%s/k8s-dns-node-cache:1.15.7", registryWithOverwrite(resources.RegistryK8SGCR)),
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           fmt.Sprintf("%s/k8s-dns-node-cache:1.15.7", resources.RegistryK8SGCR),
 					Args: []string{
 						"-localip",
 						"169.254.20.10",

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registry groups all container registry related types and helpers in one place.
+package registry
+
+// WithOverwriteFunc is a function that takes a string and either returns that string or a defined override value.
+type WithOverwriteFunc func(string) string

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -19,3 +19,15 @@ package registry
 
 // WithOverwriteFunc is a function that takes a string and either returns that string or a defined override value.
 type WithOverwriteFunc func(string) string
+
+// GetOverwriteFunc returns a WithOverwriteFunc based on the given override value.
+func GetOverwriteFunc(overwriteRegistry string) WithOverwriteFunc {
+	if overwriteRegistry != "" {
+		return func(string) string {
+			return overwriteRegistry
+		}
+	}
+	return func(s string) string {
+		return s
+	}
+}

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -27,6 +27,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -124,7 +125,7 @@ func (a *AgentConfig) newAgentConfigMap(ns string) *corev1.ConfigMap {
 
 // newAgnhostPod returns a pod returns the manifest of the agent pod.
 func (a *AgentConfig) newAgentPod(ns string) *corev1.Pod {
-	agentName, createDs := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions)()
+	agentName, createDs := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions, registry.GetOverwriteFunc(""))()
 	// TODO: errors should never be thrown here
 	ds, _ := createDs(&appsv1.DaemonSet{})
 	// We don't need the init containers in this context.


### PR DESCRIPTION
**What this PR does / why we need it**:
The documentation of the field `userCluster.overwriteRegistry` states:
```
# OverwriteRegistry specifies a custom Docker registry which will be used for all images
# used inside user clusters (user cluster control plane + addons). This also applies to
# the KubermaticDockerRepository and DNATControllerDockerRepository fields.
``` 
But this was not the case. There were multiple components that directly used hardcoded registries without the possibility to override these registries.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6562 

**Special notes for your reviewer**:
I am not yet sure about the `registry` package. If someone can show me a better place to put its content, I will adjust the PR.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The field `userCluster.overwriteRegistry` in the KubermaticConfiguration is now properly respected
by all provided addons and by more user cluster controllers: core-dns, envoy-agent, gatekeeper,
konnectivity, kubernetes-dashboard, mla-prometheus, mla-promtail, node-local-dns.
```
