### PR TITLE
Support TLS peer connections and live migration in etcd-launcher

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -340,13 +340,26 @@ func etcdCmd(config *etcdCluster) []string {
 		fmt.Sprintf("--advertise-client-urls=https://%s.etcd.%s.svc.cluster.local:2379,https://%s:2379", config.podName, config.namespace, config.podIP),
 		fmt.Sprintf("--listen-client-urls=https://%s:2379,https://127.0.0.1:2379", config.podIP),
 		fmt.Sprintf("--listen-metrics-urls=http://%s:2378,http://127.0.0.1:2378", config.podIP),
-		fmt.Sprintf("--listen-peer-urls=http://%s:2380", config.podIP),
 		fmt.Sprintf("--initial-advertise-peer-urls=http://%s.etcd.%s.svc.cluster.local:2380", config.podName, config.namespace),
 		"--client-cert-auth",
 		fmt.Sprintf("--trusted-ca-file=%s", resources.EtcdTrustedCAFile),
 		fmt.Sprintf("--cert-file=%s", resources.EtcdCertFile),
 		fmt.Sprintf("--key-file=%s", resources.EtcdKetFile),
 		"--auto-compaction-retention=8",
+	}
+
+	if config.initialState == initialStateNew {
+		cmd = append(cmd, []string{
+			fmt.Sprintf("--listen-peer-urls=https://%s:2381", config.podIP),
+			fmt.Sprintf("--peer-cert-file=%s", resources.EtcdCertFile),
+			fmt.Sprintf("--peer-key-file=%s", resources.EtcdKetFile),
+			fmt.Sprintf("--peer-trusted-ca-file=%s", resources.EtcdTrustedCAFile),
+			"--peer-client-cert-auth",
+		}...)
+	} else {
+		cmd = append(cmd, []string{
+			fmt.Sprintf("--listen-peer-urls=http://%s:2380", config.podIP),
+		}...)
 	}
 
 	if config.enableCorruptionCheck {

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -442,14 +442,14 @@ func etcdCmd(config *etcdCluster) []string {
 	if config.usePeerTLSOnly {
 		cmd = append(cmd, []string{
 			fmt.Sprintf("--listen-peer-urls=https://%s:2381", config.podIP),
-			fmt.Sprintf("--initial-advertise-peer-urls=https://%s.etd.%s.svc.cluster.local:2381", config.podName, config.namespace),
+			fmt.Sprintf("--initial-advertise-peer-urls=https://%s.etcd.%s.svc.cluster.local:2381", config.podName, config.namespace),
 			"--peer-client-cert-auth",
 		}...)
 	} else {
 		// 'mixed' mode clusters should start with both plaintext and HTTPS peer ports
 		cmd = append(cmd, []string{
 			fmt.Sprintf("--listen-peer-urls=http://%s:2380,https://%s:2381", config.podIP, config.podIP),
-			fmt.Sprintf("--initial-advertise-peer-urls=http://%s.etcd.%s.svc.cluster.local:2380,https://%s.etd.%s.svc.cluster.local:2381", config.podName, config.namespace, config.podName, config.namespace),
+			fmt.Sprintf("--initial-advertise-peer-urls=http://%s.etcd.%s.svc.cluster.local:2380,https://%s.etcd.%s.svc.cluster.local:2381", config.podName, config.namespace, config.podName, config.namespace),
 		}...)
 	}
 

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -220,9 +220,10 @@ func deleteUnwantedDeadMembers(e *etcdCluster, log *zap.SugaredLogger) (bool, er
 	}
 	// we only need to reconcile if we have members that we shouldn't have
 	if len(unwantedMembers) == 0 {
-		log.Info("no unwanted members present")
+		log.Debug("no unwanted members present")
 		return true, nil
 	}
+
 	// to avoide race conditions, we will run only on the cluster leader
 	leader, err := e.isLeader(log)
 	if err != nil {
@@ -526,7 +527,7 @@ func (e *etcdCluster) getUnwantedMembers(log *zap.SugaredLogger) ([]*etcdserverp
 
 	expectedMembers := peerHostsList(e.clusterSize, e.namespace)
 	for _, member := range members {
-		if len(member.GetPeerURLs()) != 1 || len(member.GetPeerURLs()) != 2 {
+		if len(member.GetPeerURLs()) != 1 && len(member.GetPeerURLs()) != 2 {
 			unwantedMembers = append(unwantedMembers, member)
 			continue
 		}
@@ -604,7 +605,7 @@ func (e *etcdCluster) removeDeadMembers(log *zap.SugaredLogger, unwantedMembers 
 	defer close(client, log)
 
 	for _, member := range unwantedMembers {
-		log.Infow("removing cluster member", "member-name", member.Name)
+		log.Infow("checking cluster member for removal", "member-name", member.Name)
 
 		if member.Name == e.podName {
 			continue

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -227,7 +227,7 @@ func startEtcdCmd(e *etcdCluster, log *zap.SugaredLogger) (*exec.Cmd, error) {
 func deleteUnwantedDeadMembers(e *etcdCluster, log *zap.SugaredLogger) (bool, error) {
 	unwantedMembers, err := e.getUnwantedMembers(log)
 	if err != nil {
-		log.Warnw("failed to get unwanted members ", zap.Error(err))
+		log.Warnw("failed to get unwanted members", zap.Error(err))
 		return false, nil
 	}
 	// we only need to reconcile if we have members that we shouldn't have

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -124,7 +124,7 @@ func main() {
 		log.Panicw("start etcd cmd", zap.Error(err))
 	}
 
-	if err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+	if err = wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
 		return e.isClusterHealthy(log)
 	}); err != nil {
 		log.Panicw("manager thread failed to connect to cluster", zap.Error(err))

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -300,6 +300,10 @@ func (e *etcdCluster) updatePeerURLs(log *zap.SugaredLogger) error {
 			// update the member to include both plaintext and TLS peer URLs
 			if !e.usePeerTLSOnly && (len(member.PeerURLs) == 1 || peerURL.Scheme != "http") {
 				plainPeerURL, err := url.Parse(fmt.Sprintf("http://%s:2380", peerURL.Hostname()))
+				if err != nil {
+					return err
+				}
+
 				tlsPeerURL, err := url.Parse(fmt.Sprintf("https://%s:2381", peerURL.Hostname()))
 				if err != nil {
 					return err

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -267,7 +267,7 @@ func getImagesFromCreators(log *zap.SugaredLogger, templateData *resources.Templ
 		return nil, fmt.Errorf("failed to default Seed: %v", err)
 	}
 
-	statefulsetCreators := kubernetescontroller.GetStatefulSetCreators(templateData, false)
+	statefulsetCreators := kubernetescontroller.GetStatefulSetCreators(templateData, false, false)
 	statefulsetCreators = append(statefulsetCreators, monitoring.GetStatefulSetCreators(templateData)...)
 
 	deploymentCreators := kubernetescontroller.GetDeploymentCreators(templateData, false)

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -32,7 +32,7 @@ pushElapsed gocache_download_duration_milliseconds $beforeGocache
 export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
 
 source hack/ci/setup-kind-cluster.sh
-source hack/ci/setup-kubermatic-in-kind.sh
+source hack/ci/setup-kubermatic-backups-in-kind.sh
 
 echodate "Creating UI DigitalOcean preset..."
 cat << EOF > preset-digitalocean.yaml

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -62,5 +62,5 @@ EOF
 retry 2 kubectl apply -f user.yaml
 
 echodate "Running etcd-launcher tests..."
-go test -timeout 30m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
+go test -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
 echodate "Tests completed successfully!"

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -1,0 +1,199 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script creates a local kind cluster, compiles the KKP binaries,
+### creates all Docker images and loads them into the kind cluster,
+### generates a custom CA and a certificate for minio to be used as backup location,
+### then installs KKP using the KKP installer + operator and sets up a
+### single shared master/seed system.
+### This serves as the precursor for all other tests.
+###
+### This script should be sourced, not called, so callers get the variables
+### it sets.
+
+source hack/lib.sh
+
+if [ -z "${KIND_CLUSTER_NAME:-}" ]; then
+  echodate "KIND_CLUSTER_NAME must be set by calling setup-kind-cluster.sh first."
+  exit 1
+fi
+
+# The Kubermatic version to build.
+export KUBERMATIC_VERSION="${KUBERMATIC_VERSION:-$(git rev-parse HEAD)}"
+
+REPOSUFFIX=""
+if [ "$KUBERMATIC_EDITION" != "ce" ]; then
+  REPOSUFFIX="-$KUBERMATIC_EDITION"
+fi
+
+# This is just used as a const
+# NB: The CE requires Seeds to be named this way
+export SEED_NAME=kubermatic
+
+# This defines the Kubermatic API endpoint the e2e tests will communicate with.
+# The api service is kubectl-proxied later on.
+export KUBERMATIC_API_ENDPOINT="http://localhost:8080"
+
+# Tell the conformance tester what dummy account we configure for the e2e tests.
+export KUBERMATIC_DEX_VALUES_FILE=$(realpath hack/ci/testdata/oauth_values.yaml)
+export KUBERMATIC_OIDC_LOGIN="roxy@kubermatic.com"
+export KUBERMATIC_OIDC_PASSWORD="password"
+
+# Set docker config
+echo "$IMAGE_PULL_SECRET_DATA" | base64 -d > /config.json
+
+# The alias makes it easier to access the port-forwarded Dex inside the Kind cluster;
+# the token issuer cannot be localhost:5556, because pods inside the cluster would not
+# find Dex anymore. As this script can be run multiple times in the same CI job,
+# we must make sure to only add the alias once.
+if ! grep oauth /etc/hosts > /dev/null; then
+  echodate "Setting dex.oauth alias in /etc/hosts"
+  # The container runtime allows us to change the content but not to change the inode
+  # which is what sed -i does, so write to a tempfile and write the tempfiles content back.
+  temp_hosts="$(mktemp)"
+  sed 's/localhost/localhost dex.oauth/' /etc/hosts > $temp_hosts
+  cat $temp_hosts > /etc/hosts
+  echodate "Set dex.oauth alias in /etc/hosts"
+fi
+
+# Build binaries and load the Docker images into the kind cluster
+echodate "Building binaries for $KUBERMATIC_VERSION"
+TEST_NAME="Build Kubermatic binaries"
+
+beforeGoBuild=$(nowms)
+time retry 1 make build
+pushElapsed kubermatic_go_build_duration_milliseconds $beforeGoBuild
+
+beforeDockerBuild=$(nowms)
+
+(
+  echodate "Building Kubermatic Docker image"
+  TEST_NAME="Build Kubermatic Docker image"
+  IMAGE_NAME="quay.io/kubermatic/kubermatic$REPOSUFFIX:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "$IMAGE_NAME" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building addons image"
+  TEST_NAME="Build addons Docker image"
+  cd addons
+  IMAGE_NAME="quay.io/kubermatic/addons:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building nodeport-proxy image"
+  TEST_NAME="Build nodeport-proxy Docker image"
+  cd cmd/nodeport-proxy
+  make build
+  IMAGE_NAME="quay.io/kubermatic/nodeport-proxy:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building kubeletdnat-controller image"
+  TEST_NAME="Build kubeletdnat-controller Docker image"
+  cd cmd/kubeletdnat-controller
+  make build
+  IMAGE_NAME="quay.io/kubermatic/kubeletdnat-controller:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building user-ssh-keys-agent image"
+  TEST_NAME="Build user-ssh-keys-agent Docker image"
+  retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
+  cd cmd/user-ssh-keys-agent
+  make build
+  IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 docker push "${IMAGE_NAME}"
+)
+(
+  echodate "Building etcd-launcher image"
+  TEST_NAME="Build etcd-launcher Docker image"
+  IMAGE_NAME="quay.io/kubermatic/etcd-launcher:${KUBERMATIC_VERSION}"
+  time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+
+pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
+echodate "Successfully built and loaded all images"
+
+# prepare to run kubermatic-installer
+KUBERMATIC_CONFIG="$(mktemp)"
+IMAGE_PULL_SECRET_INLINE="$(echo "$IMAGE_PULL_SECRET_DATA" | base64 --decode | jq --compact-output --monochrome-output '.')"
+KUBERMATIC_DOMAIN="${KUBERMATIC_DOMAIN:-ci.kubermatic.io}"
+
+cp hack/ci/testdata/kubermatic.yaml $KUBERMATIC_CONFIG
+
+sed -i "s;__SERVICE_ACCOUNT_KEY__;$SERVICE_ACCOUNT_KEY;g" $KUBERMATIC_CONFIG
+sed -i "s;__IMAGE_PULL_SECRET__;$IMAGE_PULL_SECRET_INLINE;g" $KUBERMATIC_CONFIG
+sed -i "s;__KUBERMATIC_DOMAIN__;$KUBERMATIC_DOMAIN;g" $KUBERMATIC_CONFIG
+
+HELM_VALUES_FILE="$(mktemp)"
+cat << EOF > $HELM_VALUES_FILE
+kubermaticOperator:
+  image:
+    repository: "quay.io/kubermatic/kubermatic$REPOSUFFIX"
+    tag: "$KUBERMATIC_VERSION"
+EOF
+
+# append custom Dex configuration
+cat hack/ci/testdata/oauth_values.yaml >> $HELM_VALUES_FILE
+
+# install dependencies and Kubermatic Operator into cluster
+./_build/kubermatic-installer deploy --disable-telemetry \
+  --storageclass copy-default \
+  --config "$KUBERMATIC_CONFIG" \
+  --helm-values "$HELM_VALUES_FILE"
+
+# TODO: The installer should wait for everything to finish reconciling.
+echodate "Waiting for Kubermatic Operator to deploy Master components..."
+# sleep a bit to prevent us from checking the Deployments too early, before
+# the operator had time to reconcile
+sleep 5
+retry 10 check_all_deployments_ready kubermatic
+
+echodate "Finished installing Kubermatic"
+
+echodate "Installing Seed..."
+SEED_MANIFEST="$(mktemp)"
+SEED_KUBECONFIG="$(cat $KUBECONFIG | sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./' | base64 -w0)"
+
+cp hack/ci/testdata/seed_backup.yaml $SEED_MANIFEST
+
+sed -i "s/__SEED_NAME__/$SEED_NAME/g" $SEED_MANIFEST
+sed -i "s/__BUILD_ID__/$BUILD_ID/g" $SEED_MANIFEST
+sed -i "s/__KUBECONFIG__/$SEED_KUBECONFIG/g" $SEED_MANIFEST
+
+retry 8 kubectl apply -f $SEED_MANIFEST
+echodate "Finished installing Seed"
+
+sleep 5
+echodate "Waiting for Kubermatic Operator to deploy Seed components..."
+retry 8 check_all_deployments_ready kubermatic
+echodate "Kubermatic Seed is ready."
+
+echodate "Waiting for VPA to be ready..."
+retry 8 check_all_deployments_ready kube-system
+echodate "VPA is ready."
+
+appendTrap cleanup_kubermatic_clusters_in_kind EXIT
+
+TEST_NAME="Expose Dex and Kubermatic API"
+echodate "Exposing Dex and Kubermatic API to localhost..."
+kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 > /dev/null &
+kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 > /dev/null &
+echodate "Finished exposing components"

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -170,8 +170,6 @@ MINIO_TLS_CERT=$(mktemp)
 openssl genrsa -out "$CUSTOM_CA_KEY" 2048
 openssl req -x509 -new -nodes -subj "/C=DE/O=Kubermatic CI/CN=kubermatic-e2e-ca" -key "$CUSTOM_CA_KEY" -sha256 -days 30 -out "$CUSTOM_CA_CERT"
 
-echo $CUSTOM_CA_KEY $CUSTOM_CA_CERT
-
 # create private key, CSR and signed certificate for minio TLS
 openssl genrsa -out "$MINIO_TLS_KEY" 2048
 openssl req -new -sha256 \
@@ -213,7 +211,7 @@ echodate "Finished installing Kubermatic"
 
 echodate "installing minio..."
 kubectl create namespace minio
-kubectl create secret tls minio-certificates --cert "$MINIO_TLS_CERT" --key "$MINIO_TLS_KEY"
+kubectl create secret tls minio-tls-cert --cert "$MINIO_TLS_CERT" --key "$MINIO_TLS_KEY"
 helm --namespace minio upgrade --install --wait --values "$HELM_VALUES_FILE" minio charts/minio/
 kubectl apply -f hack/ci/testdata/backup_s3_creds.yaml
 

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -148,6 +148,11 @@ kubermaticOperator:
   image:
     repository: "quay.io/kubermatic/kubermatic$REPOSUFFIX"
     tag: "$KUBERMATIC_VERSION"
+minio:
+  storageClass: 'copy-default'
+  credentials:
+    accessKey: "FXcD7s0tFOPuTv6jaZARJDouc2Hal8E0"
+    secretKey: "wdEZGTnhkgBDTDetaHFuizs3pwXHvWTs"
 EOF
 
 # append custom Dex configuration
@@ -167,6 +172,10 @@ sleep 5
 retry 10 check_all_deployments_ready kubermatic
 
 echodate "Finished installing Kubermatic"
+
+echodate "installing minio..."
+kubectl apply -f hack/ci/testdata/s3_secret.yaml
+helm --namespace minio upgrade --install --create-namespace --wait --values values.yaml minio charts/minio/
 
 echodate "Installing Seed..."
 SEED_MANIFEST="$(mktemp)"

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -175,6 +175,7 @@ echodate "Finished installing Kubermatic"
 
 echodate "installing minio..."
 helm --namespace minio upgrade --install --create-namespace --wait --values "$HELM_VALUES_FILE" minio charts/minio/
+kubectl apply -f hack/ci/testdata/backup_s3_creds.yaml
 
 echodate "Installing Seed..."
 SEED_MANIFEST="$(mktemp)"

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -149,7 +149,7 @@ kubermaticOperator:
     repository: "quay.io/kubermatic/kubermatic$REPOSUFFIX"
     tag: "$KUBERMATIC_VERSION"
 minio:
-  storageClass: 'copy-default'
+  storageClass: 'kubermatic-fast'
   credentials:
     accessKey: "FXcD7s0tFOPuTv6jaZARJDouc2Hal8E0"
     secretKey: "wdEZGTnhkgBDTDetaHFuizs3pwXHvWTs"

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -174,7 +174,6 @@ retry 10 check_all_deployments_ready kubermatic
 echodate "Finished installing Kubermatic"
 
 echodate "installing minio..."
-kubectl apply -f hack/ci/testdata/s3_secret.yaml
 helm --namespace minio upgrade --install --create-namespace --wait --values "$HELM_VALUES_FILE" minio charts/minio/
 
 echodate "Installing Seed..."

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -172,12 +172,16 @@ openssl req -x509 -new -nodes -subj "/C=DE/O=Kubermatic CI/CN=kubermatic-e2e-ca"
 
 # create private key, CSR and signed certificate for minio TLS
 openssl genrsa -out "$MINIO_TLS_KEY" 2048
-openssl req -new -sha256 \
+openssl req -new -nodes \
   -key "$MINIO_TLS_KEY" \
   -subj "/C=DE/O=Kubermatic CI/CN=minio.minio.svc.cluster.local" \
+  -config hack/ci/testdata/minio.cnf \
   -out "$MINIO_TLS_CSR"
 
-openssl x509 -req -in "$MINIO_TLS_CSR" -CA "$CUSTOM_CA_CERT" -CAkey "$CUSTOM_CA_KEY" -CAcreateserial -out "$MINIO_TLS_CERT" -days 7 -sha256
+openssl x509 -req -in "$MINIO_TLS_CSR" \
+  -CA "$CUSTOM_CA_CERT" -CAkey "$CUSTOM_CA_KEY" -CAcreateserial \
+  -out "$MINIO_TLS_CERT" -days 7 -sha256 \
+  -extfile hack/ci/testdata/minio.cnf -extensions req_ext
 
 CA_BUNDLE_CM=$(mktemp)
 cat << EOF > $CA_BUNDLE_CM

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -175,9 +175,9 @@ echo $CUSTOM_CA_KEY $CUSTOM_CA_CERT
 # create private key, CSR and signed certificate for minio TLS
 openssl genrsa -out "$MINIO_TLS_KEY" 2048
 openssl req -new -sha256 \
-    -key "$MINIO_TLS_KEY" \
-    -subj "/C=DE/O=Kubermatic CI/CN=minio.minio.svc.cluster.local" \
-    -out "$MINIO_TLS_CSR" 
+  -key "$MINIO_TLS_KEY" \
+  -subj "/C=DE/O=Kubermatic CI/CN=minio.minio.svc.cluster.local" \
+  -out "$MINIO_TLS_CSR"
 
 openssl x509 -req -in "$MINIO_TLS_CSR" -CA "$CUSTOM_CA_CERT" -CAkey "$CUSTOM_CA_KEY" -CAcreateserial -out "$MINIO_TLS_CERT" -days 7 -sha256
 
@@ -190,7 +190,7 @@ metadata:
   namespace: kubermatic
 data:
   ca-bundle.pem: |
-    $(cat charts/kubermatic-operator/static/ca-bundle.pem $CUSTOM_CA_CERT)
+$(cat charts/kubermatic-operator/static/ca-bundle.pem $CUSTOM_CA_CERT | sed 's/^/    /')
 EOF
 
 kubectl create namespace kubermatic

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -175,7 +175,7 @@ echodate "Finished installing Kubermatic"
 
 echodate "installing minio..."
 kubectl apply -f hack/ci/testdata/s3_secret.yaml
-helm --namespace minio upgrade --install --create-namespace --wait --values values.yaml minio charts/minio/
+helm --namespace minio upgrade --install --create-namespace --wait --values "$HELM_VALUES_FILE" minio charts/minio/
 
 echodate "Installing Seed..."
 SEED_MANIFEST="$(mktemp)"

--- a/hack/ci/testdata/backup_s3_creds.yaml
+++ b/hack/ci/testdata/backup_s3_creds.yaml
@@ -1,3 +1,16 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/hack/ci/testdata/backup_s3_creds.yaml
+++ b/hack/ci/testdata/backup_s3_creds.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backup-s3
+  namespace: kube-system
+data:
+  ACCESS_KEY_ID: RlhjRDdzMHRGT1B1VHY2amFaQVJKRG91YzJIYWw4RTA=
+  SECRET_ACCESS_KEY: d2RFWkdUbmhrZ0JEVERldGFIRnVpenMzcHdYSHZXVHM=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s3-settings
+  namespace: kube-system
+data:
+  BUCKET_NAME: kkpbackupe2e
+  ENDPOINT: minio.minio.svc.cluster.local:9000

--- a/hack/ci/testdata/kubermatic_backup.yaml
+++ b/hack/ci/testdata/kubermatic_backup.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operator.kubermatic.io/v1alpha1
+kind: KubermaticConfiguration
+metadata:
+  name: e2e
+  namespace: kubermatic
+spec:
+  caBundle:
+    name: custom-ca-bundle
+  ingress:
+    domain: '__KUBERMATIC_DOMAIN__'
+    disable: true
+  imagePullSecret: '__IMAGE_PULL_SECRET__'
+  userCluster:
+    apiserverReplicas: 1
+  api:
+    replicas: 1
+    debugLog: true
+  featureGates:
+    # VPA won't do anything useful due to missing Prometheus, but we can
+    # at least ensure we deploy a working set of Deployments.
+    VerticalPodAutoscaler: {}
+  ui:
+    replicas: 0
+  # Dex integration
+  auth:
+    tokenIssuer: "http://dex.oauth:5556/dex"
+    issuerRedirectURL: "http://localhost:8000"
+    serviceAccountKey: "__SERVICE_ACCOUNT_KEY__"

--- a/hack/ci/testdata/minio.cnf
+++ b/hack/ci/testdata/minio.cnf
@@ -1,0 +1,13 @@
+[ req ]
+default_bits       = 2048
+distinguished_name = req_distinguished_name
+req_extensions     = req_ext
+[ req_distinguished_name ]
+countryName                 = DE
+organizationName           = Kubermatic CI
+commonName                 = minio.minio.svc.cluster.local
+[ req_ext ]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1   = minio.minio.svc.cluster.local
+DNS.2   = minio

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Job
+metadata:
+  name: create-minio-backup-bucket
+  namespace: minio
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: mc
+          image: docker.io/minio/minio:RELEASE.2021-08-20T18-32-01Z
+          args:
+            - /bin/sh
+            - -c
+            - mc --insecure config host add src https://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc mb kkpbackupe2e
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: accessKey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: secretKey
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          restartPolicy: Never

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -28,4 +28,4 @@ spec:
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
-          restartPolicy: Never
+      restartPolicy: Never

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-minio-backup-bucket

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -1,3 +1,16 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -13,7 +13,7 @@ spec:
           args:
             - /bin/sh
             - -c
-            - mc --insecure config host add src https://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc mb kkpbackupe2e
+            - mc --insecure config host add src https://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc --insecure mb src/kkpbackupe2e
           env:
             - name: MINIO_ACCESS_KEY
               valueFrom:

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: docker.io/minio/minio:RELEASE.2021-08-20T18-32-01Z
+          image: quay.io/kubermatic/util:2.0.0
           args:
             - /bin/sh
             - -c

--- a/hack/ci/testdata/s3_secret.yaml
+++ b/hack/ci/testdata/s3_secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-credentials
+  namespace: kube-system
+data:
+  ACCESS_KEY_ID: "RlhjRDdzMHRGT1B1VHY2amFaQVJKRG91YzJIYWw4RTA="
+  SECRET_ACCESS_KEY: "d2RFWkdUbmhrZ0JEVERldGFIRnVpenMzcHdYSHZXVHM="

--- a/hack/ci/testdata/s3_secret.yaml
+++ b/hack/ci/testdata/s3_secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: s3-credentials
-  namespace: kube-system
-data:
-  ACCESS_KEY_ID: "RlhjRDdzMHRGT1B1VHY2amFaQVJKRG91YzJIYWw4RTA="
-  SECRET_ACCESS_KEY: "d2RFWkdUbmhrZ0JEVERldGFIRnVpenMzcHdYSHZXVHM="

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -30,8 +30,8 @@ metadata:
     worker-name: "__BUILD_ID__"
 spec:
   backupRestore:
-    s3BucketName: kkpbackuptest
-    s3Endpoint: SOMETHING SOMETHING
+    s3BucketName: kkpbackupe2e
+    s3Endpoint: minio.minio.svc.cluster.local:9000
   country: Germany
   location: Hamburg
   kubeconfig:

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -1,0 +1,158 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: "__SEED_NAME__-kubeconfig"
+  namespace: kubermatic
+data:
+  kubeconfig: "__KUBECONFIG__"
+
+---
+kind: Seed
+apiVersion: kubermatic.k8s.io/v1
+metadata:
+  name: "__SEED_NAME__"
+  namespace: kubermatic
+  labels:
+    worker-name: "__BUILD_ID__"
+spec:
+  backupRestore:
+    s3BucketName: kkpbackuptest
+    s3Endpoint: SOMETHING SOMETHING
+  country: Germany
+  location: Hamburg
+  kubeconfig:
+    name: "__SEED_NAME__-kubeconfig"
+    namespace: kubermatic
+    fieldPath: kubeconfig
+  datacenters:
+    byo-kubernetes:
+      location: Frankfurt
+      country: DE
+      spec:
+        bringyourown: {}
+    alibaba-eu-central-1a:
+      location: Frankfurt
+      country: DE
+      spec:
+        alibaba:
+          region: eu-central-1
+    aws-eu-central-1a:
+      location: EU (Frankfurt)
+      country: DE
+      spec:
+        aws:
+          region: eu-central-1
+    hetzner-nbg1:
+      location: Nuremberg 1 DC 3
+      country: DE
+      spec:
+        hetzner:
+          datacenter: nbg1-dc3
+          network: kubermatic-e2e
+    vsphere-ger:
+      location: Hamburg
+      country: DE
+      spec:
+        vsphere:
+          endpoint: "https://vcenter.loodse.io"
+          datacenter: "dc-1"
+          datastore: "exsi-nas"
+          cluster: "cl-1"
+          root_path: "/dc-1/vm/e2e-tests"
+          templates:
+            ubuntu: "machine-controller-e2e-ubuntu"
+            centos: "machine-controller-e2e-centos"
+            coreos: "machine-controller-e2e-coreos"
+    azure-westeurope:
+      location: "Azure West europe"
+      country: NL
+      spec:
+        azure:
+          location: "westeurope"
+    gcp-westeurope:
+      location: "Europe West (Germany)"
+      country: DE
+      spec:
+        gcp:
+          region: europe-west3
+          zone_suffixes:
+          - c
+    packet-ewr1:
+      location: "Packet EWR1 (New York)"
+      country: US
+      spec:
+        packet:
+          facilities:
+          - ewr1
+    do-ams3:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    do-fra1:
+      location: Frankfurt
+      country: DE
+      spec:
+        digitalocean:
+          region: fra1
+    kubevirt-europe-west3-c:
+      location: Frankfurt
+      country: DE
+      spec:
+        kubevirt:
+          dns_config:
+            nameservers:
+            - 8.8.8.8
+    syseleven-dbl1:
+      country: DE
+      location: Syseleven - dbl1
+      spec:
+        openstack:
+          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
+          availability_zone: dbl1
+          dns_servers:
+          - 37.123.105.116
+          - 37.123.105.117
+          enforce_floating_ip: true
+          ignore_volume_az: false
+          images:
+            centos: kubermatic-e2e-centos
+            coreos: kubermatic-e2e-coreos
+            ubuntu: kubermatic-e2e-ubuntu
+          node_size_requirements:
+            minimum_memory: 0
+            minimum_vcpus: 0
+          region: dbl
+    dc-to-delete:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    dc-to-update:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    dc-to-patch:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3

--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -131,5 +131,5 @@ func (r *Reconciler) statefulSetHealthCheck(ctx context.Context, c *kubermaticv1
 		}
 	}
 
-	return statefulSet.Status.Replicas == statefulSet.Status.ReadyReplicas, nil
+	return statefulSet.Status.Replicas == statefulSet.Status.ReadyReplicas && statefulSet.Status.Replicas == statefulSet.Status.UpdatedReplicas, nil
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -131,5 +131,8 @@ func (r *Reconciler) statefulSetHealthCheck(ctx context.Context, c *kubermaticv1
 		}
 	}
 
-	return statefulSet.Status.Replicas == statefulSet.Status.ReadyReplicas && statefulSet.Status.Replicas == statefulSet.Status.UpdatedReplicas, nil
+	ready := statefulSet.Status.Replicas == statefulSet.Status.ReadyReplicas
+	updated := statefulSet.Status.Replicas == statefulSet.Status.UpdatedReplicas
+
+	return ready && updated, nil
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -20,10 +20,17 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/etcd"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // clusterIsReachable checks if the cluster is reachable via its external name
@@ -39,4 +46,40 @@ func (r *Reconciler) clusterIsReachable(ctx context.Context, c *kubermaticv1.Clu
 	}
 
 	return true, nil
+}
+
+func (r *Reconciler) etcdUseStrictTLS(ctx context.Context, c *kubermaticv1.Cluster) (bool, error) {
+	statefulSet := &appsv1.StatefulSet{}
+	err := r.Client.Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.EtcdStatefulSetName}, statefulSet)
+
+	if err != nil {
+		// if the StatefulSet for etcd doesn't exist yet, a new one can be deployed with strict TLS peers
+		if kerrors.IsNotFound(err) {
+			return true, nil
+		} else {
+			return false, err
+		}
+	}
+
+	pods := &corev1.PodList{}
+	labelSet := etcd.GetBasePodLabels(c)
+
+	err = r.Client.List(ctx, pods, &client.ListOptions{
+		Namespace:     c.Status.NamespaceName,
+		LabelSelector: labels.SelectorFromSet(labelSet),
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	useStrictTls := true
+
+	for _, pod := range pods.Items {
+		if _, ok := pod.Annotations[resources.EtcdTLSEnabledAnnotation]; !ok {
+			useStrictTls = false
+		}
+	}
+
+	return useStrictTls, nil
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -73,13 +73,11 @@ func (r *Reconciler) etcdUseStrictTLS(ctx context.Context, c *kubermaticv1.Clust
 		return false, err
 	}
 
-	useStrictTls := true
-
 	for _, pod := range pods.Items {
 		if _, ok := pod.Annotations[resources.EtcdTLSEnabledAnnotation]; !ok {
-			useStrictTls = false
+			return false, nil
 		}
 	}
 
-	return useStrictTls, nil
+	return true, nil
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"go.uber.org/zap"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -31,6 +30,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // clusterIsReachable checks if the cluster is reachable via its external name

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -119,6 +119,12 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		return nil, err
 	}
 
+	// ensure StatefulSet health, requeue otherwise
+	if ok, err := r.statefulSetHealthCheck(ctx, cluster); !ok || err != nil {
+		r.log.Info("StatefulSets not healthy yet, requeuing request")
+		return &reconcile.Result{RequeueAfter: time.Second * 10}, err
+	}
+
 	// check that all StatefulSets are created
 	if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
 		return nil, err

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -119,15 +119,13 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		return nil, err
 	}
 
-	// ensure StatefulSet health, requeue otherwise
-	if ok, err := r.statefulSetHealthCheck(ctx, cluster); !ok || err != nil {
-		r.log.Info("StatefulSets not healthy yet, requeuing request")
-		return &reconcile.Result{RequeueAfter: time.Second * 10}, err
-	}
-
 	// check that all StatefulSets are created
-	if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
-		return nil, err
+	if ok, err := r.statefulSetHealthCheck(ctx, cluster); !ok || err != nil {
+		r.log.Info("Skipping reconcile for StatefulSets, not healthy yet")
+	} else {
+		if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := r.ensureEtcdBackupConfigs(ctx, cluster, data); err != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -122,10 +122,8 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	// check that all StatefulSets are created
 	if ok, err := r.statefulSetHealthCheck(ctx, cluster); !ok || err != nil {
 		r.log.Info("Skipping reconcile for StatefulSets, not healthy yet")
-	} else {
-		if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
-			return nil, err
-		}
+	} else if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
+		return nil, err
 	}
 
 	if err := r.ensureEtcdBackupConfigs(ctx, cluster, data); err != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -518,9 +518,9 @@ func (r *Reconciler) ensureConfigMaps(ctx context.Context, c *kubermaticv1.Clust
 }
 
 // GetStatefulSetCreators returns all StatefulSetCreators that are currently in use
-func GetStatefulSetCreators(data *resources.TemplateData, enableDataCorruptionChecks bool, enableTSOnly bool) []reconciling.NamedStatefulSetCreatorGetter {
+func GetStatefulSetCreators(data *resources.TemplateData, enableDataCorruptionChecks bool, enableTLSOnly bool) []reconciling.NamedStatefulSetCreatorGetter {
 	creators := []reconciling.NamedStatefulSetCreatorGetter{
-		etcd.StatefulSetCreator(data, enableDataCorruptionChecks, enableTSOnly),
+		etcd.StatefulSetCreator(data, enableDataCorruptionChecks, enableTLSOnly),
 	}
 	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureRancherIntegration]; flag {
 		creators = append(creators, rancherserver.StatefulSetCreator(data))

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -95,23 +95,7 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		return nil, err
 	}
 
-	if err := r.ensureServiceAccounts(ctx, cluster); err != nil {
-		return nil, err
-	}
-
-	if err := r.ensureRoles(ctx, cluster); err != nil {
-		return nil, err
-	}
-
-	if err := r.ensureRoleBindings(ctx, cluster); err != nil {
-		return nil, err
-	}
-
-	if err := r.ensureClusterRoles(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := r.ensureClusterRoleBindings(ctx, cluster); err != nil {
+	if err := r.ensureRBAC(ctx, cluster); err != nil {
 		return nil, err
 	}
 
@@ -631,6 +615,30 @@ func (r *Reconciler) ensureOldOPAIntegrationIsRemoved(ctx context.Context, data 
 		if err := r.Client.Delete(ctx, resource); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure old OPA integration version resources are removed/not present: %v", err)
 		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) ensureRBAC(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	if err := r.ensureServiceAccounts(ctx, cluster); err != nil {
+		return err
+	}
+
+	if err := r.ensureRoles(ctx, cluster); err != nil {
+		return err
+	}
+
+	if err := r.ensureRoleBindings(ctx, cluster); err != nil {
+		return err
+	}
+
+	if err := r.ensureClusterRoles(ctx); err != nil {
+		return err
+	}
+
+	if err := r.ensureClusterRoleBindings(ctx, cluster); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/resources/etcd/etcdservices.go
+++ b/pkg/resources/etcd/etcdservices.go
@@ -58,6 +58,12 @@ func ServiceCreator(data serviceCreatorData) reconciling.NamedServiceCreatorGett
 					TargetPort: intstr.FromInt(2380),
 					Protocol:   corev1.ProtocolTCP,
 				},
+				{
+					Name:       "peer-tls",
+					Port:       2381,
+					TargetPort: intstr.FromInt(2381),
+					Protocol:   corev1.ProtocolTCP,
+				},
 			}
 
 			return se, nil

--- a/pkg/resources/etcd/pdb.go
+++ b/pkg/resources/etcd/pdb.go
@@ -37,7 +37,7 @@ func PodDisruptionBudgetCreator(data pdbData) reconciling.NamedPodDisruptionBudg
 			minAvailable := intstr.FromInt((resources.EtcdClusterSize / 2) + 1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: getBasePodLabels(data.Cluster()),
+					MatchLabels: GetBasePodLabels(data.Cluster()),
 				},
 				MinAvailable: &minAvailable,
 			}

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -100,6 +100,11 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 
 			launcherEnabled := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]
 			if launcherEnabled {
+				// TODO: check for a better annotation scheme
+				set.Spec.Template.ObjectMeta.Annotations = map[string]string{
+					"etcd-launcher.k8c.io/tls-peer-enabled": "",
+				}
+
 				set.Spec.Template.Spec.InitContainers = []corev1.Container{
 					{
 						Name:            "etcd-launcher-init",
@@ -189,6 +194,11 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 							ContainerPort: 2380,
 							Protocol:      corev1.ProtocolTCP,
 							Name:          "peer",
+						},
+						{
+							ContainerPort: 2381,
+							Protocol:      corev1.ProtocolTCP,
+							Name:          "peer-tls",
 						},
 					},
 					ReadinessProbe: &corev1.Probe{

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -167,11 +167,6 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 
 			launcherEnabled := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]
 			if launcherEnabled {
-				// TODO: check for a better annotation scheme
-				set.Spec.Template.ObjectMeta.Annotations = map[string]string{
-					resources.EtcdTLSEnabledAnnotation: "",
-				}
-
 				set.Spec.Template.Spec.InitContainers = []corev1.Container{
 					{
 						Name:            "etcd-launcher-init",
@@ -187,15 +182,19 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 					},
 				}
 
-				if enableTLSOnly {
-					etcdEnv = append(etcdEnv, corev1.EnvVar{Name: "PEER_TLS_MODE", Value: "strict"})
-				}
-
 				etcdPorts = append(etcdPorts, corev1.ContainerPort{
 					ContainerPort: 2381,
 					Protocol:      corev1.ProtocolTCP,
 					Name:          "peer-tls",
 				})
+
+				set.Spec.Template.ObjectMeta.Annotations = map[string]string{
+					resources.EtcdTLSEnabledAnnotation: "",
+				}
+
+				if enableTLSOnly {
+					etcdEnv = append(etcdEnv, corev1.EnvVar{Name: "PEER_TLS_MODE", Value: "strict"})
+				}
 			}
 
 			etcdStartCmd, err := getEtcdCommand(data.Cluster().Name, data.Cluster().Status.NamespaceName, enableDataCorruptionChecks, launcherEnabled)

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -69,7 +69,7 @@ type etcdStatefulSetCreatorData interface {
 }
 
 // StatefulSetCreator returns the function to reconcile the etcd StatefulSet
-func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChecks bool) reconciling.NamedStatefulSetCreatorGetter {
+func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChecks bool, enableTLSOnly bool) reconciling.NamedStatefulSetCreatorGetter {
 	return func() (string, reconciling.StatefulSetCreator) {
 		return resources.EtcdStatefulSetName, func(set *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 
@@ -81,7 +81,7 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 			set.Spec.ServiceName = resources.EtcdServiceName
 			set.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-			baseLabels := getBasePodLabels(data.Cluster())
+			baseLabels := GetBasePodLabels(data.Cluster())
 			set.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: baseLabels,
 			}
@@ -98,11 +98,78 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 			}
 			set.Spec.Template.Spec.ServiceAccountName = rbac.EtcdLauncherServiceAccountName
 
+			etcdEnv := []corev1.EnvVar{
+				{
+					Name: "POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: "v1",
+							FieldPath:  "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: "v1",
+							FieldPath:  "status.podIP",
+						},
+					},
+				},
+				{
+					Name: "NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: "v1",
+							FieldPath:  "metadata.namespace",
+						},
+					},
+				},
+				{
+					Name:  "TOKEN",
+					Value: data.Cluster().Name,
+				},
+				{
+					Name:  "ENABLE_CORRUPTION_CHECK",
+					Value: strconv.FormatBool(enableDataCorruptionChecks),
+				},
+				{
+					Name:  "ETCDCTL_API",
+					Value: "3",
+				},
+				{
+					Name:  "ETCDCTL_CACERT",
+					Value: resources.EtcdTrustedCAFile,
+				},
+				{
+					Name:  "ETCDCTL_CERT",
+					Value: resources.EtcdClientCertFile,
+				},
+				{
+					Name:  "ETCDCTL_KEY",
+					Value: resources.EtcdClientKeyFile,
+				},
+			}
+
+			etcdPorts := []corev1.ContainerPort{
+				{
+					ContainerPort: 2379,
+					Protocol:      corev1.ProtocolTCP,
+					Name:          "client",
+				},
+				{
+					ContainerPort: 2380,
+					Protocol:      corev1.ProtocolTCP,
+					Name:          "peer",
+				},
+			}
+
 			launcherEnabled := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]
 			if launcherEnabled {
 				// TODO: check for a better annotation scheme
 				set.Spec.Template.ObjectMeta.Annotations = map[string]string{
-					"etcd-launcher.k8c.io/tls-peer-enabled": "",
+					resources.EtcdTLSEnabledAnnotation: "",
 				}
 
 				set.Spec.Template.Spec.InitContainers = []corev1.Container{
@@ -119,7 +186,18 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 						},
 					},
 				}
+
+				if enableTLSOnly {
+					etcdEnv = append(etcdEnv, corev1.EnvVar{Name: "PEER_TLS_MODE", Value: "strict"})
+				}
+
+				etcdPorts = append(etcdPorts, corev1.ContainerPort{
+					ContainerPort: 2381,
+					Protocol:      corev1.ProtocolTCP,
+					Name:          "peer-tls",
+				})
 			}
+
 			etcdStartCmd, err := getEtcdCommand(data.Cluster().Name, data.Cluster().Status.NamespaceName, enableDataCorruptionChecks, launcherEnabled)
 			if err != nil {
 				return nil, err
@@ -131,76 +209,8 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag(data.Cluster()),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         etcdStartCmd,
-					Env: []corev1.EnvVar{
-						{
-							Name: "POD_NAME",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{
-									APIVersion: "v1",
-									FieldPath:  "metadata.name",
-								},
-							},
-						},
-						{
-							Name: "POD_IP",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{
-									APIVersion: "v1",
-									FieldPath:  "status.podIP",
-								},
-							},
-						},
-						{
-							Name: "NAMESPACE",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{
-									APIVersion: "v1",
-									FieldPath:  "metadata.namespace",
-								},
-							},
-						},
-						{
-							Name:  "TOKEN",
-							Value: data.Cluster().Name,
-						},
-						{
-							Name:  "ENABLE_CORRUPTION_CHECK",
-							Value: strconv.FormatBool(enableDataCorruptionChecks),
-						},
-						{
-							Name:  "ETCDCTL_API",
-							Value: "3",
-						},
-						{
-							Name:  "ETCDCTL_CACERT",
-							Value: resources.EtcdTrustedCAFile,
-						},
-						{
-							Name:  "ETCDCTL_CERT",
-							Value: resources.EtcdClientCertFile,
-						},
-						{
-							Name:  "ETCDCTL_KEY",
-							Value: resources.EtcdClientKeyFile,
-						},
-					},
-					Ports: []corev1.ContainerPort{
-						{
-							ContainerPort: 2379,
-							Protocol:      corev1.ProtocolTCP,
-							Name:          "client",
-						},
-						{
-							ContainerPort: 2380,
-							Protocol:      corev1.ProtocolTCP,
-							Name:          "peer",
-						},
-						{
-							ContainerPort: 2381,
-							Protocol:      corev1.ProtocolTCP,
-							Name:          "peer-tls",
-						},
-					},
+					Env:             etcdEnv,
+					Ports:           etcdPorts,
 					ReadinessProbe: &corev1.Probe{
 						TimeoutSeconds:      10,
 						PeriodSeconds:       15,
@@ -347,7 +357,7 @@ func getVolumes() []corev1.Volume {
 	}
 }
 
-func getBasePodLabels(cluster *kubermaticv1.Cluster) map[string]string {
+func GetBasePodLabels(cluster *kubermaticv1.Cluster) map[string]string {
 	additionalLabels := map[string]string{
 		"cluster": cluster.Name,
 	}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -105,6 +105,8 @@ const (
 	EtcdStatefulSetName = "etcd"
 	// EtcdDefaultBackupConfigName is the name for the default (preinstalled) EtcdBackupConfig of a cluster
 	EtcdDefaultBackupConfigName = "default-backups"
+	// EtcdTLSEnabledAnnotation is the annotation assigned to etcd Pods that run with a TLS peer endpoint
+	EtcdTLSEnabledAnnotation = "etcd-launcher.k8c.io/tls-peer-enabled"
 
 	// ApiserverServiceName is the name for the apiserver service
 	ApiserverServiceName = "apiserver-external"

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -106,7 +106,7 @@ const (
 	// EtcdDefaultBackupConfigName is the name for the default (preinstalled) EtcdBackupConfig of a cluster
 	EtcdDefaultBackupConfigName = "default-backups"
 	// EtcdTLSEnabledAnnotation is the annotation assigned to etcd Pods that run with a TLS peer endpoint
-	EtcdTLSEnabledAnnotation = "etcd-launcher.k8c.io/tls-peer-enabled"
+	EtcdTLSEnabledAnnotation = "etcd.k8c.io/tls-peer-enabled"
 
 	// ApiserverServiceName is the name for the apiserver service
 	ApiserverServiceName = "apiserver-external"

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -106,7 +106,7 @@ const (
 	// EtcdDefaultBackupConfigName is the name for the default (preinstalled) EtcdBackupConfig of a cluster
 	EtcdDefaultBackupConfigName = "default-backups"
 	// EtcdTLSEnabledAnnotation is the annotation assigned to etcd Pods that run with a TLS peer endpoint
-	EtcdTLSEnabledAnnotation = "etcd.k8c.io/tls-peer-enabled"
+	EtcdTLSEnabledAnnotation = "etcd.kubermatic.k8c.io/tls-peer-enabled"
 
 	// ApiserverServiceName is the name for the apiserver service
 	ApiserverServiceName = "apiserver-external"

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-aws-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.21.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-azure-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.21.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-bringyourown-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.21.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-digitalocean-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.21.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd-externalCloudProvider.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd-externalCloudProvider.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.21.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd-externalCloudProvider.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd-externalCloudProvider.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.21.0-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd.yaml
@@ -21,6 +21,10 @@ spec:
     port: 2380
     protocol: TCP
     targetPort: 2380
+  - name: peer-tls
+    port: 2381
+    protocol: TCP
+    targetPort: 2381
   publishNotReadyAddresses: true
   selector:
     app: etcd

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -721,7 +721,7 @@ func TestLoadFiles(t *testing.T) {
 					}
 
 					var statefulSetCreators []reconciling.NamedStatefulSetCreatorGetter
-					statefulSetCreators = append(statefulSetCreators, kubernetescontroller.GetStatefulSetCreators(data, false)...)
+					statefulSetCreators = append(statefulSetCreators, kubernetescontroller.GetStatefulSetCreators(data, false, false)...)
 					statefulSetCreators = append(statefulSetCreators, monitoringcontroller.GetStatefulSetCreators(data)...)
 					for _, creatorGetter := range statefulSetCreators {
 						_, create := creatorGetter()

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -234,9 +234,9 @@ func isClusterEtcdHealthy(ctx context.Context, client ctrlruntimeclient.Client, 
 		return false, fmt.Errorf("failed to get StatefulSet: %v", err)
 	}
 
-	clusterSize := 3
+	clusterSize := int32(3)
 	if size := cluster.Spec.ComponentsOverride.Etcd.ClusterSize; size != nil {
-		clusterSize = int(*size)
+		clusterSize = *size
 	}
 
 	// we are healthy if the cluster controller is happy and the sts has ready replicas

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -218,6 +218,7 @@ func createBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.Cl
 }
 
 func restoreBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, backup *kubermaticv1.EtcdBackupConfig) error {
+	t.Log("restoring etcd cluster from backup...")
 	restore := &kubermaticv1.EtcdRestore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "etcd-e2e-restore",
@@ -496,7 +497,7 @@ func waitForClusterHealthy(ctx context.Context, t *testing.T, client ctrlruntime
 		return fmt.Errorf("failed to check etcd health status: %v", err)
 	}
 
-	t.Logf("cluster became healthy after %v.", time.Since(before))
+	t.Logf("etcd cluster became healthy after %v.", time.Since(before))
 
 	return nil
 }
@@ -519,7 +520,7 @@ func waitForStrictTLSMode(ctx context.Context, t *testing.T, client ctrlruntimec
 		return fmt.Errorf("failed to check etcd health status: %v", err)
 	}
 
-	t.Logf("cluster became healthy after %v.", time.Since(before))
+	t.Logf("etcd cluster is running in strict TLS mode after %v.", time.Since(before))
 
 	return nil
 }

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -211,7 +211,7 @@ func createBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.Cl
 	}
 
 	if err := waitForEtcdBackup(ctx, t, client, backup); err != nil {
-		return fmt.Errorf("failed to wait for etcd backup finishing: %v", err), nil
+		return fmt.Errorf("failed to wait for etcd backup finishing: %v (%v)", err, backup.Status), nil
 	}
 
 	return nil, backup
@@ -454,7 +454,7 @@ func waitForEtcdBackup(ctx context.Context, t *testing.T, client ctrlruntimeclie
 
 		return isEtcdBackupCompleted(&backup.Status), nil
 	}); err != nil {
-		return fmt.Errorf("failed waiting for backup to complete: %v (%v)", err, backup.Status)
+		return err
 	}
 
 	t.Logf("etcd backup finished after %v.", time.Since(before))

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -254,7 +254,7 @@ func isStrictTLSEnabled(ctx context.Context, client ctrlruntimeclient.Client, cl
 
 	for _, env := range sts.Spec.Template.Spec.Containers[0].Env {
 		if env.Name == "PEER_TLS_MODE" && env.Value == "strict" {
-			strictModeEnvSet := true
+			strictModeEnvSet = true
 		}
 	}
 

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -153,6 +153,8 @@ func disableLauncher(ctx context.Context, t *testing.T, client ctrlruntimeclient
 	if err := disableEtcdlauncherForCluster(ctx, client, cluster); err == nil {
 		return fmt.Errorf("no error disabling etcd-launcher, expected validation to fail")
 	}
+
+	return nil
 }
 
 func scaleUp(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
@@ -307,7 +309,7 @@ func waitForClusterHealthy(ctx context.Context, t *testing.T, client ctrlruntime
 	return nil
 }
 
-func waitForStrictTLSMode(ctx context.Context, t *testing.T, client ctrlruntimeclient.Clientn, cluster *kubermaticv1.Cluster) error {
+func waitForStrictTLSMode(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	before := time.Now()
 	if err := wait.PollImmediate(3*time.Second, 10*time.Minute, func() (bool, error) {
 		healthy, err := isStrictTLSEnabled(ctx, client, cluster)

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -192,6 +192,10 @@ func breakAndRecover(ctx context.Context, t *testing.T, client ctrlruntimeclient
 		return fmt.Errorf("failed to delete etcd node PV: %v", err)
 	}
 
+	// wait for a bit before checking health as the PV recovery process
+	// is a controller-manager loop that doesn't necessarily kick in immediately
+	time.Sleep(30 * time.Second)
+
 	// auto recovery should kick in. We need to wait for it
 	if err := waitForClusterHealthy(ctx, t, client, cluster); err != nil {
 		return fmt.Errorf("etcd cluster is not healthy: %v", err)

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -115,7 +115,7 @@ func TestScaling(t *testing.T) {
 	}
 	waitForQuorum(t)
 
-	if err := disableLauncher(ctx, t, client, cluster); err == nil {
+	if err := disableLauncher(ctx, t, client, cluster); err != nil {
 		t.Fatalf("succeeded in disabling immutable feature etcd-launcher: %v", err)
 	}
 
@@ -149,7 +149,7 @@ func enableLauncher(ctx context.Context, t *testing.T, client ctrlruntimeclient.
 }
 
 func disableLauncher(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
-	t.Log("trying to disable etcd-launcher...")
+	t.Log("trying to disable etcd-launcher (not expected to succeed) ...")
 	if err := disableEtcdlauncherForCluster(ctx, client, cluster); err == nil {
 		return fmt.Errorf("no error disabling etcd-launcher, expected validation to fail")
 	}

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -236,7 +236,7 @@ func isClusterEtcdHealthy(ctx context.Context, client ctrlruntimeclient.Client, 
 
 	clusterSize := 3
 	if size := cluster.Spec.ComponentsOverride.Etcd.ClusterSize; size != nil {
-		clusterSize = *size
+		clusterSize = int(*size)
 	}
 
 	// we are healthy if the cluster controller is happy and the sts has ready replicas

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -171,6 +171,14 @@ func validateUpdateImmutability(c, oldC *kubermaticv1.Cluster) field.ErrorList {
 		c.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; vOld && !v {
 		allErrs = append(allErrs, field.Invalid(specFldPath.Child("features").Key(kubermaticv1.ClusterFeatureExternalCloudProvider), v, fmt.Sprintf("feature gate %q cannot be disabled once it's enabled", kubermaticv1.ClusterFeatureExternalCloudProvider)))
 	}
+
+	// Validate EtcdLauncher feature flag immutability.
+	// Once the feature flag is enabled, it must not be disabled.
+	if vOld, v := oldC.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher],
+		c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; vOld && !v {
+		allErrs = append(allErrs, field.Invalid(specFldPath.Child("features").Key(kubermaticv1.ClusterFeatureEtcdLauncher), v, fmt.Sprintf("feature gate %q cannot be disabled once it's enabled", kubermaticv1.ClusterFeatureEtcdLauncher)))
+	}
+
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
 		c.Spec.ExposeStrategy,
 		oldC.Spec.ExposeStrategy,


### PR DESCRIPTION
**What this PR does / why we need it**:
Our etcd clusters currently use unencrypted peering connections via plaintext HTTP. It's recommended by various standards to use TLS-encrypted peer connections via HTTPS instead.

This PR introduces (when using etcd-launcher) TLS peer connection setups for fresh clusters and an automated migration for existing etcd clusters via etcd-launcher and seed-controller-manager.

The migration is a two-step process:

1. Deploys `etcd-launcher` with a new, "mixed" mode where both plaintext and TLS peer ports are available. During this first rollout, "old" peers can still communicate with the "new" peers via the plaintext port, while the TLS port is made available and the necessary certificate information is passed. Pods are annotated to show they support TLS now.
2. As second step, `seed-controller-manager` supervises the rollout / status of etcd Pods, and updates the StatefulSet to switch to a "strict" mode, where only the TLS port is enabled. Peers from the previous rollout can switch from the plaintext port to the TLS port once a peer comes up again after the upgrade.

This also supports undoing the second step of the migration, so going from "strict" TLS-only peers to "mixed" peers with both plaintext and TLS endpoints. That would be a manual operation on the StatefulSet though, it's not an expected automated operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/edgematic/issues/55

**Special notes for your reviewer**:

Still Work-in-Progress.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
- etcd-launcher uses TLS peer connections for new etcd clusters and automatically upgrades existing etcd clusters
- etcd-launcher cannot be disabled as a feature on a cluster to go back to plain etcd
```
