### PR TITLE
add a zone for GKE external cluster

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -19363,6 +19363,10 @@
         "serviceAccount": {
           "type": "string",
           "x-go-name": "ServiceAccount"
+        },
+        "zone": {
+          "type": "string",
+          "x-go-name": "Zone"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
@@ -19378,6 +19382,10 @@
         "name": {
           "type": "string",
           "x-go-name": "Name"
+        },
+        "zone": {
+          "type": "string",
+          "x-go-name": "Zone"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -353,6 +353,7 @@ type ExternalClusterCloudSpec struct {
 type GKECloudSpec struct {
 	Name           string `json:"name"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
+	Zone           string `json:"zone"`
 }
 
 // ExternalClusterNode represents an object holding external cluster node
@@ -366,6 +367,7 @@ type ExternalClusterNode struct {
 type GKECluster struct {
 	Name       string `json:"name"`
 	IsImported bool   `json:"imported"`
+	Zone       string `json:"zone"`
 }
 
 // GKEClusterList represents an array of GKE clusters.

--- a/pkg/crd/kubermatic/v1/external_cluster.go
+++ b/pkg/crd/kubermatic/v1/external_cluster.go
@@ -74,6 +74,7 @@ type ExternalClusterCloudSpec struct {
 type ExternalClusterGKECloudSpec struct {
 	Name                 string                                  `json:"name"`
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
+	Zone                 string                                  `json:"zone"`
 }
 
 type ExternalClusterEKSCloudSpec struct {

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -371,7 +371,7 @@ func ListGKEClusters(ctx context.Context, sa string) (apiv2.GKEClusterList, erro
 		return clusters, fmt.Errorf("clusters list project=%s: %w", project, err)
 	}
 	for _, f := range resp.Clusters {
-		clusters = append(clusters, apiv2.GKECluster{Name: f.Name})
+		clusters = append(clusters, apiv2.GKECluster{Name: f.Name, Zone: f.Zone})
 	}
 	return clusters, nil
 }

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -126,10 +126,15 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 }
 
 func createGKECluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticapiv1.Project, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticapiv1.ExternalCluster, error) {
+	if cloud.GKE.Name == "" || cloud.GKE.Zone == "" || cloud.GKE.ServiceAccount == "" {
+		return nil, errors.NewBadRequest("the GKE cluster name, zone or service account can not be empty")
+	}
+
 	newCluster := genExternalCluster(name, project.Name)
 	newCluster.Spec.CloudSpec = &kubermaticapiv1.ExternalClusterCloudSpec{
 		GKE: &kubermaticapiv1.ExternalClusterGKECloudSpec{
 			Name: cloud.GKE.Name,
+			Zone: cloud.GKE.Zone,
 		},
 	}
 	keyRef, err := clusterProvider.CreateOrUpdateCredentialSecretForCluster(ctx, cloud, project.Name, newCluster.Name)

--- a/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -109,10 +109,30 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		// scenario 5
 		{
 			Name:                   "scenario 5: create GKE cluster",
-			Body:                   `{"name":"test", "cloud":{"gke":{"serviceAccount":"abc"}}}`,
+			Body:                   `{"name":"test", "cloud":{"gke":{"name":"gke-cluster","serviceAccount":"abc","zone":"abc"}}}`,
 			ExpectedResponse:       `{"id":"%s","name":"test","creationTimestamp":"0001-01-01T00:00:00Z","labels":{"project-id":"my-first-project-ID"},"type":"kubernetes","spec":{"cloud":{"dc":""},"version":"","oidc":{}},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 			RewriteClusterID:       true,
 			HTTPStatus:             http.StatusCreated,
+			ProjectToSync:          test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+		},
+		// scenario 6
+		{
+			Name:                   "scenario 6: create GKE cluster with empty zone",
+			Body:                   `{"name":"test", "cloud":{"gke":{"name":"gke-cluster","serviceAccount":"abc"}}}`,
+			ExpectedResponse:       `{"error":{"code":400,"message":"the GKE cluster name, zone or service account can not be empty"}}`,
+			HTTPStatus:             http.StatusBadRequest,
+			ProjectToSync:          test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+		},
+		// scenario 7
+		{
+			Name:                   "scenario 7: create GKE cluster with empty SA",
+			Body:                   `{"name":"test", "cloud":{"gke":{"name":"gke-cluster","zone":"abc"}}}`,
+			ExpectedResponse:       `{"error":{"code":400,"message":"the GKE cluster name, zone or service account can not be empty"}}`,
+			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),

--- a/pkg/test/e2e/utils/apiclient/models/g_k_e_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/g_k_e_cloud_spec.go
@@ -22,6 +22,9 @@ type GKECloudSpec struct {
 
 	// service account
 	ServiceAccount string `json:"serviceAccount,omitempty"`
+
+	// zone
+	Zone string `json:"zone,omitempty"`
 }
 
 // Validate validates this g k e cloud spec

--- a/pkg/test/e2e/utils/apiclient/models/g_k_e_cluster.go
+++ b/pkg/test/e2e/utils/apiclient/models/g_k_e_cluster.go
@@ -22,6 +22,9 @@ type GKECluster struct {
 
 	// name
 	Name string `json:"name,omitempty"`
+
+	// zone
+	Zone string `json:"zone,omitempty"`
 }
 
 // Validate validates this g k e cluster


### PR DESCRIPTION
**What this PR does / why we need it**: add a zone for GKE external cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8075


```release-note
NONE
```
