### PR TITLE
Add shutdown command to installer to make CRD migration preparation easier

### DIFF
--- a/cmd/kubermatic-installer/cmd_migrate_crds.go
+++ b/cmd/kubermatic-installer/cmd_migrate_crds.go
@@ -72,7 +72,7 @@ func MigrateCRDsAction(logger *logrus.Logger) cli.ActionFunc {
 		// phase 0: preparations
 
 		// get kube client to master cluster
-		kubeContext := ctx.String(deployKubeContextFlag.Name)
+		kubeContext := ctx.String(migrateCRDsKubeContextFlag.Name)
 
 		logger.Info("Creating Kubernetes client to the master cluster…")
 

--- a/cmd/kubermatic-installer/cmd_shutdown.go
+++ b/cmd/kubermatic-installer/cmd_shutdown.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
+	"k8c.io/kubermatic/v2/pkg/install/crdmigration"
+	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
+	"k8c.io/kubermatic/v2/pkg/provider"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	shutdownKubeContextFlag = cli.StringFlag{
+		Name:   "kube-context",
+		Usage:  "Context to use from the given kubeconfig",
+		EnvVar: "KUBE_CONTEXT",
+	}
+)
+
+func ShutdownCommand(logger *logrus.Logger) cli.Command {
+	return cli.Command{
+		Name:   "shutdown",
+		Usage:  "(development only) Scales all KKP controllers on all clusters to 0, in preparation for the CRD migration",
+		Action: ShutdownAction(logger),
+		Hidden: true, // users should not run this before it's released
+		Flags: []cli.Flag{
+			shutdownKubeContextFlag,
+		},
+	}
+}
+
+func ShutdownAction(logger *logrus.Logger) cli.ActionFunc {
+	return handleErrors(logger, setupLogger(logger, func(ctx *cli.Context) error {
+		appContext := context.Background()
+		namespace := kubermaticmaster.KubermaticOperatorNamespace
+
+		// get kube client to master cluster
+		kubeContext := ctx.String(shutdownKubeContextFlag.Name)
+
+		logger.Info("Creating Kubernetes client to the master cluster…")
+
+		kubeClient, err := getKubeClient(appContext, logger, kubeContext)
+		if err != nil {
+			return fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
+
+		// retrieve KubermaticConfiguration
+		configGetter, err := provider.DynamicKubermaticConfigurationGetterFactory(kubeClient, namespace)
+		if err != nil {
+			return fmt.Errorf("failed to create KubermaticConfiguration client: %w", err)
+		}
+
+		config, err := configGetter(appContext)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve KubermaticConfiguration: %w", err)
+		}
+
+		// find all seeds
+		seedsGetter, err := seedsGetterFactory(appContext, kubeClient)
+		if err != nil {
+			return fmt.Errorf("failed to create Seeds getter: %w", err)
+		}
+
+		seedKubeconfigGetter, err := seedKubeconfigGetterFactory(appContext, kubeClient)
+		if err != nil {
+			return fmt.Errorf("failed to create Seed kubeconfig getter: %w", err)
+		}
+
+		logger.Info("Retrieving Seeds…")
+
+		allSeeds, err := seedsGetter()
+		if err != nil {
+			return fmt.Errorf("failed to list Seeds: %w", err)
+		}
+
+		logger.Infof("Found %d Seeds.", len(allSeeds))
+
+		// build kube client for each seed cluster
+		seedClients := map[string]ctrlruntimeclient.Client{}
+		seedClientGetter := provider.SeedClientGetterFactory(seedKubeconfigGetter)
+
+		logger.Info("Creating Kubernetes client for each Seed…")
+
+		for _, seed := range allSeeds {
+			seedClient, err := seedClientGetter(seed)
+			if err != nil {
+				return fmt.Errorf("failed to create Kubernetes client for Seed %q: %w", seed.Name, err)
+			}
+
+			seedClients[seed.Name] = seedClient
+		}
+
+		// assemble migration options
+		opt := crdmigration.Options{
+			KubermaticNamespace:     namespace,
+			KubermaticConfiguration: config,
+			MasterClient:            kubeClient,
+			Seeds:                   allSeeds,
+			SeedClients:             seedClients,
+		}
+
+		// here we go
+		if err := crdmigration.ShutdownControllers(appContext, logger, &opt); err != nil {
+			return fmt.Errorf("operation failed: %w", err)
+		}
+
+		logger.Info("All controllers have been scaled down to 0 replicas now. It can take up to 3 minutes for all pods to be terminated.")
+		logger.Info("Please run the `migrate-crds` command now to migrate your resources. The migration will first ensure that all controller pods have been removed.")
+
+		return nil
+	}))
+}

--- a/cmd/kubermatic-installer/main_ce.go
+++ b/cmd/kubermatic-installer/main_ce.go
@@ -38,6 +38,7 @@ func commands(logger *logrus.Logger, versions kubermaticversion.Versions) []cli.
 		PrintCommand(),
 		ConvertKubeconfigCommand(logger),
 		MigrateCRDsCommand(logger),
+		ShutdownCommand(logger),
 	}
 }
 

--- a/cmd/kubermatic-installer/main_ee.go
+++ b/cmd/kubermatic-installer/main_ee.go
@@ -38,6 +38,7 @@ func commands(logger *logrus.Logger, versions kubermaticversion.Versions) []cli.
 		DeployCommand(logger, versions),
 		ConvertKubeconfigCommand(logger),
 		MigrateCRDsCommand(logger),
+		ShutdownCommand(logger),
 		PrintCommand(),
 	}
 }

--- a/hack/run-crd-migration-in-kind.sh
+++ b/hack/run-crd-migration-in-kind.sh
@@ -124,5 +124,4 @@ export KUBERMATIC_EDITION=ee
 make clean kubermatic-installer
 
 export KUBECONFIG="$MASTER_KUBECONFIG"
-_build/kubermatic-installer shutdown
-# migrate-crds
+_build/kubermatic-installer migrate-crds

--- a/hack/run-crd-migration-in-kind.sh
+++ b/hack/run-crd-migration-in-kind.sh
@@ -124,4 +124,5 @@ export KUBERMATIC_EDITION=ee
 make clean kubermatic-installer
 
 export KUBECONFIG="$MASTER_KUBECONFIG"
-_build/kubermatic-installer migrate-crds
+_build/kubermatic-installer shutdown
+# migrate-crds

--- a/pkg/install/crdmigration/shutdown.go
+++ b/pkg/install/crdmigration/shutdown.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdmigration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	kubermaticmaster "k8c.io/kubermatic/v2/pkg/controller/operator/master/resources/kubermatic"
+	kubermaticseed "k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/kubermatic"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ShutdownControllers(ctx context.Context, logger logrus.FieldLogger, opt *Options) error {
+	// master cluster
+	if err := shutdownCluster(ctx, logger.WithField("master", true), opt.MasterClient, opt); err != nil {
+		return fmt.Errorf("shutting down the master cluster failed: %w", err)
+	}
+
+	// seed clusters
+	for seedName, seedClient := range opt.SeedClients {
+		if err := shutdownCluster(ctx, logger.WithField("seed", seedName), seedClient, opt); err != nil {
+			return fmt.Errorf("shutting down the seed cluster failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func shutdownCluster(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, opt *Options) error {
+	logger.Info("Shutting down in cluster…")
+
+	if err := shutdownDeploymentsInCluster(ctx, logger, client, opt.KubermaticNamespace); err != nil {
+		return err
+	}
+
+	if err := shutdownWebhooksInCluster(ctx, logger, client, opt.KubermaticConfiguration); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func shutdownDeploymentsInCluster(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, kubermaticNamespace string) error {
+	deployments := []string{
+		"kubermatic-operator", // as named in our Helm chart
+		common.MasterControllerManagerDeploymentName,
+		kubermaticmaster.APIDeploymentName,
+		common.SeedControllerManagerDeploymentName,
+	}
+
+	for _, deploymentName := range deployments {
+		depLogger := logger.WithField("deployment", deploymentName)
+
+		deployment := appsv1.Deployment{}
+		key := types.NamespacedName{Name: deploymentName, Namespace: kubermaticNamespace}
+
+		if err := client.Get(ctx, key, &deployment); err != nil {
+			// not all deployments need to exist in all clusters
+			if apierrors.IsNotFound(err) {
+				depLogger.Debug("Deployment not found.")
+				continue
+			}
+
+			return fmt.Errorf("failed to get Deployment %s: %w", deploymentName, err)
+		}
+
+		if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas > 0 {
+			depLogger.Debug("Scaling down…")
+
+			oldDeployment := deployment.DeepCopy()
+			deployment.Spec.Replicas = pointer.Int32(0)
+
+			if err := client.Patch(ctx, &deployment, ctrlruntimeclient.MergeFrom(oldDeployment)); err != nil {
+				return fmt.Errorf("failed to scale down Deployment %s: %w", deploymentName, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func shutdownWebhooksInCluster(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, config *operatorv1alpha1.KubermaticConfiguration) error {
+	webhooks := []string{
+		kubermaticseed.ClusterAdmissionWebhookName,
+		common.SeedAdmissionWebhookName(config),
+	}
+
+	for _, webhookName := range webhooks {
+		hookLogger := logger.WithField("webhook", webhookName)
+
+		webhook := admissionregistrationv1.ValidatingWebhookConfiguration{}
+		key := types.NamespacedName{Name: webhookName}
+
+		if err := client.Get(ctx, key, &webhook); err != nil {
+			// not all webhooks need to exist in all clusters / maybe we already cleaned up
+			// because the user ran the "shutdown" command twice
+			if apierrors.IsNotFound(err) {
+				hookLogger.Debug("Webhook not found.")
+				continue
+			}
+
+			return fmt.Errorf("failed to get Webhook %s: %w", webhookName, err)
+		}
+
+		if err := client.Delete(ctx, &webhook); err != nil {
+			return fmt.Errorf("failed to remove Webhook %s: %w", webhookName, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The new `migrate-crds` subcommand requires that all KKP controllers everywhere have been turned off. To make it easier to achieve this, this PR adds another new subcommand, `shutdown`, to automatically shutdown all controllers/webhooks.

The `migrate-crds` command has extensive preflight checks to reduce the chance to shoot yourself in the foot. The new `shutdown` command cannot perform any meaningful checks, so instead it was an emergency break flag called `--stop-the-world` that must be set to `yes`.

After the migration happened, the user is supposed to update KKP (i.e. use the `deploy` subcommand), which will restore the KKP operator, which will/should then restore all other KKP controllers. So there is no need to have a `reboot` subcommand in the installer.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
