### PR TITLE
Add support to update Preset requiredEmails/EmailDomain via REST-API

### DIFF
--- a/pkg/handler/v2/preset/preset.go
+++ b/pkg/handler/v2/preset/preset.go
@@ -424,6 +424,8 @@ func UpdatePreset(presetsProvider provider.PresetProvider, userInfoGetter provid
 
 func mergePresets(oldPreset *crdapiv1.Preset, newPreset *crdapiv1.Preset, providerType crdapiv1.ProviderType) *crdapiv1.Preset {
 	oldPreset.Spec.OverrideProvider(providerType, &newPreset.Spec)
+	oldPreset.Spec.RequiredEmails = newPreset.Spec.RequiredEmails
+	oldPreset.Spec.RequiredEmailDomain = newPreset.Spec.RequiredEmailDomain
 	return oldPreset
 }
 

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -206,7 +206,7 @@ func filterOutPresets(userInfo *provider.UserInfo, list *kubermaticv1.PresetList
 			return nil, err
 		}
 
-		if matches {
+		if matches || userInfo.IsAdmin {
 			result = append(result, preset)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements that presets can be updated via the REST-API and it adds respective test cases. Furthermore, it adds the capability that an Admin can update and view all presets, what is currently not the case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8086 

**Special notes for your reviewer**:
- Update of requiredEmails is very crucial because adding a member to KKP sometimes requires the member to be added to the preset too. Project bounded presets would be more aligned with the multi-tenant thought of KKP. (but let's leave this for another PR ;) )
- **Important**: In `TestListPresets ` the `GenDefaultAPIUser` was promoted to an Admin because of the addition of this PR: https://github.com/kubermatic/kubermatic/pull/7972 
  Can you check that this does not happen for other tests as well (in another Issue)? This goes beyond the scope of this PR.
   This heavily influences the tests you are conducting because the first user is always Admin, this is not what you wanted to test in the fixed Presets tests. I could imagine that this happened on several Tests throughout the KKP repo. Thanks for checking!
- Added that the Admin sees all Presets, independent of his `email`. This is required to update a preset and is generally beneficial.


**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support to update the requiredEmails of a preset via REST-API and Admins will see all presets within KKP independent of their email.
```
