### PR TITLE
add DefaultClusterTemplate to seed

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -92,9 +92,9 @@ func createSeedConditionUpToDateController(ctrlCtx *controllerContext) error {
 	)
 }
 
-func defaultComponentSettings(runOptions controllerRunOptions, seed *kubermaticv1.Seed) (kubermaticv1.ComponentSettings, error) {
+func defaultComponentSettings(runOptions controllerRunOptions, defaultComponentSettings kubermaticv1.ComponentSettings) (kubermaticv1.ComponentSettings, error) {
 	// Copy default settings.
-	settings := seed.Spec.DefaultComponentSettings
+	settings := defaultComponentSettings
 
 	if replicas := runOptions.apiServerDefaultReplicas; replicas != 0 {
 		if settings.Apiserver.Replicas != nil && replicas != int(*settings.Apiserver.Replicas) {

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -28,7 +28,6 @@ import (
 	gatekeeperv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
@@ -47,6 +46,7 @@ import (
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -238,6 +238,11 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 				log.Fatal(err)
 			}
 
+			scope, ok := defaultingTemplate.Labels["scope"]
+			if !ok || scope != kubermaticv1.SeedTemplateScope {
+				log.Fatalf("invalid scope of default cluster template: %s", seed.Spec.DefaultClusterTemplate)
+			}
+
 		}
 
 		clustermutation.NewAdmissionHandler(defaultingTemplate).SetupWebhookWithManager(mgr)

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -215,7 +215,11 @@ spec:
             rhel: ""
             sles: ""
             ubuntu: ""
+  # DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used
+  # to default all new created clusters
+  defaultClusterTemplate: ""
   # DefaultComponentSettings are default values to set for newly created clusters.
+  # Deprecated: Use DefaultClusterTemplate instead.
   defaultComponentSettings:
     apiserver:
       endpointReconcilingDisabled: null

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hetznercloud/hcloud-go v1.32.0
 	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12
 	github.com/jetstack/cert-manager v1.1.0
 	github.com/kubermatic/grafanasdk v0.9.11
 	github.com/kubermatic/machine-controller v1.36.0
@@ -159,7 +160,6 @@ require (
 	github.com/gosimple/slug v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -24,6 +24,7 @@ const (
 	UserClusterTemplateScope    = "user"
 	ProjectClusterTemplateScope = "project"
 	GlobalClusterTemplateScope  = "global"
+	SeedTemplateScope           = "seed"
 )
 
 const (

--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -24,7 +24,6 @@ const (
 	UserClusterTemplateScope    = "user"
 	ProjectClusterTemplateScope = "project"
 	GlobalClusterTemplateScope  = "global"
-	SeedTemplateScope           = "seed"
 )
 
 const (

--- a/pkg/crd/kubermatic/v1/cluster_templates.go
+++ b/pkg/crd/kubermatic/v1/cluster_templates.go
@@ -24,6 +24,7 @@ const (
 	UserClusterTemplateScope    = "user"
 	ProjectClusterTemplateScope = "project"
 	GlobalClusterTemplateScope  = "global"
+	SeedTemplateScope           = "seed"
 )
 
 const (

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -92,7 +92,11 @@ type SeedSpec struct {
 	// Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.
 	MLA *SeedMLASettings `json:"mla,omitempty"`
 	// DefaultComponentSettings are default values to set for newly created clusters.
+	// Deprecated: Use DefaultClusterTemplate instead.
 	DefaultComponentSettings ComponentSettings `json:"defaultComponentSettings,omitempty"`
+	// DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used
+	// to default all new created clusters
+	DefaultClusterTemplate string `json:"defaultClusterTemplate,omitempty"`
 	// Metering configures the metering tool on user clusters across the seed.
 	Metering *MeteringConfigurations `json:"metering,omitempty"`
 	// BackupRestore when set, enables backup and restore controllers with given configuration.

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -52,7 +52,6 @@ func TestHandle(t *testing.T) {
 	tests := []struct {
 		name                   string
 		req                    webhook.AdmissionRequest
-		componentSettings      kubermaticv1.ComponentSettings
 		defaultClusterTemplate kubermaticv1.ClusterTemplate
 		wantAllowed            bool
 		wantPatches            []jsonpatch.JsonPatchOperation
@@ -88,88 +87,96 @@ func TestHandle(t *testing.T) {
 					},
 				},
 			},
-			componentSettings: kubermaticv1.ComponentSettings{
-				Apiserver: kubermaticv1.APIServerSettings{
-					DeploymentSettings: kubermaticv1.DeploymentSettings{
-						Replicas: pointer.Int32Ptr(2),
-						Resources: &corev1.ResourceRequirements{
-							Requests: map[corev1.ResourceName]resource.Quantity{
-								"memory": resource.MustParse("500M"),
+			defaultClusterTemplate: kubermaticv1.ClusterTemplate{
+				Spec: kubermaticv1.ClusterSpec{
+					CNIPlugin: &kubermaticv1.CNIPluginSettings{
+						Type: kubermaticv1.CNIPluginTypeCilium,
+					},
+					ComponentsOverride: kubermaticv1.ComponentSettings{
+						Apiserver: kubermaticv1.APIServerSettings{
+							DeploymentSettings: kubermaticv1.DeploymentSettings{
+								Replicas: pointer.Int32Ptr(2),
+								Resources: &corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										"memory": resource.MustParse("500M"),
+									},
+								},
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "test-no-schedule",
+										Operator: corev1.TolerationOpExists,
+										Effect:   corev1.TaintEffectPreferNoSchedule,
+									},
+								},
+							},
+							EndpointReconcilingDisabled: pointer.BoolPtr(true),
+							NodePortRange:               "30000-32768",
+						},
+						ControllerManager: kubermaticv1.ControllerSettings{
+							DeploymentSettings: kubermaticv1.DeploymentSettings{
+								Replicas: pointer.Int32Ptr(2),
+								Resources: &corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										"memory": resource.MustParse("500M"),
+									},
+								},
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "test-no-schedule",
+										Operator: corev1.TolerationOpExists,
+										Effect:   corev1.TaintEffectPreferNoSchedule,
+									},
+								},
+							},
+							LeaderElectionSettings: kubermaticv1.LeaderElectionSettings{
+								LeaseDurationSeconds: pointer.Int32Ptr(10),
+								RenewDeadlineSeconds: pointer.Int32Ptr(5),
+								RetryPeriodSeconds:   pointer.Int32Ptr(2),
 							},
 						},
-						Tolerations: []corev1.Toleration{
-							{
-								Key:      "test-no-schedule",
-								Operator: corev1.TolerationOpExists,
-								Effect:   corev1.TaintEffectPreferNoSchedule,
+						Scheduler: kubermaticv1.ControllerSettings{
+							DeploymentSettings: kubermaticv1.DeploymentSettings{
+								Replicas: pointer.Int32Ptr(2),
+								Resources: &corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										"memory": resource.MustParse("500M"),
+									},
+								},
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "test-no-schedule",
+										Operator: corev1.TolerationOpExists,
+										Effect:   corev1.TaintEffectPreferNoSchedule,
+									},
+								},
+							},
+							LeaderElectionSettings: kubermaticv1.LeaderElectionSettings{
+								LeaseDurationSeconds: pointer.Int32Ptr(10),
+								RenewDeadlineSeconds: pointer.Int32Ptr(5),
+								RetryPeriodSeconds:   pointer.Int32Ptr(2),
 							},
 						},
-					},
-					EndpointReconcilingDisabled: pointer.BoolPtr(true),
-					NodePortRange:               "30000-32768",
-				},
-				ControllerManager: kubermaticv1.ControllerSettings{
-					DeploymentSettings: kubermaticv1.DeploymentSettings{
-						Replicas: pointer.Int32Ptr(2),
-						Resources: &corev1.ResourceRequirements{
-							Requests: map[corev1.ResourceName]resource.Quantity{
-								"memory": resource.MustParse("500M"),
+						Etcd: kubermaticv1.EtcdStatefulSetSettings{
+							ClusterSize:  pointer.Int32Ptr(7),
+							StorageClass: "fast-storage",
+							DiskSize:     &oneGB,
+							Resources: &corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									"memory": resource.MustParse("500M"),
+								},
 							},
 						},
-						Tolerations: []corev1.Toleration{
-							{
-								Key:      "test-no-schedule",
-								Operator: corev1.TolerationOpExists,
-								Effect:   corev1.TaintEffectPreferNoSchedule,
+						Prometheus: kubermaticv1.StatefulSetSettings{
+							Resources: &corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									"memory": resource.MustParse("500M"),
+								},
 							},
-						},
-					},
-					LeaderElectionSettings: kubermaticv1.LeaderElectionSettings{
-						LeaseDurationSeconds: pointer.Int32Ptr(10),
-						RenewDeadlineSeconds: pointer.Int32Ptr(5),
-						RetryPeriodSeconds:   pointer.Int32Ptr(2),
-					},
-				},
-				Scheduler: kubermaticv1.ControllerSettings{
-					DeploymentSettings: kubermaticv1.DeploymentSettings{
-						Replicas: pointer.Int32Ptr(2),
-						Resources: &corev1.ResourceRequirements{
-							Requests: map[corev1.ResourceName]resource.Quantity{
-								"memory": resource.MustParse("500M"),
-							},
-						},
-						Tolerations: []corev1.Toleration{
-							{
-								Key:      "test-no-schedule",
-								Operator: corev1.TolerationOpExists,
-								Effect:   corev1.TaintEffectPreferNoSchedule,
-							},
-						},
-					},
-					LeaderElectionSettings: kubermaticv1.LeaderElectionSettings{
-						LeaseDurationSeconds: pointer.Int32Ptr(10),
-						RenewDeadlineSeconds: pointer.Int32Ptr(5),
-						RetryPeriodSeconds:   pointer.Int32Ptr(2),
-					},
-				},
-				Etcd: kubermaticv1.EtcdStatefulSetSettings{
-					ClusterSize:  pointer.Int32Ptr(7),
-					StorageClass: "fast-storage",
-					DiskSize:     &oneGB,
-					Resources: &corev1.ResourceRequirements{
-						Requests: map[corev1.ResourceName]resource.Quantity{
-							"memory": resource.MustParse("500M"),
-						},
-					},
-				},
-				Prometheus: kubermaticv1.StatefulSetSettings{
-					Resources: &corev1.ResourceRequirements{
-						Requests: map[corev1.ResourceName]resource.Quantity{
-							"memory": resource.MustParse("500M"),
 						},
 					},
 				},
 			},
+
 			wantAllowed: true,
 			wantPatches: []jsonpatch.JsonPatchOperation{
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/nodePortRange", "30000-32768"),
@@ -195,6 +202,55 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/diskSize", "1G"),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/prometheus/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
+			},
+		},
+		{
+			name: "Create cluster sets default cni settings",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{
+							Name:                  "foo",
+							CloudSpec:             kubermaticv1.CloudSpec{Openstack: &kubermaticv1.OpenstackCloudSpec{}},
+							ExternalCloudProvider: true,
+						}.Do(),
+					},
+				},
+			},
+			defaultClusterTemplate: kubermaticv1.ClusterTemplate{
+				Spec: kubermaticv1.ClusterSpec{
+					CNIPlugin: &kubermaticv1.CNIPluginSettings{
+						Type: kubermaticv1.CNIPluginTypeCilium,
+					},
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+						Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+						DNSDomain:                "example.local",
+						ProxyMode:                resources.EBPFProxyMode,
+						NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+					},
+				},
+			},
+
+			wantAllowed: true,
+			wantPatches: []jsonpatch.JsonPatchOperation{
+				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]interface{}{
+					"type":    "cilium",
+					"version": "v1.10",
+				}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []interface{}{"10.240.32.0/20"}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []interface{}{"10.241.0.0/16"}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/dnsDomain", "example.local"),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", resources.EBPFProxyMode),
+				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", true),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
 			},
 		},
@@ -517,13 +573,9 @@ func TestHandle(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			handler := AdmissionHandler{
-				log:     logr.Discard(),
-				decoder: d,
-				defaultTemplate: kubermaticv1.ClusterTemplate{
-					Spec: kubermaticv1.ClusterSpec{
-						ComponentsOverride: tt.componentSettings,
-					},
-				},
+				log:             logr.Discard(),
+				decoder:         d,
+				defaultTemplate: tt.defaultClusterTemplate,
 			}
 			res := handler.Handle(context.Background(), tt.req)
 			if res.Allowed != tt.wantAllowed {


### PR DESCRIPTION
**What this PR does / why we need it**:

Provides a way to define default for new clusters on a template base.


**Which issue(s) this PR fixes**
Fixes #7958

```release-note
Provide functionality to define a default cluster template for new clusters per seed.
DefaultComponentSettings of the Seed object is deprecated in favor of DefaultClusterTemplate.
```
