### PR TITLE
Relax OpenVPN & envoy-agent CPU limits to enhance apiserver-to-node throughput

### DIFF
--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -40,7 +40,7 @@ spec:
             cpu: 5m
             memory: 5Mi
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
         livenessProbe:
           exec:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -40,7 +40,7 @@ var (
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
-				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
 			},
 		},
 	}

--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -40,7 +40,7 @@ var (
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("50Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 		},
 	}
 

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -88,7 +88,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
@@ -85,7 +85,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -114,7 +114,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server.yaml
@@ -106,7 +106,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -161,7 +161,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m
@@ -195,7 +195,7 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 50Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -86,7 +86,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 32Mi
           requests:
             cpu: 5m

--- a/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/pkg/resources/vpnsidecar/openvpnClient.go
@@ -32,7 +32,7 @@ var (
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 		},
 	}
 )


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
CPU limits on OpenVPN & envoy-agent containers constrained the apiserver-to-node traffic throughput (which was considerably lower compared to Konnectivity). That could cause delays in large scale setups, and could impact user experience for example when using `kubectl cp` command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8100

**Special notes for your reviewer**:
A change of 4 lines rendered into into changes in 200 generated test fixtures files..

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Enhance apiserver-to-node throughput by relaxing OpenVPN & envoy-agent CPU limits.
```
