### PR TITLE
Set sig/crd label when pkg/crd is changed

### DIFF
--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -8,6 +8,7 @@ reviewers:
 
 labels:
   - sig/cluster-management
+  - sig/crd
 
 options:
   no_parent_owners: true

--- a/pkg/crd/OWNERS
+++ b/pkg/crd/OWNERS
@@ -8,6 +8,7 @@ reviewers:
 
 labels:
   - sig/cluster-management
+  - sig/crd
 
 options:
   no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:
To automate detection of PRs that change pkg/crd, so we could backport change to new pkg/apis/kubermatic API.

```release-note
NONE
```
