### PR TITLE
Add support for CNI type "none"

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.11
+version: 0.3.12
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -864,6 +864,7 @@ spec:
                     enum:
                     - canal
                     - cilium
+                    - none
                     type: string
                   version:
                     type: string

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -841,6 +841,7 @@ spec:
                     enum:
                     - canal
                     - cilium
+                    - none
                     type: string
                   version:
                     type: string

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -188,7 +188,7 @@ type CNIPluginSettings struct {
 	Version string        `json:"version"`
 }
 
-// +kubebuilder:validation:Enum=canal;cilium
+// +kubebuilder:validation:Enum=canal;cilium;none
 
 // CNIPluginType define the type of CNI plugin installed. e.g. Canal
 type CNIPluginType string
@@ -204,6 +204,10 @@ const (
 
 	// CNIPluginTypeCilium corresponds to Cilium CNI plugin
 	CNIPluginTypeCilium CNIPluginType = "cilium"
+
+	// CNIPluginTypeNone corresponds to no CNI plugin managed by KKP
+	// (cluster users are responsible for managing the CNI in the cluster themselves).
+	CNIPluginTypeNone CNIPluginType = "none"
 )
 
 const (

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -196,6 +196,10 @@ const (
 
 	// CNIPluginTypeCilium corresponds to Cilium CNI plugin
 	CNIPluginTypeCilium CNIPluginType = "cilium"
+
+	// CNIPluginTypeNone corresponds to no CNI plugin managed by KKP
+	// (cluster users are responsible for managing the CNI in the cluster themselves).
+	CNIPluginTypeNone CNIPluginType = "none"
 )
 
 const (

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -37,10 +37,11 @@ import (
 )
 
 var (
-	supportedCNIPlugins        = sets.NewString(kubermaticv1.CNIPluginTypeCanal.String(), kubermaticv1.CNIPluginTypeCilium.String())
+	supportedCNIPlugins        = sets.NewString(kubermaticv1.CNIPluginTypeCanal.String(), kubermaticv1.CNIPluginTypeCilium.String(), kubermaticv1.CNIPluginTypeNone.String())
 	supportedCNIPluginVersions = map[kubermaticv1.CNIPluginType]sets.String{
 		kubermaticv1.CNIPluginTypeCanal:  sets.NewString("v3.8", "v3.19", "v3.20"),
 		kubermaticv1.CNIPluginTypeCilium: sets.NewString("v1.10"),
+		kubermaticv1.CNIPluginTypeNone:   sets.NewString(""),
 	}
 )
 

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -319,6 +319,44 @@ func TestHandle(t *testing.T) {
 			wantAllowed: true,
 		},
 		{
+			name: "Supported CNIPlugin none",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{
+							Name:           "foo",
+							Namespace:      "kubermatic",
+							ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+							NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+								Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+								Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+								DNSDomain:                "cluster.local",
+								ProxyMode:                resources.IPVSProxyMode,
+								NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+							},
+							ComponentSettings: kubermaticv1.ComponentSettings{
+								Apiserver: kubermaticv1.APIServerSettings{
+									NodePortRange: "30000-32768",
+								},
+							},
+							CNIPlugin: &kubermaticv1.CNIPluginSettings{
+								Type:    "none",
+								Version: "",
+							},
+						}.Do(),
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
 			name: "Reject unsupported ebpf proxy mode",
 			req: webhook.AdmissionRequest{
 				AdmissionRequest: admissionv1.AdmissionRequest{


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Adds support for CNI type "none" that can be used for special use-cases, where CNIs built in KKP (or their customization options that KKP allows) may not be sufficient. CNI type "none" will not install any CNI into the user cluster, and leave the CNI management fully on the user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8060 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for CNI type "none".
```
