### PR TITLE
Set GOARCH in Makefile to easily allow cross-compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ REPO = $(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && e
 CMD = $(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS ?= -v
 GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 TAGS ?= $(shell git describe --tags --always)
 DOCKERTAGS = $(TAGS) latestbuild
 DOCKER_BUILD_FLAG += $(foreach tag, $(DOCKERTAGS), -t $(REPO):$(tag))
@@ -47,7 +48,7 @@ build: $(CMD)
 $(CMD): %: $(BUILD_DEST)/%
 
 $(BUILD_DEST)/%: cmd/% download-gocache
-	GOOS=$(GOOS) go build -tags "$(KUBERMATIC_EDITION)" $(GOTOOLFLAGS) -o $@ ./cmd/$*
+	GOARCH=$(GOARCH) GOOS=$(GOOS) go build -tags "$(KUBERMATIC_EDITION)" $(GOTOOLFLAGS) -o $@ ./cmd/$*
 
 .PHONY: install
 install:


### PR DESCRIPTION


**What this PR does / why we need it**:
When running on a non-x86_64 system (like a MacBook Pro/Air with a M1 CPU), you can't easily cross-compile kubermatic binaries to `amd64` (x86_64), for example because you'd like to build a container image that can be used on x86_64 clusters. This PR adds the same support for `GOARCH` to the Makefile that `GOOS` already has to target a different OS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>