### PR TITLE
Rollout RuleGroups from mla namespace to user cluster namespaces

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -197,6 +197,11 @@ func main() {
 				ImportAlias:        "networkingv1",
 				ResourceImportPath: "k8s.io/api/networking/v1",
 			},
+			{
+				ResourceName:     "RuleGroup",
+				ImportAlias:      "kubermaticv1",
+				APIVersionPrefix: "KubermaticV1",
+			},
 		},
 	}
 

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
@@ -48,7 +48,7 @@ func newTestRuleGroupReconciler(objects []ctrlruntimeclient.Object, handler http
 		Build()
 	ts := httptest.NewServer(handler)
 
-	controller := newRuleGroupController(fakeClient, kubermaticlog.Logger, ts.Client(), ts.URL, ts.URL)
+	controller := newRuleGroupController(fakeClient, kubermaticlog.Logger, ts.Client(), ts.URL, ts.URL, mlaNamespace)
 	reconciler := ruleGroupReconciler{
 		Client:              fakeClient,
 		log:                 kubermaticlog.Logger,

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mla
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type ruleGroupSyncReconciler struct {
+	ctrlruntimeclient.Client
+	log                     *zap.SugaredLogger
+	workerName              string
+	recorder                record.EventRecorder
+	versions                kubermatic.Versions
+	ruleGroupSyncController *ruleGroupSyncController
+}
+
+func newRuleGroupSyncReconciler(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+	workerName string,
+	versions kubermatic.Versions,
+	ruleGroupSyncController *ruleGroupSyncController,
+) error {
+	log = log.Named(ControllerName)
+	client := mgr.GetClient()
+
+	reconciler := &ruleGroupSyncReconciler{
+		Client:                  client,
+		log:                     log,
+		workerName:              workerName,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		versions:                versions,
+		ruleGroupSyncController: ruleGroupSyncController,
+	}
+
+	ctrlOptions := controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: numWorkers,
+	}
+	c, err := controller.New(ControllerName, mgr, ctrlOptions)
+	if err != nil {
+		return err
+	}
+
+	enqueueRuleGroup := handler.EnqueueRequestsFromMapFunc(func(object ctrlruntimeclient.Object) []reconcile.Request {
+		ruleGroup := &kubermaticv1.RuleGroup{}
+		nn := types.NamespacedName{
+			Name:      object.GetName(),
+			Namespace: reconciler.ruleGroupSyncController.mlaNamespace,
+		}
+		err = client.Get(context.Background(), nn, ruleGroup)
+		if apierrors.IsNotFound(err) {
+			return []reconcile.Request{}
+		}
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to get rulegroup: %w", err))
+		}
+		return []reconcile.Request{{NamespacedName: nn}}
+	})
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.RuleGroup{}}, enqueueRuleGroup); err != nil {
+		return fmt.Errorf("failed to watch RuleGroup: %w", err)
+	}
+	return nil
+}
+
+func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+	log.Debug("Processing")
+
+	ruleGroup := &kubermaticv1.RuleGroup{}
+	if err := r.Get(ctx, request.NamespacedName, ruleGroup); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if !ruleGroup.DeletionTimestamp.IsZero() {
+		if err := r.ruleGroupSyncController.handleDeletion(ctx, log, ruleGroup); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to delete ruleGroup: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !kubernetes.HasFinalizer(ruleGroup, ruleGroupFinalizer) {
+		kubernetes.AddFinalizer(ruleGroup, ruleGroupFinalizer)
+		if err := r.Update(ctx, ruleGroup); err != nil {
+			return reconcile.Result{}, fmt.Errorf("updating finalizers for ruleGroup object: %w", err)
+		}
+	}
+
+	if err := r.ruleGroupSyncController.syncClusterNS(ctx, log, ruleGroup, func(seedClient ctrlruntimeclient.Client, ruleGroup *kubermaticv1.RuleGroup, cluster *kubermaticv1.Cluster) error {
+		ruleGroupCreatorGetter := []reconciling.NamedKubermaticV1RuleGroupCreatorGetter{
+			ruleGroupCreatorGetter(ruleGroup, cluster),
+		}
+		return reconciling.ReconcileKubermaticV1RuleGroups(ctx, ruleGroupCreatorGetter, cluster.Status.NamespaceName, seedClient)
+	}); err != nil {
+		r.recorder.Eventf(ruleGroup, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		return reconcile.Result{}, fmt.Errorf("failed to reconcle rulegroup %s: %w", ruleGroup.Name, err)
+	}
+	return reconcile.Result{}, nil
+}
+
+type ruleGroupSyncController struct {
+	ctrlruntimeclient.Client
+	mlaNamespace string
+	log          *zap.SugaredLogger
+}
+
+func newRuleGroupSyncController(
+	client ctrlruntimeclient.Client,
+	log *zap.SugaredLogger,
+	mlaNamespace string,
+) *ruleGroupSyncController {
+	return &ruleGroupSyncController{
+		Client:       client,
+		mlaNamespace: mlaNamespace,
+		log:          log,
+	}
+}
+
+func (r *ruleGroupSyncController) cleanUp(ctx context.Context) error {
+	ruleGroupList := &kubermaticv1.RuleGroupList{}
+	if err := r.List(ctx, ruleGroupList, ctrlruntimeclient.InNamespace(r.mlaNamespace)); err != nil {
+		return err
+	}
+	for _, ruleGroup := range ruleGroupList.Items {
+		if err := r.handleDeletion(ctx, r.log, &ruleGroup); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ruleGroupSyncController) handleDeletion(ctx context.Context, log *zap.SugaredLogger, ruleGroup *kubermaticv1.RuleGroup) error {
+	if err := r.syncClusterNS(ctx, log, ruleGroup, func(seedClient ctrlruntimeclient.Client, ruleGroup *kubermaticv1.RuleGroup, cluster *kubermaticv1.Cluster) error {
+		ruleGroup = &kubermaticv1.RuleGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ruleGroup.Name,
+				Namespace: cluster.Status.NamespaceName,
+			},
+		}
+		if err := seedClient.Delete(ctx, ruleGroup); err != nil {
+			return ctrlruntimeclient.IgnoreNotFound(err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if kubernetes.HasFinalizer(ruleGroup, ruleGroupFinalizer) {
+		kubernetes.RemoveFinalizer(ruleGroup, ruleGroupFinalizer)
+		if err := r.Update(ctx, ruleGroup); err != nil {
+			return fmt.Errorf("updating ruleGroup finalizer: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *ruleGroupSyncController) syncClusterNS(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	ruleGroup *kubermaticv1.RuleGroup,
+	action func(seedClient ctrlruntimeclient.Client, ruleGroup *kubermaticv1.RuleGroup, cluster *kubermaticv1.Cluster) error) error {
+	clusterList := &kubermaticv1.ClusterList{}
+	if err := r.List(ctx, clusterList); err != nil {
+		return fmt.Errorf("failed to list clusters: %w", err)
+	}
+	for _, cluster := range clusterList.Items {
+		if cluster.Spec.Pause {
+			log.Debugw("cluster paused, skipping", "cluster", cluster.Name)
+			continue
+		}
+		if !cluster.DeletionTimestamp.IsZero() {
+			log.Debugw("cluster deletion in progress, skipping", "cluster", cluster.Name)
+			continue
+		}
+		if cluster.Status.NamespaceName == "" {
+			log.Debugw("cluster namespace not available, skipping", "cluster", cluster.Name)
+			continue
+		}
+		if !mlaEnabled(cluster) {
+			log.Debugw("cluster have mla disabled, skipping", "cluster", cluster.Name)
+			continue
+		}
+		if err := action(r.Client, ruleGroup, &cluster); err != nil {
+			return fmt.Errorf("failed to sync rulegroup for cluster %s: %w", cluster.Name, err)
+		}
+	}
+	return nil
+}
+
+func ruleGroupCreatorGetter(ruleGroup *kubermaticv1.RuleGroup, cluster *kubermaticv1.Cluster) reconciling.NamedKubermaticV1RuleGroupCreatorGetter {
+	return func() (string, reconciling.KubermaticV1RuleGroupCreator) {
+		return ruleGroup.Name, func(r *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
+			r.Name = ruleGroup.Name
+			r.Spec = kubermaticv1.RuleGroupSpec{
+				RuleGroupType: ruleGroup.Spec.RuleGroupType,
+				Cluster: corev1.ObjectReference{
+					Kind:            kubermaticv1.ClusterKindName,
+					Namespace:       "",
+					Name:            cluster.Name,
+					UID:             cluster.UID,
+					APIVersion:      cluster.APIVersion,
+					ResourceVersion: cluster.ResourceVersion,
+				},
+				Data: ruleGroup.Spec.Data,
+			}
+			return r, nil
+		}
+	}
+}
+
+func mlaEnabled(cluster kubermaticv1.Cluster) bool {
+	return cluster.Spec.MLA != nil && (cluster.Spec.MLA.LoggingEnabled || cluster.Spec.MLA.MonitoringEnabled)
+}

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mla
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	mlaNamespace = "mla"
+)
+
+func newTestRuleGroupSyncReconciler(objects []ctrlruntimeclient.Object) *ruleGroupSyncReconciler {
+	fakeClient := ctrlruntimefakeclient.
+		NewClientBuilder().
+		WithObjects(objects...).
+		WithScheme(testScheme).
+		Build()
+	controller := newRuleGroupSyncController(fakeClient, kubermaticlog.Logger, mlaNamespace)
+	reconciler := ruleGroupSyncReconciler{
+		Client:                  fakeClient,
+		log:                     kubermaticlog.Logger,
+		recorder:                record.NewFakeRecorder(10),
+		ruleGroupSyncController: controller,
+	}
+	return &reconciler
+}
+
+func TestReconcile(t *testing.T) {
+	testCases := []struct {
+		name           string
+		namespacedName types.NamespacedName
+		objects        []ctrlruntimeclient.Object
+		isSynced       bool
+	}{
+		{
+			name: "sync rulegroup to user cluster namespace",
+			namespacedName: types.NamespacedName{
+				Name:      "test-rule",
+				Namespace: mlaNamespace,
+			},
+			objects: []ctrlruntimeclient.Object{
+				generateCluster("test", true, false, false),
+				generateMLARuleGroup("test-rule", mlaNamespace, kubermaticv1.RuleGroupTypeMetrics, false),
+			},
+			isSynced: true,
+		},
+		{
+			name: "do not sync rulegroup to user cluster namespace which has mla disabled",
+			namespacedName: types.NamespacedName{
+				Name:      "test-rule",
+				Namespace: mlaNamespace,
+			},
+			objects: []ctrlruntimeclient.Object{
+				generateCluster("test", false, false, false),
+				generateMLARuleGroup("test-rule", mlaNamespace, kubermaticv1.RuleGroupTypeMetrics, false),
+			},
+			isSynced: false,
+		},
+		{
+			name: "cleanup rulegroup on user cluster namespace when rulegroup in mla namespace is deleted",
+			namespacedName: types.NamespacedName{
+				Name:      "test-rule",
+				Namespace: mlaNamespace,
+			},
+			objects: []ctrlruntimeclient.Object{
+				generateCluster("test", true, false, false),
+				generateMLARuleGroup("test-rule", "cluster-test", kubermaticv1.RuleGroupTypeMetrics, false),
+				generateMLARuleGroup("test-rule", mlaNamespace, kubermaticv1.RuleGroupTypeMetrics, true),
+			},
+			isSynced: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler := newTestRuleGroupSyncReconciler(tc.objects)
+			req := reconcile.Request{NamespacedName: tc.namespacedName}
+			_, err := reconciler.Reconcile(ctx, req)
+			assert.NoError(t, err)
+			ruleGroup := &kubermaticv1.RuleGroup{}
+			err = reconciler.Get(ctx, types.NamespacedName{
+				Name:      tc.namespacedName.Name,
+				Namespace: "cluster-test",
+			}, ruleGroup)
+			if tc.isSynced {
+				assert.NoError(t, err)
+			} else {
+				assert.True(t, apierrors.IsNotFound(err), err.Error())
+			}
+		})
+	}
+}
+
+func generateMLARuleGroup(name, namespace string, ruleGroupType kubermaticv1.RuleGroupType, deleted bool) *kubermaticv1.RuleGroup {
+	group := &kubermaticv1.RuleGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kubermaticv1.RuleGroupKindName,
+			APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+		},
+		Spec: kubermaticv1.RuleGroupSpec{
+			RuleGroupType: ruleGroupType,
+			Data:          test.GenerateTestRuleGroupData(name),
+		},
+	}
+	if deleted {
+		deleteTime := metav1.NewTime(time.Now())
+		group.DeletionTimestamp = &deleteTime
+	}
+	return group
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a controller to rollout RuleGroups from MLA namespace to user cluster namespaces. This can be used in the scenario that we predefine some alerting/recording rule groups or KKP admins would like to rollout some rule groups to all user clusters with MLA enabled, so that those rules can be used by users.

API endpoints for this feature will be implemented in a dedicated PR.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7104 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
