### PR TITLE
fix api client usage

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -230,7 +230,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 			defaultingTemplate.Spec.ComponentsOverride = settings
 
 		} else {
-			err = mgr.GetClient().Get(context.Background(), types.NamespacedName{
+			err = mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{
 				Namespace: options.namespace,
 				Name:      seed.Spec.DefaultClusterTemplate,
 			}, &defaultingTemplate)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes api client usage for defaultClusterTemplates. Usual manager client uses a cache that is not initialized at the point it is used. 


```release-note
NONE
```
