### PR TITLE
Sync pkg/crd/kubermatic/v1 APIs to pkg/apis/kubermatic/v1

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.12
+version: 0.3.13
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1639,7 +1639,19 @@ spec:
                     - HealthStatusUp
                     - HealthStatusProvisioning
                     type: string
+                  logging:
+                    enum:
+                    - HealthStatusDown
+                    - HealthStatusUp
+                    - HealthStatusProvisioning
+                    type: string
                   machineController:
+                    enum:
+                    - HealthStatusDown
+                    - HealthStatusUp
+                    - HealthStatusProvisioning
+                    type: string
+                  monitoring:
                     enum:
                     - HealthStatusDown
                     - HealthStatusUp

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -469,9 +469,13 @@ spec:
                   (DCs) in this seed. Each DC must have a globally unique identifier
                   (i.e. names must be unique across all seeds).
                 type: object
+              defaultClusterTemplate:
+                description: DefaultClusterTemplate is the name of a cluster template
+                  of scope "seed" that is used to default all new created clusters
+                type: string
               defaultComponentSettings:
-                description: DefaultComponentSettings are default values to set for
-                  newly created clusters.
+                description: 'DefaultComponentSettings are default values to set for
+                  newly created clusters. Deprecated: Use DefaultClusterTemplate instead.'
                 properties:
                   apiserver:
                     properties:

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -803,6 +803,8 @@ type ExtendedClusterHealth struct {
 	UserClusterControllerManager HealthStatus `json:"userClusterControllerManager"`
 	GatekeeperController         HealthStatus `json:"gatekeeperController,omitempty"`
 	GatekeeperAudit              HealthStatus `json:"gatekeeperAudit,omitempty"`
+	Monitoring                   HealthStatus `json:"monitoring,omitempty"`
+	Logging                      HealthStatus `json:"logging,omitempty"`
 }
 
 // AllHealthy returns if all components are healthy. Gatekeeper components not included as they are optional and not

--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -24,6 +24,7 @@ const (
 	UserClusterTemplateScope    = "user"
 	ProjectClusterTemplateScope = "project"
 	GlobalClusterTemplateScope  = "global"
+	SeedTemplateScope           = "seed"
 )
 
 const (

--- a/pkg/apis/kubermatic/v1/constraint.go
+++ b/pkg/apis/kubermatic/v1/constraint.go
@@ -69,6 +69,8 @@ type ConstraintSpec struct {
 	Selector ConstraintSelector `json:"selector,omitempty"`
 }
 
+type Parameters map[string]json.RawMessage
+
 // ConstraintSelector is the object holding the cluster selection filters
 type ConstraintSelector struct {
 	// Providers is a list of cloud providers to which the Constraint applies to. Empty means all providers are selected.
@@ -76,8 +78,6 @@ type ConstraintSelector struct {
 	// LabelSelector selects the Clusters to which the Constraint applies based on their labels
 	LabelSelector metav1.LabelSelector `json:"labelSelector,omitempty"`
 }
-
-type Parameters map[string]json.RawMessage
 
 // Match contains the constraint to resource matching data
 type Match struct {

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -90,7 +90,11 @@ type SeedSpec struct {
 	// Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.
 	MLA *SeedMLASettings `json:"mla,omitempty"`
 	// DefaultComponentSettings are default values to set for newly created clusters.
+	// Deprecated: Use DefaultClusterTemplate instead.
 	DefaultComponentSettings ComponentSettings `json:"defaultComponentSettings,omitempty"`
+	// DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used
+	// to default all new created clusters
+	DefaultClusterTemplate string `json:"defaultClusterTemplate,omitempty"`
 	// Metering configures the metering tool on user clusters across the seed.
 	Metering *MeteringConfiguration `json:"metering,omitempty"`
 	// BackupRestore when set, enables backup and restore controllers with given configuration.

--- a/pkg/apis/kubermatic/v1/etcd_backup_config.go
+++ b/pkg/apis/kubermatic/v1/etcd_backup_config.go
@@ -71,15 +71,6 @@ type EtcdBackupConfigSpec struct {
 	Keep *int `json:"keep,omitempty"`
 }
 
-type EtcdBackupConfigStatus struct {
-	// CurrentBackups tracks the creation and deletion progress if all backups managed by the EtcdBackupConfig
-	CurrentBackups []BackupStatus `json:"lastBackups,omitempty"`
-	// Conditions contains conditions of the EtcdBackupConfig
-	Conditions []EtcdBackupConfigCondition `json:"conditions,omitempty"`
-	// If the controller was configured with a cleanupContainer, CleanupRunning keeps track of the corresponding job
-	CleanupRunning bool `json:"cleanupRunning,omitempty"`
-}
-
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 
@@ -89,6 +80,15 @@ type EtcdBackupConfigList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []EtcdBackupConfig `json:"items"`
+}
+
+type EtcdBackupConfigStatus struct {
+	// CurrentBackups tracks the creation and deletion progress if all backups managed by the EtcdBackupConfig
+	CurrentBackups []BackupStatus `json:"lastBackups,omitempty"`
+	// Conditions contains conditions of the EtcdBackupConfig
+	Conditions []EtcdBackupConfigCondition `json:"conditions,omitempty"`
+	// If the controller was configured with a cleanupContainer, CleanupRunning keeps track of the corresponding job
+	CleanupRunning bool `json:"cleanupRunning,omitempty"`
 }
 
 type BackupStatusPhase string

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -71,11 +71,6 @@ type EtcdRestoreSpec struct {
 	BackupDownloadCredentialsSecret string `json:"backupDownloadCredentialsSecret,omitempty"`
 }
 
-type EtcdRestoreStatus struct {
-	Phase       EtcdRestorePhase `json:"phase"`
-	RestoreTime *metav1.Time     `json:"restoreTime,omitempty"`
-}
-
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 
@@ -85,4 +80,9 @@ type EtcdRestoreList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []EtcdRestore `json:"items"`
+}
+
+type EtcdRestoreStatus struct {
+	Phase       EtcdRestorePhase `json:"phase"`
+	RestoreTime *metav1.Time     `json:"restoreTime,omitempty"`
 }

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -147,6 +147,17 @@ func (s PresetSpec) HasProvider(providerType ProviderType) (bool, reflect.Value)
 	return !provider.IsZero(), provider
 }
 
+func (s PresetSpec) GetProviderList() []ProviderType {
+	existingProviders := []ProviderType{}
+	for _, provType := range SupportedProviders() {
+		hasProvider, _ := s.HasProvider(provType)
+		if hasProvider {
+			existingProviders = append(existingProviders, provType)
+		}
+	}
+	return existingProviders
+}
+
 func (s PresetSpec) GetPresetProvider(providerType ProviderType) *PresetProvider {
 	hasProvider, providerField := s.HasProvider(providerType)
 	if !hasProvider {
@@ -199,6 +210,11 @@ func (s *PresetSpec) OverrideProvider(providerType ProviderType, spec *PresetSpe
 	dest := s.getProviderValue(providerType)
 	src := spec.getProviderValue(providerType)
 	dest.Set(src)
+}
+
+func (s *PresetSpec) RemoveProvider(providerType ProviderType) {
+	provider := s.getProviderValue(providerType)
+	provider.Set(reflect.Zero(provider.Type()))
 }
 
 type PresetProvider struct {

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -66,6 +66,17 @@ type UserSettings struct {
 	LastSeenChangelogVersion   string `json:"lastSeenChangelogVersion,omitempty"`
 }
 
+// +kubebuilder:object:generate=true
+// +kubebuilder:object:root=true
+
+// UserList is a list of users
+type UserList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	Items []User `json:"items"`
+}
+
 // ProjectGroup is a helper data structure that
 // stores the information about a project and a group that
 // a user belongs to
@@ -76,15 +87,4 @@ type ProjectGroup struct {
 
 func (u *User) GetTokenBlackListSecretName() string {
 	return fmt.Sprintf("token-blacklist-%s", u.Name)
-}
-
-// +kubebuilder:object:generate=true
-// +kubebuilder:object:root=true
-
-// UserList is a list of users
-type UserList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-
-	Items []User `json:"items"`
 }

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -346,6 +346,8 @@ func cloneClusterResourcesInCluster(ctx context.Context, logger logrus.FieldLogg
 					UserClusterControllerManager: convertHealthStatus(oldObject.Status.ExtendedHealth.UserClusterControllerManager),
 					GatekeeperController:         convertHealthStatus(oldObject.Status.ExtendedHealth.GatekeeperController),
 					GatekeeperAudit:              convertHealthStatus(oldObject.Status.ExtendedHealth.GatekeeperAudit),
+					Monitoring:                   convertHealthStatus(oldObject.Status.ExtendedHealth.Monitoring),
+					Logging:                      convertHealthStatus(oldObject.Status.ExtendedHealth.Logging),
 				},
 			},
 		}
@@ -1091,6 +1093,7 @@ func cloneSeedResourcesInCluster(ctx context.Context, logger logrus.FieldLogger,
 				},
 				ExposeStrategy:           newv1.ExposeStrategy(oldObject.Spec.ExposeStrategy),
 				DefaultComponentSettings: convertComponentSettings(oldObject.Spec.DefaultComponentSettings),
+				DefaultClusterTemplate:   oldObject.Spec.DefaultClusterTemplate,
 			},
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* sync types from pkg/crd/kubermatic/v1 to pkg/apis/kubermatic/v1
* add cloning logic

changes coming from:
* #8107 
* #8106 
* #8093
* #8089 
* #8082


```release-note
NONE
```
