### PR TITLE
Allow patching Konnectivity status

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -476,6 +476,7 @@ func PatchEndpoint(
 	newInternalCluster.Spec.ServiceAccount = patchedCluster.Spec.ServiceAccount
 	newInternalCluster.Spec.MLA = patchedCluster.Spec.MLA
 	newInternalCluster.Spec.ContainerRuntime = patchedCluster.Spec.ContainerRuntime
+	newInternalCluster.Spec.ClusterNetwork.KonnectivityEnabled = patchedCluster.Spec.ClusterNetwork.KonnectivityEnabled
 
 	incompatibleKubelets, err := common.CheckClusterVersionSkew(ctx, userInfoGetter, clusterProvider, newInternalCluster, projectID)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: Patching `KonnectivityEnabled` was not enabled before but it was added originally in https://github.com/kubermatic/dashboard/pull/3661. Because of that it's also part of https://github.com/kubermatic/dashboard/pull/3822 but to make it work this change is required. Please let me know if this should not be done and instead we should block the updates in the dashboard.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
