### PR TITLE
Set apiVersion of kubeadm-config based on Kubernetes version

### DIFF
--- a/addons/kubeadm-configmap/kubeadm-configmap.yaml
+++ b/addons/kubeadm-configmap/kubeadm-configmap.yaml
@@ -23,12 +23,20 @@ data:
       extraArgs:
         authorization-mode: Webhook
       timeoutForControlPlane: 4m0s
-    apiVersion: kubeadm.k8s.io/v1beta1
+    {{- if and (eq .Cluster.Version.Major 1) (le .Cluster.Version.Minor 21) }}
+    apiVersion: kubeadm.k8s.io/v1beta2
+    {{- else if and (eq .Cluster.Version.Major 1) (ge .Cluster.Version.Minor 22) }}
+    apiVersion: kubeadm.k8s.io/v1beta3
+    {{- end }}
     certificatesDir: /etc/kubernetes/pki
     imageRepository: k8s.gcr.io
     kind: ClusterConfiguration
     kubernetesVersion: {{ .Cluster.Version }}
   ClusterStatus: |
-    apiVersion: kubeadm.k8s.io/v1beta1
+    {{- if and (eq .Cluster.Version.Major 1) (le .Cluster.Version.Minor 21) }}
+    apiVersion: kubeadm.k8s.io/v1beta2
+    {{- else if and (eq .Cluster.Version.Major 1) (ge .Cluster.Version.Minor 22) }}
+    apiVersion: kubeadm.k8s.io/v1beta3
+    {{- end }}
     kind: ClusterStatus
     apiEndpoints:

--- a/addons/kubeadm-configmap/kubeadm-configmap.yaml
+++ b/addons/kubeadm-configmap/kubeadm-configmap.yaml
@@ -25,7 +25,7 @@ data:
       timeoutForControlPlane: 4m0s
     {{- if and (eq .Cluster.Version.Major 1) (le .Cluster.Version.Minor 21) }}
     apiVersion: kubeadm.k8s.io/v1beta2
-    {{- else if and (eq .Cluster.Version.Major 1) (ge .Cluster.Version.Minor 22) }}
+    {{- else }}
     apiVersion: kubeadm.k8s.io/v1beta3
     {{- end }}
     certificatesDir: /etc/kubernetes/pki
@@ -35,7 +35,7 @@ data:
   ClusterStatus: |
     {{- if and (eq .Cluster.Version.Major 1) (le .Cluster.Version.Minor 21) }}
     apiVersion: kubeadm.k8s.io/v1beta2
-    {{- else if and (eq .Cluster.Version.Major 1) (ge .Cluster.Version.Minor 22) }}
+    {{- else }}
     apiVersion: kubeadm.k8s.io/v1beta3
     {{- end }}
     kind: ClusterStatus


### PR DESCRIPTION
**What this PR does / why we need it**:

The v1beta1 API types have been removed from kubeadm in 1.22, thus kubeadm 1.22 cannot be used to join a cluster created via KKP's "kubeadm" provider type as the kubeadm configmap is using the removed API type. v1beta2 is available since kubeadm 1.15.0 [1], so v1beta2 should be save to use. v1beta3 can be used for Kubernetes 1.22+.

[1] https://pkg.go.dev/k8s.io/kubernetes@v1.15.0/cmd/kubeadm/app/apis/kubeadm/v1beta2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8039

**Special notes for your reviewer**:

- Should this be backported to 2.18?

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
kubeadm-config is updated based on Kubernetes version
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>