### PR TITLE
fix vsphere CSI addon manifests

### DIFF
--- a/addons/csi/vsphere/csiController.yaml
+++ b/addons/csi/vsphere/csiController.yaml
@@ -17,13 +17,13 @@
 {{ if eq .Cluster.CloudProviderName "vsphere" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
-{{ $version = "v2.3.0 "}}
+{{ $version = "v2.3.0" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v2.3.0 "}}
+{{ $version = "v2.3.0" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v2.3.0 "}}
+{{ $version = "v2.3.0" }}
 {{ end }}
 
 ---

--- a/addons/csi/vsphere/csiNode-ds.yaml
+++ b/addons/csi/vsphere/csiNode-ds.yaml
@@ -17,13 +17,13 @@
 {{ if eq .Cluster.CloudProviderName "vsphere" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
-{{ $version = "v2.3.0 "}}
+{{ $version = "v2.3.0" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.20" }}
-{{ $version = "v2.3.0 "}}
+{{ $version = "v2.3.0" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.21" }}
-{{ $version = "v2.3.0 "}}
+{{ $version = "v2.3.0" }}
 {{ end }}
 
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Since #8055 we quote the docker images in the YAML, which unearthed the slightly broken version tags with a space at the end. This PR fixes that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
