### PR TITLE
Remove double implementation of registry override function

### DIFF
--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -32,6 +32,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/util/yaml"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,13 +46,7 @@ const (
 
 func txtFuncMap(overwriteRegistry string) template.FuncMap {
 	funcs := sprig.TxtFuncMap()
-	funcs["Registry"] = func(registry string) string {
-		if overwriteRegistry != "" {
-			return overwriteRegistry
-		}
-		return registry
-	}
-
+	funcs["Registry"] = registry.GetOverwriteFunc(overwriteRegistry)
 	return funcs
 }
 

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -101,7 +101,7 @@ func Add(
 	addonEnforceInterval int,
 	addonCtxVariables map[string]interface{},
 	kubernetesAddonDir,
-	overwriteRegistey string,
+	overwriteRegistry string,
 	kubeconfigProvider KubeconfigProvider,
 	versions kubermatic.Versions,
 ) error {
@@ -118,7 +118,7 @@ func Add(
 		KubeconfigProvider:   kubeconfigProvider,
 		workerName:           workerName,
 		recorder:             mgr.GetEventRecorderFor(ControllerName),
-		overwriteRegistry:    overwriteRegistey,
+		overwriteRegistry:    overwriteRegistry,
 		versions:             versions,
 	}
 

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -440,7 +440,7 @@ func (d *TemplateData) KubermaticAPIImage() string {
 func (d *TemplateData) parseImage(image string) string {
 	named, _ := reference.ParseNormalizedNamed(image)
 	domain := reference.Domain(named)
-	reminder := reference.Path(named)
+	remainder := reference.Path(named)
 
 	if d.OverwriteRegistry != "" {
 		domain = d.OverwriteRegistry
@@ -449,7 +449,7 @@ func (d *TemplateData) parseImage(image string) string {
 		domain = RegistryDocker
 	}
 
-	return domain + "/" + reminder
+	return domain + "/" + remainder
 }
 
 func (d *TemplateData) KubermaticDockerTag() string {


### PR DESCRIPTION
**What this PR does / why we need it**: This is a tiny refactoring follow-up PR to #8055. I expected there to be more potential for refactoring and clean up and I didn't want it in the initial PR where the fix was implemented to avoid distraction.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
