### PR TITLE
[release/v2.18] Add support to update Preset requiredEmails/EmailDomain via REST-API

### DIFF
--- a/pkg/handler/v2/preset/preset.go
+++ b/pkg/handler/v2/preset/preset.go
@@ -424,6 +424,8 @@ func UpdatePreset(presetsProvider provider.PresetProvider, userInfoGetter provid
 
 func mergePresets(oldPreset *crdapiv1.Preset, newPreset *crdapiv1.Preset, providerType crdapiv1.ProviderType) *crdapiv1.Preset {
 	oldPreset.Spec.OverrideProvider(providerType, &newPreset.Spec)
+	oldPreset.Spec.RequiredEmails = newPreset.Spec.RequiredEmails
+	oldPreset.Spec.RequiredEmailDomain = newPreset.Spec.RequiredEmailDomain
 	return oldPreset
 }
 

--- a/pkg/handler/v2/preset/preset_test.go
+++ b/pkg/handler/v2/preset/preset_test.go
@@ -197,7 +197,8 @@ func TestListPresets(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/presets?disabled=%v", tc.Disabled), strings.NewReader(""))
 			res := httptest.NewRecorder()
-			kubermaticObj := make([]ctrlruntimeclient.Object, 0)
+			// Tests need a default user otherwise, the GenDefaultAPIUser gets admin
+			kubermaticObj := []ctrlruntimeclient.Object{test.GenDefaultUser()}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, kubermaticObj, nil, nil, nil, hack.NewTestRouting)
 			if err != nil {
@@ -338,7 +339,8 @@ func TestListProviderPresets(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/providers/%s/presets?disabled=%v&datacenter=%s", tc.Provider, tc.Disabled, tc.Datacenter), strings.NewReader(""))
 			res := httptest.NewRecorder()
-			kubermaticObj := make([]ctrlruntimeclient.Object, 0)
+			// Tests need a default user otherwise, the GenDefaultAPIUser gets admin
+			kubermaticObj := []ctrlruntimeclient.Object{test.GenDefaultUser()}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, kubermaticObj, nil, nil, nil, hack.NewTestRouting)
 			if err != nil {
@@ -1028,6 +1030,126 @@ func TestUpdatePreset(t *testing.T) {
 			}`,
 			HTTPStatus:      http.StatusForbidden,
 			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
+
+		// scenario 6
+		{
+			Name:       "scenario 6: add requiredEmails",
+			PresetName: "do-preset",
+			Provider:   v2.PresetProvider{Name: kubermaticv1.ProviderDigitalocean, Enabled: true},
+			Body: `{
+					  "metadata": {
+						"name": "do-preset"
+					  },
+					  "spec": {
+						"requiredEmails": ["foo.bar@example.com"],
+						"digitalocean": {
+						  "token": "test"
+						}
+					  }
+			}`,
+			ExistingPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "do-preset"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+				},
+			},
+			ExpectedPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "do-preset", ResourceVersion: "1"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					RequiredEmails: []string{"foo.bar@example.com"},
+					Digitalocean: &kubermaticv1.Digitalocean{
+						PresetProvider: kubermaticv1.PresetProvider{Enabled: boolPtr(true)},
+						Token:          "test",
+					},
+				},
+			},
+			HTTPStatus:      http.StatusOK,
+			ExistingAPIUser: test.GenDefaultAdminAPIUser(),
+		},
+
+		// scenario 7
+		{
+			Name:       "scenario 7: update requiredEmails",
+			PresetName: "do-preset",
+			Provider:   v2.PresetProvider{Name: kubermaticv1.ProviderDigitalocean, Enabled: true},
+			Body: `{
+					  "metadata": {
+						"name": "do-preset"
+					  },
+					  "spec": {
+						"requiredEmails": ["foobar.com","test.com"],
+						"digitalocean": {
+							"token": "test"
+						}
+					  }
+			}`,
+			ExistingPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "do-preset"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					// use a domain that is not the domain of the admin (i.e. acme.com)!
+					RequiredEmails: []string{"foobar.com"},
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+				},
+			},
+			ExpectedPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "do-preset", ResourceVersion: "1"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					RequiredEmails: []string{"foobar.com", "test.com"},
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+				},
+			},
+			HTTPStatus:      http.StatusOK,
+			ExistingAPIUser: test.GenDefaultAdminAPIUser(),
+		},
+
+		// scenario 8
+		{
+			Name:       "scenario 8: remove requiredEmails",
+			PresetName: "do-preset",
+			Provider:   v2.PresetProvider{Name: kubermaticv1.ProviderDigitalocean, Enabled: true},
+			Body: `{
+					  "metadata": {
+						"name": "do-preset"
+					  },
+					  "spec": {
+						"digitalocean": {
+							"token": "test"
+						}
+					  }
+			}`,
+			ExistingPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "do-preset"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					// use a domain that is not the domain of the admin (i.e. acme.com)!
+					RequiredEmails: []string{"foobar.com"},
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+				},
+			},
+			ExpectedPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "do-preset", ResourceVersion: "1"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+				},
+			},
+			HTTPStatus:      http.StatusOK,
+			ExistingAPIUser: test.GenDefaultAdminAPIUser(),
 		},
 	}
 

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -220,13 +220,13 @@ func filterOutPresets(userInfo *provider.UserInfo, list *kubermaticv1.PresetList
 				// otherwise, it has to match the whole email
 				if len(reqEmail) == 1 {
 					// domain provided
-					if len(userDomain) >= 2 && strings.EqualFold(userDomain[len(userDomain)-1], reqEmail[0]) {
+					if len(userDomain) >= 2 && (strings.EqualFold(userDomain[len(userDomain)-1], reqEmail[0]) || userInfo.IsAdmin) {
 						presetList = append(presetList, preset)
 						break
 					}
 				} else {
 					// email provided
-					if strings.EqualFold(userInfo.Email, emailItem) {
+					if strings.EqualFold(userInfo.Email, emailItem) || userInfo.IsAdmin {
 						presetList = append(presetList, preset)
 						break
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of bug that was fixed in #8087 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8086

**Special notes for your reviewer**:
- This is the backport of #8087 based on the release/v2.18
- cherry-pick did not fully work because of the outsourcing of `pkg/provider/kubernetes/preset.go`, a tiny adjustment provides the same functionality.
Do you accept such a backport or are only cherry-picks allowed?

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support to update the requiredEmails of a preset via REST-API and Admins will see all presets within KKP independent of their email.
```
