### PR TITLE
Fix setting of nodeport-proxy resource requests/limits, relax default envoy limits

### DIFF
--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -332,8 +332,8 @@ spec:
         # Limits describes the maximum amount of compute resources allowed.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         limits:
-          cpu: 200m
-          memory: 64Mi
+          cpu: "1"
+          memory: 128Mi
         # Requests describes the minimum amount of compute resources required.
         # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
         # otherwise to an implementation-defined value.

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -151,8 +151,8 @@ var (
 			corev1.ResourceMemory: resource.MustParse("32Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("200m"),
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 	}
 

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -119,6 +119,7 @@ func EnvoyDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, seed 
 							MountPath: "/etc/envoy",
 						},
 					},
+					Resources: seed.Spec.NodeportProxy.EnvoyManager.Resources,
 				},
 
 				{
@@ -170,6 +171,7 @@ func EnvoyDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, seed 
 							},
 						},
 					},
+					Resources: seed.Spec.NodeportProxy.Envoy.Resources,
 				},
 			}
 
@@ -244,6 +246,7 @@ func UpdaterDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, see
 							},
 						},
 					},
+					Resources: seed.Spec.NodeportProxy.Updater.Resources,
 				},
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP operator does not set any resource requests/limits on the nodeport-proxy deployment in Seed - not default, nor the ones specified in the Seed CR. This PR fixes it.

Also, the current default resource limits for the envoy container of the nodeport-proxy may not be sufficient for high load-scenarios as on the example below, so relaxing it:

![image](https://user-images.githubusercontent.com/15926980/140531468-a7ad9689-bf4a-498a-9ae3-adf3ac5f6fc6.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix setting of nodeport-proxy resource requests/limits, relax default nodeport-proxy envoy limits.
```
