### PR TITLE
Update Kubernetes Dashboard to v2.4.0

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -49,7 +49,7 @@ var (
 const (
 	scraperName      = resources.MetricsScraperDeploymentName
 	scraperImageName = "kubernetesui/metrics-scraper"
-	scraperTag       = "v1.0.3"
+	scraperTag       = "v1.0.7"
 )
 
 // DeploymentCreator returns the function to create and update the dashboard-metrics-scraper deployment

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -50,7 +50,7 @@ var (
 const (
 	name      = resources.KubernetesDashboardDeploymentName
 	imageName = "kubernetesui/dashboard"
-	tag       = "v2.0.4"
+	tag       = "v2.4.0"
 	// Namespace used by Dashboard to find required resources.
 	Namespace     = "kubernetes-dashboard"
 	ContainerPort = 9090

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.4
+        image: docker.io/kubernetesui/dashboard:v2.4.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug that occurs on v1.22.2 clusters:

Bug (on the dashboard home page):
```
Unknown error (404)
the server could not find the requested resource (get ingresses.extensions)
```
This is mainly because of the Ingress object adjustments in v1.22.
An upgrade to the newest kubernetes-dashboard version fixes the problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
- Updates Kubernetes Dashboard to v2.4.0, a quick test showed that this resolves the above bug.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update Kubernetes Dashboard to v2.4.0
```
