### PR TITLE
Group alerts in Alertmanager and support multiple alerts in template

### DIFF
--- a/charts/monitoring/alertmanager/Chart.yaml
+++ b/charts/monitoring/alertmanager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: alertmanager
-version: 2.1.2
+version: 2.1.3
 appVersion: v0.22.2
 description: Alertmanager for Kubermatic
 keywords:

--- a/charts/monitoring/alertmanager/kubermatic.tmpl
+++ b/charts/monitoring/alertmanager/kubermatic.tmpl
@@ -2,40 +2,38 @@
 {* Capable of displaying the user-cluster from which alerts originate. *}
 {* Shows a pretty flag if the seed cluster name matches regex. *}
 
-{{ define "slack.kubermatic.pretty.runbook" }}{{ with .Annotations.runbook_url }}<{{ .}}|:notebook:>{{ end }}{{ end }}
+{{ define "slack.kubermatic.pretty.runbook" }}{{ with .Annotations.runbook_url }}<{{ . }}|:notebook:>{{ end }}{{ end }}
 {{ define "slack.kubermatic.titlelink" }}{{ end }}
 {{ define "slack.kubermatic.pretty.icon" }}{{ end }}
 {{ define "slack.kubermatic.color" }}{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}{{ end }}
 
 {{ define "slack.kubermatic.pretty.labels" -}}
-{{- with .Labels.seed_cluster -}}
+{{- with .CommonLabels.seed_cluster -}}
 {{- if      (match "^(eu|europe)-" .) }}:flag-eu:
 {{- else if (match "^usa?-" .) }}:flag-us:
 {{- else if (match "^asia-" .) }}:flag-cn:
 {{- else }}[{{ . }}]{{ end -}}
-{{- end -}} {{ with .Labels.cluster }} [{{ . }}]{{ end }}
+{{- end -}} {{ with .CommonLabels.cluster }} [{{ . }}]{{ end }}
 {{- end }}
 
 {{ define "slack.kubermatic.title" -}}
-{{- with (index .Alerts 0) -}}
-{{- template "slack.kubermatic.pretty.icon" . }} {{ template "slack.kubermatic.pretty.labels" . }} <{{ $.ExternalURL }}/#/alerts?receiver={{ $.Receiver }}|{{ .Labels.alertname }}>
-{{- end -}}
+    {{- template "slack.kubermatic.pretty.icon" . -}}
+    {{- if eq .Status "firing" }} [ {{ .Alerts.Firing | len }} ]{{ end - }}
+    {{ template "slack.kubermatic.pretty.labels" . }} <{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}|{{ .CommonLabels.alertname }}>
 {{- end }}
 
 {{ define "slack.kubermatic.text" -}}
-{{- with (index .Alerts 0) -}}
+{{- range .Alerts }}
 {{ .Annotations.message }} {{ template "slack.kubermatic.pretty.runbook" . }}
-{{- end -}}
+{{ end -}}
 {{- end }}
 
 {* slack fallback for constraint environments like Android notifications *}
 
 {{ define "slack.kubermatic.fallback.icon" }}{{ if eq .Status "firing" }}✗{{ else }}✓{{ end }}{{ end }}
-{{ define "slack.kubermatic.fallback.labels" }}[{{ .Labels.seed_cluster | toUpper }}]{{ end }} {* do not include user cluster IDs in fallbacks *}
-{{ define "slack.kubermatic.fallback.runbook" }}{{ with .Annotations.runbook_url }}<{{ .}}|:notebook:>{{ end }}{{ end }}
+{{ define "slack.kubermatic.fallback.labels" }}[{{ .CommonLabels.seed_cluster | toUpper }}]{{ end }} {* do not include user cluster IDs in fallbacks *}
+{{ define "slack.kubermatic.fallback.runbook" }}{{ with .Annotations.runbook_url }}<{{ . }}|:notebook:>{{ end }}{{ end }}
 
 {{ define "slack.kubermatic.fallback" -}}
-{{- with (index .Alerts 0) -}}
-{{- template "slack.kubermatic.fallback.icon" . }} {{ template "slack.kubermatic.fallback.labels" . }} {{ .Labels.alertname }} {{ .Annotations.message }}
-{{- end -}}
+{{- template "slack.kubermatic.fallback.icon" . }} {{ template "slack.kubermatic.fallback.labels" . }} {{ .CommonLabels.alertname }} {{ range .Alerts }} {{ .Annotations.message }} {{ end }}
 {{- end }}

--- a/charts/monitoring/alertmanager/kubermatic.tmpl
+++ b/charts/monitoring/alertmanager/kubermatic.tmpl
@@ -18,12 +18,13 @@
 
 {{ define "slack.kubermatic.title" -}}
     {{- template "slack.kubermatic.pretty.icon" . -}}
-    {{- if eq .Status "firing" }} [ {{ .Alerts.Firing | len }} ]{{ end - }}
     {{ template "slack.kubermatic.pretty.labels" . }} <{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}|{{ .CommonLabels.alertname }}>
+    {{- if eq .Status "firing" }} [ {{ .Alerts.Firing | len }} ]{{ end -}}
 {{- end }}
 
 {{ define "slack.kubermatic.text" -}}
 {{- range .Alerts }}
+{{- if eq .Status "resolved" }}[RESOLVED] {{ end -}}
 {{ .Annotations.message }} {{ template "slack.kubermatic.pretty.runbook" . }}
 {{ end -}}
 {{- end }}

--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -45,6 +45,7 @@ alertmanager:
     route:
       receiver: default
       repeat_interval: 1h
+      group_by: [alertname, namespace, seed_cluster, cluster]
       routes:
       - receiver: blackhole
         match:


### PR DESCRIPTION
**What this PR does / why we need it**:
No grouping in Alertmanager routing means that every alert is grouped into the same group. This PR provides a sensible top-level `group_by` setting for KKP environments and updates the Slack templates to support multiple alerts sent from a group in a batch (the current kubermatic template - if used, which isn't the default, I think - drops everything except the first alert).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8192

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Alertmanager groups alerts by alertname, namespace, seed_cluster, cluster labels
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>