### PR TITLE
Pull dependencies for helm charts during installation.

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -62,6 +62,9 @@ func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) erro
 	}
 
 	chart, err := LoadChart(chartDirectory)
+	if err != nil {
+		return err
+	}
 
 	for idx, dep := range chart.Dependencies {
 		repoAddFlags := []string{

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -68,14 +68,14 @@ func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) (err
 
 	for idx, dep := range chart.Dependencies {
 		repoAddFlags := []string{
-			"repository",
+			"repo",
 			"add",
 			fmt.Sprintf("dep-%s-%d", chart.Name, idx),
 			dep.Repository,
 		}
 
 		repoRemoveFlags := []string{
-			"repository",
+			"repo",
 			"remove",
 			fmt.Sprintf("dep-%s-%d", chart.Name, idx),
 		}
@@ -86,6 +86,7 @@ func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) (err
 				err = removeErr
 			}
 		}()
+
 		_, err = c.run("default", repoAddFlags...)
 	}
 

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -55,6 +55,38 @@ func NewCLI(binary string, kubeconfig string, kubeContext string, timeout time.D
 	}, nil
 }
 
+func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) error {
+	command := []string{
+		"dependency",
+		"build",
+	}
+
+	chart, err := LoadChart(chartDirectory)
+
+	for idx, dep := range chart.Dependencies {
+		repoAddFlags := []string{
+			"repository",
+			"add",
+			fmt.Sprintf("dep-%s-%d", chart.Name, idx),
+			dep.Repository,
+		}
+
+		repoRemoveFlags := []string{
+			"repository",
+			"remove",
+			fmt.Sprintf("dep-%s-%d", chart.Name, idx),
+		}
+
+		defer c.run("default", repoRemoveFlags...)
+		c.run("default", repoAddFlags...)
+	}
+
+	command = append(command, chartDirectory)
+
+	_, err = c.run("default", command...)
+
+	return err
+}
 func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error {
 	command := []string{
 		"upgrade",

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -55,7 +55,7 @@ func NewCLI(binary string, kubeconfig string, kubeContext string, timeout time.D
 	}, nil
 }
 
-func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) error {
+func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) (err error) {
 	command := []string{
 		"dependency",
 		"build",
@@ -80,8 +80,13 @@ func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) erro
 			fmt.Sprintf("dep-%s-%d", chart.Name, idx),
 		}
 
-		defer c.run("default", repoRemoveFlags...)
-		c.run("default", repoAddFlags...)
+		defer func() {
+			_, removeErr := c.run("default", repoRemoveFlags...)
+			if err != nil {
+				err = removeErr
+			}
+		}()
+		_, err = c.run("default", repoAddFlags...)
 	}
 
 	command = append(command, chartDirectory)

--- a/pkg/install/helm/interface.go
+++ b/pkg/install/helm/interface.go
@@ -27,6 +27,7 @@ import (
 // perform a Kubermatic installation.
 type Client interface {
 	Version() (*semver.Version, error)
+	BuildChartDependencies(chartDirectory string, flags []string) error
 	InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error
 	GetRelease(namespace string, name string) (*Release, error)
 	ListReleases(namespace string) ([]Release, error)

--- a/pkg/install/helm/types.go
+++ b/pkg/install/helm/types.go
@@ -48,8 +48,9 @@ type Chart struct {
 	Version    *semver.Version `yaml:"-"`
 	VersionRaw string          `yaml:"version"`
 	// AppVersion is not a semver, for example Minio has date-based versions.
-	AppVersion string `yaml:"appVersion"`
-	Directory  string
+	AppVersion   string `yaml:"appVersion"`
+	Directory    string
+	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 }
 
 func (c *Chart) Clone() Chart {
@@ -80,4 +81,15 @@ func LoadChart(directory string) (*Chart, error) {
 	chart.Directory = directory
 
 	return chart, nil
+}
+
+type Dependency struct {
+	Name         string        `yaml:"name"`
+	Version      string        `yaml:"version,omitempty"`
+	Repository   string        `yaml:"repository"`
+	Condition    string        `yaml:"condition,omitempty"`
+	Tags         []string      `yaml:"tags,omitempty"`
+	Enabled      bool          `yaml:"enabled,omitempty"`
+	ImportValues []interface{} `json:"import-values,omitempty"`
+	Alias        string        `yaml:"alias,omitempty"`
 }

--- a/pkg/install/util/helm.go
+++ b/pkg/install/util/helm.go
@@ -114,6 +114,10 @@ func DeployHelmChart(ctx context.Context, log logrus.FieldLogger, helmClient hel
 		flags = append(flags, "--atomic")
 	}
 
+	if err := helmClient.BuildChartDependencies(chart.Directory, flags); err != nil {
+		return fmt.Errorf("failed to download dependencies: %v", err)
+	}
+
 	if err := helmClient.InstallChart(namespace, releaseName, chart.Directory, helmValues, nil, flags); err != nil {
 		return fmt.Errorf("failed to install: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
To enable usage of upstream charts as dependencies in our charts, installer needs to handle downloading the dependencies up-to-spec, e,.g. using `helm dependency build` (not update).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8163

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
