### PR TITLE
Allow registry override on user-ssh-keys-agent ds

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -730,7 +730,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context, data reconcileData)
 	}
 
 	if r.userSSHKeyAgent {
-		dsCreators = append(dsCreators, usersshkeys.DaemonSetCreator(r.versions))
+		dsCreators = append(dsCreators, usersshkeys.DaemonSetCreator(r.versions, r.overwriteRegistryFunc))
 	}
 
 	if len(r.tunnelingAgentIP) > 0 {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
@@ -19,7 +19,9 @@ package usersshkeys
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,7 +32,7 @@ import (
 
 const (
 	daemonSetName = "user-ssh-keys-agent"
-	dockerImage   = "quay.io/kubermatic/user-ssh-keys-agent"
+	dockerImage   = "kubermatic/user-ssh-keys-agent"
 )
 
 var (
@@ -38,7 +40,7 @@ var (
 	hostPathType            = corev1.HostPathDirectoryOrCreate
 )
 
-func DaemonSetCreator(versions kubermatic.Versions) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(versions kubermatic.Versions, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return daemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Spec.UpdateStrategy.Type = appsv1.RollingUpdateDaemonSetStrategyType
@@ -60,7 +62,7 @@ func DaemonSetCreator(versions kubermatic.Versions) reconciling.NamedDaemonSetCr
 				{
 					Name:            daemonSetName,
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           fmt.Sprintf("%s:%s", dockerImage, versions.Kubermatic),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), dockerImage, versions.Kubermatic),
 					Command:         []string{fmt.Sprintf("/usr/local/bin/%v", daemonSetName)},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:
Another follow-up to #8055. I missed this one on the first run and just found it.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
