### PR TITLE
Fix wrong status 0 for MLA Health Status

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -305,7 +305,7 @@ func (r *alertmanagerController) cleanUpAlertmanagerConfigurationStatus(ctx cont
 	oldCluster := cluster.DeepCopy()
 	// Remove the alertmanager config status in Cluster CR
 	cluster.Status.ExtendedHealth.AlertmanagerConfig = nil
-	if errC != nil {
+	if errC != nil && !errors.IsNotFound(errC) {
 		cluster.Status.ExtendedHealth.AlertmanagerConfig = kubermaticv1.HealthStatusDown.Ptr()
 	}
 

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -368,7 +368,7 @@ func (r *datasourceGrafanaController) cleanUpMlaGatewayHealthStatus(ctx context.
 	oldCluster := cluster.DeepCopy()
 	// Remove the health status in Cluster CR
 	cluster.Status.ExtendedHealth.MLAGateway = nil
-	if resourceDeletionErr != nil {
+	if resourceDeletionErr != nil && !apiErrors.IsNotFound(resourceDeletionErr) {
 		cluster.Status.ExtendedHealth.MLAGateway = kubermaticv1.HealthStatusDown.Ptr()
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -1040,7 +1040,7 @@ func (r *reconciler) cleanUpOPAHealthStatus(ctx context.Context, errC error) err
 
 	cluster.Status.ExtendedHealth.GatekeeperAudit = nil
 	cluster.Status.ExtendedHealth.GatekeeperController = nil
-	if errC != nil {
+	if errC != nil && !errors.IsNotFound(errC) {
 		cluster.Status.ExtendedHealth.GatekeeperAudit = kubermaticv1.HealthStatusDown.Ptr()
 		cluster.Status.ExtendedHealth.GatekeeperController = kubermaticv1.HealthStatusDown.Ptr()
 	}
@@ -1063,13 +1063,13 @@ func (r *reconciler) cleanUpMLAHealthStatus(ctx context.Context, logging, monito
 
 	if !r.userClusterMLA.Logging && logging {
 		cluster.Status.ExtendedHealth.Logging = nil
-		if errC != nil {
+		if errC != nil && !errors.IsNotFound(errC) {
 			cluster.Status.ExtendedHealth.Logging = kubermaticv1.HealthStatusDown.Ptr()
 		}
 	}
 	if !r.userClusterMLA.Monitoring && monitoring {
 		cluster.Status.ExtendedHealth.Monitoring = nil
-		if errC != nil {
+		if errC != nil && !errors.IsNotFound(errC) {
 			cluster.Status.ExtendedHealth.Monitoring = kubermaticv1.HealthStatusDown.Ptr()
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
This PR fixes some wrong Health Status with value `0` when the MLA feature are disabled, issue introduced by PR #8176. 
When the feature is disabled, and if the resources are already deleted, the status should not be `Down` but removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
