### PR TITLE
ensure clusters are deleted after CCM migration e2e tests

### DIFF
--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -274,10 +274,13 @@ EXTRA_ARGS="-openstack-domain=${OS_DOMAIN}
     -openstack-floating-ip-pool=${OS_FLOATING_IP_POOL}
     -openstack-network=${OS_NETWORK_NAME}"
 
+# delete userclusters when ending the test
+appendTrap cleanup_kubermatic_clusters_in_kind EXIT
+
 # run tests
 # use ginkgo binary by preference to have better output:
 # https://github.com/onsi/ginkgo/issues/633
-if type ginkgo > /dev/null; then
+if [ -x "$(command -v ginkgo)" ]; then
   ginkgo --tags=e2e -v pkg/test/e2e/ccm-migration/ $EXTRA_ARGS \
     -r \
     --randomizeAllSpecs \


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently leaking resources in this test, as the tests only deletes the kind cluster at the end, but not the userclusters. This PR fixes that. It also removes one ugly `./hack/run-ccm-migration-e2e-test-in-kind.sh: line XXX: type: ginkgo: not found` warning, which was misleading.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
