### PR TITLE
Fix reconciliation of Konnectivity Agent in user cluster

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 // DeploymentCreator returns function to create/update deployment for konnectivity agents in user cluster.
@@ -95,11 +96,13 @@ func DeploymentCreator(clusterHostname string, registryWithOverwrite registry.Wi
 							Sources: []corev1.VolumeProjection{
 								{
 									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-										Audience: resources.KonnectivityClusterRoleBindingUsername, // TODO(pratik): what?
-										Path:     resources.KonnectivityAgentToken,
+										Audience:          resources.KonnectivityClusterRoleBindingUsername,
+										Path:              resources.KonnectivityAgentToken,
+										ExpirationSeconds: pointer.Int64Ptr(3600),
 									},
 								},
 							},
+							DefaultMode: pointer.Int32Ptr(420),
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Similarly to https://github.com/kubermatic/kubermatic/pull/8198, this PR fixes reconciliation of Konnectivity Agent, but this time in the user cluster. Explicitly sets all optional fields that would be otherwise defaulted.

Without this, the `EnsureNamedObject` never passes [this condition](https://github.com/kubermatic/kubermatic/blob/98300dbd10fbd79b325760c81260fc996be83225/pkg/resources/reconciling/ensure.go#L105) and the reconciliation is stuck with the `failed waiting for the cache to contain our latest changes` error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
