### PR TITLE
Fix variable name for certificate secrets in minio chart

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.25
+version: 1.0.26
 appVersion: RELEASE.2021-08-20T18-32-01Z
 description: minio
 keywords:

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         ports:
         - containerPort: 9000
         volumeMounts:
-        {{- if .Values.minio.certificatesSecret }}
+        {{- if .Values.minio.certificateSecret }}
         - name: certificates-volume
           mountPath: /root/.minio/certs
         {{- end }}
@@ -82,7 +82,7 @@ spec:
         args:
         - /bin/sh
         - -c
-        {{- if .Values.minio.certificatesSecret }}
+        {{- if .Values.minio.certificateSecret }}
         - mc --insecure config host add src https://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         {{- else }}
         - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
@@ -116,10 +116,10 @@ spec:
       - name: minio-backup
         emptyDir: {}
       {{- end }}
-      {{- if .Values.minio.certificatesSecret }}
+      {{- if .Values.minio.certificateSecret }}
       - name: certificates-volume
         secret:
-          secretName: {{ .Values.minio.certificatesSecret }}
+          secretName: {{ .Values.minio.certificateSecret }}
           items:
           - key: tls.crt
             path: public.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
#7665 introduced an optional value for configuring a TLS secret to make minio use HTTPS to our Helm chart. Unfortunately, there's a typo / inconsistency between the template and the `values.yaml` file. This PR brings the templates back in line with the variable name, which is `certificateSecret` in `values.yaml`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix minio chart template to correctly reference 'certificateSecret' value for TLS setup
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>