### PR TITLE
Make minio.certificateSecret optional by not setting it by default

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.26
+version: 1.0.27
 appVersion: RELEASE.2021-08-20T18-32-01Z
 description: minio
 keywords:

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -21,7 +21,7 @@ minio:
   # The is required to enable the BackupRestore controller so it can backup
   # and restore from the local minio deployment. The TLS certificates should be
   # signed by the global KKP CA.
-  certificateSecret: minio-certificates # tls secret used by minio.
+  certificateSecret: '' # tls secret used by minio.
 
   # These settings are required. Keys must be alphanumeric.
   credentials:


### PR DESCRIPTION
**What this PR does / why we need it**:

A small follow-up to #8234 because I realised that fixing the if conditions made the `certificateSecret` value no longer optional as it was intended in the initial PR (#7665). The default value in there will make minio deploy with TLS enabled by default, referencing a likely non-existent secret.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
