### PR TITLE
Credentials for backup destinations

### DIFF
--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -319,6 +319,8 @@ func createInitProviders(ctx context.Context, options serverRunOptions, masterCf
 
 	privilegedMLAAdminSettingProviderGetter := kubernetesprovider.PrivilegedMLAAdminSettingProviderFactory(mgr.GetRESTMapper(), seedKubeconfigGetter)
 
+	seedProvider := kubernetesprovider.NewSeedProvider(mgr.GetClient())
+
 	settingsWatcher, err := kuberneteswatcher.NewSettingsWatcher(settingsProvider)
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to create settings watcher due to %v", err)
@@ -375,6 +377,7 @@ func createInitProviders(ctx context.Context, options serverRunOptions, masterCf
 		etcdRestoreProjectProviderGetter:        etcdRestoreProjectProviderGetter,
 		backupCredentialsProviderGetter:         backupCredentialsProviderGetter,
 		privilegedMLAAdminSettingProviderGetter: privilegedMLAAdminSettingProviderGetter,
+		seedProvider:                            seedProvider,
 	}, nil
 }
 
@@ -493,7 +496,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		EtcdRestoreProjectProviderGetter:        prov.etcdRestoreProjectProviderGetter,
 		BackupCredentialsProviderGetter:         prov.backupCredentialsProviderGetter,
 		PrivilegedMLAAdminSettingProviderGetter: prov.privilegedMLAAdminSettingProviderGetter,
-		MasterClient:                            mgr.GetClient(),
+		SeedProvider:                            prov.seedProvider,
 		Versions:                                options.versions,
 		CABundle:                                options.caBundle.CertPool(),
 	}

--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -493,6 +493,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		EtcdRestoreProjectProviderGetter:        prov.etcdRestoreProjectProviderGetter,
 		BackupCredentialsProviderGetter:         prov.backupCredentialsProviderGetter,
 		PrivilegedMLAAdminSettingProviderGetter: prov.privilegedMLAAdminSettingProviderGetter,
+		MasterClient:                            mgr.GetClient(),
 		Versions:                                options.versions,
 		CABundle:                                options.caBundle.CertPool(),
 	}

--- a/cmd/kubermatic-api/options.go
+++ b/cmd/kubermatic-api/options.go
@@ -190,6 +190,7 @@ type providers struct {
 	etcdRestoreProjectProviderGetter        provider.EtcdRestoreProjectProviderGetter
 	backupCredentialsProviderGetter         provider.BackupCredentialsProviderGetter
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter
+	seedProvider                            provider.SeedProvider
 }
 
 func loadKubermaticConfiguration(filename string) (*operatorv1alpha1.KubermaticConfiguration, error) {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17870,6 +17870,11 @@
       "description": "BackupCredentials contains credentials for etcd backups",
       "type": "object",
       "properties": {
+        "destination": {
+          "description": "Destination corresponds to the Seeds Seed.Spec.EtcdBackupRestore.Destinations, it defines for which destination\nthe backup credentials will be created. If set, it updates the credentials ref in the related Seed BackupDestination",
+          "type": "string",
+          "x-go-name": "Destination"
+        },
         "s3": {
           "$ref": "#/definitions/S3BackupCredentials"
         }

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -322,7 +322,11 @@ type OIDCSpec struct {
 // BackupCredentials contains credentials for etcd backups
 // swagger:model BackupCredentials
 type BackupCredentials struct {
+	// S3BackupCredentials holds credentials for a S3 client compatible backup destination
 	S3BackupCredentials S3BackupCredentials `json:"s3,omitempty"`
+	// Destination corresponds to the Seeds Seed.Spec.EtcdBackupRestore.Destinations, it defines for which destination
+	// the backup credentials will be created. If set, it updates the credentials ref in the related Seed BackupDestination
+	Destination string `json:"destination,omitempty"`
 }
 
 // S3BackupCredentials contains credentials for S3 etcd backups

--- a/pkg/handler/routing.go
+++ b/pkg/handler/routing.go
@@ -184,6 +184,7 @@ type RoutingParams struct {
 	EtcdRestoreProjectProviderGetter        provider.EtcdRestoreProjectProviderGetter
 	BackupCredentialsProviderGetter         provider.BackupCredentialsProviderGetter
 	PrivilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter
+	MasterClient                            client.Client
 	Versions                                kubermatic.Versions
 	CABundle                                *x509.CertPool
 }

--- a/pkg/handler/routing.go
+++ b/pkg/handler/routing.go
@@ -184,7 +184,7 @@ type RoutingParams struct {
 	EtcdRestoreProjectProviderGetter        provider.EtcdRestoreProjectProviderGetter
 	BackupCredentialsProviderGetter         provider.BackupCredentialsProviderGetter
 	PrivilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter
-	MasterClient                            client.Client
+	SeedProvider                            provider.SeedProvider
 	Versions                                kubermatic.Versions
 	CABundle                                *x509.CertPool
 }

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -92,7 +92,8 @@ func NewTestRouting(
 	backupCredentialsProviderGetter provider.BackupCredentialsProviderGetter,
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter,
 	masterClient client.Client,
-	featureGatesProvider provider.FeatureGatesProvider) http.Handler {
+	featureGatesProvider provider.FeatureGatesProvider,
+	seedProvider provider.SeedProvider) http.Handler {
 	routingParams := handler.RoutingParams{
 		Log:                                     kubermaticlog.Logger,
 		PresetsProvider:                         presetsProvider,
@@ -145,7 +146,7 @@ func NewTestRouting(
 		EtcdRestoreProjectProviderGetter:        etcdRestoreProjectProviderGetter,
 		BackupCredentialsProviderGetter:         backupCredentialsProviderGetter,
 		PrivilegedMLAAdminSettingProviderGetter: privilegedMLAAdminSettingProviderGetter,
-		MasterClient:                            masterClient,
+		SeedProvider:                            seedProvider,
 		Versions:                                kubermaticVersions,
 		CABundle:                                certificates.NewFakeCABundle().CertPool(),
 	}

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -145,6 +145,7 @@ func NewTestRouting(
 		EtcdRestoreProjectProviderGetter:        etcdRestoreProjectProviderGetter,
 		BackupCredentialsProviderGetter:         backupCredentialsProviderGetter,
 		PrivilegedMLAAdminSettingProviderGetter: privilegedMLAAdminSettingProviderGetter,
+		MasterClient:                            masterClient,
 		Versions:                                kubermaticVersions,
 		CABundle:                                certificates.NewFakeCABundle().CertPool(),
 	}

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -218,6 +218,7 @@ type newRoutingFunc func(
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter,
 	masterClient client.Client,
 	featureGatesProvider provider.FeatureGatesProvider,
+	seedProvider provider.SeedProvider,
 ) http.Handler
 
 func getRuntimeObjects(objs ...ctrlruntimeclient.Object) []runtime.Object {
@@ -510,6 +511,11 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		return nil, fmt.Errorf("can not find privilegedMLAAdminSettingProvider for cluster %q", seed.Name)
 	}
 
+	seedProvider := kubernetes.NewSeedProvider(fakeClient)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	eventRecorderProvider := kubernetes.NewEventRecorder()
 
 	settingsWatcher, err := kuberneteswatcher.NewSettingsWatcher(settingsProvider)
@@ -583,6 +589,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		privilegedMLAAdminSettingProviderGetter,
 		fakeClient,
 		featureGatesProvider,
+		seedProvider,
 	)
 
 	return mainRouter, &ClientsSets{kubermaticClient, fakeClient, kubernetesClient, tokenAuth, tokenGenerator}, nil

--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -35,10 +35,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateOrUpdateEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient client.Client) endpoint.Endpoint {
+func CreateOrUpdateEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, seedProvider provider.SeedProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(createOrUpdateBackupCredentialsReq)
 
@@ -92,7 +91,7 @@ func CreateOrUpdateEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter 
 				Namespace: bc.Namespace,
 			}
 
-			err = masterClient.Update(ctx, seed)
+			_, err = seedProvider.UpdateUnsecured(seed)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("error setting seed backup destination credentials: %v", err))
 			}

--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -140,7 +140,7 @@ func DecodeBackupCredentialsReq(c context.Context, r *http.Request) (interface{}
 func convertAPIToInternalBackupCredentials(bc *apiv2.BackupCredentials) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      genBackupCredentialsSecretName(bc.Destination),
+			Name:      GenBackupCredentialsSecretName(bc.Destination),
 			Namespace: metav1.NamespaceSystem,
 		},
 		StringData: map[string]string{
@@ -150,8 +150,8 @@ func convertAPIToInternalBackupCredentials(bc *apiv2.BackupCredentials) *v1.Secr
 	}
 }
 
-// if backup destination is not set, then use the legacy credentials secret
-func genBackupCredentialsSecretName(destination string) string {
+// GenBackupCredentialsSecretName generates etcd backup credentials secret name. If backup destination is not set, then use the legacy credentials secret
+func GenBackupCredentialsSecretName(destination string) string {
 	if len(destination) != 0 {
 		return fmt.Sprintf("%s-etcd-backup-credentials", destination)
 	}

--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -140,7 +140,7 @@ func DecodeBackupCredentialsReq(c context.Context, r *http.Request) (interface{}
 func convertAPIToInternalBackupCredentials(bc *apiv2.BackupCredentials) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.EtcdRestoreS3CredentialsSecret,
+			Name:      genBackupCredentialsSecretName(bc.Destination),
 			Namespace: metav1.NamespaceSystem,
 		},
 		StringData: map[string]string{

--- a/pkg/handler/v2/backupcredentials/backupcredentials_test.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials_test.go
@@ -28,7 +28,9 @@ import (
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
+	v1 "k8s.io/api/core/v1"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -94,12 +96,87 @@ func TestCreateOrUpdateEndpoint(t *testing.T) {
 			BackupCredentials:      test.GenDefaultAPIBackupCredentials(),
 			ExpectedHTTPStatusCode: http.StatusOK,
 		},
+		{
+			Name:     "create backup credentials for given seed with destination",
+			SeedName: test.GenTestSeed().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(func(seed *kubermaticv1.Seed) {
+					seed.Spec.EtcdBackupRestore = &kubermaticv1.EtcdBackupRestore{
+						Destinations: map[string]*kubermaticv1.BackupDestination{
+							"s3": {
+								Endpoint:   "aws.s3.com",
+								BucketName: "testbucket",
+							},
+						},
+					}
+				}),
+				test.GenDefaultCluster(),
+				test.GenAdminUser("John", "john@acme.com", true),
+			),
+			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
+			BackupCredentials: func() *apiv2.BackupCredentials {
+				cred := test.GenDefaultAPIBackupCredentials()
+				cred.Destination = "s3"
+				return cred
+			}(),
+			ExpectedHTTPStatusCode: http.StatusOK,
+		},
+		{
+			Name:     "update backup credentials for given seed with destination",
+			SeedName: test.GenTestSeed().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(func(seed *kubermaticv1.Seed) {
+					seed.Spec.EtcdBackupRestore = &kubermaticv1.EtcdBackupRestore{
+						Destinations: map[string]*kubermaticv1.BackupDestination{
+							"s3": {
+								Endpoint:   "aws.s3.com",
+								BucketName: "testbucket",
+								Credentials: &v1.SecretReference{
+									Name:      "secret",
+									Namespace: "kubermatic",
+								},
+							},
+						},
+					}
+				}),
+				test.GenDefaultCluster(),
+				test.GenAdminUser("John", "john@acme.com", true),
+			),
+			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
+			BackupCredentials: func() *apiv2.BackupCredentials {
+				cred := test.GenDefaultAPIBackupCredentials()
+				cred.Destination = "s3"
+				return cred
+			}(),
+			ExpectedHTTPStatusCode: http.StatusOK,
+		},
+		{
+			Name:     "can't manage backup credentials for non-existing seed destination",
+			SeedName: "nothere",
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+				test.GenAdminUser("John", "john@acme.com", true),
+			),
+			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
+			BackupCredentials: func() *apiv2.BackupCredentials {
+				cred := test.GenDefaultAPIBackupCredentials()
+				cred.Destination = "s3"
+				return cred
+			}(),
+			ExpectedHTTPStatusCode: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			creds := struct {
+				BackupCredentials *apiv2.BackupCredentials `json:"backup_credentials"`
+			}{
+				BackupCredentials: tc.BackupCredentials,
+			}
 			requestURL := fmt.Sprintf("/api/v2/seeds/%s/backupcredentials", tc.SeedName)
-			body, err := json.Marshal(tc.BackupCredentials)
+			body, err := json.Marshal(creds)
 			if err != nil {
 				t.Fatalf("failed marshalling backupcredentials: %v", err)
 			}

--- a/pkg/handler/v2/backupcredentials/backupcredentials_test.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials_test.go
@@ -26,11 +26,11 @@ import (
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
-	v1 "k8s.io/api/core/v1"
 
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	v1 "k8s.io/api/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/handler/v2/backupcredentials/backupcredentials_test.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials_test.go
@@ -31,10 +31,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/backupcredentials"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -4707,7 +4707,7 @@ func (r Routing) createOrUpdateBackupCredentials() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
 			middleware.BackupCredentials(r.backupCredentialsProviderGetter, r.seedsGetter),
-		)(backupcredentials.CreateOrUpdateEndpoint(r.userInfoGetter)),
+		)(backupcredentials.CreateOrUpdateEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		backupcredentials.DecodeBackupCredentialsReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -4707,7 +4707,7 @@ func (r Routing) createOrUpdateBackupCredentials() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
 			middleware.BackupCredentials(r.backupCredentialsProviderGetter, r.seedsGetter),
-		)(backupcredentials.CreateOrUpdateEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
+		)(backupcredentials.CreateOrUpdateEndpoint(r.userInfoGetter, r.seedsGetter, r.seedProvider)),
 		backupcredentials.DecodeBackupCredentialsReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/handler/v2/routing.go
+++ b/pkg/handler/v2/routing.go
@@ -33,8 +33,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/kubermatic/v2/pkg/watcher"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Routing represents an object which binds endpoints to http handlers.
@@ -91,7 +89,7 @@ type Routing struct {
 	etcdRestoreProjectProviderGetter        provider.EtcdRestoreProjectProviderGetter
 	backupCredentialsProviderGetter         provider.BackupCredentialsProviderGetter
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter
-	masterClient                            client.Client
+	seedProvider                            provider.SeedProvider
 	versions                                kubermatic.Versions
 	caBundle                                *x509.CertPool
 }
@@ -151,7 +149,7 @@ func NewV2Routing(routingParams handler.RoutingParams) Routing {
 		etcdRestoreProjectProviderGetter:        routingParams.EtcdRestoreProjectProviderGetter,
 		backupCredentialsProviderGetter:         routingParams.BackupCredentialsProviderGetter,
 		privilegedMLAAdminSettingProviderGetter: routingParams.PrivilegedMLAAdminSettingProviderGetter,
-		masterClient:                            routingParams.MasterClient,
+		seedProvider:                            routingParams.SeedProvider,
 		versions:                                routingParams.Versions,
 		caBundle:                                routingParams.CABundle,
 	}

--- a/pkg/handler/v2/routing.go
+++ b/pkg/handler/v2/routing.go
@@ -33,6 +33,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/kubermatic/v2/pkg/watcher"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Routing represents an object which binds endpoints to http handlers.
@@ -89,6 +91,7 @@ type Routing struct {
 	etcdRestoreProjectProviderGetter        provider.EtcdRestoreProjectProviderGetter
 	backupCredentialsProviderGetter         provider.BackupCredentialsProviderGetter
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter
+	masterClient                            client.Client
 	versions                                kubermatic.Versions
 	caBundle                                *x509.CertPool
 }
@@ -148,6 +151,7 @@ func NewV2Routing(routingParams handler.RoutingParams) Routing {
 		etcdRestoreProjectProviderGetter:        routingParams.EtcdRestoreProjectProviderGetter,
 		backupCredentialsProviderGetter:         routingParams.BackupCredentialsProviderGetter,
 		privilegedMLAAdminSettingProviderGetter: routingParams.PrivilegedMLAAdminSettingProviderGetter,
+		masterClient:                            routingParams.MasterClient,
 		versions:                                routingParams.Versions,
 		caBundle:                                routingParams.CABundle,
 	}

--- a/pkg/provider/kubernetes/seed.go
+++ b/pkg/provider/kubernetes/seed.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import (

--- a/pkg/provider/kubernetes/seed.go
+++ b/pkg/provider/kubernetes/seed.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SeedProvider struct that holds required components in order seeds
+type SeedProvider struct {
+	clientPrivileged ctrlruntimeclient.Client
+}
+
+func NewSeedProvider(client ctrlruntimeclient.Client) *SeedProvider {
+	return &SeedProvider{
+		clientPrivileged: client,
+	}
+}
+
+func (p *SeedProvider) UpdateUnsecured(seed *kubermaticv1.Seed) (*kubermaticv1.Seed, error) {
+	if err := p.clientPrivileged.Update(context.Background(), seed); err != nil {
+		return nil, err
+	}
+	return seed, nil
+}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1290,3 +1290,12 @@ type PrivilegedMLAAdminSettingProvider interface {
 	// is unsafe in a sense that it uses privileged account to delete the resource
 	DeleteUnsecured(cluster *kubermaticv1.Cluster) error
 }
+
+type SeedProvider interface {
+
+	// UpdateUnsecured updates a Seed
+	//
+	// Note that this function:
+	// is unsafe in a sense that it uses privileged account to update the resource
+	UpdateUnsecured(seed *kubermaticv1.Seed) (*kubermaticv1.Seed, error)
+}

--- a/pkg/test/e2e/utils/apiclient/models/backup_credentials.go
+++ b/pkg/test/e2e/utils/apiclient/models/backup_credentials.go
@@ -18,6 +18,10 @@ import (
 // swagger:model BackupCredentials
 type BackupCredentials struct {
 
+	// Destination corresponds to the Seeds Seed.Spec.EtcdBackupRestore.Destinations, it defines for which destination
+	// the backup credentials will be created. If set, it updates the credentials ref in the related Seed BackupDestination
+	Destination string `json:"destination,omitempty"`
+
 	// s3
 	S3 *S3BackupCredentials `json:"s3,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates backup credentials endpoint to support multiple backup destinations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8230 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Backup credentials API endpoint now supports multiple Seed backup destinations
```
