### PR TITLE
Add additionalPrinterColumns to new API

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.19
+version: 0.3.20
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
@@ -16,7 +16,14 @@ spec:
     singular: allowedregistry
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: RegistryPrefix contains the prefix of the registry which will be
+        allowed. User clusters will be able to deploy only images which are prefixed
+        with one of the allowed image registry prefixes.
+      jsonPath: .spec.registryPrefix
+      name: RegistryPrefix
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AllowedRegistry is the object representing an allowed registry.
@@ -48,6 +55,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -16,7 +16,20 @@ spec:
     singular: cluster
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.humanReadableName
+      name: HumanReadableName
+      type: string
+    - jsonPath: .status.userEmail
+      name: Owner
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.pause
+      name: Paused
+      type: boolean
+    name: v1
     schema:
       openAPIV3Schema:
         description: Cluster is the object representing a cluster.

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
@@ -16,7 +16,17 @@ spec:
     singular: clustertemplateinstance
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.projectID
+      name: ProjectID
+      type: string
+    - jsonPath: .spec.clusterTemplateID
+      name: ClusterTemplateID
+      type: string
+    - jsonPath: .spec.replicas
+      name: Replicas
+      type: integer
+    name: v1
     schema:
       openAPIV3Schema:
         description: ClusterTemplateInstance is the object representing a cluster
@@ -56,6 +66,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -16,7 +16,14 @@ spec:
     singular: clustertemplate
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.humanReadableName
+      name: HumanReadableName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ClusterTemplate is the object representing a cluster template.
@@ -1506,6 +1513,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
@@ -136,9 +136,9 @@ spec:
                   - type
                   type: object
                 type: array
-              lastBackups:
+              currentBackups:
                 description: CurrentBackups tracks the creation and deletion progress
-                  if all backups managed by the EtcdBackupConfig
+                  of all backups managed by the EtcdBackupConfig
                 items:
                   properties:
                     backupFinishedTime:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -16,7 +16,11 @@ spec:
     singular: etcdrestore
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: EtcdRestore specifies a add-on

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -16,7 +16,11 @@ spec:
     singular: externalcluster
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.humanReadableName
+      name: HumanReadableName
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ExternalCluster is the object representing an external kubernetes
@@ -195,6 +199,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_projects.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_projects.yaml
@@ -16,7 +16,14 @@ spec:
     singular: project
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: HumanReadableName
+      type: string
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: Project is the type describing a project.

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -77,7 +77,7 @@ spec:
                 type: string
               ruleGroupType:
                 description: RuleGroupType is the type of this ruleGroup applies to.
-                  It can be `Metrics`.
+                  It can be `Metrics` or `Logs`.
                 enum:
                 - Metrics
                 - Logs

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
@@ -16,7 +16,17 @@ spec:
     singular: userprojectbinding
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.projectID
+      name: ProjectID
+      type: string
+    - jsonPath: .spec.group
+      name: Group
+      type: string
+    - jsonPath: .spec.userEmail
+      name: UserEmail
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: UserProjectBinding specifies a binding between a user and a project
@@ -52,6 +62,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -16,7 +16,14 @@ spec:
     singular: user
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.email
+      name: Email
+      type: string
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: User specifies a user
@@ -113,6 +120,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -16,7 +16,14 @@ spec:
     singular: usersshkey
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: HumanReadableName
+      type: string
+    - jsonPath: .spec.owner
+      name: Owner
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: UserSSHKey specifies a users UserSSHKey
@@ -57,6 +64,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/hack/ci/testdata/crdmigration/master/01-setup.yaml
+++ b/hack/ci/testdata/crdmigration/master/01-setup.yaml
@@ -491,3 +491,20 @@ metadata:
   name: test
 spec:
   registryPrefix: quay.io
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: AdmissionPlugin
+metadata:
+  name: test
+spec:
+  pluginName: test
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: AdmissionPlugin
+metadata:
+  name: test-with-version
+spec:
+  pluginName: test
+  fromVersion: 1.22.3

--- a/hack/ci/testdata/crdmigration/master/01-setup.yaml
+++ b/hack/ci/testdata/crdmigration/master/01-setup.yaml
@@ -143,7 +143,7 @@ spec:
     clientId: ATOTALLY-FAKE-UUID-HERE-XXXXXXXXXXXX
     clientSecret: oooooooooooooooooooooooooooooooo
     enabled: true
-    loadBalancerSKU: ""
+    loadBalancerSKU: "standard"
     subscriptionId: ATOTALLY-FAKE-UUID-HERE-XXXXXXXXXXXX
     tenantId: ATOTALLY-FAKE-UUID-HERE-XXXXXXXXXXXX
   digitalocean:

--- a/hack/ci/testdata/crdmigration/master/04-project-contents.yaml
+++ b/hack/ci/testdata/crdmigration/master/04-project-contents.yaml
@@ -57,7 +57,7 @@ spec:
     dnsDomain: ""
     pods:
       cidrBlocks: []
-    proxyMode: ""
+    proxyMode: "ipvs"
     services:
       cidrBlocks: []
   componentsOverride:

--- a/hack/ci/testdata/crdmigration/seed/04-project-contents.yaml
+++ b/hack/ci/testdata/crdmigration/seed/04-project-contents.yaml
@@ -66,3 +66,14 @@ spec:
 clusterLabels:
   project-id: kkpproject
 credential: ""
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: ClusterTemplateInstance
+metadata:
+  name: my-cluster-template-instance
+spec:
+  projectID: kkpproject
+  clusterTemplateID: 2m26r56qdx
+  clusterTemplateName: test-cluster-template
+  replicas: 7

--- a/hack/ci/testdata/crdmigration/seed/04-project-contents.yaml
+++ b/hack/ci/testdata/crdmigration/seed/04-project-contents.yaml
@@ -40,7 +40,7 @@ spec:
     dnsDomain: ""
     pods:
       cidrBlocks: []
-    proxyMode: ""
+    proxyMode: "ipvs"
     services:
       cidrBlocks: []
   componentsOverride:

--- a/hack/ci/testdata/crdmigration/seed/06-cluster-contents.yaml
+++ b/hack/ci/testdata/crdmigration/seed/06-cluster-contents.yaml
@@ -186,3 +186,88 @@ status:
       deleteJobName: kkpcluster-backup-default-backups-delete-dgl6ttpkdj
       jobName: kkpcluster-backup-default-backups-create-r7pd5j5g6b
       scheduledTime: "2021-10-18T18:32:25Z"
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: EtcdRestore
+metadata:
+  name: my-restore
+  namespace: cluster-kkpcluster
+spec:
+  name: test1
+  backupName: test2
+  backupDownloadCredentialsSecret: i-do-not-exist
+  cluster:
+    apiVersion: kubermatic.k8s.io/v1
+    kind: Cluster
+    name: kkpcluster
+    uid: __CLUSTER_UID__
+status:
+  phase: Started
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: EtcdRestore
+metadata:
+  name: my-other-restore
+  namespace: cluster-kkpcluster
+spec:
+  name: test1
+  backupName: test2
+  backupDownloadCredentialsSecret: i-do-not-exist
+  cluster:
+    apiVersion: kubermatic.k8s.io/v1
+    kind: Cluster
+    name: kkpcluster
+    uid: __CLUSTER_UID__
+status:
+  phase: Started
+  restoreTime: "2021-10-18T07:52:27Z"
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: RuleGroup
+metadata:
+  name: my-rule-group
+  namespace: cluster-kkpcluster
+spec:
+  ruleGroupType: Logs
+  cluster:
+    apiVersion: kubermatic.k8s.io/v1
+    kind: Cluster
+    name: kkpcluster
+    uid: __CLUSTER_UID__
+  data: bmFtZTogbXktZ3JvdXAKcnVsZXM6IFtd
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: MLAAdminSetting
+metadata:
+  name: settings-empty
+  namespace: cluster-kkpcluster
+spec:
+  clusterName: kkpcluster
+
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: MLAAdminSetting
+metadata:
+  name: settings
+  namespace: cluster-kkpcluster
+spec:
+  clusterName: kkpcluster
+  monitoringRateLimits:
+    ingestionRate: 1
+    ingestionBurstSize: 2
+    maxSeriesPerMetric: 3
+    maxSeriesTotal: 4
+    queryRate: 5
+    queryBurstSize: 6
+    maxSamplesPerQuery: 7
+    maxSeriesPerQuery: 8
+
+  loggingRateLimits:
+    ingestionRate: 1
+    ingestionBurstSize: 2
+    queryRate: 3
+    queryBurstSize: 4

--- a/pkg/apis/kubermatic/v1/allowed_registry.go
+++ b/pkg/apis/kubermatic/v1/allowed_registry.go
@@ -29,6 +29,7 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.registryPrefix",name="RegistryPrefix",type="string",description="RegistryPrefix contains the prefix of the registry which will be allowed. User clusters will be able to deploy only images which are prefixed with one of the allowed image registry prefixes."
 
 // AllowedRegistry is the object representing an allowed registry.
 type AllowedRegistry struct {

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -80,6 +80,10 @@ var ProtectedClusterLabels = sets.NewString(WorkerNameLabelKey, ProjectIDLabelKe
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".spec.humanReadableName",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".status.userEmail",name="Owner",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.version",name="Version",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.pause",name="Paused",type="boolean"
 
 // Cluster is the object representing a cluster.
 type Cluster struct {

--- a/pkg/apis/kubermatic/v1/cluster_template_instance.go
+++ b/pkg/apis/kubermatic/v1/cluster_template_instance.go
@@ -29,6 +29,9 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.projectID",name="ProjectID",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.clusterTemplateID",name="ClusterTemplateID",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.replicas",name="Replicas",type="integer"
 
 // ClusterTemplateInstance is the object representing a cluster template instance.
 type ClusterTemplateInstance struct {

--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -45,6 +45,8 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.humanReadableName",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.version",name="Version",type="string"
 
 // ClusterTemplate is the object representing a cluster template.
 type ClusterTemplate struct {

--- a/pkg/apis/kubermatic/v1/etcd_backup_config.go
+++ b/pkg/apis/kubermatic/v1/etcd_backup_config.go
@@ -86,8 +86,8 @@ type EtcdBackupConfigList struct {
 }
 
 type EtcdBackupConfigStatus struct {
-	// CurrentBackups tracks the creation and deletion progress if all backups managed by the EtcdBackupConfig
-	CurrentBackups []BackupStatus `json:"lastBackups,omitempty"`
+	// CurrentBackups tracks the creation and deletion progress of all backups managed by the EtcdBackupConfig
+	CurrentBackups []BackupStatus `json:"currentBackups,omitempty"`
 	// Conditions contains conditions of the EtcdBackupConfig
 	Conditions []EtcdBackupConfigCondition `json:"conditions,omitempty"`
 	// If the controller was configured with a cleanupContainer, CleanupRunning keeps track of the corresponding job

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -46,6 +46,7 @@ type EtcdRestorePhase string
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".status.phase",name="Phase",type="string"
 
 // EtcdRestore specifies a add-on
 type EtcdRestore struct {

--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -36,6 +36,7 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.humanReadableName",name="HumanReadableName",type="string"
 
 // ExternalCluster is the object representing an external kubernetes cluster.
 type ExternalCluster struct {
@@ -58,7 +59,6 @@ type ExternalClusterList struct {
 
 // ExternalClusterSpec specifies the data for a new external kubernetes cluster.
 type ExternalClusterSpec struct {
-
 	// HumanReadableName is the cluster name provided by the user
 	HumanReadableName string `json:"humanReadableName"`
 

--- a/pkg/apis/kubermatic/v1/project.go
+++ b/pkg/apis/kubermatic/v1/project.go
@@ -48,6 +48,8 @@ const (
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".spec.name",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".status.phase",name="Status",type="string"
 
 // Project is the type describing a project.
 type Project struct {

--- a/pkg/apis/kubermatic/v1/rulegroup.go
+++ b/pkg/apis/kubermatic/v1/rulegroup.go
@@ -40,7 +40,7 @@ type RuleGroup struct {
 }
 
 type RuleGroupSpec struct {
-	// RuleGroupType is the type of this ruleGroup applies to. It can be `Metrics`.
+	// RuleGroupType is the type of this ruleGroup applies to. It can be `Metrics` or `Logs`.
 	RuleGroupType RuleGroupType `json:"ruleGroupType"`
 	// Cluster is the reference to the cluster the ruleGroup should be created in.
 	Cluster corev1.ObjectReference `json:"cluster"`

--- a/pkg/apis/kubermatic/v1/sshkeys.go
+++ b/pkg/apis/kubermatic/v1/sshkeys.go
@@ -31,6 +31,8 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.name",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.owner",name="Owner",type="string"
 
 // UserSSHKey specifies a users UserSSHKey
 type UserSSHKey struct {

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -35,6 +35,8 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.email",name="Email",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.name",name="Name",type="string"
 
 // User specifies a user
 type User struct {

--- a/pkg/apis/kubermatic/v1/user_project_binding.go
+++ b/pkg/apis/kubermatic/v1/user_project_binding.go
@@ -32,6 +32,9 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:JSONPath=".spec.projectID",name="ProjectID",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.group",name="Group",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.userEmail",name="UserEmail",type="string"
 
 // UserProjectBinding specifies a binding between a user and a project
 // This resource is used by the user management to manipulate members of the given project

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -19,6 +19,7 @@ package crdmigration
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -157,6 +158,14 @@ func convertObjectMeta(om metav1.ObjectMeta) metav1.ObjectMeta {
 	om.Generation = 0
 	om.ResourceVersion = ""
 	om.CreationTimestamp = metav1.Time{}
+
+	// normalize/rename finalizers
+	for i, finalizer := range om.Finalizers {
+		finalizer = strings.Replace(finalizer, "operator.kubermatic.io/", "kubermatic.k8c.io/", -1)
+		finalizer = strings.Replace(finalizer, "kubermatic.io/", "kubermatic.k8c.io/", -1)
+
+		om.Finalizers[i] = finalizer
+	}
 
 	return om
 }
@@ -596,7 +605,7 @@ func cloneAdmissionPluginResourcesInCluster(ctx context.Context, logger logrus.F
 			ObjectMeta: convertObjectMeta(oldObject.ObjectMeta),
 			Spec: newv1.AdmissionPluginSpec{
 				PluginName:  oldObject.Spec.PluginName,
-				FromVersion: oldObject.Spec.DeepCopy().FromVersion,
+				FromVersion: oldObject.Spec.FromVersion,
 			},
 		}
 

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -161,8 +161,8 @@ func convertObjectMeta(om metav1.ObjectMeta) metav1.ObjectMeta {
 
 	// normalize/rename finalizers
 	for i, finalizer := range om.Finalizers {
-		finalizer = strings.Replace(finalizer, "operator.kubermatic.io/", "kubermatic.k8c.io/", -1)
-		finalizer = strings.Replace(finalizer, "kubermatic.io/", "kubermatic.k8c.io/", -1)
+		finalizer = strings.ReplaceAll(finalizer, "operator.kubermatic.io/", "kubermatic.k8c.io/")
+		finalizer = strings.ReplaceAll(finalizer, "kubermatic.io/", "kubermatic.k8c.io/")
 
 		om.Finalizers[i] = finalizer
 	}

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -955,23 +955,29 @@ func cloneMLAAdminSettingResourcesInCluster(ctx context.Context, logger logrus.F
 			ObjectMeta: convertObjectMeta(oldObject.ObjectMeta),
 			Spec: newv1.MLAAdminSettingSpec{
 				ClusterName: oldObject.Spec.ClusterName,
-				MonitoringRateLimits: &newv1.MonitoringRateLimitSettings{
-					IngestionRate:      oldObject.Spec.MonitoringRateLimits.IngestionRate,
-					IngestionBurstSize: oldObject.Spec.MonitoringRateLimits.IngestionBurstSize,
-					MaxSeriesPerMetric: oldObject.Spec.MonitoringRateLimits.MaxSeriesPerMetric,
-					MaxSeriesTotal:     oldObject.Spec.MonitoringRateLimits.MaxSeriesTotal,
-					QueryRate:          oldObject.Spec.MonitoringRateLimits.QueryRate,
-					QueryBurstSize:     oldObject.Spec.MonitoringRateLimits.QueryBurstSize,
-					MaxSamplesPerQuery: oldObject.Spec.MonitoringRateLimits.MaxSamplesPerQuery,
-					MaxSeriesPerQuery:  oldObject.Spec.MonitoringRateLimits.MaxSeriesPerQuery,
-				},
-				LoggingRateLimits: &newv1.LoggingRateLimitSettings{
-					IngestionRate:      oldObject.Spec.LoggingRateLimits.IngestionRate,
-					IngestionBurstSize: oldObject.Spec.LoggingRateLimits.IngestionBurstSize,
-					QueryRate:          oldObject.Spec.LoggingRateLimits.QueryRate,
-					QueryBurstSize:     oldObject.Spec.LoggingRateLimits.QueryBurstSize,
-				},
 			},
+		}
+
+		if oldObject.Spec.MonitoringRateLimits != nil {
+			newObject.Spec.MonitoringRateLimits = &newv1.MonitoringRateLimitSettings{
+				IngestionRate:      oldObject.Spec.MonitoringRateLimits.IngestionRate,
+				IngestionBurstSize: oldObject.Spec.MonitoringRateLimits.IngestionBurstSize,
+				MaxSeriesPerMetric: oldObject.Spec.MonitoringRateLimits.MaxSeriesPerMetric,
+				MaxSeriesTotal:     oldObject.Spec.MonitoringRateLimits.MaxSeriesTotal,
+				QueryRate:          oldObject.Spec.MonitoringRateLimits.QueryRate,
+				QueryBurstSize:     oldObject.Spec.MonitoringRateLimits.QueryBurstSize,
+				MaxSamplesPerQuery: oldObject.Spec.MonitoringRateLimits.MaxSamplesPerQuery,
+				MaxSeriesPerQuery:  oldObject.Spec.MonitoringRateLimits.MaxSeriesPerQuery,
+			}
+		}
+
+		if oldObject.Spec.LoggingRateLimits != nil {
+			newObject.Spec.LoggingRateLimits = &newv1.LoggingRateLimitSettings{
+				IngestionRate:      oldObject.Spec.LoggingRateLimits.IngestionRate,
+				IngestionBurstSize: oldObject.Spec.LoggingRateLimits.IngestionBurstSize,
+				QueryRate:          oldObject.Spec.LoggingRateLimits.QueryRate,
+				QueryBurstSize:     oldObject.Spec.LoggingRateLimits.QueryBurstSize,
+			}
 		}
 
 		if err := ensureObject(ctx, client, &newObject, false); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings a few updates to the new CRDs:

* bring back the additional printer columns in our new CRDs
* improves the status subresource conversion
* rename all finalizers to be `kubermatic.k8c.io/...`
* add more testdata
* fixes a few conversion mistakes

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
