### PR TITLE
Add apiserver network policy to allow traffic to OIDC issuer

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -507,6 +507,11 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 				apiserver.OpenVPNServerAllowCreator(c),
 			)
 		}
+		if c.Spec.OIDC.IssuerURL != "" {
+			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, apiserver.OIDCIssuerAllowCreator(c.Spec.OIDC.IssuerURL))
+		} else if r.features.KubernetesOIDCAuthentication {
+			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, apiserver.OIDCIssuerAllowCreator(data.OIDCIssuerURL()))
+		}
 		if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, c.Status.NamespaceName, r.Client); err != nil {
 			return fmt.Errorf("failed to ensure Network Policies: %v", err)
 		}

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -17,6 +17,14 @@ limitations under the License.
 package apiserver
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"time"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -214,4 +222,60 @@ func MetricsServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 			return np, nil
 		}
 	}
+}
+
+// OIDCIssuerAllowCreator returns a func to create/update the apiserver oidc-issuer-allow policy.
+func OIDCIssuerAllowCreator(issuerURL string) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "oidc-issuer-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			u, err := url.Parse(issuerURL)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse OIDC issuer URL %s: %v", issuerURL, err)
+			}
+			ipList, err := lookupIPWithTimeout(u.Hostname(), 1*time.Second)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve OIDC issuer hostname %s: %v", u.Hostname(), err)
+			}
+			if len(ipList) == 0 {
+				return nil, fmt.Errorf("failed to resolve OIDC issuer hostname: no resolved IP address for %s", u.Hostname())
+			}
+			sort.Slice(ipList, func(i, j int) bool {
+				return bytes.Compare(ipList[i], ipList[j]) < 0
+			})
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{},
+					},
+				},
+			}
+			for _, ip := range ipList {
+				cidr := fmt.Sprintf("%s/%d", ip.String(), net.IPv4len*8)
+				if ip.To4() == nil {
+					cidr = fmt.Sprintf("%s/%d", ip.String(), net.IPv6len*8)
+				}
+				np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: cidr,
+					},
+				})
+			}
+			return np, nil
+		}
+	}
+}
+
+func lookupIPWithTimeout(host string, timeout time.Duration) ([]net.IP, error) {
+	var r net.Resolver
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel() // to avoid possible resource leak
+	return r.LookupIP(ctx, "ip", host)
 }


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
The apiserver network policies do not allow apiserver to oidc-issuer connections, which breaks the Delegated OIDC Authentication feature of KKP.

This PR adds a network policy that allow apiserver to oidc-issuer connections using an ipBlock egress policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8255

**Special notes for your reviewer**:

**Documentation**:
Docs update on disabling apiserver network policies: https://github.com/kubermatic/docs/pull/860
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix Delegated OIDC Authentication feature by allowing appiserver to oidc-issuer communication in apiserver network policies. 
```
