### PR TITLE
Update metering image and remove old annotations/port settings

### DIFF
--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -60,11 +60,6 @@ func deploymentCreator(seed *kubermaticv1.Seed) reconciling.NamedDeploymentCreat
 			d.Spec.Template.Labels = map[string]string{
 				"role": meteringToolName,
 			}
-			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8080",
-				"fluentbit.io/parser":  "glog",
-			}
 
 			d.Spec.Template.Spec.ServiceAccountName = "kubermatic-metering"
 			d.Spec.Template.Spec.InitContainers = []corev1.Container{
@@ -145,15 +140,8 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 						"--seed",
 						seed.Name,
 					},
-					Image:           "quay.io/kubermatic/metering:v0.5",
+					Image:           "quay.io/kubermatic/metering:v0.6",
 					ImagePullPolicy: corev1.PullAlways,
-					Ports: []corev1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 2112,
-							Protocol:      corev1.ProtocolTCP,
-						},
-					},
 					LivenessProbe: &corev1.Probe{
 						InitialDelaySeconds: 15,
 						Handler: corev1.Handler{


### PR DESCRIPTION
**What this PR does / why we need it**: Use metering version v0.6 with fix for high resource usage during startup and remove old scraping annotations which are causing prometheus errors.
Related metering PRs: https://github.com/kubermatic/metering/pull/80 https://github.com/kubermatic/metering/pull/72

<!--**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #-->

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed high resource usage during metering startup.
```
