### PR TITLE
Fix openvpn and dnat-controller secrets usage in Konnectivity setup 

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -363,7 +363,6 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 
 		// Kubeconfigs
 		resources.GetInternalKubeconfigCreator(resources.SchedulerKubeconfigSecretName, resources.SchedulerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.MachineControllerKubeconfigSecretName, resources.MachineControllerCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
@@ -387,6 +386,7 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 			openvpn.CACreator(),
 			openvpn.TLSServingCertificateCreator(data),
 			openvpn.InternalClientCertificateCreator(data),
+			resources.GetInternalKubeconfigCreator(resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil, data),
 		)
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -66,10 +66,6 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get caCert: %v", err)
 	}
-	openVPNCACert, err := r.openVPNCA(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get openVPN CA cert: %v", err)
-	}
 	userSSHKeys, err := r.userSSHKeys(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get userSSHKeys: %v", err)
@@ -88,11 +84,17 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 
 	data := reconcileData{
 		caCert:         caCert,
-		openVPNCACert:  openVPNCACert,
 		userSSHKeys:    userSSHKeys,
 		cloudConfig:    cloudConfig,
 		csiCloudConfig: CSICloudConfig,
 		ccmMigration:   r.ccmMigration || r.ccmMigrationCompleted,
+	}
+
+	if !r.isKonnectivityEnabled {
+		data.openVPNCACert, err = r.openVPNCA(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get openVPN CA cert: %v", err)
+		}
 	}
 
 	if r.userClusterMLA.Monitoring || r.userClusterMLA.Logging {

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -558,14 +558,6 @@ func getVolumes(isKonnectivityEnabled bool) []corev1.Volume {
 			},
 		},
 		{
-			Name: resources.OpenVPNClientCertificatesSecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.OpenVPNClientCertificatesSecretName,
-				},
-			},
-		},
-		{
 			Name: resources.KubeletClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -640,14 +632,6 @@ func getVolumes(isKonnectivityEnabled bool) []corev1.Volume {
 			},
 		},
 		{
-			Name: resources.KubeletDnatControllerKubeconfigSecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
-				},
-			},
-		},
-		{
 			Name: resources.AuditConfigMapName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -710,6 +694,25 @@ func getVolumes(isKonnectivityEnabled bool) []corev1.Volume {
 							Name: resources.KonnectivityKubeApiserverEgress,
 						},
 						DefaultMode: intPtr(420),
+					},
+				},
+			},
+		}...)
+	} else {
+		vs = append(vs, []corev1.Volume{
+			{
+				Name: resources.OpenVPNClientCertificatesSecretName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: resources.OpenVPNClientCertificatesSecretName,
+					},
+				},
+			},
+			{
+				Name: resources.KubeletDnatControllerKubeconfigSecretName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
 					},
 				},
 			},

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -59,7 +59,7 @@ func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDepl
 				return nil, fmt.Errorf("failed to get credentials: %v", err)
 			}
 
-			deployment.Spec.Template.Spec.Volumes = getVolumes()
+			deployment.Spec.Template.Spec.Volumes = getVolumes(data.IsKonnectivityEnabled())
 
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -81,7 +81,7 @@ func hetznerDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 				network = data.DC().Spec.Hetzner.Network
 			}
 
-			dep.Spec.Template.Spec.Volumes = getVolumes()
+			dep.Spec.Template.Spec.Volumes = getVolumes(data.IsKonnectivityEnabled())
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -78,7 +78,7 @@ func kubevirtDeploymentCreator(data *resources.TemplateData) reconciling.NamedDe
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)
 
-			dep.Spec.Template.Spec.Volumes = append(getVolumes(), corev1.Volume{
+			dep.Spec.Template.Spec.Volumes = append(getVolumes(data.IsKonnectivityEnabled()), corev1.Volume{
 				Name: resources.CloudConfigConfigMapName,
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -83,7 +83,7 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 				return nil, err
 			}
 
-			dep.Spec.Template.Spec.Volumes = append(getVolumes(),
+			dep.Spec.Template.Spec.Volumes = append(getVolumes(data.IsKonnectivityEnabled()),
 				corev1.Volume{
 					Name: resources.CloudConfigConfigMapName,
 					VolumeSource: corev1.VolumeSource{

--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -119,16 +119,8 @@ func isOTC(dc *kubermaticv1.DatacenterSpecOpenstack) bool {
 	return u.Host == "iam.eu-de.otc.t-systems.com"
 }
 
-func getVolumes() []corev1.Volume {
-	return []corev1.Volume{
-		{
-			Name: resources.OpenVPNClientCertificatesSecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.OpenVPNClientCertificatesSecretName,
-				},
-			},
-		},
+func getVolumes(isKonnectivityEnabled bool) []corev1.Volume {
+	vs := []corev1.Volume{
 		{
 			Name: resources.CloudControllerManagerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
@@ -138,6 +130,17 @@ func getVolumes() []corev1.Volume {
 			},
 		},
 	}
+	if !isKonnectivityEnabled {
+		vs = append(vs, corev1.Volume{
+			Name: resources.OpenVPNClientCertificatesSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
+				},
+			},
+		})
+	}
+	return vs
 }
 
 func getVolumeMounts() []corev1.VolumeMount {

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -94,7 +94,7 @@ func vsphereDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 				dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, *openvpnSidecar)
 			}
 
-			dep.Spec.Template.Spec.Volumes = append(getVolumes(),
+			dep.Spec.Template.Spec.Volumes = append(getVolumes(data.IsKonnectivityEnabled()),
 				corev1.Volume{
 					Name: resources.CloudConfigConfigMapName,
 					VolumeSource: corev1.VolumeSource{

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -76,7 +76,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-			volumes := getVolumes()
+			volumes := getVolumes(data.IsKonnectivityEnabled())
 			volumeMounts := getVolumeMounts()
 
 			if data.Cluster().Spec.Cloud.GCP != nil {
@@ -309,8 +309,8 @@ func getVolumeMounts() []corev1.VolumeMount {
 	}
 }
 
-func getVolumes() []corev1.Volume {
-	return []corev1.Volume{
+func getVolumes(isKonnectivityEnabled bool) []corev1.Volume {
+	vs := []corev1.Volume{
 		{
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
@@ -348,14 +348,6 @@ func getVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: resources.OpenVPNClientCertificatesSecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.OpenVPNClientCertificatesSecretName,
-				},
-			},
-		},
-		{
 			Name: resources.ControllerManagerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -364,6 +356,17 @@ func getVolumes() []corev1.Volume {
 			},
 		},
 	}
+	if !isKonnectivityEnabled {
+		vs = append(vs, corev1.Volume{
+			Name: resources.OpenVPNClientCertificatesSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
+				},
+			},
+		})
+	}
+	return vs
 }
 
 type kubeControllerManagerEnvData interface {

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -89,7 +89,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 
-			volumes := getVolumes()
+			volumes := getVolumes(data.IsKonnectivityEnabled())
 			volumeMounts := getVolumeMounts()
 
 			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
@@ -208,16 +208,8 @@ func getVolumeMounts() []corev1.VolumeMount {
 	}
 }
 
-func getVolumes() []corev1.Volume {
-	return []corev1.Volume{
-		{
-			Name: resources.OpenVPNClientCertificatesSecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.OpenVPNClientCertificatesSecretName,
-				},
-			},
-		},
+func getVolumes(isKonnectivityEnabled bool) []corev1.Volume {
+	vs := []corev1.Volume{
 		{
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
@@ -251,4 +243,15 @@ func getVolumes() []corev1.Volume {
 			},
 		},
 	}
+	if !isKonnectivityEnabled {
+		vs = append(vs, corev1.Volume{
+			Name: resources.OpenVPNClientCertificatesSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
+				},
+			},
+		})
+	}
+	return vs
 }

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -360,9 +360,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -390,9 +387,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -402,4 +396,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -217,12 +217,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -360,9 +360,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -390,9 +387,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -402,4 +396,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
@@ -217,12 +217,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -360,9 +360,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -390,9 +387,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -402,4 +396,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -217,12 +217,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver-externalCloudProvider.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -112,12 +112,12 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: cloud-controller-manager-kubeconfig
         secret:
           secretName: cloud-controller-manager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - configMap:
           name: cloud-config
         name: cloud-config

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver-externalCloudProvider.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -112,12 +112,12 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: cloud-controller-manager-kubeconfig
         secret:
           secretName: cloud-controller-manager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - configMap:
           name: cloud-config
         name: cloud-config

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -211,12 +211,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -112,12 +112,12 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: cloud-controller-manager-kubeconfig
         secret:
           secretName: cloud-controller-manager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - configMap:
           name: cloud-config
         name: cloud-config

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -215,12 +215,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -215,12 +215,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver-externalCloudProvider.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -112,12 +112,12 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: cloud-controller-manager-kubeconfig
         secret:
           secretName: cloud-controller-manager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - configMap:
           name: cloud-config
         name: cloud-config

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -215,12 +215,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
@@ -215,12 +215,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver-externalCloudProvider.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -112,12 +112,12 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: cloud-controller-manager-kubeconfig
         secret:
           secretName: cloud-controller-manager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - configMap:
           name: cloud-config
         name: cloud-config

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -350,9 +350,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -380,9 +377,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -392,4 +386,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -354,9 +354,6 @@ spec:
       - name: tokens
         secret:
           secretName: tokens
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
           secretName: kubelet-client-certificates
@@ -384,9 +381,6 @@ spec:
       - name: front-proxy-ca
         secret:
           secretName: front-proxy-ca
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
-          secretName: kubeletdnatcontroller-kubeconfig
       - configMap:
           name: audit-config
           optional: false
@@ -396,4 +390,10 @@ spec:
       - configMap:
           name: adm-control
         name: adm-control
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -215,12 +215,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -215,12 +215,12 @@ spec:
       - configMap:
           name: cloud-config
         name: cloud-config
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
           secretName: controllermanager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
@@ -43,6 +43,32 @@ spec:
             weight: 10
       containers:
       - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      - args:
         - --client
         - --proto
         - tcp
@@ -96,45 +122,19 @@ spec:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
           readOnly: true
-      - args:
-        - -conf
-        - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
-        name: dns-resolver
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/coredns
-          name: dns-resolver
-          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       volumes:
       - configMap:
           name: dns-resolver
         name: dns-resolver
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -168,15 +168,15 @@ spec:
       - name: metrics-server
         secret:
           secretName: metrics-server
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
       - name: openvpn-client-certificates
         secret:
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
-      - name: metrics-server-serving-cert
-        secret:
-          secretName: metrics-server-serving-cert
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -179,9 +179,6 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: ca
         secret:
           items:
@@ -194,6 +191,9 @@ spec:
       - name: scheduler-kubeconfig
         secret:
           secretName: scheduler-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -112,12 +112,12 @@ spec:
         - mountPath: /http-prober-bin
           name: http-prober-bin
       volumes:
-      - name: openvpn-client-certificates
-        secret:
-          secretName: openvpn-client-certificates
       - name: cloud-controller-manager-kubeconfig
         secret:
           secretName: cloud-controller-manager-kubeconfig
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
       - configMap:
           name: cloud-config
         name: cloud-config


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a continuation of https://github.com/kubermatic/kubermatic/pull/8208 with cleanup of Seed resources that are not necessary in Konnectivity setup. It makes sure that removed openvpn and dnat-controller secrets are not used by any of the seed cluster components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
