### PR TITLE
network policies for user cluster kube-system namespace

### DIFF
--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -1,8 +1,9 @@
 # Source: https://docs.projectcalico.org/v3.8/manifests/canal.yaml
-# 3 modification:
+# 4 modification:
 #   - The ClusterRoleBinding canal-calico was renamed to canal-calico-node as upstream changed it in a way that we cannot roll out via kubectl apply
 #   - All images now use the canonical name
 #   - Remove the flexvolume installation as its broken for CoreOS & only required for application policies (Which we don't use.)
+#   - Add custom network policy
 {{ if hasKey (dict "" "" "canal" "" ) .Cluster.CNIPlugin.Type }}
 {{ if hasKey (dict "" "" "v3.8" "" ) .Cluster.CNIPlugin.Version }}
 ---
@@ -596,6 +597,7 @@ metadata:
   name: canal
   namespace: kube-system
 
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -612,7 +614,7 @@ spec:
   ingress: []
   egress:
     - {}
-
+{{ end }}
 ---
 # Source: calico/templates/calico-etcd-secrets.yaml
 

--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -597,6 +597,23 @@ metadata:
   namespace: kube-system
 
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: calico
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - {}
+
+---
 # Source: calico/templates/calico-etcd-secrets.yaml
 
 ---

--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -3879,6 +3879,24 @@ metadata:
   namespace: kube-system
 
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: calico
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - {}
+
+
+---
 
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 

--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 # Source: https://docs.projectcalico.org/v3.19/manifests/canal.yaml
-# 2 modifications:
+# 3 modification:
 #   - Remove the flexvolume installation as its broken for Flatcar Linux & only required for application policies (Which we don't use).
-#   - Add envoyagent interface to the exclusion list for Calico IP autodetection. 
-{{ if eq .Cluster.CNIPlugin.Type "canal" }}
+#   - Add envoyagent interface to the exclusion list for Calico IP autodetection.
+#   - Add custom network policy
+
+  {{ if eq .Cluster.CNIPlugin.Type "canal" }}
 {{ if eq .Cluster.CNIPlugin.Version "v3.19" }}
 ---
 # Source: calico/templates/calico-config.yaml
@@ -3878,6 +3880,7 @@ metadata:
   name: calico-kube-controllers
   namespace: kube-system
 
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -3894,7 +3897,7 @@ spec:
   ingress: []
   egress:
     - {}
-
+{{ end }}
 
 ---
 

--- a/addons/canal/canal_v3.20.yaml
+++ b/addons/canal/canal_v3.20.yaml
@@ -21,6 +21,8 @@
 #     (https://docs.projectcalico.org/reference/faq#are-the-calico-manifests-compatible-with-coreos)
 #   - added envoyagent interface to the exclusion list for Calico IP autodetection
 #   - added seccomp profile to calico-controllers
+#   - Add custom network policy
+
 
 {{ if eq .Cluster.CNIPlugin.Type "canal" }}
 {{ if eq .Cluster.CNIPlugin.Version "v3.20" }}
@@ -4094,6 +4096,7 @@ metadata:
   name: calico-kube-controllers
   namespace: kube-system
 
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -4110,7 +4113,7 @@ spec:
   ingress: []
   egress:
     - {}
-
+{{ end }}
 ---
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 

--- a/addons/canal/canal_v3.20.yaml
+++ b/addons/canal/canal_v3.20.yaml
@@ -4095,7 +4095,23 @@ metadata:
   namespace: kube-system
 
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: calico
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - {}
 
+---
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
 apiVersion: policy/v1beta1

--- a/addons/cilium/cilium.yaml
+++ b/addons/cilium/cilium.yaml
@@ -24,7 +24,7 @@
 {{ if eq .Cluster.CNIPlugin.Type "cilium" }}
 {{ if eq .Cluster.CNIPlugin.Version "v1.11" }}
 
-{ { $apiServerURL := urlParse .Cluster.Address.URL } }
+{{ $apiServerURL := urlParse .Cluster.Address.URL }}
 {{ $hostParts := split ":" $apiServerURL.host }}
 {{ $apiServerHost := $hostParts._0 }}
 {{ $apiServerPort := $hostParts._1 }}

--- a/addons/cilium/cilium.yaml
+++ b/addons/cilium/cilium.yaml
@@ -24,7 +24,7 @@
 {{ if eq .Cluster.CNIPlugin.Type "cilium" }}
 {{ if eq .Cluster.CNIPlugin.Version "v1.11" }}
 
-{{ $apiServerURL := urlParse .Cluster.ApiserverExternalURL }}
+{ { $apiServerURL := urlParse .Cluster.Address.URL } }
 {{ $hostParts := split ":" $apiServerURL.host }}
 {{ $apiServerHost := $hostParts._0 }}
 {{ $apiServerPort := $hostParts._1 }}

--- a/addons/cilium/cilium.yaml
+++ b/addons/cilium/cilium.yaml
@@ -860,5 +860,23 @@ spec:
         configMap:
           name: cilium-config
 
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      name: cilium-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - {}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -373,6 +373,8 @@ spec:
     - port: 9189
       name: metrics
       targetPort: metrics
+
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -389,6 +391,7 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -373,6 +373,22 @@ spec:
     - port: 9189
       name: metrics
       targetPort: metrics
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: hcloud-csi
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 {{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -176,5 +176,21 @@ spec:
         - name: ca-bundle
           configMap:
             name: ca-bundle
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: csi-cinder-controllerplugin
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: csi-cinder-controllerplugin
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 {{ end }}
 {{ end }}

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -176,6 +176,8 @@ spec:
         - name: ca-bundle
           configMap:
             name: ca-bundle
+
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -192,5 +194,6 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+{{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/vsphere/csiAdmissionWebhook.yaml
+++ b/addons/csi/vsphere/csiAdmissionWebhook.yaml
@@ -112,6 +112,22 @@ spec:
         - name: ca-bundle
           configMap:
             name: ca-bundle
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vsphere-csi-migration-webhook
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      role: csi-migration-webhook
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 {{ end }}
 {{ end }}
 {{ end }}

--- a/addons/csi/vsphere/csiController.yaml
+++ b/addons/csi/vsphere/csiController.yaml
@@ -231,5 +231,22 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vsphere-csi
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      role: vsphere-csi
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 {{ end }}
 {{ end }}

--- a/addons/csi/vsphere/csiController.yaml
+++ b/addons/csi/vsphere/csiController.yaml
@@ -232,6 +232,7 @@ spec:
   selector:
     app: vsphere-csi-controller
 
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -248,5 +249,6 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+{{ end }}
 {{ end }}
 {{ end }}

--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -66,7 +66,7 @@ data:
     clusters:
     - cluster:
         certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        server: {{ .Cluster.ApiserverExternalURL }}
+        server: {{ .Cluster.Address.URL }}
       name: default
     contexts:
     - context:

--- a/addons/kube-state-metrics/networkpolicy.yaml
+++ b/addons/kube-state-metrics/networkpolicy.yaml
@@ -1,0 +1,46 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: mla
+          podSelector:
+            matchLabels:
+              component: mla
+      ports:
+        - port: 8443
+          protocol: TCP
+  egress:
+    - to:
+        - ipBlock:
+            cidr: {{ .Cluster.Address.IP }}/32
+      ports:
+        - port: {{ .Cluster.Address.Port }}
+{{ end }}

--- a/addons/node-exporter/networkpolicy.yaml
+++ b/addons/node-exporter/networkpolicy.yaml
@@ -1,0 +1,41 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: node-exporter
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: mla
+          podSelector:
+            matchLabels:
+              component: mla
+      ports:
+        - port: 9100
+          protocol: TCP
+  egress: []
+{{ end }}

--- a/addons/openvpn/networkpolicy.yaml
+++ b/addons/openvpn/networkpolicy.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openvpn-client
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      role: openvpn-client
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - {}

--- a/addons/openvpn/networkpolicy.yaml
+++ b/addons/openvpn/networkpolicy.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
+
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -27,3 +29,5 @@ spec:
   ingress: []
   egress:
     - {}
+
+{{ end }}

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
 	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	ccmcsimigrator "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator"
 	clusterrolelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/cluster-role-labeler"
@@ -85,6 +86,7 @@ type controllerRunOptions struct {
 	opaEnableMutation            bool
 	opaWebhookTimeout            int
 	useSSHKeyAgent               bool
+	networkPolicies              bool
 	caBundleFile                 string
 	mlaGatewayURL                string
 	userClusterLogging           bool
@@ -128,6 +130,7 @@ func main() {
 	flag.BoolVar(&runOp.opaEnableMutation, "enable-mutation", false, "Enable OPA experimental mutation in user cluster")
 	flag.IntVar(&runOp.opaWebhookTimeout, "opa-webhook-timeout", 1, "Timeout for OPA Integration validating webhook, in seconds")
 	flag.BoolVar(&runOp.useSSHKeyAgent, "enable-ssh-key-agent", false, "Enable UserSSHKeyAgent integration in user cluster")
+	flag.BoolVar(&runOp.networkPolicies, "enable-network-policies", false, "Enable deployment of network policies to kube-system namespace in user cluster")
 	flag.StringVar(&runOp.caBundleFile, "ca-bundle", "", "The path to the cluster's CA bundle (PEM-encoded).")
 	flag.StringVar(&runOp.mlaGatewayURL, "mla-gateway-url", "", "The URL of MLA (Monitoring, Logging, and Alerting) gateway endpoint.")
 	flag.BoolVar(&runOp.userClusterLogging, "user-cluster-logging", false, "Enable logging in user cluster.")
@@ -272,6 +275,7 @@ func main() {
 		runOp.opaEnableMutation,
 		versions,
 		runOp.useSSHKeyAgent,
+		runOp.networkPolicies,
 		runOp.opaWebhookTimeout,
 		caBundle,
 		usercluster.UserClusterMLA{

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -32,15 +32,10 @@ type ClusterData struct {
 	// inside the user-cluster. The kubeconfig uses the external URL to reach
 	// the apiserver.
 	Kubeconfig string
-	// ApiserverExternalURL is the full URL to the apiserver service from the
-	// outside, including protocol and port number. It does not contain any
-	// trailing slashes.
-	ApiserverExternalURL string
-	// ApiserverExternalURL is the full URL to the apiserver from within the
-	// seed cluster itself. It does not contain any trailing slashes.
-	ApiserverInternalURL string
-	// AdminToken is the cluster's admin token.
-	AdminToken string
+
+	// ClusterAddress stores access and address information of a cluster.
+	Address kubermaticv1.ClusterAddress
+
 	// CloudProviderName is the name of the cloud provider used, one of
 	// "alibaba", "aws", "azure", "bringyourown", "digitalocean", "gcp",
 	// "hetzner", "kubevirt", "openstack", "packet", "vsphere" depending on
@@ -62,6 +57,22 @@ type ClusterData struct {
 	StoragePolicy string
 	// CSIMigration indicates if the cluster needed the CSIMigration
 	CSIMigration bool
+}
+
+// ClusterAddress stores access and address information of a cluster.
+type ClusterAddress struct {
+	// URL under which the Apiserver is available
+	URL string `json:"url"`
+	// Port is the port the API server listens on
+	Port int32 `json:"port"`
+	// ExternalName is the DNS name for this cluster
+	ExternalName string `json:"externalName"`
+	// InternalName is the seed cluster internal absolute DNS name to the API server
+	InternalName string `json:"internalURL"`
+	// AdminToken is the token for the kubeconfig, the user can download
+	AdminToken string `json:"adminToken"`
+	// IP is the external IP under which the apiserver is available
+	IP string `json:"ip"`
 }
 
 type ClusterNetwork struct {

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -114,22 +114,20 @@ func NewTemplateData(
 		Variables:      variables,
 		Credentials:    credentials,
 		Cluster: ClusterData{
-			Type:                 ClusterTypeKubernetes,
-			Name:                 cluster.Name,
-			HumanReadableName:    cluster.Spec.HumanReadableName,
-			Namespace:            cluster.Status.NamespaceName,
-			Labels:               cluster.Labels,
-			Annotations:          cluster.Annotations,
-			Kubeconfig:           kubeconfig,
-			OwnerName:            cluster.Status.UserName,
-			OwnerEmail:           cluster.Status.UserEmail,
-			ApiserverExternalURL: cluster.Address.URL,
-			ApiserverInternalURL: fmt.Sprintf("https://%s:%d", cluster.Address.InternalName, cluster.Address.Port),
-			AdminToken:           cluster.Address.AdminToken,
-			CloudProviderName:    providerName,
-			Version:              semver.MustParse(cluster.Spec.Version.String()),
-			MajorMinorVersion:    cluster.Spec.Version.MajorMinor(),
-			Features:             sets.StringKeySet(cluster.Spec.Features),
+			Type:              ClusterTypeKubernetes,
+			Name:              cluster.Name,
+			HumanReadableName: cluster.Spec.HumanReadableName,
+			Namespace:         cluster.Status.NamespaceName,
+			Labels:            cluster.Labels,
+			Annotations:       cluster.Annotations,
+			Kubeconfig:        kubeconfig,
+			OwnerName:         cluster.Status.UserName,
+			OwnerEmail:        cluster.Status.UserEmail,
+			Address:           cluster.Address,
+			CloudProviderName: providerName,
+			Version:           semver.MustParse(cluster.Spec.Version.String()),
+			MajorMinorVersion: cluster.Spec.Version.MajorMinor(),
+			Features:          sets.StringKeySet(cluster.Spec.Features),
 			Network: ClusterNetwork{
 				DNSDomain:         cluster.Spec.ClusterNetwork.DNSDomain,
 				DNSClusterIP:      dnsClusterIP,
@@ -175,15 +173,10 @@ type ClusterData struct {
 	// inside the user-cluster. The kubeconfig uses the external URL to reach
 	// the apiserver.
 	Kubeconfig string
-	// ApiserverExternalURL is the full URL to the apiserver service from the
-	// outside, including protocol and port number. It does not contain any
-	// trailing slashes.
-	ApiserverExternalURL string
-	// ApiserverExternalURL is the full URL to the apiserver from within the
-	// seed cluster itself. It does not contain any trailing slashes.
-	ApiserverInternalURL string
-	// AdminToken is the cluster's admin token.
-	AdminToken string
+
+	// ClusterAddress stores access and address information of a cluster.
+	Address kubermaticv1.ClusterAddress
+
 	// CloudProviderName is the name of the cloud provider used, one of
 	// "alibaba", "aws", "azure", "bringyourown", "digitalocean", "gcp",
 	// "hetzner", "kubevirt", "openstack", "packet", "vsphere" depending on

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -46,6 +46,12 @@ const (
 	// VersionLabel is the label containing the application's version.
 	VersionLabel = "app.kubernetes.io/version"
 
+	// InstanceLabel is A unique name identifying the instance of an application
+	InstanceLabel = "app.kubernetes.io/instance"
+
+	// ComponentLabel is the label of the component within the architecture.
+	ComponentLabel = "app.kubernetes.io/component"
+
 	DockercfgSecretName = "dockercfg"
 
 	SeedWebhookServiceName    = "seed-webhook"

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -90,6 +90,7 @@ func Add(
 	opaEnableMutation bool,
 	versions kubermatic.Versions,
 	userSSHKeyAgent bool,
+	networkPolices bool,
 	opaWebhookTimeout int,
 	caBundle resources.CABundle,
 	userClusterMLA UserClusterMLA,
@@ -101,32 +102,33 @@ func Add(
 	ccmMigrationCompleted bool,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
-		version:                version,
-		rLock:                  &sync.Mutex{},
-		namespace:              namespace,
-		clusterURL:             clusterURL,
-		clusterIsPaused:        clusterIsPaused,
-		overwriteRegistryFunc:  registry.GetOverwriteFunc(overwriteRegistry),
-		openvpnServerPort:      openvpnServerPort,
-		kasSecurePort:          kasSecurePort,
-		tunnelingAgentIP:       tunnelingAgentIP,
-		log:                    log,
-		dnsClusterIP:           dnsClusterIP,
-		nodeLocalDNSCache:      nodeLocalDNSCache,
-		opaIntegration:         opaIntegration,
-		opaEnableMutation:      opaEnableMutation,
-		opaWebhookTimeout:      opaWebhookTimeout,
-		userSSHKeyAgent:        userSSHKeyAgent,
-		versions:               versions,
-		caBundle:               caBundle,
-		userClusterMLA:         userClusterMLA,
-		cloudProvider:          kubermaticv1.ProviderType(cloudProviderName),
-		clusterName:            clusterName,
-		isKonnectivityEnabled:  konnectivity,
+		version:               version,
+		rLock:                 &sync.Mutex{},
+		namespace:             namespace,
+		clusterURL:            clusterURL,
+		clusterIsPaused:       clusterIsPaused,
+		overwriteRegistryFunc: registry.GetOverwriteFunc(overwriteRegistry),
+		openvpnServerPort:     openvpnServerPort,
+		kasSecurePort:         kasSecurePort,
+		tunnelingAgentIP:      tunnelingAgentIP,
+		log:                   log,
+		dnsClusterIP:          dnsClusterIP,
+		nodeLocalDNSCache:     nodeLocalDNSCache,
+		opaIntegration:        opaIntegration,
+		opaEnableMutation:     opaEnableMutation,
+		opaWebhookTimeout:     opaWebhookTimeout,
+		userSSHKeyAgent:       userSSHKeyAgent,
+		networkPolices:        networkPolices,
+		versions:              versions,
+		caBundle:              caBundle,
+		userClusterMLA:        userClusterMLA,
+		cloudProvider:         kubermaticv1.ProviderType(cloudProviderName),
+		clusterName:           clusterName,
+		isKonnectivityEnabled: konnectivity,
 		konnectivityServerHost: konnectivityServerHost,
 		konnectivityServerPort: konnectivityServerPort,
-		ccmMigration:           ccmMigration,
-		ccmMigrationCompleted:  ccmMigrationCompleted,
+		ccmMigration:          ccmMigration,
+		ccmMigrationCompleted: ccmMigrationCompleted,
 	}
 
 	var err error
@@ -266,32 +268,32 @@ func Add(
 // reconcileUserCluster reconciles objects in the user cluster
 type reconciler struct {
 	ctrlruntimeclient.Client
-	seedClient             ctrlruntimeclient.Client
-	version                string
-	clusterSemVer          *semver.Version
-	cache                  cache.Cache
-	namespace              string
-	clusterURL             *url.URL
-	clusterIsPaused        userclustercontrollermanager.IsPausedChecker
-	overwriteRegistryFunc  registry.WithOverwriteFunc
-	openvpnServerPort      uint32
-	kasSecurePort          uint32
-	tunnelingAgentIP       net.IP
-	dnsClusterIP           string
-	nodeLocalDNSCache      bool
-	opaIntegration         bool
-	opaEnableMutation      bool
-	opaWebhookTimeout      int
-	userSSHKeyAgent        bool
-	versions               kubermatic.Versions
-	caBundle               resources.CABundle
-	userClusterMLA         UserClusterMLA
-	cloudProvider          kubermaticv1.ProviderType
-	clusterName            string
-	isKonnectivityEnabled  bool
+	seedClient            ctrlruntimeclient.Client
+	version               string
+	clusterSemVer         *semver.Version
+	cache                 cache.Cache
+	namespace             string
+	clusterURL            *url.URL
+	clusterIsPaused       userclustercontrollermanager.IsPausedChecker
+	overwriteRegistryFunc registry.WithOverwriteFunc
+	openvpnServerPort     uint32
+	kasSecurePort         uint32
+	tunnelingAgentIP      net.IP
+	dnsClusterIP          string
+	nodeLocalDNSCache     bool
+	opaIntegration        bool
+	opaEnableMutation     bool
+	opaWebhookTimeout     int
+	userSSHKeyAgent       bool
+	networkPolices        bool
+	versions              kubermatic.Versions
+	caBundle              resources.CABundle
+	userClusterMLA        UserClusterMLA
+	cloudProvider         kubermaticv1.ProviderType
+	clusterName           string
+	isKonnectivityEnabled bool
 	konnectivityServerHost string
 	konnectivityServerPort int
-
 	ccmMigration          bool
 	ccmMigrationCompleted bool
 

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -373,6 +373,16 @@ func (r *reconciler) mlaReconcileData(ctx context.Context) (monitoring, logging 
 	return cluster.Spec.MLA.MonitoringResources, cluster.Spec.MLA.LoggingResources, cluster.Spec.MLA.MonitoringReplicas, nil
 }
 
+func (r *reconciler) clusterAddress(ctx context.Context) (address *kubermaticv1.ClusterAddress, err error) {
+	cluster := &kubermaticv1.Cluster{}
+	if err = r.seedClient.Get(ctx, types.NamespacedName{
+		Name: r.clusterName,
+	}, cluster); err != nil {
+		return nil, fmt.Errorf("failed to get cluster: %w", err)
+	}
+	return &cluster.Address, nil
+}
+
 // reconcileDefaultServiceAccount ensures that the Kubernetes default service account has AutomountServiceAccountToken set to false
 func (r *reconciler) reconcileDefaultServiceAccount(ctx context.Context, namespace string) error {
 

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -102,33 +102,33 @@ func Add(
 	ccmMigrationCompleted bool,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
-		version:               version,
-		rLock:                 &sync.Mutex{},
-		namespace:             namespace,
-		clusterURL:            clusterURL,
-		clusterIsPaused:       clusterIsPaused,
-		overwriteRegistryFunc: registry.GetOverwriteFunc(overwriteRegistry),
-		openvpnServerPort:     openvpnServerPort,
-		kasSecurePort:         kasSecurePort,
-		tunnelingAgentIP:      tunnelingAgentIP,
-		log:                   log,
-		dnsClusterIP:          dnsClusterIP,
-		nodeLocalDNSCache:     nodeLocalDNSCache,
-		opaIntegration:        opaIntegration,
-		opaEnableMutation:     opaEnableMutation,
-		opaWebhookTimeout:     opaWebhookTimeout,
-		userSSHKeyAgent:       userSSHKeyAgent,
-		networkPolices:        networkPolices,
-		versions:              versions,
-		caBundle:              caBundle,
-		userClusterMLA:        userClusterMLA,
-		cloudProvider:         kubermaticv1.ProviderType(cloudProviderName),
-		clusterName:           clusterName,
-		isKonnectivityEnabled: konnectivity,
+		version:                version,
+		rLock:                  &sync.Mutex{},
+		namespace:              namespace,
+		clusterURL:             clusterURL,
+		clusterIsPaused:        clusterIsPaused,
+		overwriteRegistryFunc:  registry.GetOverwriteFunc(overwriteRegistry),
+		openvpnServerPort:      openvpnServerPort,
+		kasSecurePort:          kasSecurePort,
+		tunnelingAgentIP:       tunnelingAgentIP,
+		log:                    log,
+		dnsClusterIP:           dnsClusterIP,
+		nodeLocalDNSCache:      nodeLocalDNSCache,
+		opaIntegration:         opaIntegration,
+		opaEnableMutation:      opaEnableMutation,
+		opaWebhookTimeout:      opaWebhookTimeout,
+		userSSHKeyAgent:        userSSHKeyAgent,
+		networkPolices:         networkPolices,
+		versions:               versions,
+		caBundle:               caBundle,
+		userClusterMLA:         userClusterMLA,
+		cloudProvider:          kubermaticv1.ProviderType(cloudProviderName),
+		clusterName:            clusterName,
+		isKonnectivityEnabled:  konnectivity,
 		konnectivityServerHost: konnectivityServerHost,
 		konnectivityServerPort: konnectivityServerPort,
-		ccmMigration:          ccmMigration,
-		ccmMigrationCompleted: ccmMigrationCompleted,
+		ccmMigration:           ccmMigration,
+		ccmMigrationCompleted:  ccmMigrationCompleted,
 	}
 
 	var err error
@@ -268,34 +268,34 @@ func Add(
 // reconcileUserCluster reconciles objects in the user cluster
 type reconciler struct {
 	ctrlruntimeclient.Client
-	seedClient            ctrlruntimeclient.Client
-	version               string
-	clusterSemVer         *semver.Version
-	cache                 cache.Cache
-	namespace             string
-	clusterURL            *url.URL
-	clusterIsPaused       userclustercontrollermanager.IsPausedChecker
-	overwriteRegistryFunc registry.WithOverwriteFunc
-	openvpnServerPort     uint32
-	kasSecurePort         uint32
-	tunnelingAgentIP      net.IP
-	dnsClusterIP          string
-	nodeLocalDNSCache     bool
-	opaIntegration        bool
-	opaEnableMutation     bool
-	opaWebhookTimeout     int
-	userSSHKeyAgent       bool
-	networkPolices        bool
-	versions              kubermatic.Versions
-	caBundle              resources.CABundle
-	userClusterMLA        UserClusterMLA
-	cloudProvider         kubermaticv1.ProviderType
-	clusterName           string
-	isKonnectivityEnabled bool
+	seedClient             ctrlruntimeclient.Client
+	version                string
+	clusterSemVer          *semver.Version
+	cache                  cache.Cache
+	namespace              string
+	clusterURL             *url.URL
+	clusterIsPaused        userclustercontrollermanager.IsPausedChecker
+	overwriteRegistryFunc  registry.WithOverwriteFunc
+	openvpnServerPort      uint32
+	kasSecurePort          uint32
+	tunnelingAgentIP       net.IP
+	dnsClusterIP           string
+	nodeLocalDNSCache      bool
+	opaIntegration         bool
+	opaEnableMutation      bool
+	opaWebhookTimeout      int
+	userSSHKeyAgent        bool
+	networkPolices         bool
+	versions               kubermatic.Versions
+	caBundle               resources.CABundle
+	userClusterMLA         UserClusterMLA
+	cloudProvider          kubermaticv1.ProviderType
+	clusterName            string
+	isKonnectivityEnabled  bool
 	konnectivityServerHost string
 	konnectivityServerPort int
-	ccmMigration          bool
-	ccmMigrationCompleted bool
+	ccmMigration           bool
+	ccmMigrationCompleted  bool
 
 	rLock                      *sync.Mutex
 	reconciledSuccessfullyOnce bool
@@ -375,14 +375,19 @@ func (r *reconciler) mlaReconcileData(ctx context.Context) (monitoring, logging 
 	return cluster.Spec.MLA.MonitoringResources, cluster.Spec.MLA.LoggingResources, cluster.Spec.MLA.MonitoringReplicas, nil
 }
 
-func (r *reconciler) clusterAddress(ctx context.Context) (address *kubermaticv1.ClusterAddress, err error) {
+func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.ClusterAddress, k8sServiceApi *net.IP, err error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err = r.seedClient.Get(ctx, types.NamespacedName{
 		Name: r.clusterName,
 	}, cluster); err != nil {
-		return nil, fmt.Errorf("failed to get cluster: %w", err)
+		return nil, nil, fmt.Errorf("failed to get cluster: %w", err)
 	}
-	return &cluster.Address, nil
+
+	ip, err := resources.InClusterApiserverIP(cluster)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get Cluster Apiserver IP: %w", err)
+	}
+	return &cluster.Address, ip, nil
 }
 
 // reconcileDefaultServiceAccount ensures that the Kubernetes default service account has AutomountServiceAccountToken set to false

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -39,6 +39,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -175,6 +176,7 @@ func Add(
 		&apiextensionsv1.CustomResourceDefinition{},
 		&appsv1.Deployment{},
 		&v1beta1.PodDisruptionBudget{},
+		&networkingv1.NetworkPolicy{},
 	}
 
 	// Avoid getting triggered by the leader lease AKA: If the annotation exists AND changed on

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -932,15 +932,15 @@ type reconcileData struct {
 	userSSHKeys      map[string][]byte
 	cloudConfig      []byte
 	// csiCloudConfig is currently used only by vSphere, whose needs it to properly configure the external CSI driver
-	csiCloudConfig         []byte
-	ccmMigration           bool
-	monitoringRequirements *corev1.ResourceRequirements
-	loggingRequirements    *corev1.ResourceRequirements
+	csiCloudConfig              []byte
+	ccmMigration                bool
+	monitoringRequirements      *corev1.ResourceRequirements
+	loggingRequirements         *corev1.ResourceRequirements
 	gatekeeperCtrlRequirements  *corev1.ResourceRequirements
 	gatekeeperAuditRequirements *corev1.ResourceRequirements
-	monitoringReplicas     *int32
-	clusterAddress         *kubermaticv1.ClusterAddress
-	k8sServiceApiIP        *net.IP
+	monitoringReplicas          *int32
+	clusterAddress              *kubermaticv1.ClusterAddress
+	k8sServiceApiIP             *net.IP
 }
 
 func (r *reconciler) ensureOPAIntegrationIsRemoved(ctx context.Context) error {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -887,6 +887,11 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
 	}
 
+	if r.isKonnectivityEnabled {
+		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
+
+	}
+
 	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %v", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -876,7 +876,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcileData) error {
 
 	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
-		// coredns.AllowAllDnsNetworkPolicyCreator(),
+		coredns.AllowAllDnsNetworkPolicyCreator(),
 		coredns.KubeDNSNetworkPolicyCreator(data.clusterAddress.IP, int(data.clusterAddress.Port)),
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -81,6 +81,10 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 			return fmt.Errorf("failed to get cloudConfig: %v", err)
 		}
 	}
+	clusterAddress, err := r.clusterAddress(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster address: %v", err)
+	}
 
 	data := reconcileData{
 		caCert:         caCert,
@@ -88,6 +92,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		cloudConfig:    cloudConfig,
 		csiCloudConfig: CSICloudConfig,
 		ccmMigration:   r.ccmMigration || r.ccmMigrationCompleted,
+		clusterAddress: clusterAddress,
 	}
 
 	if !r.isKonnectivityEnabled {
@@ -872,7 +877,7 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 
 	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
 		// coredns.AllowAllDnsNetworkPolicyCreator(),
-		coredns.KubeDNSNetworkPolicyCreator(),
+		coredns.KubeDNSNetworkPolicyCreator(data.clusterAddress.IP, int(data.clusterAddress.Port)),
 	}
 
 	if r.userSSHKeyAgent {
@@ -918,13 +923,14 @@ type reconcileData struct {
 	userSSHKeys      map[string][]byte
 	cloudConfig      []byte
 	// csiCloudConfig is currently used only by vSphere, whose needs it to properly configure the external CSI driver
-	csiCloudConfig              []byte
-	ccmMigration                bool
-	monitoringRequirements      *corev1.ResourceRequirements
-	loggingRequirements         *corev1.ResourceRequirements
+	csiCloudConfig         []byte
+	ccmMigration           bool
+	monitoringRequirements *corev1.ResourceRequirements
+	loggingRequirements    *corev1.ResourceRequirements
 	gatekeeperCtrlRequirements  *corev1.ResourceRequirements
 	gatekeeperAuditRequirements *corev1.ResourceRequirements
-	monitoringReplicas          *int32
+	monitoringReplicas     *int32
+	clusterAddress         *kubermaticv1.ClusterAddress
 }
 
 func (r *reconciler) ensureOPAIntegrationIsRemoved(ctx context.Context) error {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -890,7 +890,7 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 	}
 
 	if r.isKonnectivityEnabled {
-		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, metricsserver.NetworkPolicyCreator())
+		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, metricsserver.NetworkPolicyCreator(), konnectivity.NetworkPolicyCreator())
 	}
 
 	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, metav1.NamespaceSystem, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -885,7 +885,8 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 	}
 
 	if r.userSSHKeyAgent {
-		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
+		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters,
+			usersshkeys.NetworkPolicyCreator(data.clusterAddress.IP, int(data.clusterAddress.Port), data.k8sServiceApiIP.String()))
 	}
 
 	if r.isKonnectivityEnabled {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -875,9 +875,9 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 		coredns.KubeDNSNetworkPolicyCreator(),
 	}
 
-	// if r.userSSHKeyAgent {
-	// 	namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
-	// }
+	if r.userSSHKeyAgent {
+		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
+	}
 
 	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %v", err)

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -889,7 +889,7 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 
 	if r.isKonnectivityEnabled {
 		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
-
+		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, metricsserver.NetworkPolicyCreator())
 	}
 
 	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, metav1.NamespaceSystem, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -188,8 +188,10 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.reconcileNetworkPolicies(ctx, data); err != nil {
-		return err
+	if r.networkPolices {
+		if err := r.reconcileNetworkPolicies(ctx, data); err != nil {
+			return err
+		}
 	}
 
 	// Try to delete OPA integration deployment if its present

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity"
 	kubestatemetrics "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem"
 	machinecontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
 	metricsserver "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla"
@@ -876,7 +877,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcileData) error {
 
 	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
-		coredns.AllowAllDnsNetworkPolicyCreator(),
+		kubesystem.DefaultNetworkPolicyCreator(),
 		coredns.KubeDNSNetworkPolicyCreator(data.clusterAddress.IP, int(data.clusterAddress.Port)),
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -75,25 +75,26 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get cloudConfig: %v", err)
 	}
-	var CSICloudConfig []byte
+
+	data := reconcileData{
+		caCert:       caCert,
+		userSSHKeys:  userSSHKeys,
+		cloudConfig:  cloudConfig,
+		ccmMigration: r.ccmMigration || r.ccmMigrationCompleted,
+	}
+
 	if r.cloudProvider == kubermaticv1.VSphereCloudProvider {
-		CSICloudConfig, err = r.cloudConfig(ctx, resources.CSICloudConfigConfigMapName)
+		data.csiCloudConfig, err = r.cloudConfig(ctx, resources.CSICloudConfigConfigMapName)
 		if err != nil {
 			return fmt.Errorf("failed to get cloudConfig: %v", err)
 		}
 	}
-	clusterAddress, err := r.clusterAddress(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get cluster address: %v", err)
-	}
 
-	data := reconcileData{
-		caCert:         caCert,
-		userSSHKeys:    userSSHKeys,
-		cloudConfig:    cloudConfig,
-		csiCloudConfig: CSICloudConfig,
-		ccmMigration:   r.ccmMigration || r.ccmMigrationCompleted,
-		clusterAddress: clusterAddress,
+	if r.networkPolices {
+		data.clusterAddress, data.k8sServiceApiIP, err = r.networkingData(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get cluster address: %v", err)
+		}
 	}
 
 	if !r.isKonnectivityEnabled {
@@ -880,7 +881,7 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 
 	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
 		kubesystem.DefaultNetworkPolicyCreator(),
-		coredns.KubeDNSNetworkPolicyCreator(data.clusterAddress.IP, int(data.clusterAddress.Port)),
+		coredns.KubeDNSNetworkPolicyCreator(data.clusterAddress.IP, int(data.clusterAddress.Port), data.k8sServiceApiIP.String()),
 	}
 
 	if r.userSSHKeyAgent {
@@ -888,7 +889,6 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 	}
 
 	if r.isKonnectivityEnabled {
-		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
 		namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, metricsserver.NetworkPolicyCreator())
 	}
 
@@ -939,6 +939,7 @@ type reconcileData struct {
 	gatekeeperAuditRequirements *corev1.ResourceRequirements
 	monitoringReplicas     *int32
 	clusterAddress         *kubermaticv1.ClusterAddress
+	k8sServiceApiIP        *net.IP
 }
 
 func (r *reconciler) ensureOPAIntegrationIsRemoved(ctx context.Context) error {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -182,6 +182,10 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return err
 	}
 
+	if err := r.reconcileNetworkPolicies(ctx, data); err != nil {
+		return err
+	}
+
 	// Try to delete OPA integration deployment if its present
 	if !r.opaIntegration {
 		if err := r.ensureOPAIntegrationIsRemoved(ctx); err != nil {
@@ -859,6 +863,24 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
 			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %v", metav1.NamespaceSystem, err)
 		}
+	}
+
+	return nil
+}
+
+func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcileData) error {
+
+	namedNetworkPolicyCreatorGetters := []reconciling.NamedNetworkPolicyCreatorGetter{
+		// coredns.AllowAllDnsNetworkPolicyCreator(),
+		coredns.KubeDNSNetworkPolicyCreator(),
+	}
+
+	// if r.userSSHKeyAgent {
+	// 	namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, usersshkeys.NetworkPolicyCreator())
+	// }
+
+	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyCreatorGetters, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to ensure Network Policies: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -41,7 +41,15 @@ func KubeDNSNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 					networkingv1.PolicyTypeEgress,
 					networkingv1.PolicyTypeIngress,
 				},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{},
+							},
+						},
+					},
+				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
 						To: []networkingv1.NetworkPolicyPeer{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -41,7 +41,7 @@ func KubeDNSNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 					networkingv1.PolicyTypeEgress,
 					networkingv1.PolicyTypeIngress,
 				},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{{}},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
 						To: []networkingv1.NetworkPolicyPeer{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -96,6 +96,9 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 						From: []networkingv1.NetworkPolicyPeer{
 							{
 								NamespaceSelector: &metav1.LabelSelector{},
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "0.0.0.0/0",
+								},
 							},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -54,6 +54,19 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 									CIDR: "0.0.0.0/0",
 								},
 							},
+							//{
+							//	NamespaceSelector: &metav1.LabelSelector{},
+							//},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protoTcp,
+								Port:     &dnsPort,
+							},
+							{
+								Protocol: &protoUdp,
+								Port:     &dnsPort,
+							},
 						},
 					},
 				},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -45,7 +45,9 @@ func KubeDNSNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 					{
 						From: []networkingv1.NetworkPolicyPeer{
 							{
-								NamespaceSelector: &metav1.LabelSelector{},
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "0.0.0.0/0",
+								},
 							},
 						},
 					},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coredns
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+// KubeDNSNetworkPolicyCreator NetworkPolicy allows ingress traffic to coredns on port 53 TCP/UDP and egress to anywhere on port 53 TCP/UDP.
+func KubeDNSNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "kube-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			// dnsPort := intstr.FromInt(53)
+			// protoUdp := v1.ProtocolUDP
+			// protoTcp := v1.ProtocolTCP
+
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{common.NameLabel: "kube-dns"},
+				},
+
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+					networkingv1.PolicyTypeIngress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{}},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "0.0.0.0/0",
+								},
+							},
+						},
+					},
+				},
+			}
+			return np, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -95,9 +95,7 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 					{
 						From: []networkingv1.NetworkPolicyPeer{
 							{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: "0.0.0.0/0",
-								},
+								NamespaceSelector: &metav1.LabelSelector{},
 							},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -32,13 +32,15 @@ import (
 // KubeDNSNetworkPolicyCreator NetworkPolicy allows ingress traffic to coredns on port 53 TCP/UDP and egress to anywhere on port 53 TCP/UDP.
 func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int, k8sServiceApi string) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
+
+		dnsPort := intstr.FromInt(53)
+		apiServicePort := intstr.FromInt(443)
+		apiPort := intstr.FromInt(k8sApiPort)
+		metricsPort := intstr.FromInt(9153)
+		protoUdp := v1.ProtocolUDP
+		protoTcp := v1.ProtocolTCP
+
 		return "kube-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
-			dnsPort := intstr.FromInt(53)
-			apiServicePort := intstr.FromInt(443)
-			apiPort := intstr.FromInt(k8sApiPort)
-			metricsPort := intstr.FromInt(9153)
-			protoUdp := v1.ProtocolUDP
-			protoTcp := v1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 )
 
@@ -77,7 +78,7 @@ func AllowAllDnsNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGett
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: "169.254.20.10/32",
+									CIDR: fmt.Sprintf("%s/32", nodelocaldns.CacheAddress),
 								},
 							},
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -36,10 +36,13 @@ func AllowAllDnsNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGett
 			protoUdp := v1.ProtocolUDP
 			protoTcp := v1.ProtocolTCP
 
+			// dns access to node local dns cache
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
 					networkingv1.PolicyTypeEgress,
 				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
 						Ports: []networkingv1.NetworkPolicyPort{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -61,6 +61,20 @@ func AllowAllDnsNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGett
 									MatchLabels: map[string]string{common.NameLabel: "kube-dns"},
 								},
 							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protoTcp,
+								Port:     &dnsPort,
+							},
+							{
+								Protocol: &protoUdp,
+								Port:     &dnsPort,
+							},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
 									CIDR: "169.254.20.10/32",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -99,6 +99,22 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 						From: []networkingv1.NetworkPolicyPeer{
 							{
 								NamespaceSelector: &metav1.LabelSelector{},
+							},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protoTcp,
+								Port:     &dnsPort,
+							},
+							{
+								Protocol: &protoUdp,
+								Port:     &dnsPort,
+							},
+						},
+					},
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
 								IPBlock: &networkingv1.IPBlock{
 									CIDR: "0.0.0.0/0",
 								},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -54,9 +54,6 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 									CIDR: "0.0.0.0/0",
 								},
 							},
-							//{
-							//	NamespaceSelector: &metav1.LabelSelector{},
-							//},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +35,7 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 		return "kube-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			dnsPort := intstr.FromInt(53)
 			apiPort := intstr.FromInt(k8sApiPort)
+			metricsPort := intstr.FromInt(9153)
 			protoUdp := v1.ProtocolUDP
 			protoTcp := v1.ProtocolTCP
 
@@ -80,6 +82,24 @@ func KubeDNSNetworkPolicyCreator(k8sApiIP string, k8sApiPort int) reconciling.Na
 							{
 								Protocol: &protoUdp,
 								Port:     &dnsPort,
+							},
+						},
+					},
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{common.ComponentLabel: resources.MLAComponentName},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{common.ComponentLabel: resources.MLAComponentName},
+								},
+							},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protoTcp,
+								Port:     &metricsPort,
 							},
 						},
 					},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/networkpolicy.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package usersshkeys
+package konnectivity
 
 import (
 	networkingv1 "k8s.io/api/networking/v1"
@@ -24,31 +24,21 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 )
 
-// NetworkPolicyCreator NetworkPolicy allows egress traffic of user ssh keys agent to the world
+// NetworkPolicyCreator NetworkPolicy allows all egress traffic
 func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return "user-ssh-key-agent", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{resources.AppLabelKey: "user-ssh-keys-agent"},
+					MatchLabels: map[string]string{resources.AppLabelKey: "konnectivity-agent"},
 				},
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
 					networkingv1.PolicyTypeIngress,
 				},
 				Ingress: []networkingv1.NetworkPolicyIngressRule{},
-				Egress: []networkingv1.NetworkPolicyEgressRule{
-					{
-						To: []networkingv1.NetworkPolicyPeer{
-							{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: "0.0.0.0/0",
-								},
-							},
-						},
-					},
-				},
+				Egress:  []networkingv1.NetworkPolicyEgressRule{{}},
 			}
 			return np, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/networkpolicy.go
@@ -17,11 +17,11 @@ limitations under the License.
 package konnectivity
 
 import (
-	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NetworkPolicyCreator NetworkPolicy allows all egress traffic

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/networkpolicy.go
@@ -27,7 +27,7 @@ import (
 // NetworkPolicyCreator NetworkPolicy allows all egress traffic
 func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "user-ssh-key-agent", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return "konnectivity", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -32,10 +32,11 @@ import (
 // DefaultNetworkPolicyCreator Default policy creator denys all expect egress to kube-dns for all pods without any network policy applied.
 func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
+		dnsPort := intstr.FromInt(53)
+		protoUdp := v1.ProtocolUDP
+		protoTcp := v1.ProtocolTCP
+
 		return "allow-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
-			dnsPort := intstr.FromInt(53)
-			protoUdp := v1.ProtocolUDP
-			protoTcp := v1.ProtocolTCP
 
 			// dns access to node local dns cache
 			np.Spec = networkingv1.NetworkPolicySpec{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -43,7 +43,8 @@ func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 					networkingv1.PolicyTypeIngress,
 					networkingv1.PolicyTypeEgress,
 				},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{},
+				PodSelector: metav1.LabelSelector{},
+				Ingress:     []networkingv1.NetworkPolicyIngressRule{},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
 						Ports: []networkingv1.NetworkPolicyPort{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
-	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
+	"k8c.io/kubermatic/v2/pkg/resources/machinecontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	v1 "k8s.io/api/core/v1"
@@ -36,7 +36,7 @@ func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 		protoUdp := v1.ProtocolUDP
 		protoTcp := v1.ProtocolTCP
 
-		return "allow-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return "default-deny", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 
 			// dns access to node local dns cache
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -80,7 +80,7 @@ func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", nodelocaldns.CacheAddress),
+									CIDR: fmt.Sprintf("%s/32", machinecontroller.NodeLocalDNSCacheAddress),
 								},
 							},
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
-	"k8c.io/kubermatic/v2/pkg/resources/machinecontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+const NodeLocalDNSCacheAddress = "169.254.20.10"
 
 // DefaultNetworkPolicyCreator Default policy creator denys all expect egress to kube-dns for all pods without any network policy applied.
 func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
@@ -80,7 +81,7 @@ func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", machinecontroller.NodeLocalDNSCacheAddress),
+									CIDR: fmt.Sprintf("%s/32", NodeLocalDNSCacheAddress),
 								},
 							},
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubesystem
 
 import (

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -1,0 +1,76 @@
+package kubesystem
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// DefaultNetworkPolicyCreator Default policy creator denys all expect egress to kube-dns for all pods without any network policy applied.
+func DefaultNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "allow-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			dnsPort := intstr.FromInt(53)
+			protoUdp := v1.ProtocolUDP
+			protoTcp := v1.ProtocolTCP
+
+			// dns access to node local dns cache
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protoTcp,
+								Port:     &dnsPort,
+							},
+							{
+								Protocol: &protoUdp,
+								Port:     &dnsPort,
+							},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{common.NameLabel: "kube-dns"},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protoTcp,
+								Port:     &dnsPort,
+							},
+							{
+								Protocol: &protoUdp,
+								Port:     &dnsPort,
+							},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: fmt.Sprintf("%s/32", nodelocaldns.CacheAddress),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsserver
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+// NetworkPolicyCreator NetworkPolicy allows egress traffic of user ssh keys agent to the world
+func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "metrics-server", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			metricsPort := intstr.FromInt(9153)
+
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{resources.AppLabelKey: resources.MetricsServerDeploymentName},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+					networkingv1.PolicyTypeIngress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{common.ComponentLabel: resources.MLAComponentName},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{common.ComponentLabel: resources.MLAComponentName},
+								},
+							},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Port: &metricsPort,
+							},
+						},
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{{}},
+			}
+			return np, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mla
 
 import (
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -25,6 +26,7 @@ import (
 
 func NamespaceCreator() (string, reconciling.NamespaceCreator) {
 	return resources.UserClusterMLANamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		ns.ObjectMeta.Labels[common.ComponentLabel] = resources.MLAComponentName
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -46,16 +47,14 @@ const (
 	storagePath            = "/data"
 	certificatesVolumeName = "certificates"
 
-	prometheusNameKey     = "app.kubernetes.io/name"
-	prometheusInstanceKey = "app.kubernetes.io/instance"
-
 	containerPort = 9090
 )
 
 var (
 	controllerLabels = map[string]string{
-		prometheusNameKey:     resources.UserClusterPrometheusDeploymentName,
-		prometheusInstanceKey: resources.UserClusterPrometheusDeploymentName,
+		common.NameLabel:      resources.UserClusterPrometheusDeploymentName,
+		common.InstanceLabel:  resources.UserClusterPrometheusDeploymentName,
+		common.ComponentLabel: resources.MLAComponentName,
 	}
 
 	defaultResourceRequirements = corev1.ResourceRequirements{
@@ -73,7 +72,7 @@ var (
 func DeploymentCreator(overrides *corev1.ResourceRequirements, replicas *int32, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterPrometheusDeploymentName, func(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-			deployment.Labels = resources.BaseAppLabels(appName, nil)
+			deployment.Labels = resources.BaseAppLabels(appName, map[string]string{})
 
 			deployment.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: controllerLabels,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
@@ -19,6 +19,7 @@ package promtail
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -50,16 +51,14 @@ const (
 	podVolumeMountPath       = "/var/log/pods"
 	metricsPortName          = "http-metrics"
 
-	promtailNameKey     = "app.kubernetes.io/name"
-	promtailInstanceKey = "app.kubernetes.io/instance"
-
 	inotifyMaxUserInstances = 256
 )
 
 var (
 	controllerLabels = map[string]string{
-		promtailNameKey:     resources.PromtailDaemonSetName,
-		promtailInstanceKey: resources.PromtailDaemonSetName,
+		common.NameLabel:      resources.PromtailDaemonSetName,
+		common.InstanceLabel:  resources.PromtailDaemonSetName,
+		common.ComponentLabel: resources.MLAComponentName,
 	}
 	defaultResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/machinecontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
@@ -29,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
-
-const CacheAddress = "169.254.20.10"
 
 func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
@@ -92,7 +91,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",
-						CacheAddress,
+						machinecontroller.NodeLocalDNSCacheAddress,
 						"-conf",
 						"/etc/coredns/Corefile",
 					},
@@ -132,7 +131,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Host:   CacheAddress,
+								Host:   machinecontroller.NodeLocalDNSCacheAddress,
 								Scheme: corev1.URISchemeHTTP,
 								Path:   "/health",
 								Port:   intstr.FromInt(8080),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const CacheAddress = "169.254.20.10"
+
 func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.NodeLocalDNSDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
@@ -90,7 +92,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",
-						"169.254.20.10",
+						CacheAddress,
 						"-conf",
 						"/etc/coredns/Corefile",
 					},
@@ -130,7 +132,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Host:   "169.254.20.10",
+								Host:   CacheAddress,
 								Scheme: corev1.URISchemeHTTP,
 								Path:   "/health",
 								Port:   intstr.FromInt(8080),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -19,8 +19,8 @@ package nodelocaldns
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/machinecontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
@@ -91,7 +91,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",
-						machinecontroller.NodeLocalDNSCacheAddress,
+						kubesystem.NodeLocalDNSCacheAddress,
 						"-conf",
 						"/etc/coredns/Corefile",
 					},
@@ -131,7 +131,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Host:   machinecontroller.NodeLocalDNSCacheAddress,
+								Host:   kubesystem.NodeLocalDNSCacheAddress,
 								Scheme: corev1.URISchemeHTTP,
 								Path:   "/health",
 								Port:   intstr.FromInt(8080),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
@@ -19,6 +19,7 @@ package usersshkeys
 import (
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,9 +31,11 @@ import (
 // NetworkPolicyCreator NetworkPolicy allows egress traffic of user ssh keys agent to the world
 func NetworkPolicyCreator(k8sApiIP string, k8sApiPort int, k8sServiceApi string) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
+		apiServicePort := intstr.FromInt(443)
+		apiPort := intstr.FromInt(k8sApiPort)
+		protoTcp := v1.ProtocolTCP
+
 		return "user-ssh-key-agent", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
-			apiServicePort := intstr.FromInt(443)
-			apiPort := intstr.FromInt(k8sApiPort)
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -54,7 +57,8 @@ func NetworkPolicyCreator(k8sApiIP string, k8sApiPort int, k8sServiceApi string)
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Port: &apiPort,
+								Port:     &apiPort,
+								Protocol: &protoTcp,
 							},
 						},
 					},
@@ -68,7 +72,8 @@ func NetworkPolicyCreator(k8sApiIP string, k8sApiPort int, k8sServiceApi string)
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Port: &apiServicePort,
+								Port:     &apiServicePort,
+								Protocol: &protoTcp,
 							},
 						},
 					},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usersshkeys
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+// NetworkPolicyCreator NetworkPolicy allows egress access to user ssh key agent.
+func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return "user-ssh-key-agent", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "user-ssh-keys-agent"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+					networkingv1.PolicyTypeIngress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "0.0.0.0/0",
+								},
+							},
+						},
+					},
+				},
+			}
+			return np, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
@@ -23,7 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 )
 
-// NetworkPolicyCreator NetworkPolicy allows egress access to user ssh key agent.
+// NetworkPolicyCreator NetworkPolicy allows egress traffic of user ssh keys agent to the world
 func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return "user-ssh-key-agent", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
@@ -231,6 +232,10 @@ const (
 	// ApiserverNetworkPolicy enables the deployment of network policies that
 	// restrict the egress traffic from Apiserver pods.
 	ApiserverNetworkPolicy = "apiserverNetworkPolicy"
+
+	// KubeSystemNetworkPolicies enables the deployment of network policies to kube-system namespace that
+	// restrict traffic from all pods in the namespace
+	KubeSystemNetworkPolicies = "kubeSystemNetworkPolicies"
 )
 
 // ClusterConditionType is used to indicate the type of a cluster condition. For all condition

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -647,7 +647,9 @@ const (
 )
 
 const (
-	UserClusterMLANamespace        = "mla-system"
+	UserClusterMLANamespace = "mla-system"
+	MLAComponentName        = "mla"
+
 	PromtailServiceAccountName     = "promtail"
 	PromtailClusterRoleName        = "system:mla:promtail"
 	PromtailClusterRoleBindingName = "system:mla:promtail"

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -87,7 +87,7 @@ const (
 	DNSResolverServiceName = "dns-resolver"
 	// DNSResolverPodDisruptionBudetName is the name of the dns resolvers pdb
 	DNSResolverPodDisruptionBudetName = "dns-resolver"
-	// DNSResolverVPAName is the name of the dns resolvers VerticalPodAutoscaler
+	// KubeStateMetricsDeploymentName is the name of the kube-state-metrics deployment
 	KubeStateMetricsDeploymentName = "kube-state-metrics"
 	// UserClusterControllerDeploymentName is the name of the usercluster-controller deployment
 	UserClusterControllerDeploymentName = "usercluster-controller"

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -73,6 +73,7 @@ type userclusterControllerData interface {
 }
 
 // DeploymentCreator returns the function to create and update the user cluster controller deployment
+// nolint:gocyclo
 func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -163,6 +163,10 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				args = append(args, "-openvpn-server-port", fmt.Sprint(openvpnServerPort))
 			}
 
+			if data.Cluster().Spec.Features[kubermaticv1.ApiserverNetworkPolicy] {
+				args = append(args, "-enable-network-policies")
+			}
+
 			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
 				args = append(args, "-tunneling-agent-ip", data.Cluster().Address.IP)
 				args = append(args, "-kas-secure-port", fmt.Sprint(data.Cluster().Address.Port))

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -163,14 +163,6 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) error {
 		}
 	}
 
-	// Network policies for Apiserver are deployed by default
-	if _, ok := c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
-		if c.Spec.Features == nil {
-			c.Spec.Features = map[string]bool{}
-		}
-		c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] = true
-	}
-
 	if c.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled == nil {
 		c.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled = pointer.BoolPtr(true)
 	}
@@ -178,6 +170,21 @@ func (h *AdmissionHandler) applyDefaults(c *kubermaticv1.Cluster) error {
 	// Always enable external CCM
 	if c.Spec.Cloud.Anexia != nil || c.Spec.Cloud.Kubevirt != nil {
 		c.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] = true
+	}
+
+	// Ensure default enabled features
+	if c.Spec.Features == nil {
+		c.Spec.Features = map[string]bool{}
+	}
+
+	// Network policies for Apiserver are deployed by default
+	if _, ok := c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
+		c.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] = true
+	}
+
+	// Network policies for kube-system are deployed by default
+	if _, ok := c.Spec.Features[kubermaticv1.KubeSystemNetworkPolicies]; !ok {
+		c.Spec.Features[kubermaticv1.KubeSystemNetworkPolicies] = true
 	}
 
 	return nil

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -203,6 +203,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/prometheus/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
+				jsonpatch.NewOperation("add", "/spec/features/kubeSystemNetworkPolicies", true),
 			},
 		},
 		{
@@ -252,6 +253,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", resources.EBPFProxyMode),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", true),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
+				jsonpatch.NewOperation("add", "/spec/features/kubeSystemNetworkPolicies", true),
 			},
 		},
 		{
@@ -283,7 +285,8 @@ func TestHandle(t *testing.T) {
 								NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
 							},
 							Features: map[string]bool{
-								kubermaticv1.ApiserverNetworkPolicy: true,
+								kubermaticv1.ApiserverNetworkPolicy:    true,
+								kubermaticv1.KubeSystemNetworkPolicies: true,
 							},
 						}.Do(),
 					},
@@ -326,6 +329,7 @@ func TestHandle(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: []jsonpatch.JsonPatchOperation{
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
+				jsonpatch.NewOperation("add", "/spec/features/kubeSystemNetworkPolicies", true),
 			},
 		},
 		{
@@ -353,7 +357,8 @@ func TestHandle(t *testing.T) {
 								NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
 							},
 							Features: map[string]bool{
-								kubermaticv1.ApiserverNetworkPolicy: true,
+								kubermaticv1.ApiserverNetworkPolicy:    true,
+								kubermaticv1.KubeSystemNetworkPolicies: true,
 							},
 						}.Do(),
 					},
@@ -387,7 +392,8 @@ func TestHandle(t *testing.T) {
 								Version: "v3.19",
 							},
 							Features: map[string]bool{
-								kubermaticv1.ApiserverNetworkPolicy: true,
+								kubermaticv1.ApiserverNetworkPolicy:    true,
+								kubermaticv1.KubeSystemNetworkPolicies: true,
 							},
 						}.Do(),
 					},
@@ -422,7 +428,8 @@ func TestHandle(t *testing.T) {
 								Version: "v3.19",
 							},
 							Features: map[string]bool{
-								kubermaticv1.ApiserverNetworkPolicy: true,
+								kubermaticv1.ApiserverNetworkPolicy:    true,
+								kubermaticv1.KubeSystemNetworkPolicies: true,
 							},
 						}.Do(),
 					},
@@ -461,7 +468,8 @@ func TestHandle(t *testing.T) {
 								IPVS: &kubermaticv1.IPVSConfiguration{},
 							},
 							Features: map[string]bool{
-								kubermaticv1.ApiserverNetworkPolicy: true,
+								kubermaticv1.ApiserverNetworkPolicy:    true,
+								kubermaticv1.KubeSystemNetworkPolicies: true,
 							},
 						}.Do(),
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce network policies for user cluster in kube-system namespace

Fixes https://github.com/kubermatic/edgematic/issues/63

Done with: https://networkpolicy.io/

Feature can be disabled via feature flag **kubeSystemNetworkPolicies** at cluster spec. It is automatically added to new clusters, existing cluster won't be affected.


Attention: 
In case any custom applications are deployed to the user clusters kube-system namespace that need specific network access, a network policy needs to be added for that application to allow traffic other than dns.

```release-note
Deploy network policies with default deny to kube-system namespace in user cluster. Adding network policies for custom deployments in kube-system namespace maybe required.
```
