### PR TITLE
added support for multiple destinations for etcd backups controller

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -247,6 +247,7 @@ func createEtcdBackupController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.backupContainerImage,
 		ctrlCtx.versions,
 		ctrlCtx.runOptions.caBundle,
+		ctrlCtx.seedGetter,
 	)
 }
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -260,6 +260,9 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, back
 		if !ok {
 			return nil, errors.Errorf("can't find backup destination %q in Seed %q", backupConfig.Spec.Destination, seed.Name)
 		}
+		if destination.Credentials == nil {
+			return nil, errors.Errorf("credentials not set for backup destination %q in Seed %q", backupConfig.Spec.Destination, seed.Name)
+		}
 	}
 
 	if err := r.ensureSecrets(ctx, cluster); err != nil {

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -31,6 +31,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
@@ -85,6 +86,14 @@ const (
 	backupKeepCountEnvVarKey = "BACKUP_KEEP_COUNT"
 	// backupConfigEnvVarKey defines the environment variable key for the name of the backup configuration resource
 	backupConfigEnvVarKey = "BACKUP_CONFIG"
+	// accessKeyIdEnvVarKey defines the environment variable key for the backup credentials access key id
+	accessKeyIdEnvVarKey = "ACCESS_KEY_ID"
+	// secretAccessKeyEnvVarKey defines the environment variable key for the backup credentials secret access key
+	secretAccessKeyEnvVarKey = "SECRET_ACCESS_KEY"
+	// bucketNameEnvVarKey defines the environment variable key for the backup bucket name
+	bucketNameEnvVarKey = "BUCKET_NAME"
+	// backupEndpointEnvVarKey defines the environment variable key for the backup endpoint
+	backupEndpointEnvVarKey = "ENDPOINT"
 
 	// requeueAfter time after starting a job
 	// should be the time after which a started job will usually have completed
@@ -118,6 +127,7 @@ type Reconciler struct {
 	caBundle             resources.CABundle
 	recorder             record.EventRecorder
 	versions             kubermatic.Versions
+	seedGetter           provider.SeedGetter
 }
 
 // Add creates a new Backup controller that is responsible for
@@ -133,6 +143,7 @@ func Add(
 	backupContainerImage string,
 	versions kubermatic.Versions,
 	caBundle resources.CABundle,
+	seedGetter provider.SeedGetter,
 ) error {
 	log = log.Named(ControllerName)
 	client := mgr.GetClient()
@@ -157,6 +168,7 @@ func Add(
 		randStringGenerator: func() string {
 			return rand.String(10)
 		},
+		seedGetter: seedGetter,
 	}
 
 	ctrlOptions := controller.Options{
@@ -189,6 +201,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	seed, err := r.seedGetter()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	log = r.log.With("cluster", cluster.Name, "backupConfig", backupConfig.Name)
 
 	var suppressedError error
@@ -202,7 +219,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		r.versions,
 		kubermaticv1.ClusterConditionNone,
 		func() (*reconcile.Result, error) {
-			result, err := r.reconcile(ctx, log, backupConfig, cluster)
+			result, err := r.reconcile(ctx, log, backupConfig, cluster, seed)
 			if kerrors.IsConflict(err) {
 				// benign update conflict -- remember this so we can
 				// suppress log.Error and event generation below
@@ -232,7 +249,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return *result, err
 }
 
-func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) (*reconcile.Result, error) {
+	var destination *kubermaticv1.BackupDestination
+	if backupConfig.Spec.Destination != "" {
+		if seed.Spec.EtcdBackupRestore == nil {
+			return nil, errors.Errorf("can't find backup destination %q in Seed %q", backupConfig.Spec.Destination, seed.Name)
+		}
+		var ok bool
+		destination, ok = seed.Spec.EtcdBackupRestore.Destinations[backupConfig.Spec.Destination]
+		if !ok {
+			return nil, errors.Errorf("can't find backup destination %q in Seed %q", backupConfig.Spec.Destination, seed.Name)
+		}
+	}
+
 	if err := r.ensureSecrets(ctx, cluster); err != nil {
 		return nil, errors.Wrap(err, "failed to create backup secrets")
 	}
@@ -251,19 +280,19 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, back
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.startPendingBackupJobs(ctx, backupConfig, cluster); err != nil {
+	if nextReconcile, err = r.startPendingBackupJobs(ctx, backupConfig, cluster, destination); err != nil {
 		return errorReconcile, errors.Wrap(err, "failed to start pending and update running backups")
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.startPendingBackupDeleteJobs(ctx, backupConfig, cluster); err != nil {
+	if nextReconcile, err = r.startPendingBackupDeleteJobs(ctx, backupConfig, cluster, destination); err != nil {
 		return errorReconcile, errors.Wrap(err, "failed to start pending backup delete jobs")
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.updateRunningBackupDeleteJobs(ctx, backupConfig, cluster); err != nil {
+	if nextReconcile, err = r.updateRunningBackupDeleteJobs(ctx, backupConfig, cluster, destination); err != nil {
 		return errorReconcile, errors.Wrap(err, "failed to update running backup delete jobs")
 	}
 
@@ -275,7 +304,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, back
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.handleFinalization(ctx, backupConfig, cluster); err != nil {
+	if nextReconcile, err = r.handleFinalization(ctx, backupConfig, cluster, destination); err != nil {
 		return errorReconcile, errors.Wrap(err, "failed to delete finished backup jobs")
 	}
 
@@ -432,7 +461,8 @@ func (r *Reconciler) setBackupConfigCondition(backupConfig *kubermaticv1.EtcdBac
 
 // create any backup jobs that can be created, i.e. that don't exist yet while their scheduled time has arrived
 // also update status of backups whose jobs have completed
-func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
+	destination *kubermaticv1.BackupDestination) (*reconcile.Result, error) {
 	var returnReconcile *reconcile.Result
 
 	for i := range backupConfig.Status.CurrentBackups {
@@ -465,7 +495,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 				}
 
 			} else if backup.BackupPhase == "" && r.clock.Now().Sub(backup.ScheduledTime.Time) >= 0 && backupConfig.DeletionTimestamp == nil {
-				job := r.backupJob(backupConfig, cluster, backup)
+				job := r.backupJob(backupConfig, cluster, backup, destination)
 				if err := r.Create(ctx, job); err != nil && !kerrors.IsAlreadyExists(err) {
 					return nil, errors.Wrapf(err, "error creating job for backup %s", backup.BackupName)
 				}
@@ -484,7 +514,8 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 }
 
 // create any backup delete jobs that can be created, i.e. for all completed backups older than the last backupConfig.GetKeptBackupsCount() ones.
-func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
+	destination *kubermaticv1.BackupDestination) (*reconcile.Result, error) {
 	// one-shot backups are not deleted until their backupConfig is deleted
 	if backupConfig.Spec.Schedule == "" && backupConfig.DeletionTimestamp == nil {
 		return nil, nil
@@ -515,7 +546,7 @@ func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupCon
 	modified := false
 	for _, backup := range backupsToDelete {
 		if runningDeleteJobsCount < maxSimultaneousDeleteJobsPerConfig {
-			if err := r.createBackupDeleteJob(ctx, backupConfig, cluster, backup); err != nil {
+			if err := r.createBackupDeleteJob(ctx, backupConfig, cluster, backup, destination); err != nil {
 				return nil, err
 			}
 			runningDeleteJobsCount++
@@ -533,9 +564,10 @@ func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupCon
 	return nil, nil
 }
 
-func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backup *kubermaticv1.BackupStatus) error {
+func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backup *kubermaticv1.BackupStatus,
+	destination *kubermaticv1.BackupDestination) error {
 	if r.deleteContainer != nil {
-		job := r.backupDeleteJob(backupConfig, cluster, backup)
+		job := r.backupDeleteJob(backupConfig, cluster, backup, destination)
 		if err := r.Create(ctx, job); err != nil && !kerrors.IsAlreadyExists(err) {
 			return errors.Wrapf(err, "error creating delete job for backup %s", backup.BackupName)
 		}
@@ -549,7 +581,8 @@ func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *ku
 }
 
 // update status of all delete jobs that have completed and are still marked as running
-func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
+	destination *kubermaticv1.BackupDestination) (*reconcile.Result, error) {
 	var returnReconcile *reconcile.Result
 
 	// structs with the backup status and the DeleteMessage to set in case we restart the delete job
@@ -597,7 +630,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 
 	for _, deleteJobToRestart := range deleteJobsToRestart {
 		if runningDeleteJobsCount < maxSimultaneousDeleteJobsPerConfig {
-			if err := r.createBackupDeleteJob(ctx, backupConfig, cluster, deleteJobToRestart.backup); err != nil {
+			if err := r.createBackupDeleteJob(ctx, backupConfig, cluster, deleteJobToRestart.backup, destination); err != nil {
 				return nil, err
 			}
 			deleteJobToRestart.backup.DeleteMessage = deleteJobToRestart.deleteMessage
@@ -723,7 +756,8 @@ func (r *Reconciler) deleteFinishedBackupJobs(ctx context.Context, backupConfig 
 	return returnReconcile, nil
 }
 
-func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
+	destination *kubermaticv1.BackupDestination) (*reconcile.Result, error) {
 	if backupConfig.DeletionTimestamp == nil || len(backupConfig.Status.CurrentBackups) > 0 {
 		return nil, nil
 	}
@@ -737,7 +771,7 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 
 		if !backupConfig.Status.CleanupRunning {
 			// job not started before. start it
-			cleanupJob := r.cleanupJob(backupConfig, cluster, cleanupJobName)
+			cleanupJob := r.cleanupJob(backupConfig, cluster, cleanupJobName, destination)
 			if err := r.Create(ctx, cleanupJob); err != nil && !kerrors.IsAlreadyExists(err) {
 				return nil, errors.Wrapf(err, "error creating cleanup job (%v)", cleanupJobName)
 			}
@@ -759,7 +793,7 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 					if jobFailed {
 						// job failed, restart it.
 						canRemoveFinalizer = false
-						cleanupJob := r.cleanupJob(backupConfig, cluster, cleanupJobName)
+						cleanupJob := r.cleanupJob(backupConfig, cluster, cleanupJobName, destination)
 						if err := r.Create(ctx, cleanupJob); err != nil && !kerrors.IsAlreadyExists(err) {
 							return nil, errors.Wrapf(err, "error recreating cleanup job (%v)", cleanupJobName)
 						}
@@ -790,8 +824,24 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 	return returnReconcile, nil
 }
 
-func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus) *batchv1.Job {
+func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus,
+	destination *kubermaticv1.BackupDestination) *batchv1.Job {
 	storeContainer := r.storeContainer.DeepCopy()
+
+	// If destination is set, we need to set the credentials and backup bucket details to match the destination
+	if destination != nil {
+		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(accessKeyIdEnvVarKey, accessKeyIdEnvVarKey, destination))
+		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(secretAccessKeyEnvVarKey, secretAccessKeyEnvVarKey, destination))
+		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
+			Name:  bucketNameEnvVarKey,
+			Value: destination.BucketName,
+		})
+		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
+			Name:  backupEndpointEnvVarKey,
+			Value: destination.Endpoint,
+		})
+	}
+
 	storeContainer.Env = append(
 		storeContainer.Env,
 		corev1.EnvVar{
@@ -905,8 +955,47 @@ func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, clus
 	return job
 }
 
-func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus) *batchv1.Job {
+func setEnvVar(envVars []corev1.EnvVar, newEnvVar corev1.EnvVar) []corev1.EnvVar {
+	for i, envVar := range envVars {
+		if strings.EqualFold(envVar.Name, newEnvVar.Name) {
+			envVars[i] = newEnvVar
+			return envVars
+		}
+	}
+	envVars = append(envVars, newEnvVar)
+	return envVars
+}
+
+func genSecretEnvVar(name, key string, destination *kubermaticv1.BackupDestination) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: destination.Credentials.Name},
+				Key:                  key,
+			},
+		},
+	}
+}
+
+func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus,
+	destination *kubermaticv1.BackupDestination) *batchv1.Job {
 	deleteContainer := r.deleteContainer.DeepCopy()
+
+	// If destination is set, we need to set the credentials and backup bucket details to match the destination
+	if destination != nil {
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(accessKeyIdEnvVarKey, accessKeyIdEnvVarKey, destination))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(secretAccessKeyEnvVarKey, secretAccessKeyEnvVarKey, destination))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
+			Name:  bucketNameEnvVarKey,
+			Value: destination.BucketName,
+		})
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
+			Name:  backupEndpointEnvVarKey,
+			Value: destination.Endpoint,
+		})
+	}
+
 	deleteContainer.Env = append(
 		deleteContainer.Env,
 		corev1.EnvVar{
@@ -954,8 +1043,24 @@ func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig
 	return job
 }
 
-func (r *Reconciler) cleanupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, jobName string) *batchv1.Job {
+func (r *Reconciler) cleanupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, jobName string,
+	destination *kubermaticv1.BackupDestination) *batchv1.Job {
 	cleanupContainer := r.cleanupContainer.DeepCopy()
+
+	// If destination is set, we need to set the credentials and backup bucket details to match the destination
+	if destination != nil {
+		cleanupContainer.Env = setEnvVar(cleanupContainer.Env, genSecretEnvVar(accessKeyIdEnvVarKey, accessKeyIdEnvVarKey, destination))
+		cleanupContainer.Env = setEnvVar(cleanupContainer.Env, genSecretEnvVar(secretAccessKeyEnvVarKey, secretAccessKeyEnvVarKey, destination))
+		cleanupContainer.Env = setEnvVar(cleanupContainer.Env, corev1.EnvVar{
+			Name:  bucketNameEnvVarKey,
+			Value: destination.BucketName,
+		})
+		cleanupContainer.Env = setEnvVar(cleanupContainer.Env, corev1.EnvVar{
+			Name:  backupEndpointEnvVarKey,
+			Value: destination.Endpoint,
+		})
+	}
+
 	cleanupContainer.Env = append(
 		cleanupContainer.Env,
 		corev1.EnvVar{

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-test/deep"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -139,8 +140,11 @@ func genBackupJob(backupName string, jobName string) *batchv1.Job {
 		storeContainer: genStoreContainer(),
 		recorder:       record.NewFakeRecorder(10),
 		clock:          clock.RealClock{},
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return test.GenTestSeed(), nil
+		},
 	}
-	job := reconciler.backupJob(backupConfig, cluster, backup)
+	job := reconciler.backupJob(backupConfig, cluster, backup, nil)
 	job.ResourceVersion = "1"
 	// remove all env variables from the job so they're comparable against the
 	// ones we get from fake clusters during tests, where we strip the variables too
@@ -163,8 +167,11 @@ func genBackupDeleteJob(backupName string, jobName string) *batchv1.Job {
 		deleteContainer: genDeleteContainer(),
 		recorder:        record.NewFakeRecorder(10),
 		clock:           clock.RealClock{},
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return test.GenTestSeed(), nil
+		},
 	}
-	job := reconciler.backupDeleteJob(backupConfig, cluster, backup)
+	job := reconciler.backupDeleteJob(backupConfig, cluster, backup, nil)
 	job.ResourceVersion = "1"
 	// remove all env variables from the job so they're comparable against the
 	// ones we get from fake clusters during tests, where we strip the variables too
@@ -183,8 +190,11 @@ func genCleanupJob(jobName string) *batchv1.Job {
 		cleanupContainer: genCleanupContainer(),
 		recorder:         record.NewFakeRecorder(10),
 		clock:            clock.RealClock{},
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return test.GenTestSeed(), nil
+		},
 	}
-	job := reconciler.cleanupJob(backupConfig, cluster, jobName)
+	job := reconciler.cleanupJob(backupConfig, cluster, jobName, nil)
 	job.ResourceVersion = "1"
 	// remove all env variables from the job so they're comparable against the
 	// ones we get from fake clusters during tests, where we strip the variables too
@@ -429,6 +439,9 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 				recorder:            record.NewFakeRecorder(10),
 				clock:               clock,
 				randStringGenerator: constRandStringGenerator("xxxx"),
+				seedGetter: func() (*kubermaticv1.Seed, error) {
+					return test.GenTestSeed(), nil
+				},
 			}
 
 			reconcileAfter, err := reconciler.ensurePendingBackupIsScheduled(context.Background(), backupConfig, cluster)
@@ -624,9 +637,12 @@ func TestStartPendingBackupJobs(t *testing.T) {
 				storeContainer: genStoreContainer(),
 				recorder:       record.NewFakeRecorder(10),
 				clock:          clock,
+				seedGetter: func() (*kubermaticv1.Seed, error) {
+					return test.GenTestSeed(), nil
+				},
 			}
 
-			reconcileAfter, err := reconciler.startPendingBackupJobs(context.Background(), backupConfig, cluster)
+			reconcileAfter, err := reconciler.startPendingBackupJobs(context.Background(), backupConfig, cluster, nil)
 			if err != nil {
 				t.Fatalf("ensurePendingBackupIsScheduled returned an error: %v", err)
 			}
@@ -934,9 +950,12 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				deleteContainer: genDeleteContainer(),
 				recorder:        record.NewFakeRecorder(10),
 				clock:           clock,
+				seedGetter: func() (*kubermaticv1.Seed, error) {
+					return test.GenTestSeed(), nil
+				},
 			}
 
-			reconcileAfter, err := reconciler.startPendingBackupDeleteJobs(context.Background(), backupConfig, cluster)
+			reconcileAfter, err := reconciler.startPendingBackupDeleteJobs(context.Background(), backupConfig, cluster, nil)
 			if err != nil {
 				t.Fatalf("ensurePendingBackupIsScheduled returned an error: %v", err)
 			}
@@ -1197,9 +1216,12 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				deleteContainer: genDeleteContainer(),
 				recorder:        record.NewFakeRecorder(10),
 				clock:           clock,
+				seedGetter: func() (*kubermaticv1.Seed, error) {
+					return test.GenTestSeed(), nil
+				},
 			}
 
-			reconcileAfter, err := reconciler.updateRunningBackupDeleteJobs(context.Background(), backupConfig, cluster)
+			reconcileAfter, err := reconciler.updateRunningBackupDeleteJobs(context.Background(), backupConfig, cluster, nil)
 			if err != nil {
 				t.Fatalf("ensurePendingBackupIsScheduled returned an error: %v", err)
 			}
@@ -1490,6 +1512,9 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				deleteContainer: genDeleteContainer(),
 				recorder:        record.NewFakeRecorder(10),
 				clock:           clock,
+				seedGetter: func() (*kubermaticv1.Seed, error) {
+					return test.GenTestSeed(), nil
+				},
 			}
 
 			reconcileAfter, err := reconciler.deleteFinishedBackupJobs(context.Background(), backupConfig, cluster)
@@ -1803,6 +1828,9 @@ func TestFinalization(t *testing.T) {
 				recorder:        record.NewFakeRecorder(10),
 				clock:           clock,
 				caBundle:        certificates.NewFakeCABundle(),
+				seedGetter: func() (*kubermaticv1.Seed, error) {
+					return test.GenTestSeed(), nil
+				},
 			}
 			if tc.cleanupContainerDefined {
 				reconciler.cleanupContainer = genCleanupContainer()


### PR DESCRIPTION
**What this PR does / why we need it**:
added support for multiple destinations for etcd backups controller.

The backup, and backup cleanup/delete job containers are defined in:
https://github.com/kubermatic/kubermatic/tree/master/charts/kubermatic/static

They use hardcoded env Vars for the secret and configmap(both are one per Seed) from which to take the credentials, and bucket info. 
As we want to introduce multiple destinations, this doesnt work for us as we support multiple pairs of credentials and bucket details.

So the approach is that if the destination is set, it will change the env vars of the backup job for the credentials and backup bucket name and endpoint. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7939 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Etcd backups now support multiple destinations, which can be configured per Seed. If a destination is set for an EtcdBackupConfig, it will be used instead of the legacy `backup-s3` credentials secret and `s3-settings` backup bucket details. 
```
