### PR TITLE
Fix escaping of dots in user cluster dashboard

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.5.3
+version: 1.5.4
 appVersion: 8.1.2
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/dashboards/kubermatic/user-clusters.json
+++ b/charts/monitoring/grafana/dashboards/kubermatic/user-clusters.json
@@ -594,7 +594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count by (master_version) (count by (name, master_version) (label_replace(kubermatic_cluster_info{type=\"kubernetes\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\.[0-9]+).*\")))",
+          "expr": "count by (master_version) (count by (name, master_version) (label_replace(kubermatic_cluster_info{type=\"kubernetes\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\")))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ master_version }}",
@@ -782,7 +782,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "count by (master_version) (count by (name, master_version) (count by (name, master_version) (label_replace(kubermatic_cluster_info{type=\"openshift\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\.[0-9]+).*\"))))",
+          "expr": "count by (master_version) (count by (name, master_version) (count by (name, master_version) (label_replace(kubermatic_cluster_info{type=\"openshift\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\"))))",
           "instant": true,
           "legendFormat": "{{ master_version }}",
           "refId": "A"


### PR DESCRIPTION
**What this PR does / why we need it**:
The dots in the PromQL query of the panels 'Minor Releases' and 'Minor Release History' in the user cluster dashboard were not escaped with double backslashes and therefore no data could be displayed.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
