### PR TITLE
Fix OpenStack cloud initialization for subnets that are already attached to router

### DIFF
--- a/pkg/provider/cloud/aws/role_test.go
+++ b/pkg/provider/cloud/aws/role_test.go
@@ -78,7 +78,7 @@ func assertRolePolicies(t *testing.T, client iamiface.IAMAPI, roleName string, e
 		RoleName: aws.String(roleName),
 	})
 	if err != nil {
-		t.Errorf("Failed to list policies for role %q: %w", roleName, err)
+		t.Errorf("Failed to list policies for role %q: %v", roleName, err)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes cloud initialization at OpenStack when users use their own subnets that are already attached to router.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
