### PR TITLE
Extend DNS lookup timeout in apiserver network policy creator

### DIFF
--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -232,7 +232,7 @@ func OIDCIssuerAllowCreator(issuerURL string) reconciling.NamedNetworkPolicyCrea
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse OIDC issuer URL %s: %v", issuerURL, err)
 			}
-			ipList, err := lookupIPWithTimeout(u.Hostname(), 1*time.Second)
+			ipList, err := lookupIPWithTimeout(u.Hostname(), 5*time.Second)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve OIDC issuer hostname %s: %v", u.Hostname(), err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems that 1 second DNS lookup timeout is too short for some busy environments, where timeouts can be seen occasionally. This PR extends it a bit more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
