### PR TITLE
Reduce scope for user-ssh-keys-agent Role to name of secret

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/serviceaccount.go
@@ -17,6 +17,7 @@ limitations under the License.
 package usersshkeys
 
 import (
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,9 @@ func RoleCreator() reconciling.NamedRoleCreatorGetter {
 							"get",
 							"list",
 							"watch",
+						},
+						ResourceNames: []string{
+							resources.UserSSHKeys,
 						},
 					},
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

The user-ssh-keys-agent has an RBAC `Role` created for it to access the secret containing the user ssh keys. That Role had access to all `Secrets` in the `kube-system` namespace, which isn't necessary as the user-ssh-keys-agent hardcodes a secret name. This PR reduces the `Role` to only include that name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8248

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>