### PR TITLE
Etcd restore CRD support multiple destinations

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.21
+version: 0.3.22
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -85,6 +85,12 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              destination:
+                description: Destination indicates where the backup was stored. The
+                  destination name should correspond to a destination in the cluster's
+                  Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination
+                  configured in Seed.Spec.BackupRestore
+                type: string
               name:
                 description: Name defines the name of the restore The name of the
                   restore file in S3 will be <cluster>-<restore name> If a schedule

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -12780,6 +12780,13 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -12791,13 +12798,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
           }
         ],
         "responses": {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -12780,13 +12780,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -12798,6 +12791,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -28,13 +28,13 @@ const (
 	// EtcdRestoreKindName represents "Kind" defined in Kubernetes
 	EtcdRestoreKindName = "EtcdRestore"
 
-	// EtcdRestorePhase value indicating that the restore has started
+	// EtcdRestorePhaseStarted value indicating that the restore has started
 	EtcdRestorePhaseStarted EtcdRestorePhase = "Started"
 
-	// EtcdRestorePhase value indicating that the old Etcd statefulset has been deleted and is now rebuilding
+	// EtcdRestorePhaseStsRebuilding value indicating that the old Etcd statefulset has been deleted and is now rebuilding
 	EtcdRestorePhaseStsRebuilding EtcdRestorePhase = "StsRebuilding"
 
-	// EtcdRestorePhase value indicating that the old Etcd statefulset has completed successfully
+	// EtcdRestorePhaseCompleted value indicating that the old Etcd statefulset has completed successfully
 	EtcdRestorePhaseCompleted EtcdRestorePhase = "Completed"
 )
 
@@ -70,6 +70,9 @@ type EtcdRestoreSpec struct {
 	// BackupDownloadCredentialsSecret is the name of a secret in the cluster-xxx namespace containing
 	// credentials needed to download the backup
 	BackupDownloadCredentialsSecret string `json:"backupDownloadCredentialsSecret,omitempty"`
+	// Destination indicates where the backup was stored. The destination name should correspond to a destination in
+	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+	Destination string `json:"destination,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/crd/kubermatic/v1/etcd_restore.go
+++ b/pkg/crd/kubermatic/v1/etcd_restore.go
@@ -28,13 +28,13 @@ const (
 	// EtcdRestoreKindName represents "Kind" defined in Kubernetes
 	EtcdRestoreKindName = "EtcdRestore"
 
-	// EtcdRestorePhase value indicating that the restore has started
+	// EtcdRestorePhaseStarted value indicating that the restore has started
 	EtcdRestorePhaseStarted = "Started"
 
-	// EtcdRestorePhase value indicating that the old Etcd statefulset has been deleted and is now rebuilding
+	// EtcdRestorePhaseStsRebuilding value indicating that the old Etcd statefulset has been deleted and is now rebuilding
 	EtcdRestorePhaseStsRebuilding = "StsRebuilding"
 
-	// EtcdRestorePhase value indicating that the old Etcd statefulset has completed successfully
+	// EtcdRestorePhaseCompleted value indicating that the old Etcd statefulset has completed successfully
 	EtcdRestorePhaseCompleted = "Completed"
 )
 
@@ -66,6 +66,9 @@ type EtcdRestoreSpec struct {
 	// BackupDownloadCredentialsSecret is the name of a secret in the cluster-xxx namespace containing
 	// credentials needed to download the backup
 	BackupDownloadCredentialsSecret string `json:"backupDownloadCredentialsSecret,omitempty"`
+	// Destination indicates where the backup was stored. The destination name should correspond to a destination in
+	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+	Destination string `json:"destination,omitempty"`
 }
 
 // EtcdRestoreList is a list of etcd restores

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -863,6 +863,11 @@ func cloneEtcdRestoreResourcesInCluster(ctx context.Context, logger logrus.Field
 				BackupDownloadCredentialsSecret: oldObject.Spec.BackupDownloadCredentialsSecret,
 				BackupName:                      oldObject.Spec.BackupName,
 				Cluster:                         migrateObjectReference(oldObject.Spec.Cluster, ""),
+				Destination:                     oldObject.Spec.Destination,
+			},
+			Status: newv1.EtcdRestoreStatus{
+				Phase:       etcdRestoreStatusPhases[oldObject.Status.Phase],
+				RestoreTime: oldObject.Status.RestoreTime,
 			},
 		}
 
@@ -881,6 +886,12 @@ func cloneEtcdRestoreResourcesInCluster(ctx context.Context, logger logrus.Field
 	}
 
 	return len(oldObjects.Items), nil
+}
+
+var etcdRestoreStatusPhases = map[kubermaticv1.EtcdRestorePhase]newv1.EtcdRestorePhase{
+	kubermaticv1.EtcdRestorePhaseStarted:       newv1.EtcdRestorePhaseStarted,
+	kubermaticv1.EtcdRestorePhaseStsRebuilding: newv1.EtcdRestorePhaseStsRebuilding,
+	kubermaticv1.EtcdRestorePhaseCompleted:     newv1.EtcdRestorePhaseCompleted,
 }
 
 func cloneExternalClusterResourcesInCluster(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client) (int, error) {

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -865,10 +865,6 @@ func cloneEtcdRestoreResourcesInCluster(ctx context.Context, logger logrus.Field
 				Cluster:                         migrateObjectReference(oldObject.Spec.Cluster, ""),
 				Destination:                     oldObject.Spec.Destination,
 			},
-			Status: newv1.EtcdRestoreStatus{
-				Phase:       etcdRestoreStatusPhases[oldObject.Status.Phase],
-				RestoreTime: oldObject.Status.RestoreTime,
-			},
 		}
 
 		if err := ensureObject(ctx, client, &newObject, false); err != nil {
@@ -886,12 +882,6 @@ func cloneEtcdRestoreResourcesInCluster(ctx context.Context, logger logrus.Field
 	}
 
 	return len(oldObjects.Items), nil
-}
-
-var etcdRestoreStatusPhases = map[kubermaticv1.EtcdRestorePhase]newv1.EtcdRestorePhase{
-	kubermaticv1.EtcdRestorePhaseStarted:       newv1.EtcdRestorePhaseStarted,
-	kubermaticv1.EtcdRestorePhaseStsRebuilding: newv1.EtcdRestorePhaseStsRebuilding,
-	kubermaticv1.EtcdRestorePhaseCompleted:     newv1.EtcdRestorePhaseCompleted,
 }
 
 func cloneExternalClusterResourcesInCluster(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client) (int, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `Destination` field to EtcdRestores, so that the restore knows in which backup destination to look for the backup it needs to restore. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8303

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
