### PR TITLE
Fix IDP icons in Dex theme

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.6.0
+version: 1.6.1
 appVersion: v2.30.0
 description: Dex
 keywords:

--- a/charts/oauth/theme/styles.css
+++ b/charts/oauth/theme/styles.css
@@ -142,12 +142,6 @@
 	filter: invert(100%) !important;
 }
 
-.dex-btn-icon--oidc {
-	background-color: white;
-	background-image: url('../static/img/google-icon.svg');
-	background-size: 24px;
-}
-
 .dex-btn-text {
 	font-size: 16px;
 	font-weight: normal;


### PR DESCRIPTION
**What this PR does / why we need it**:
We accidentally created a rule for "OIDC" providers to use the Google icon, but this made all OIDC providers use the Google icon. We should just reconfigure our dev setup to use "google" as the connector in Dex, instead of "oidc". At that point, the built-in CSS rules by Dex will already take care of styling and our custom OIDC rule can be removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/kubermatic/issues/8312

**Special notes for your reviewer**: We have to switch connector name from "oidc" to "google" to display correct icon on our side.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix IDP icons in Dex theme.
```
