### PR TITLE
Support multi-arch builds for kubeletdnat-controller

### DIFF
--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -1,0 +1,36 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.io/golang:1.17.1 as builder
+
+# import the GOPROXY variable from Buildah via an arg and then use
+# that arg to define the environment variable later on
+ARG GOPROXY=
+ARG KUBERMATIC_EDITION=ce
+
+ENV GOPROXY=$GOPROXY
+ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
+
+WORKDIR /go/src/k8c.io/kubermatic
+COPY . .
+RUN make -C ./cmd/kubeletdnat-controller build
+
+FROM docker.io/alpine:3.13
+LABEL maintainer="support@kubermatic.com"
+
+RUN apk add -u iptables
+
+COPY --from=builder /go/src/k8c.io/kubermatic/cmd/kubeletdnat-controller/_build/kubeletdnat-controller /usr/local/bin/kubeletdnat-controller
+
+ENTRYPOINT ["/usr/local/bin/kubeletdnat-controller"]


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubeletdnat-controller` isn't built as a multi-arch image. Because of that, a user cluster with ARM-only nodes will fail to come up as `envoy-agent` cannot start. `kubeletdnat-controller` is the container image that breaks this Pod (https://github.com/kubermatic/kubermatic/blob/master/pkg/resources/resources.go#L586). This likely only affects the `Tunneling` expose strategy and might have flown under the radar because of that (ARM is already supported, sort of).

I've adapted the multiarch build strategy for `user-ssh-keys-agent`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8253

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>