### PR TITLE
Provide custom cache to user-ssh-keys-agent manager to fix cache RBAC issues

### DIFF
--- a/cmd/user-ssh-keys-agent/main.go
+++ b/cmd/user-ssh-keys-agent/main.go
@@ -55,7 +55,10 @@ func main() {
 	ctx := signals.SetupSignalHandler()
 	ctrlruntimelog.Log = ctrlruntimelog.NewDelegatingLogger(zapr.NewLogger(rawLog).WithName("controller_runtime"))
 
-	mgr, err := manager.New(cfg, manager.Options{Namespace: metav1.NamespaceSystem})
+	mgr, err := manager.New(cfg, manager.Options{
+		Namespace: metav1.NamespaceSystem,
+		NewCache:  usersshkeys.NewCacheFunc(),
+	})
 	if err != nil {
 		log.Fatalw("Failed creating user ssh key controller", zap.Error(err))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow-up to #8306. I didn't notice that the initial PR wasn't fully functional because SSH was working (but only because the keys are also passed to `MachineDeployments` for node creation), but `user-ssh-keys-agent` was throwing errors and crashed eventually:

```
E1130 11:06:41.079148    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:06:42.312727    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:06:45.091067    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:06:49.286159    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:07:01.790294    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:07:20.739232    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:07:53.255387    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1130 11:08:38.300238    3349 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
{"level":"fatal","time":"2021-11-30T11:08:41.054+0100","caller":"user-ssh-keys-agent/main.go:72","msg":"error occurred while running the controller manager","error":"failed to wait for usersshkeys-controller caches to sync: timed out waiting for cache to be synced"}
```

This PR fixes the cache for user-ssh-keys-agent by passing a custom `NewCacheFunc` to the manager, which allows targeting the one `Secret` we're interested in, and the cache will not fail anymore due to lack of permissions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up #8248

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
