### PR TITLE
Enable nginx-ingress chart migration in the installer, re-enable validating webhooks

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.0.2
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.3.1
+version: 1.3.2
 appVersion: 1.0.2
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -1,4 +1,25 @@
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/component: controller
+  minAvailable: 1
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -279,7 +300,7 @@ spec:
       app.kubernetes.io/name: nginx
       app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 10
   minReadySeconds: 0
   template:

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -245,6 +245,31 @@ subjects:
     name: nginx-ingress
     namespace: "default"
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller-admission
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: webhook
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/component: controller
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
 apiVersion: v1
 kind: Service
@@ -326,6 +351,9 @@ spec:
             - --election-id=ingress-controller-leader
             - --controller-class=k8s.io/ingress-nginx
             - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller
+            - --validating-webhook=:8443
+            - --validating-webhook-certificate=/usr/local/certificates/cert
+            - --validating-webhook-key=/usr/local/certificates/key
           securityContext: 
             capabilities:
               drop:
@@ -372,6 +400,13 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+            - name: webhook
+              containerPort: 8443
+              protocol: TCP
+          volumeMounts:
+            - name: webhook-cert
+              mountPath: /usr/local/certificates/
+              readOnly: true
           resources: 
             limits:
               cpu: 500m
@@ -398,6 +433,10 @@ spec:
             weight: 100
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 300
+      volumes:
+        - name: webhook-cert
+          secret:
+            secretName: nginx-ingress-admission
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-ingressclass.yaml
 # We don't support namespaced ingressClass yet
@@ -415,3 +454,257 @@ metadata:
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/validating-webhook.yaml
+# before changing this value, check the required kubernetes version
+# https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  name: nginx-ingress-admission
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io
+    matchPolicy: Equivalent
+    rules:
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        namespace: "default"
+        name: nginx-ingress-controller-admission
+        path: /networking/v1/ingresses
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  nginx-ingress-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-admission
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-admission
+    namespace: "default"
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-admission
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-admission
+    namespace: "default"
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nginx-ingress-admission-create
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: nginx-ingress-admission-create
+      labels:
+        helm.sh/chart: nginx-4.0.9
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "1.0.5"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: create
+          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          imagePullPolicy: IfNotPresent
+          args:
+            - create
+            - --host=nginx-ingress-controller-admission,nginx-ingress-controller-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
+            - --secret-name=nginx-ingress-admission
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: nginx-ingress-admission
+      nodeSelector: 
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nginx-ingress-admission-patch
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: nginx-ingress-admission-patch
+      labels:
+        helm.sh/chart: nginx-4.0.9
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "1.0.5"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: patch
+          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          imagePullPolicy: IfNotPresent
+          args:
+            - patch
+            - --webhook-name=nginx-ingress-admission
+            - --namespace=$(POD_NAMESPACE)
+            - --patch-mutating=false
+            - --secret-name=nginx-ingress-admission
+            - --patch-failure-policy=Fail
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: nginx-ingress-admission
+      nodeSelector: 
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -1,4 +1,25 @@
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/component: controller
+  minAvailable: 1
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -279,7 +300,7 @@ spec:
       app.kubernetes.io/name: nginx
       app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 10
   minReadySeconds: 0
   template:

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -245,6 +245,31 @@ subjects:
     name: nginx-ingress
     namespace: "default"
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller-admission
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: webhook
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/component: controller
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
 apiVersion: v1
 kind: Service
@@ -326,6 +351,9 @@ spec:
             - --election-id=ingress-controller-leader
             - --controller-class=k8s.io/ingress-nginx
             - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller
+            - --validating-webhook=:8443
+            - --validating-webhook-certificate=/usr/local/certificates/cert
+            - --validating-webhook-key=/usr/local/certificates/key
           securityContext: 
             capabilities:
               drop:
@@ -372,6 +400,13 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+            - name: webhook
+              containerPort: 8443
+              protocol: TCP
+          volumeMounts:
+            - name: webhook-cert
+              mountPath: /usr/local/certificates/
+              readOnly: true
           resources: 
             limits:
               cpu: 500m
@@ -398,6 +433,10 @@ spec:
             weight: 100
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 300
+      volumes:
+        - name: webhook-cert
+          secret:
+            secretName: nginx-ingress-admission
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-ingressclass.yaml
 # We don't support namespaced ingressClass yet
@@ -415,3 +454,257 @@ metadata:
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/validating-webhook.yaml
+# before changing this value, check the required kubernetes version
+# https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  name: nginx-ingress-admission
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io
+    matchPolicy: Equivalent
+    rules:
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        namespace: "default"
+        name: nginx-ingress-controller-admission
+        path: /networking/v1/ingresses
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  nginx-ingress-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-admission
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-admission
+    namespace: "default"
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-admission
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-admission
+    namespace: "default"
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nginx-ingress-admission-create
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: nginx-ingress-admission-create
+      labels:
+        helm.sh/chart: nginx-4.0.9
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "1.0.5"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: create
+          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          imagePullPolicy: IfNotPresent
+          args:
+            - create
+            - --host=nginx-ingress-controller-admission,nginx-ingress-controller-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
+            - --secret-name=nginx-ingress-admission
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: nginx-ingress-admission
+      nodeSelector: 
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nginx-ingress-admission-patch
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: nginx-ingress-admission-patch
+      labels:
+        helm.sh/chart: nginx-4.0.9
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "1.0.5"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: patch
+          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          imagePullPolicy: IfNotPresent
+          args:
+            - patch
+            - --webhook-name=nginx-ingress-admission
+            - --namespace=$(POD_NAMESPACE)
+            - --patch-mutating=false
+            - --secret-name=nginx-ingress-admission
+            - --patch-failure-policy=Fail
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: nginx-ingress-admission
+      nodeSelector: 
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -1,4 +1,25 @@
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/component: controller
+  minAvailable: 1
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -279,7 +300,7 @@ spec:
       app.kubernetes.io/name: nginx
       app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 10
   minReadySeconds: 0
   template:

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -245,6 +245,31 @@ subjects:
     name: nginx-ingress
     namespace: "default"
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller-admission
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: webhook
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/component: controller
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
 apiVersion: v1
 kind: Service
@@ -326,6 +351,9 @@ spec:
             - --election-id=ingress-controller-leader
             - --controller-class=k8s.io/ingress-nginx
             - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller
+            - --validating-webhook=:8443
+            - --validating-webhook-certificate=/usr/local/certificates/cert
+            - --validating-webhook-key=/usr/local/certificates/key
           securityContext: 
             capabilities:
               drop:
@@ -372,6 +400,13 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+            - name: webhook
+              containerPort: 8443
+              protocol: TCP
+          volumeMounts:
+            - name: webhook-cert
+              mountPath: /usr/local/certificates/
+              readOnly: true
           resources: 
             limits:
               cpu: 500m
@@ -398,6 +433,10 @@ spec:
             weight: 100
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 300
+      volumes:
+        - name: webhook-cert
+          secret:
+            secretName: nginx-ingress-admission
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-ingressclass.yaml
 # We don't support namespaced ingressClass yet
@@ -415,3 +454,257 @@ metadata:
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/validating-webhook.yaml
+# before changing this value, check the required kubernetes version
+# https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  name: nginx-ingress-admission
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io
+    matchPolicy: Equivalent
+    rules:
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        namespace: "default"
+        name: nginx-ingress-controller-admission
+        path: /networking/v1/ingresses
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  nginx-ingress-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-admission
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-admission
+    namespace: "default"
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-admission
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-admission
+    namespace: "default"
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nginx-ingress-admission-create
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: nginx-ingress-admission-create
+      labels:
+        helm.sh/chart: nginx-4.0.9
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "1.0.5"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: create
+          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          imagePullPolicy: IfNotPresent
+          args:
+            - create
+            - --host=nginx-ingress-controller-admission,nginx-ingress-controller-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
+            - --secret-name=nginx-ingress-admission
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: nginx-ingress-admission
+      nodeSelector: 
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+---
+# Source: nginx-ingress-controller/charts/nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nginx-ingress-admission-patch
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: nginx-ingress-admission-patch
+      labels:
+        helm.sh/chart: nginx-4.0.9
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "1.0.5"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: patch
+          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          imagePullPolicy: IfNotPresent
+          args:
+            - patch
+            - --webhook-name=nginx-ingress-admission
+            - --namespace=$(POD_NAMESPACE)
+            - --patch-mutating=false
+            - --secret-name=nginx-ingress-admission
+            - --patch-failure-policy=Fail
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: nginx-ingress-admission
+      nodeSelector: 
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -75,4 +75,4 @@ nginx:
     
     # Temporarily disable the admission webhooks
     admissionWebhooks:
-      enabled: false
+      enabled: true

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -19,7 +19,7 @@ nginx:
   # reference: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   controller:
     hostNetwork: false
-    replicas: 3
+    replicaCount: 3
     config: {}
   #   load-balance: "least_conn"
     extraArgs: {}

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -90,6 +90,10 @@ var (
 		Name:  "migrate-cert-manager",
 		Usage: "enable the migration for cert-manager CRDs from v1alpha2 to v1",
 	}
+	enableNginxIngressMigrationFlag = cli.BoolFlag{
+		Name:  "migrate-nginx-ingress",
+		Usage: "enable the migration procedure for nginx-ingress-controller (upgrade from v1.3.0+)",
+	}
 	migrateOpenstackCSIdriversFlag = cli.BoolFlag{
 		Name:  "migrate-openstack-csidrivers",
 		Usage: "(kubermatic-seed STACK only) enable the data migration of CSIDriver of openstack user-clusters",
@@ -120,6 +124,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) c
 			deployHelmBinaryFlag,
 			deployStorageClassFlag,
 			enableCertManagerV2MigrationFlag,
+			enableNginxIngressMigrationFlag,
 			migrateOpenstackCSIdriversFlag,
 			migrateLogrotateFlag,
 			disableTelemetryFlag,
@@ -201,6 +206,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			ForceHelmReleaseUpgrade:           ctx.Bool(deployForceFlag.Name),
 			ChartsDirectory:                   ctx.GlobalString(chartsDirectoryFlag.Name),
 			EnableCertManagerV2Migration:      ctx.Bool(enableCertManagerV2MigrationFlag.Name),
+			EnableNginxIngressMigration:       ctx.Bool(enableNginxIngressMigrationFlag.Name),
 			EnableOpenstackCSIDriverMigration: ctx.Bool(migrateOpenstackCSIdriversFlag.Name),
 			EnableLogrotateMigration:          ctx.Bool(migrateLogrotateFlag.Name),
 			DisableTelemetry:                  ctx.Bool(disableTelemetryFlag.Name),

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -64,7 +64,7 @@ func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kub
 
 	if release != nil && release.Version.LessThan(v13) && !chart.Version.LessThan(v13) {
 		if !opt.EnableNginxIngressMigration {
-			sublogger.Warn("To upgrade nginx-ingress-controller to a new version, installer")
+			sublogger.Warn("To upgrade nginx-ingress-controller to a new version, the installer")
 			sublogger.Warn("will remove the old deployment object before proceeding with the upgrade.")
 			sublogger.Warn("Rerun the installer with --migrate-nginx-ingress to enable the migration process.")
 			sublogger.Warn("Please refer to the KKP 2.19 upgrade notes for more information.")
@@ -189,7 +189,7 @@ func waitForNginxIngressWebhook(
 	}
 
 	var lastCreateErr error
-	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
 		lastCreateErr = kubeClient.Create(ctx, dummyIngress)
 		return lastCreateErr == nil, nil
 	})

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubermaticmaster
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/sirupsen/logrus"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
+	"k8c.io/kubermatic/v2/pkg/install/stack"
+	"k8c.io/kubermatic/v2/pkg/install/util"
+	"k8c.io/kubermatic/v2/pkg/log"
+	networkingv1 "k8s.io/api/networking/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	logger.Info("📦 Deploying nginx-ingress-controller…")
+	sublogger := log.Prefix(logger, "   ")
+
+	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "nginx-ingress-controller"))
+	if err != nil {
+		return fmt.Errorf("failed to load Helm chart: %v", err)
+	}
+
+	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, NginxIngressControllerNamespace); err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, NginxIngressControllerNamespace, NginxIngressControllerReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to check to Helm release: %v", err)
+	}
+
+	// if version older than 1.3.0 is installed, we must perform a migration
+	// by deleting the old deployment object for the controller
+	v13 := semver.MustParse("1.3.0")
+	backupTS := time.Now().Format("2006-01-02T150405")
+
+	if release != nil && release.Version.LessThan(v13) && !chart.Version.LessThan(v13) {
+		if !opt.EnableNginxIngressMigration {
+			sublogger.Warn("To upgrade nginx-ingress-controller to a new version, installer")
+			sublogger.Warn("will remove the old deployment object before proceeding with the upgrade.")
+			sublogger.Warn("Rerun the installer with --migrate-nginx-ingress to enable the migration process.")
+			sublogger.Warn("Please refer to the KKP 2.19 upgrade notes for more information.")
+
+			return fmt.Errorf("user must acknowledge the migration using --migrate-nginx-ingress")
+		}
+
+		err = upgradeNginxIngress(ctx, sublogger, kubeClient, helmClient, opt, chart, release, backupTS)
+		if err != nil {
+			return fmt.Errorf("failed to upgrade nginx-ingress-controller: %v", err)
+		}
+
+	}
+
+	// do not perform an atomic installation, as this will make Helm wait for the LoadBalancer to
+	// get an IP and this can require manual intervention based on the target environment
+	sublogger.Info("Deploying Helm chart...")
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, NginxIngressControllerNamespace, NginxIngressControllerReleaseName, opt.HelmValues, false, opt.ForceHelmReleaseUpgrade, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	}
+
+	if err := waitForNginxIngressWebhook(ctx, sublogger, kubeClient, helmClient, opt); err != nil {
+		return fmt.Errorf("failed to verify that the webhook is functioning: %v", err)
+	}
+
+	logger.Info("✅ Success.")
+
+	return nil
+}
+
+func upgradeNginxIngress(
+	ctx context.Context,
+	logger *logrus.Entry,
+	kubeClient ctrlruntimeclient.Client,
+	helmClient helm.Client,
+	opt stack.DeployOptions,
+	chart *helm.Chart,
+	release *helm.Release,
+	backupTS string,
+) error {
+	logger.Infof("%s: %s detected, performing upgrade to %s…", release.Name, release.Version.String(), chart.Version.String())
+	// 1: find the old deployment
+	logger.Info("Backing up old ingress deployment...")
+	deploymentsList := &unstructured.UnstructuredList{}
+	deploymentsList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps",
+		Kind:    "DeploymentList",
+		Version: "v1",
+	})
+
+	if err := kubeClient.List(ctx, deploymentsList, client.InNamespace(NginxIngressControllerNamespace), client.MatchingLabels{
+		"app.kubernetes.io/name":       "ingress-nginx",
+		"app.kubernetes.io/managed-by": "Helm",
+		"app.kubernetes.io/instance":   release.Name,
+	}); err != nil {
+		logger.Warn("Error querying API for the existing deployment, attempting to upgrade without removing it...")
+	} else {
+		logger.Info("attempting to store the deployment")
+		// 2: store the deployment for backup
+		// There can be only one...
+		if len(deploymentsList.Items) == 1 {
+			filename := fmt.Sprintf("backup_%s_%s.yaml", NginxIngressControllerReleaseName, backupTS)
+			if err := util.DumpResources(ctx, filename, deploymentsList.Items); err != nil {
+				return fmt.Errorf("failed to back up the deployment: %v", err)
+			}
+
+			// 3: delete the deployment
+			logger.Info("Deleting the deployment from the cluster")
+			if err := kubeClient.Delete(ctx, &deploymentsList.Items[0]); err != nil {
+				return fmt.Errorf("failed to remove the deployment: %v\n\nuse backup file: %s to check the changes and restore if needed", err, filename)
+			}
+
+		} else {
+			return fmt.Errorf("found more than one deployment (%d) matching the nginx-ingress-controller release, stopping upgrade...", len(deploymentsList.Items))
+		}
+	}
+	return nil
+}
+
+func waitForNginxIngressWebhook(
+	ctx context.Context,
+	logger *logrus.Entry,
+	kubeClient ctrlruntimeclient.Client,
+	helmClient helm.Client,
+	opt stack.DeployOptions,
+) error {
+	ingressName := "kubermatic-installer-test"
+	ingressClassName := "nginx"
+
+	// delete any leftovers from previous installer runs
+	if err := deleteIngress(ctx, kubeClient, NginxIngressControllerNamespace, ingressName); err != nil {
+		return fmt.Errorf("failed to prepare webhook: %v", err)
+	}
+
+	// always clean up on a best-effort basis
+	defer func() {
+		// it can take a moment for the cert to appear
+		time.Sleep(3 * time.Second)
+
+		if err := deleteIngress(ctx, kubeClient, NginxIngressControllerNamespace, ingressName); err != nil {
+			logger.Warnf("Failed to clean up: %v", err)
+		}
+	}()
+
+	// create an Ingress object to check if the webhook is responsive
+	dummyIngress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: NginxIngressControllerNamespace,
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingressClassName,
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: NginxIngressControllerReleaseName,
+					Port: networkingv1.ServiceBackendPort{
+						Name: "http",
+					},
+				},
+			},
+		},
+	}
+
+	var lastCreateErr error
+	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		lastCreateErr = kubeClient.Create(ctx, dummyIngress)
+		return lastCreateErr == nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for webhook to become ready: %v", lastCreateErr)
+	}
+
+	return nil
+}
+
+func deleteIngress(ctx context.Context, kubeClient ctrlruntimeclient.Client, namespace string, name string) error {
+	ingress := &networkingv1.Ingress{}
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	if err := kubeClient.Get(ctx, key, ingress); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to probe for leftover test ingress: %v", err)
+	}
+
+	if err := kubeClient.Delete(ctx, ingress); err != nil {
+		return fmt.Errorf("failed to delete test ingress: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -194,35 +194,6 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	return nil
 }
 
-func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
-	logger.Info("📦 Deploying nginx-ingress-controller…")
-	sublogger := log.Prefix(logger, "   ")
-
-	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "nginx-ingress-controller"))
-	if err != nil {
-		return fmt.Errorf("failed to load Helm chart: %v", err)
-	}
-
-	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, NginxIngressControllerNamespace); err != nil {
-		return fmt.Errorf("failed to create namespace: %v", err)
-	}
-
-	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, NginxIngressControllerNamespace, NginxIngressControllerReleaseName)
-	if err != nil {
-		return fmt.Errorf("failed to check to Helm release: %v", err)
-	}
-
-	// do not perform an atomic installation, as this will make Helm wait for the LoadBalancer to
-	// get an IP and this can require manual intervention based on the target environment
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, NginxIngressControllerNamespace, NginxIngressControllerReleaseName, opt.HelmValues, false, opt.ForceHelmReleaseUpgrade, release); err != nil {
-		return fmt.Errorf("failed to deploy Helm release: %v", err)
-	}
-
-	logger.Info("✅ Success.")
-
-	return nil
-}
-
 func deployDex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
 	logger.Info("📦 Deploying Dex…")
 	sublogger := log.Prefix(logger, "   ")

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -40,6 +40,7 @@ type DeployOptions struct {
 	ChartsDirectory                   string
 	Logger                            *logrus.Entry
 	EnableCertManagerV2Migration      bool
+	EnableNginxIngressMigration       bool
 	EnableOpenstackCSIDriverMigration bool
 	EnableLogrotateMigration          bool
 	DisableTelemetry                  bool


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables migration required for upgrade of nginx-ingress in KKP 2.19+. It also re-enables the validation webhook by default in the Chart's configuration
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8295 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: When upgrading from older KKP versions, additional flag --migrate-upstream-nginx-ingress is required to perform upgrade of nginx-ingress-controller. Ingress will be briefly unavailable during this process.
```
