### PR TITLE
Default service account token mount

### DIFF
--- a/pkg/controller/seed-controller-manager/update/update_controller.go
+++ b/pkg/controller/seed-controller-manager/update/update_controller.go
@@ -29,6 +29,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -161,7 +162,7 @@ func (r *Reconciler) nodeUpdate(ctx context.Context, cluster *kubermaticv1.Clust
 
 	machineDeployments := &clusterv1alpha1.MachineDeploymentList{}
 	// Kubermatic only creates MachineDeployments in the kube-system namespace, everything else is essentially unsupported
-	if err := c.List(ctx, machineDeployments, ctrlruntimeclient.InNamespace("kube-system")); err != nil {
+	if err := c.List(ctx, machineDeployments, ctrlruntimeclient.InNamespace(resources.KubeSystemNamespaceName)); err != nil {
 		return fmt.Errorf("failed to list MachineDeployments: %v", err)
 	}
 

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -96,7 +96,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 
 		md.Spec.Template.Spec.ConfigSource = &corev1.NodeConfigSource{
 			ConfigMap: &corev1.ConfigMapNodeConfigSource{
-				Namespace:        "kube-system",
+				Namespace:        resources.KubeSystemNamespaceName,
 				Name:             fmt.Sprintf("kubelet-config-%d.%d", kubeletVersion.Major(), kubeletVersion.Minor()),
 				KubeletConfigKey: "kubelet",
 			},

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -243,6 +243,11 @@ const (
 	// CloudControllerManagerRoleBindingName is the name for the cloud controller manager rolebinding.
 	CloudControllerManagerRoleBindingName = "cloud-controller-manager"
 
+	// DefaultServiceAccountName is the name of Kubernetes default service accounts
+	DefaultServiceAccountName = "default"
+	// KubeSystemNamespaceName is the name of Kubernetes kube-system namespace
+	KubeSystemNamespaceName = "kube-system"
+
 	// MachineControllerCertUsername is the name of the user coming from kubeconfig cert
 	MachineControllerCertUsername = "machine-controller"
 	// KubeStateMetricsCertUsername is the name of the user coming from kubeconfig cert


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets automountServiceAccountToken to false for default service accounts in user cluster namespaces provided by KKP


Fixes #https://github.com/kubermatic/edgematic/issues/61

```release-note
[ACTION REQUIRED] Set the default Service Accounts automountServiceAccountToken property to false for all KKP provided namespaces and kube-system.
```
