### PR TITLE
Explicitly set metrics-server service type to ClusterIP in Konnectivity setup

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/service.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/service.go
@@ -30,8 +30,9 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 			se.Name = resources.MetricsServerServiceName
 			labels := resources.BaseAppLabels(resources.MetricsServerDeploymentName, nil)
 			se.Labels = labels
-
 			se.Spec.Selector = labels
+
+			se.Spec.Type = corev1.ServiceTypeClusterIP
 			se.Spec.Ports = []corev1.ServicePort{
 				{
 					Port:       443,


### PR DESCRIPTION
**What this PR does / why we need it**:
Explicitly set user cluster metrics-server service type to `ClusterIP`.

This service is used only in Konnectivity setup. This change enables the switch from the OpenVPN setup which uses `ExtrenalService` service type with the same name for the metrics-server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
