### PR TITLE
Add ProviderName to CloudSpec, so we can have it as a printer column

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.34
+version: 0.3.35
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/crd-clusters.yaml
+++ b/charts/kubermatic-operator/crd/crd-clusters.yaml
@@ -53,6 +53,12 @@ spec:
       - jsonPath: .spec.version
         name: Version
         type: string
+      - jsonPath: .spec.cloud.providerName
+        name: Provider
+        type: string
+      - jsonPath: .spec.cloud.dc
+        name: Datacenter
+        type: string
       - jsonPath: .spec.pause
         name: Paused
         type: boolean

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -19661,6 +19661,11 @@
         "packet": {
           "$ref": "#/definitions/PacketCloudSpec"
         },
+        "providerName": {
+          "description": "ProviderName is the name of the cloud provider used for this cluster.\nThis must match the given provider spec (e.g. if the providerName is\n\"aws\", then the AWSCloudSpec must be set)",
+          "type": "string",
+          "x-go-name": "ProviderName"
+        },
         "vsphere": {
           "$ref": "#/definitions/VSphereCloudSpec"
         }

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -580,6 +580,11 @@ type CloudSpec struct {
 	// DatacenterName where the users 'cloud' lives in.
 	DatacenterName string `json:"dc"`
 
+	// ProviderName is the name of the cloud provider used for this cluster.
+	// This must match the given provider spec (e.g. if the providerName is
+	// "aws", then the AWSCloudSpec must be set)
+	ProviderName string `json:"providerName"`
+
 	Fake         *FakeCloudSpec         `json:"fake,omitempty"`
 	Digitalocean *DigitaloceanCloudSpec `json:"digitalocean,omitempty"`
 	BringYourOwn *BringYourOwnCloudSpec `json:"bringyourown,omitempty"`

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -106,6 +106,14 @@ func DefaultClusterSpec(spec *kubermaticv1.ClusterSpec, template *kubermaticv1.C
 		spec.UsePodSecurityPolicyAdmissionPlugin = true
 	}
 
+	// Ensure provider name matches the given spec
+	providerName, err := provider.ClusterCloudProviderName(spec.Cloud)
+	if err != nil {
+		return fmt.Errorf("failed to determine cloud provider: %w", err)
+	}
+
+	spec.Cloud.ProviderName = providerName
+
 	// Add default CNI plugin settings if not present.
 	if spec.CNIPlugin == nil {
 		spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -84,7 +84,7 @@ func ValidateKubernetesToken(token string) error {
 }
 
 func ValidateSecretKeySelector(selector *providerconfig.GlobalSecretKeySelector, key string) error {
-	if selector.Name == "" || selector.Namespace == "" || key == "" {
+	if selector == nil || selector.Name == "" || selector.Namespace == "" || key == "" {
 		return fmt.Errorf("%q cannot be empty", key)
 	}
 	return nil

--- a/pkg/test/e2e/utils/apiclient/models/cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/cloud_spec.go
@@ -21,6 +21,11 @@ type CloudSpec struct {
 	// DatacenterName where the users 'cloud' lives in.
 	DatacenterName string `json:"dc,omitempty"`
 
+	// ProviderName is the name of the cloud provider used for this cluster.
+	// This must match the given provider spec (e.g. if the providerName is
+	// "aws", then the AWSCloudSpec must be set)
+	ProviderName string `json:"providerName,omitempty"`
+
 	// alibaba
 	Alibaba *AlibabaCloudSpec `json:"alibaba,omitempty"`
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -331,6 +331,20 @@ func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter,
 		allErrs = append(allErrs, field.Required(parentFieldPath.Child("dc"), "no node datacenter specified"))
 	}
 
+	providerName, err := provider.ClusterCloudProviderName(spec)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(parentFieldPath, "<redacted>", err.Error()))
+	}
+
+	// if this field is set, it must match the given provider;
+	// if the field is not set, the mutation webhook will fill it in
+	if spec.ProviderName != "" {
+		if spec.ProviderName != providerName {
+			msg := fmt.Sprintf("expected providerName to be %q", providerName)
+			allErrs = append(allErrs, field.Invalid(parentFieldPath.Child("providerName"), spec.ProviderName, msg))
+		}
+	}
+
 	if dc != nil {
 		clusterCloudProvider, err := provider.ClusterCloudProviderName(spec)
 		if err != nil {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -120,6 +120,36 @@ func TestValidateCloudSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "valid provider name",
+			valid: true,
+			spec: kubermaticv1.CloudSpec{
+				DatacenterName: "some-datacenter",
+				ProviderName:   "openstack",
+				Openstack: &kubermaticv1.OpenstackCloudSpec{
+					Tenant:         "some-tenant",
+					Username:       "some-user",
+					Password:       "some-password",
+					Domain:         "some-domain",
+					FloatingIPPool: "some-network",
+				},
+			},
+		},
+		{
+			name:  "invalid provider name",
+			valid: false,
+			spec: kubermaticv1.CloudSpec{
+				DatacenterName: "some-datacenter",
+				ProviderName:   "closedstack",
+				Openstack: &kubermaticv1.OpenstackCloudSpec{
+					Tenant:         "some-tenant",
+					Username:       "some-user",
+					Password:       "some-password",
+					Domain:         "some-domain",
+					FloatingIPPool: "some-network",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes new columns appear in the `kubectl` output:

![screenshot-2021-12-03-084843](https://user-images.githubusercontent.com/127499/144567129-b7a2e034-f86b-4546-bbb3-4f048891029a.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8281

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
`kubectl get clusters` now shows the cloud provider and datacenter name
```
