### PR TITLE
Run Konnectivity agent in HA mode + misc Konnectivity improvements

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -853,7 +853,10 @@ func (r *reconciler) reconcilePodDisruptionBudgets(ctx context.Context) error {
 		}
 	}
 	if r.isKonnectivityEnabled {
-		creators = append(creators, metricsserver.PodDisruptionBudgetCreator())
+		creators = append(creators,
+			konnectivity.PodDisruptionBudgetCreator(),
+			metricsserver.PodDisruptionBudgetCreator(),
+		)
 	}
 	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %v", err)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -367,6 +367,8 @@ const (
 
 	// RegistryK8SGCR defines the kubernetes specific docker registry at google
 	RegistryK8SGCR = "k8s.gcr.io"
+	// RegistryEUGCR defines the docker registry at google EU
+	RegistryEUGCR = "eu.gcr.io"
 	// RegistryUSGCR defines the docker registry at google US
 	RegistryUSGCR = "us.gcr.io"
 	// RegistryGCR defines the kubernetes docker registry at google
@@ -702,16 +704,15 @@ alertmanager_config: |
 	KonnectivityClusterRoleBindingUsername = "system:konnectivity-server"
 	KonnectivityServiceAccountName         = "system-konnectivity-agent"
 	KonnectivityAgentContainer             = "konnectivity-agent"
+	KonnectivityServerContainer            = "konnectivity-server"
 	KonnectivityAgentToken                 = "system-konnectivity-agent-token"
 	KonnectivityProxyServiceName           = "konnectivity-server"
 	KonnectivityProxyTLSSecretName         = "konnectivityproxy-tls"
 	KonnectivityKubeconfigSecretName       = "konnectivity-kubeconfig"
 	KonnectivityServerConf                 = "konnectivity-server.conf"
-	KonnectivityStolenAgentTokenSecretName = "stolen-agent-ca"
-	KonnectivityStolenAgentTokenNameCert   = "agentca.crt"
-	KonnectivityStolenAgentTokenNameToken  = "agenttoken.txt"
 	KonnectivityKubeApiserverEgress        = "kube-apiserver-egress"
 	KonnectivityUDS                        = "konnectivity-uds"
+	KonnectivityPodDisruptionBudgetName    = "konnectivity-agent"
 )
 
 // List of allowed TLS cipher suites


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains various enhancements for the Konnectivity deployment:
 - runs Konnectivity agent in HA mode (2 replicas), with node anti-affinity and podDisruptionBudget,
 - updates the version to the latest release (`v0.0.26`) and pulls images from the EU registry by default,
 - lowers log verbosity for the agent and the server,
 - sets resource requests & limits for the agent and server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8313 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
