### PR TITLE
[release/v2.18] Fix CNI reconciliation issue after upgrade to k8s 1.22

### DIFF
--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -169,7 +169,9 @@ func validateUpdateImmutability(c, oldC *kubermaticv1.Cluster) field.ErrorList {
 			*oldC.Spec.CNIPlugin,
 			specFldPath.Child("cniPlugin"),
 		)...)
-	} else {
+	} else if oldC.Spec.CNIPlugin != nil {
+		// If there was no CNI setting, we allow the initial mutation to happen.
+		// Otherwise, the mutation is denied.
 		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
 			c.Spec.CNIPlugin,
 			oldC.Spec.CNIPlugin,


### PR DESCRIPTION
**What this PR does / why we need it**:
User clusters started before upgrading KKP version to 2.18 run Canal CNI version 3.8. This version is not compatible with Kubernetes version 1.22 and above. This PR allows upgrading CNI in such clusters (`cluster.Spec.CNIPlugin == nil`) and automatically upgrades the Canal CNI to v3.19 upon Kubernets version upgrade to >= 1.22.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8393 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix CNI reconciliation issue after upgrade to k8s 1.22. For clusters running Canal v3.8, automatically upgrade Canal CNI version to v3.19 upon k8s upgrade to version >= 1.22.
```
