### PR TITLE
figure out weather to use https or http for minio access

### DIFF
--- a/pkg/ee/metering/report_handler.go
+++ b/pkg/ee/metering/report_handler.go
@@ -177,12 +177,18 @@ func getS3DataFromSeed(ctx context.Context, seedClient ctrlruntimeclient.Client)
 	s3accessKeyID := string(s3.Data[AccessKey])
 	s3secretAccessKey := string(s3.Data[SecretKey])
 
-	s3endpoint = strings.Replace(s3endpoint, "https://", "", 1)
-	s3endpoint = strings.Replace(s3endpoint, "http://", "", 1)
+	secure := true
+
+	if strings.Contains(s3endpoint, "https://") {
+		s3endpoint = strings.Replace(s3endpoint, "https://", "", 1)
+	} else if strings.Contains(s3endpoint, "http://") {
+		s3endpoint = strings.Replace(s3endpoint, "http://", "", 1)
+		secure = false
+	}
 
 	mc, err := minio.New(s3endpoint, &minio.Options{
 		Creds:  minioCredentials.NewStaticV4(s3accessKeyID, s3secretAccessKey, ""),
-		Secure: true,
+		Secure: secure,
 	})
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses http or https prefix to figure out the connection type. If not set, by default uses https but gives the option to the user by configuring the url with http.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubermatic/metering/issues/79

```release-note
NONE
```
