### PR TITLE
Fix flaky admin api e2e test

### DIFF
--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -67,7 +67,7 @@ func Add(
 
 	for seedName, seedManager := range seedManagers {
 		// skip case when master/seed is on the same cluster as we could have races
-		if !strings.EqualFold(seedManager.GetConfig().Host, masterManager.GetConfig().Host) {
+		if seedManager.GetConfig() != nil && masterManager.GetConfig() != nil && !strings.EqualFold(seedManager.GetConfig().Host, masterManager.GetConfig().Host) {
 			r.seedClients[seedName] = seedManager.GetClient()
 		}
 	}

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -85,11 +85,10 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			r := &reconciler{
-				log:             kubermaticlog.Logger,
-				recorder:        &record.FakeRecorder{},
-				masterClient:    tc.masterClient,
-				masterAPIReader: tc.masterClient,
-				seedClients:     map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: tc.masterClient,
+				seedClients:  map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -85,10 +85,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			r := &reconciler{
-				log:          kubermaticlog.Logger,
-				recorder:     &record.FakeRecorder{},
-				masterClient: tc.masterClient,
-				seedClients:  map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+				log:             kubermaticlog.Logger,
+				recorder:        &record.FakeRecorder{},
+				masterClient:    tc.masterClient,
+				masterAPIReader: tc.masterClient,
+				seedClients:     map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Tries to fix the flaky api e2e test: TestUpdateProjectByAdmin/admin_can_update_other_users_projects.

It turns out that the test was flaky because there is a race when updating Projects. 

In the case of master/seed being on the same cluster, it is possible that a race happens when updating Projects in which the project-synchronizer overwrites the update with its cache state. This happens because we sync the Project on different Seed clusters, and for that we reconcile a Project without resourceVersion set.

Because the Master cluster is also a Seed cluster, it also gets updated. If the reconcile happens before the cache is refreshed, the project update gets overwritten with the cached state. 

For now fixing it with the project-sync skipping the master cluster client in its seed-clients map.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
