### PR TITLE
Remove dns-resolver deployment and custom dnsConfig in Konnectivity setup

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -315,7 +315,8 @@ func createMonitoringController(ctrlCtx *controllerContext) error {
 		ctrlCtx.dockerPullConfigJSON,
 		ctrlCtx.runOptions.concurrentClusterUpdate,
 		monitoring.Features{
-			VPA: ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),
+			VPA:          ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),
+			Konnectivity: ctrlCtx.runOptions.featureGates.Enabled(features.KonnectivityService),
 		},
 		ctrlCtx.versions,
 	)

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -59,7 +59,8 @@ type userClusterConnectionProvider interface {
 
 // Features describes the enabled features for the monitoring controller
 type Features struct {
-	VPA bool
+	VPA          bool
+	Konnectivity bool
 }
 
 // Reconciler stores all components required for monitoring

--- a/pkg/controller/seed-controller-manager/monitoring/resources.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources.go
@@ -47,6 +47,9 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
 	}
 
+	// Konnectivity is enabled if the feature gate is enabled and the cluster flag is enabled as well
+	konnectivityEnabled := r.features.Konnectivity && cluster.Spec.ClusterNetwork.KonnectivityEnabled != nil && *cluster.Spec.ClusterNetwork.KonnectivityEnabled
+
 	return resources.NewTemplateDataBuilder().
 		WithContext(ctx).
 		WithClient(client).
@@ -60,6 +63,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		WithEtcdDiskSize(resource.Quantity{}).
 		WithBackupPeriod(20 * time.Minute).
 		WithVersions(r.versions).
+		WithKonnectivityEnabled(konnectivityEnabled).
 		Build(), nil
 }
 

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -90,11 +90,17 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 			etcdEndpoints := etcd.GetClientEndpoints(data.Cluster().Status.NamespaceName)
 
-			// Configure user cluster DNS resolver for this pod.
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
+
 			dep.Spec.Template.Spec.Volumes = volumes
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				etcdrunning.Container(etcdEndpoints, data),

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -90,15 +90,9 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 			etcdEndpoints := etcd.GetClientEndpoints(data.Cluster().Status.NamespaceName)
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -29,12 +29,11 @@ import (
 	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // DenyAllPolicyCreator returns a func to create/update the apiserver

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -62,10 +62,16 @@ func hetznerDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 				Labels: podLabels,
 			}
 
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-				resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+					resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
 
 			f := false

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -62,16 +62,10 @@ func hetznerDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 				Labels: podLabels,
 			}
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-					resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+				resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			f := false

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -70,16 +70,10 @@ func kubevirtDeploymentCreator(data *resources.TemplateData) reconciling.NamedDe
 				Labels: podLabels,
 			}
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-					resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+				resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -70,10 +70,16 @@ func kubevirtDeploymentCreator(data *resources.TemplateData) reconciling.NamedDe
 				Labels: podLabels,
 			}
 
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-				resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+					resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -70,10 +70,16 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 				Labels: podLabels,
 			}
 
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-				resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+					resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -70,16 +70,10 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 				Labels: podLabels,
 			}
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-					resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+				resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -70,16 +70,10 @@ func vsphereDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 				Labels: podLabels,
 			}
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-					resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+				resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -70,11 +70,18 @@ func vsphereDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 				Labels: podLabels,
 			}
 
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
-				resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+					resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
+
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)
 
 			version, err := getVsphereCPIVersion(data.Cluster().Spec.Version)

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -105,10 +105,15 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			// Configure user cluster DNS resolver for this pod.
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -105,15 +105,9 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -139,6 +139,12 @@ func ConfigMapCreator(data *resources.TemplateData) reconciling.NamedConfigMapCr
 				delete(cm.Data, "rules.yaml")
 			} else {
 				cm.Data["rules.yaml"] = prometheusRules
+
+				// deploy DNSResolverDownAlert rule only if Konnectivity is disabled
+				// (custom DNS resolver in not deployed in Konnectivity setup)
+				if !data.IsKonnectivityEnabled() {
+					cm.Data["rules.yaml"] += prometheusRuleDNSResolverDownAlert
+				}
 			}
 
 			if customRules == "" {

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -108,10 +108,15 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			// Configure user cluster DNS resolver for this pod.
-			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-			if err != nil {
-				return nil, err
+			if !data.IsKonnectivityEnabled() {
+				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// custom DNS resolver in not needed in Konnectivity setup
+				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+				dep.Spec.Template.Spec.DNSConfig = nil
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -108,15 +108,9 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			if !data.IsKonnectivityEnabled() {
-				dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				// custom DNS resolver in not needed in Konnectivity setup
-				dep.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
-				dep.Spec.Template.Spec.DNSConfig = nil
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
@@ -521,6 +521,16 @@ data:
         labels:
           severity: critical
 
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown
@@ -589,16 +599,6 @@ data:
           message: DNS resolver has disappeared from Prometheus target discovery.
         expr: absent(up{job="dns-resolver"} == 1)
         for: 15m
-        labels:
-          severity: warning
-
-    - name: kubernetes-nodes
-      rules:
-      - alert: KubernetesNodeNotReady
-        annotations:
-          message: '{{ $labels.node }} has been unready for more than an hour.'
-        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-        for: 30m
         labels:
           severity: warning
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
When Konnectivity is used for control-plane to worker-nodes communication, custom dns-resolver for each user cluster running in seed is not required anymore for the apiserver to resolve user-cluster service names. This PR makes sure it is not deployed if Konenctivity is enabled, but at the same time does not change anything in the deployment of old OpenVPN setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8256 

**Special notes for your reviewer**:
- Apiserver network policy needs to be modified as well, to allow all egress DNS traffic (as DNS requests from apiserver now go directly to the default DNS resolver of the seed cluster, which is platform-specific).
- `DNSResolverDown` alerting rule should not be active if dns-resolver is not deployed.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
