### PR TITLE
Add additional seccomp profiles to CSI addons

### DIFF
--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -17,6 +17,7 @@
 # and is applicable for k8s 1.20+ clusters.
 # modifications:
 # - seccomp profile in DaemonSet hcloud-csi-node
+# - seccomp profile in StatefulSet hcloud-csi-controller
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "hetzner" }}
@@ -132,6 +133,9 @@ spec:
         app: hcloud-csi-controller
     spec:
       serviceAccount: hcloud-csi
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: csi-attacher
           image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.2.1'

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -15,6 +15,8 @@
 # This is based on
 # https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml
 # and is applicable for k8s 1.20+ clusters.
+# modifications:
+# - seccomp profile in DaemonSet hcloud-csi-node
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "hetzner" }}
@@ -249,6 +251,9 @@ spec:
                     values:
                       - "true"
       serviceAccount: hcloud-csi
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: csi-node-driver-registrar
           image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -59,6 +59,9 @@ spec:
         app: csi-cinder-controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: csi-attacher
           image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.1.0'

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -44,6 +44,9 @@ spec:
       tolerations:
         - operator: Exists
       serviceAccount: csi-cinder-node-sa
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       hostNetwork: true
       containers:
         - name: node-driver-registrar

--- a/addons/csi/vsphere/csiController.yaml
+++ b/addons/csi/vsphere/csiController.yaml
@@ -41,6 +41,9 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-controller
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher

--- a/addons/csi/vsphere/csiNode-ds.yaml
+++ b/addons/csi/vsphere/csiNode-ds.yaml
@@ -44,6 +44,9 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       dnsPolicy: "Default"
       containers:
         - name: node-driver-registrar


### PR DESCRIPTION
**What this PR does / why we need it**:
I missed a couple of components (the CSI addons for cloud providers) in the initial PR (#8326). This adds them. It really only affects the liveness probe containers within the Pods, as everything else is running as privileged, but hey, one container more secured is better than nothing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8413

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>