### PR TITLE
Enable annotations for metrics scraping in nginx-ingress

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.3.3
+version: 1.3.4
 appVersion: 1.0.2
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -245,6 +245,31 @@ subjects:
     name: nginx-ingress
     namespace: "default"
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-service-metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller-metrics
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 10254
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/component: controller
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
 kind: Service
@@ -330,6 +355,9 @@ spec:
   minReadySeconds: 0
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: RELEASE-NAME
@@ -399,6 +427,9 @@ spec:
               protocol: TCP
             - name: https
               containerPort: 443
+              protocol: TCP
+            - name: metrics
+              containerPort: 10254
               protocol: TCP
             - name: webhook
               containerPort: 8443

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -245,6 +245,31 @@ subjects:
     name: nginx-ingress
     namespace: "default"
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-service-metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller-metrics
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 10254
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/component: controller
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
 kind: Service
@@ -330,6 +355,9 @@ spec:
   minReadySeconds: 0
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: RELEASE-NAME
@@ -399,6 +427,9 @@ spec:
               protocol: TCP
             - name: https
               containerPort: 443
+              protocol: TCP
+            - name: metrics
+              containerPort: 10254
               protocol: TCP
             - name: webhook
               containerPort: 8443

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -245,6 +245,31 @@ subjects:
     name: nginx-ingress
     namespace: "default"
 ---
+# Source: nginx-ingress-controller/charts/nginx/templates/controller-service-metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: nginx-4.0.9
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/version: "1.0.5"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx-ingress-controller-metrics
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 10254
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/component: controller
+---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
 kind: Service
@@ -330,6 +355,9 @@ spec:
   minReadySeconds: 0
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: RELEASE-NAME
@@ -399,6 +427,9 @@ spec:
               protocol: TCP
             - name: https
               containerPort: 443
+              protocol: TCP
+            - name: metrics
+              containerPort: 10254
               protocol: TCP
             - name: webhook
               containerPort: 8443

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -41,6 +41,15 @@ nginx:
               operator: In
               values:
               - stable
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "10254"
+
+    metrics:
+      port: 10254
+      # if this port is changed, change healthz-port: in extraArgs: accordingly
+      enabled: true
+
     tolerations:
     - key: only_critical
       operator: Equal


### PR DESCRIPTION
**What this PR does / why we need it**:
After upgrading the chart to use upstream, there are missing annotations for metrics scraping.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8421

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
