### PR TITLE
Fixed for below Duplicate Keys issue faced during Cert-manager deployment using Flux

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: cert-manager
-version: 2.0.4
+version: 2.0.5
 appVersion: v1.5.2
 description: A Helm chart for cert-manager
 keywords:

--- a/charts/cert-manager/templates/cert-manager-rbac.yaml
+++ b/charts/cert-manager/templates/cert-manager-rbac.yaml
@@ -417,6 +417,7 @@ rules:
     resources: ["challenges", "orders"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
 
+---
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION


Signed-off-by: archups <archupsawant@gmail.com>

**What this PR does / why we need it**:

Fixed below issue encounter during Cert-Manager Helm chart deployment using Flux CD. Required to automate GitOps way the cert-manager deployment on separate KKP Seed Cluster
```
cert-manager    False   Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:                  False
                          line 22: mapping key "apiVersion" already defined at line 2

                          line 23: mapping key "kind" already defined at line 3

                          line 24: mapping key "metadata" already defined at line 4

                          line 31: mapping key "rules" already defined at line 14

```


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
