### PR TITLE
Etcd restore update api

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -20708,6 +20708,11 @@
           "description": "ClusterID is the id of the cluster which will be restored from the backup",
           "type": "string",
           "x-go-name": "ClusterID"
+        },
+        "destination": {
+          "description": "Destination indicates where the backup was stored. The destination name should correspond to a destination in\nthe cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore",
+          "type": "string",
+          "x-go-name": "Destination"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -19,10 +19,9 @@ package v2
 import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	crdapiv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -18,6 +18,7 @@ package v2
 
 import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -312,6 +313,9 @@ type EtcdRestoreSpec struct {
 	// BackupDownloadCredentialsSecret is the name of a secret in the cluster-xxx namespace containing
 	// credentials needed to download the backup
 	BackupDownloadCredentialsSecret string `json:"backupDownloadCredentialsSecret,omitempty"`
+	// Destination indicates where the backup was stored. The destination name should correspond to a destination in
+	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+	Destination string `json:"destination,omitempty"`
 }
 
 // OIDCSpec contains OIDC params that can be used to access user cluster.

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1990,6 +1990,7 @@ func GenAPIEtcdRestore(name, clusterID string) *apiv2.EtcdRestore {
 			ClusterID:                       clusterID,
 			BackupName:                      "backup-1",
 			BackupDownloadCredentialsSecret: "secret",
+			Destination:                     "s3",
 		},
 	}
 }
@@ -2013,6 +2014,7 @@ func GenEtcdRestore(name string, cluster *kubermaticv1.Cluster, projectID string
 			Cluster:                         *clusterObjectRef,
 			BackupName:                      "backup-1",
 			BackupDownloadCredentialsSecret: "secret",
+			Destination:                     "s3",
 		},
 	}
 }

--- a/pkg/handler/v2/etcdrestore/etcdrestore.go
+++ b/pkg/handler/v2/etcdrestore/etcdrestore.go
@@ -283,6 +283,7 @@ func convertInternalToAPIEtcdRestore(er *kubermaticv1.EtcdRestore) *apiv2.EtcdRe
 			ClusterID:                       er.Spec.Cluster.Name,
 			BackupName:                      er.Spec.BackupName,
 			BackupDownloadCredentialsSecret: er.Spec.BackupDownloadCredentialsSecret,
+			Destination:                     er.Spec.Destination,
 		},
 		Status: apiv2.EtcdRestoreStatus{
 			Phase: er.Status.Phase,
@@ -315,6 +316,7 @@ func convertAPIToInternalEtcdRestore(name string, erSpec *apiv2.EtcdRestoreSpec,
 			Cluster:                         *clusterObjectRef,
 			BackupName:                      erSpec.BackupName,
 			BackupDownloadCredentialsSecret: erSpec.BackupDownloadCredentialsSecret,
+			Destination:                     erSpec.Destination,
 		},
 	}, nil
 }

--- a/pkg/test/e2e/utils/apiclient/models/etcd_restore_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/etcd_restore_spec.go
@@ -26,6 +26,10 @@ type EtcdRestoreSpec struct {
 
 	// ClusterID is the id of the cluster which will be restored from the backup
 	ClusterID string `json:"clusterId,omitempty"`
+
+	// Destination indicates where the backup was stored. The destination name should correspond to a destination in
+	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+	Destination string `json:"destination,omitempty"`
 }
 
 // Validate validates this etcd restore spec


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing destination in EtcdRestore API object


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
