### PR TITLE
fix flaky API e2e tests

### DIFF
--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -85,10 +85,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			r := &reconciler{
-				log:          kubermaticlog.Logger,
-				recorder:     &record.FakeRecorder{},
-				masterClient: tc.masterClient,
-				seedClients:  map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+				log:             kubermaticlog.Logger,
+				recorder:        &record.FakeRecorder{},
+				masterClient:    tc.masterClient,
+				masterAPIClient: tc.masterClient,
+				seedClients:     map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -1302,7 +1302,11 @@ func (r *TestClient) DetachSSHKeyFromClusterParams(projectID, clusterID, dc, key
 		KeyID:     keyID,
 		ProjectID: projectID,
 	}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	SetupRetryParams(r.test, params, Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	}, http.StatusForbidden)
 
 	_, err := r.client.Project.DetachSSHKeyFromCluster(params, r.bearerToken)
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for flaky api e2e test, which flakes on ssh detach (TestCreateUpdateDOCluster)
Fix for flaky api e2e test, which was attempted already in https://github.com/kubermatic/kubermatic/pull/8404. But this time, we need to skip the cache for the project sync, because seed and master host comparison doesnt work as expected, as they domain or ip hosts.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
