### PR TITLE
add prometheus scraping if minio is running with TLS

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.27
+version: 1.0.28
 appVersion: RELEASE.2021-08-20T18-32-01Z
 description: minio
 keywords:

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -21,6 +21,7 @@ minio:
   # The is required to enable the BackupRestore controller so it can backup
   # and restore from the local minio deployment. The TLS certificates should be
   # signed by the global KKP CA.
+  # If you are enabling it, make sure to enable prometheus scraping for minio as well.
   certificateSecret: '' # tls secret used by minio.
 
   # These settings are required. Keys must be alphanumeric.

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.9
+version: 2.4.10
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/config/scraping/minio.yaml
+++ b/charts/monitoring/prometheus/config/scraping/minio.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.prometheus.scraping.minio.tls.enabled }}
+job_name: minio-job
+scheme: https
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecure_skip_verify: true
+bearer_token: /var/run/secrets/kubernetes.io/serviceaccount/token
+metrics_path: /minio/v2/metrics/cluster
+kubernetes_sd_configs:
+- role: pod
+relabel_configs:
+# only keep minio
+- source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+  regex: '{{ .Values.prometheus.scraping.minio.namespace | default "minio" }};{{ .Values.prometheus.scraping.minio.appLabel | default "minio" }}'
+  action: keep
+{{ else }}
+job_name: minio-job
+{{ end }}

--- a/charts/monitoring/prometheus/config/scraping/pods.yaml
+++ b/charts/monitoring/prometheus/config/scraping/pods.yaml
@@ -21,6 +21,13 @@ relabel_configs:
   regex: '{{ .Release.Namespace }};node-exporter'
   action: drop
 
+# drop minio, if it's running with TLS
+{{ if .Values.prometheus.scraping.minio.tls.enabled }}
+- source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+  regex: '{{ .Values.prometheus.scraping.minio.namespace | default "minio" }};{{ .Values.prometheus.scraping.minio.appLabel | default "minio" }}'
+  action: drop
+{{ end }}
+
 # drop kube-state-metrics, as we have dedicated rules to properly map all the labels
 # to their original pods
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -69,6 +69,13 @@ prometheus:
     blackBoxExporter:
       enabled: false
       #url: blackbox-exporter:9115
+    # Enable if minio is running with tls in the same cluster
+    minio:
+      tls:
+        enabled: false
+      # Change values if minio running in different namespace and having different label. default is is set to minio.
+      #namespace: minio
+      #appLabel: minio
 
   # Similarly to the scraping config, you can configure the
   # target alertmanagers here.


### PR DESCRIPTION
**What this PR does / why we need it**: `BackupRestore controller` is dependant on running minio with TLS according to [comment](https://github.com/kubermatic/kubermatic/blob/5328f8a481e62a3d7656a6990bbe971b1d12347f/charts/minio/values.yaml#L21-L24). Once minio runs with TLS, Prometheus scraping fails and gives an alert `PromScrapeFailed`. Example below.

```bash
up{app="minio", instance="10.244.37.21:9000", job="pods", namespace="minio", pod="minio-78cf8fcdbc-pdfqs", pod_template_hash="78cf8fcdbc"}
```
To fix that I have added Prometheus scraping job-specific for minio and updated pod job to skip it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
```release-note
add Prometheus scraping if minio is running with TLS
```
