### PR TITLE
Add support for switching between OpenVPN and Konnectivity

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -218,6 +218,18 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
+	// TODO
+	if r.isKonnectivityEnabled {
+		if err := r.ensureOpenVPNIsRemoved(ctx); err != nil {
+			return err
+		}
+	} else {
+		if err := r.ensureKonnectivityIsRemoved(ctx); err != nil {
+			return err
+		}
+		// TODO: metrics-server
+	}
+
 	return nil
 }
 
@@ -1055,6 +1067,26 @@ func (r *reconciler) ensureMLAIsRemoved(ctx context.Context) error {
 		}
 		if err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure mla is removed/not present: %v", err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) ensureOpenVPNIsRemoved(ctx context.Context) error {
+	for _, resource := range openvpn.ResourcesOnDeletion() {
+		err := r.Client.Delete(ctx, resource)
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to ensure OpenVPN resources are removed/not present: %v", err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) ensureKonnectivityIsRemoved(ctx context.Context) error {
+	for _, resource := range konnectivity.ResourcesOnDeletion() {
+		err := r.Client.Delete(ctx, resource)
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to ensure Konnectivity resources are removed/not present: %v", err)
 		}
 	}
 	return nil

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/clusterrolebinding.go
@@ -27,10 +27,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.KonnectivityClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.ObjectMeta.Labels = map[string]string{
-				"kubernetes.io/cluster-service":   "true",
-				"addonmanager.kubernetes.io/mode": "Reconcile",
-			}
+			crb.ObjectMeta.Labels = resources.BaseAppLabels(resources.KonnectivityDeploymentName, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deletion.go
@@ -18,16 +18,16 @@ package konnectivity
 
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResourcesOnDeletion() []ctrlruntimeclient.Object {
+func ResourcesForDeletion() []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deletion.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesOnDeletion() []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityDeploymentName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&policyv1beta1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityPodDisruptionBudgetName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityServiceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityClusterRoleBindingName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/serviceaccount.go
@@ -27,11 +27,7 @@ import (
 func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 	return func() (string, reconciling.ServiceAccountCreator) {
 		return resources.KonnectivityServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			// TODO(pratik): these labels, why?
-			sa.Labels = map[string]string{
-				"kubernetes.io/cluster-service":   "true",
-				"addonmanager.kubernetes.io/mode": "Reconcile",
-			}
+			sa.Labels = resources.BaseAppLabels(resources.KonnectivityDeploymentName, nil)
 			return sa, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deletion.go
@@ -14,53 +14,45 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package openvpn
+package metricsserver
 
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResourcesForDeletion() []ctrlruntimeclient.Object {
+// UserClusterResourcesForDeletion contains a set of resources deployed in user
+// cluster if metrics-server is running fully in the user cluster (not in seed).
+// It does not cover common metrics-server resources that are being deployed
+// regardless of the deployment strategy (in seed / in user cluster).
+func UserClusterResourcesForDeletion() []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openvpn-client",
-				Namespace: metav1.NamespaceSystem,
-			},
-		},
-		&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNClientConfigConfigMapName,
+				Name:      resources.MetricsServerDeploymentName,
 				Namespace: metav1.NamespaceSystem,
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNClientCertificatesSecretName,
+				Name:      servingCertSecretName,
 				Namespace: metav1.NamespaceSystem,
 			},
 		},
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
+				Name:      resources.MetricsServerServiceAccountName,
 				Namespace: metav1.NamespaceSystem,
 			},
 		},
-		&rbacv1.Role{
+		&policyv1beta1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
-			},
-		},
-		&rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
+				Name:      resources.MetricsServerPodDisruptionBudgetName,
 				Namespace: metav1.NamespaceSystem,
 			},
 		},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/openvpn/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/openvpn/deletion.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openvpn
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesOnDeletion() []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "openvpn-client",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNClientConfigConfigMapName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNClientCertificatesSecretName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vpn-client",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vpn-client",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vpn-client",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+	}
+}

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -40,7 +40,7 @@ import (
 // deny all egress policy.
 func DenyAllPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "default-deny-all-egress", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyDefaultDenyAllEgress, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
@@ -61,7 +61,7 @@ func DenyAllPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 // EctdAllowCreator returns a func to create/update the apiserver ETCD allow egress policy.
 func EctdAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "etcd-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyEtcdAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
@@ -95,7 +95,7 @@ func EctdAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCre
 // DNSAllowCreator returns a func to create/update the apiserver DNS allow egress policy.
 func DNSAllowCreator(c *kubermaticv1.Cluster, data *resources.TemplateData) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "dns-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyDNSAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			dnsPort := intstr.FromInt(53)
 			protoUdp := corev1.ProtocolUDP
 			protoTcp := corev1.ProtocolTCP
@@ -153,7 +153,7 @@ func DNSAllowCreator(c *kubermaticv1.Cluster, data *resources.TemplateData) reco
 // OpenVPNServerAllowCreator returns a func to create/update the apiserver OpenVPN allow egress policy.
 func OpenVPNServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "openvpn-server-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyOpenVPNServerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
@@ -186,7 +186,7 @@ func OpenVPNServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 
 func MachineControllerWebhookCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "machine-controller-webhook-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyMachineControllerWebhookAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
@@ -218,7 +218,7 @@ func MachineControllerWebhookCreator(c *kubermaticv1.Cluster) reconciling.NamedN
 
 func MetricsServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "metrics-server-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyMetricsServerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
@@ -251,7 +251,7 @@ func MetricsServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 // OIDCIssuerAllowCreator returns a func to create/update the apiserver oidc-issuer-allow egress policy.
 func OIDCIssuerAllowCreator(issuerURL string) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
-		return "oidc-issuer-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyOIDCIssuerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			var ipList []net.IP
 			u, err := url.Parse(issuerURL)
 			if err != nil {

--- a/pkg/resources/dns/deletion.go
+++ b/pkg/resources/dns/deletion.go
@@ -14,54 +14,49 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package openvpn
+package dns
 
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResourcesForDeletion() []ctrlruntimeclient.Object {
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openvpn-client",
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.DNSResolverDeploymentName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.DNSResolverServiceName,
+				Namespace: namespace,
 			},
 		},
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNClientConfigConfigMapName,
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.DNSResolverConfigMapName,
+				Namespace: namespace,
 			},
 		},
-		&corev1.Secret{
+		&policyv1beta1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNClientCertificatesSecretName,
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.DNSResolverPodDisruptionBudetName,
+				Namespace: namespace,
 			},
 		},
-		&corev1.ServiceAccount{
+		&autoscalingv1beta2.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
-			},
-		},
-		&rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
-			},
-		},
-		&rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.DNSResolverDeploymentName,
+				Namespace: namespace,
 			},
 		},
 	}

--- a/pkg/resources/konnectivity/deletion.go
+++ b/pkg/resources/konnectivity/deletion.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konnectivity
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesOnDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityProxyServiceName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityKubeApiserverEgress,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityKubeconfigSecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityProxyTLSSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/konnectivity/deletion.go
+++ b/pkg/resources/konnectivity/deletion.go
@@ -18,12 +18,13 @@ package konnectivity
 
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResourcesOnDeletion(namespace string) []ctrlruntimeclient.Object {
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/metrics-server/deletion.go
+++ b/pkg/resources/metrics-server/deletion.go
@@ -14,54 +14,62 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package openvpn
+package metricsserver
 
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResourcesForDeletion() []ctrlruntimeclient.Object {
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openvpn-client",
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.MetricsServerDeploymentName,
+				Namespace: namespace,
 			},
 		},
-		&corev1.ConfigMap{
+		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNClientConfigConfigMapName,
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.MetricsServerServiceName,
+				Namespace: namespace,
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNClientCertificatesSecretName,
-				Namespace: metav1.NamespaceSystem,
+				Name:      ServingCertSecretName,
+				Namespace: namespace,
 			},
 		},
-		&corev1.ServiceAccount{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.MetricsServerKubeconfigSecretName,
+				Namespace: namespace,
 			},
 		},
-		&rbacv1.Role{
+		&policyv1beta1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.MetricsServerPodDisruptionBudgetName,
+				Namespace: namespace,
 			},
 		},
-		&rbacv1.RoleBinding{
+		&autoscalingv1beta2.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vpn-client",
-				Namespace: metav1.NamespaceSystem,
+				Name:      resources.MetricsServerDeploymentName,
+				Namespace: namespace,
+			},
+		},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.NetworkPolicyMetricsServerAllow,
+				Namespace: namespace,
 			},
 		},
 	}

--- a/pkg/resources/openvpn/deletion.go
+++ b/pkg/resources/openvpn/deletion.go
@@ -18,6 +18,7 @@ package openvpn
 
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -26,7 +27,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResourcesOnDeletion(namespace string) []ctrlruntimeclient.Object {
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 	return []ctrlruntimeclient.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +73,7 @@ func ResourcesOnDeletion(namespace string) []ctrlruntimeclient.Object {
 		},
 		&networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openvpn-server-allow",
+				Name:      resources.NetworkPolicyOpenVPNServerAllow,
 				Namespace: namespace,
 			},
 		},

--- a/pkg/resources/openvpn/deletion.go
+++ b/pkg/resources/openvpn/deletion.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openvpn
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesOnDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNServerDeploymentName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNServerServiceName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNClientConfigsConfigMapName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNServerCertificatesSecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNClientCertificatesSecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNCASecretName,
+				Namespace: namespace,
+			},
+		},
+		&autoscalingv1beta2.VerticalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNServerDeploymentName,
+				Namespace: namespace,
+			},
+		},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "openvpn-server-allow",
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -721,6 +721,16 @@ alertmanager_config: |
 	KonnectivityPodDisruptionBudgetName    = "konnectivity-agent"
 )
 
+const (
+	NetworkPolicyDefaultDenyAllEgress          = "default-deny-all-egress"
+	NetworkPolicyEtcdAllow                     = "etcd-allow"
+	NetworkPolicyDNSAllow                      = "dns-allow"
+	NetworkPolicyOpenVPNServerAllow            = "openvpn-server-allow"
+	NetworkPolicyMachineControllerWebhookAllow = "machine-controller-webhook-allow"
+	NetworkPolicyMetricsServerAllow            = "metrics-server-allow"
+	NetworkPolicyOIDCIssuerAllow               = "oidc-issuer-allow"
+)
+
 // List of allowed TLS cipher suites
 var allowedTLSCipherSuites = []string{
 	// TLS 1.3 cipher suites


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for seamless switching between OpenVPN and Konnectivity setup (in both directions) for already running user clusters. It makes sure that the resources of the old strategy are properly cleaned up after switching.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7118 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
