### PR TITLE
[release/v2.18] Bump Flannel version in Canal to v0.15.1

### DIFF
--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -3732,7 +3732,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.13.0
+          image: quay.io/coreos/flannel:v0.15.1
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Flannel version in Canal to v0.15.1 to prevent segfaults in iptables, see 
- https://github.com/flannel-io/flannel/issues/1408

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8041 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Bump Flannel version in Canal to v0.15.1
```
