### PR TITLE
Fix for Kubesystem network policiies

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
@@ -32,6 +32,7 @@ func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return "metrics-server", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			metricsPort := intstr.FromInt(9153)
+			httpsPort := intstr.FromInt(443)
 			protoTcp := v1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -57,6 +58,21 @@ func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Port:     &metricsPort,
+								Protocol: &protoTcp,
+							},
+						},
+					},
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{resources.AppLabelKey: resources.KonnectivityDeploymentName},
+								},
+							},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Port:     &httpsPort,
 								Protocol: &protoTcp,
 							},
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metricsserver
 
 import (
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,6 +32,7 @@ func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return "metrics-server", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			metricsPort := intstr.FromInt(9153)
+			protoTcp := v1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -54,7 +56,8 @@ func NetworkPolicyCreator() reconciling.NamedNetworkPolicyCreatorGetter {
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Port: &metricsPort,
+								Port:     &metricsPort,
+								Protocol: &protoTcp,
 							},
 						},
 					},

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -164,7 +164,7 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				args = append(args, "-openvpn-server-port", fmt.Sprint(openvpnServerPort))
 			}
 
-			if data.Cluster().Spec.Features[kubermaticv1.ApiserverNetworkPolicy] {
+			if data.Cluster().Spec.Features[kubermaticv1.KubeSystemNetworkPolicies] {
 				args = append(args, "-enable-network-policies")
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fixes wrong feature gate condition
- Sets protocol for metrics-server networkpolicy that causes a fail of reconciliation otherwise
- Fix ingress premission for metric-server

```release-note
NONE
```
