### PR TITLE
Fix forgotten to regenerate CRD

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.31
+version: 0.3.32
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -80,7 +80,7 @@ spec:
                   between controllers and the API
                 items:
                   properties:
-                    Message:
+                    message:
                       description: Human readable message indicating details about
                         last transition.
                       type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
During review of #8480 we've forgot to regenerate CRD

```release-note
NONE
```
