### PR TITLE
Allow ebpf proxy mode only if Konnectivity is enabled

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -246,6 +246,11 @@ func ValidateClusterNetworkConfig(n *kubermaticv1.ClusterNetworkingConfig, cni *
 			fmt.Sprintf("%s proxy mode is valid only for %s CNI", resources.EBPFProxyMode, kubermaticv1.CNIPluginTypeCilium)))
 	}
 
+	if n.ProxyMode == resources.EBPFProxyMode && (n.KonnectivityEnabled == nil || *n.KonnectivityEnabled == false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("proxyMode"), n.ProxyMode,
+			fmt.Sprintf("%s proxy mode can be used only when Konnectivity is enabled", resources.EBPFProxyMode)))
+	}
+
 	return allErrs
 }
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -246,7 +246,7 @@ func ValidateClusterNetworkConfig(n *kubermaticv1.ClusterNetworkingConfig, cni *
 			fmt.Sprintf("%s proxy mode is valid only for %s CNI", resources.EBPFProxyMode, kubermaticv1.CNIPluginTypeCilium)))
 	}
 
-	if n.ProxyMode == resources.EBPFProxyMode && (n.KonnectivityEnabled == nil || *n.KonnectivityEnabled == false) {
+	if n.ProxyMode == resources.EBPFProxyMode && (n.KonnectivityEnabled == nil || !*n.KonnectivityEnabled) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("proxyMode"), n.ProxyMode,
 			fmt.Sprintf("%s proxy mode can be used only when Konnectivity is enabled", resources.EBPFProxyMode)))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
ebpf proxy mode for Cilium CNi works correctly only when Konnectivity is used for control-plane to worker-nodes connections (See #8011).
This PR prevents using ebpf proxy mode without Konnectivity using cluster validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8011

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
