### PR TITLE
Fix an issue with user NPE during lastSeen update

### DIFF
--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -202,7 +202,11 @@ func UserSaver(userProvider provider.UserProvider) endpoint.Middleware {
 
 			// Ignore conflict error during update of the lastSeen field as it is not super important.
 			// It can be updated next time.
-			if err != nil && !kerrors.IsConflict(err) {
+			if kerrors.IsConflict(err) {
+				return next(context.WithValue(ctx, kubermaticcontext.UserCRContextKey, user), request)
+			}
+
+			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There was sometimes an NPE thrown in the API logs due to improper error handling when updating the lastSeen field on the user object.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
