### PR TITLE
validate zone_suffixes is not empty

### DIFF
--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -218,6 +218,11 @@ func CloudConfig(
 		}
 
 		tag := fmt.Sprintf("kubernetes-cluster-%s", cluster.Name)
+
+		if len(dc.Spec.GCP.ZoneSuffixes) == 0 {
+			return "", errors.New("empty zone_suffixes")
+		}
+
 		localZone := dc.Spec.GCP.Region + "-" + dc.Spec.GCP.ZoneSuffixes[0]
 
 		// By default, all GCP clusters are assumed to be the in the same zone. If the control plane


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a npe where zone_suffixes is empty in gce datacenter

```release-note
Fix missing validation for GCE datacenter zone_suffixes
```
