### PR TITLE
Enhance CNI versioning & webhooks

### DIFF
--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -34,6 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/util/yaml"
+	"k8c.io/kubermatic/v2/pkg/version/cni"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -93,7 +94,7 @@ func NewTemplateData(
 			Type: kubermaticv1.CNIPluginTypeCanal.String(),
 			// This is to keep backward compatibility with clusters created before
 			// those settings were introduced.
-			Version: "v3.8",
+			Version: cni.CanalCNILastUnspecifiedVersion,
 		}
 	} else {
 		cniPlugin = CNIPlugin{

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -74,7 +74,7 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 	if spec.CNIPlugin != nil {
 		if !cni.GetSupportedCNIPlugins().Has(spec.CNIPlugin.Type.String()) {
 			allErrs = append(allErrs, field.NotSupported(parentFieldPath.Child("cniPlugin", "type"), spec.CNIPlugin.Type.String(), cni.GetSupportedCNIPlugins().List()))
-		} else if versions, err := cni.GetSupportedCNIPluginVersions(spec.CNIPlugin.Type); err != nil || !versions.Has(spec.CNIPlugin.Version) {
+		} else if versions, err := cni.GetAllowedCNIPluginVersions(spec.CNIPlugin.Type); err != nil || !versions.Has(spec.CNIPlugin.Version) {
 			allErrs = append(allErrs, field.NotSupported(parentFieldPath.Child("cniPlugin", "version"), spec.CNIPlugin.Version, versions.List()))
 		}
 	}
@@ -706,27 +706,24 @@ func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.Clu
 	return allErrs
 }
 
-func validateCNIUpdate(cni *kubermaticv1.CNIPluginSettings, oldCni *kubermaticv1.CNIPluginSettings, labels map[string]string) *field.Error {
+func validateCNIUpdate(newCni *kubermaticv1.CNIPluginSettings, oldCni *kubermaticv1.CNIPluginSettings, labels map[string]string) *field.Error {
 	basePath := field.NewPath("spec", "cniPlugin")
 
 	// if there was no CNI setting, we allow the mutation to happen
 	// allowed for backward compatibility with older KKP with existing clusters with no CNI settings
-	if cni == nil && oldCni == nil {
+	if newCni == nil && oldCni == nil {
 		return nil
 	}
 
-	if oldCni != nil && cni == nil {
+	if oldCni != nil && newCni == nil {
 		return field.Required(basePath, "CNI plugin settings cannot be removed")
 	}
 
-	if oldCni == nil && cni != nil {
-		if _, ok := labels[UnsafeCNIUpgradeLabel]; ok {
-			return nil // allowed for migration path from older KKP with existing clusters with no CNI settings
-		}
-		return field.Forbidden(basePath, fmt.Sprintf("cannot add CNI plugin settings, unless %s label is present", UnsafeCNIUpgradeLabel))
+	if oldCni == nil && newCni != nil {
+		return nil // allowed for automated setting of CNI type and version
 	}
 
-	if cni.Type != oldCni.Type {
+	if newCni.Type != oldCni.Type {
 		if _, ok := labels[UnsafeCNIMigrationLabel]; ok {
 			return nil // allowed for CNI type migration path
 		}
@@ -734,10 +731,14 @@ func validateCNIUpdate(cni *kubermaticv1.CNIPluginSettings, oldCni *kubermaticv1
 		return field.Forbidden(basePath.Child("type"), fmt.Sprintf("cannot change CNI plugin type, unless %s label is present", UnsafeCNIMigrationLabel))
 	}
 
-	if cni.Version != oldCni.Version {
-		newV, err := semver.NewVersion(cni.Version)
+	if newCni.Version != oldCni.Version {
+		if !cni.IsSupportedCNIPluginTypeAndVersion(oldCni) {
+			return nil // allowed for automated migration from deprecated CNI
+		}
+
+		newV, err := semver.NewVersion(newCni.Version)
 		if err != nil {
-			return field.Invalid(basePath.Child("version"), cni.Version, fmt.Sprintf("couldn't parse CNI version `%s`: %v", cni.Version, err))
+			return field.Invalid(basePath.Child("version"), newCni.Version, fmt.Sprintf("couldn't parse CNI version `%s`: %v", newCni.Version, err))
 		}
 
 		oldV, err := semver.NewVersion(oldCni.Version)
@@ -747,7 +748,7 @@ func validateCNIUpdate(cni *kubermaticv1.CNIPluginSettings, oldCni *kubermaticv1
 
 		if newV.Major() != oldV.Major() || (newV.Minor() != oldV.Minor()+1 && oldV.Minor() != newV.Minor()+1) {
 			if _, ok := labels[UnsafeCNIUpgradeLabel]; !ok {
-				return field.Forbidden(basePath.Child("version"), fmt.Sprintf("cannot upgrade CNI from %s to %s, only one minor version difference is allowed unless %s label is present", oldCni.Version, cni.Version, UnsafeCNIUpgradeLabel))
+				return field.Forbidden(basePath.Child("version"), fmt.Sprintf("cannot upgrade CNI from %s to %s, only one minor version difference is allowed unless %s label is present", oldCni.Version, newCni.Version, UnsafeCNIUpgradeLabel))
 			}
 		}
 	}

--- a/pkg/version/cni/version.go
+++ b/pkg/version/cni/version.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// CanalCNILastUnspecifiedVersion is the last Canal CNI version applied in KKP user-clusters
+// started in KKP before v2.18 release. If cluster.spec.cniPlugin is not set, it means Canal of this version.
+const CanalCNILastUnspecifiedVersion = "v3.8"
+
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.21",
@@ -32,11 +36,24 @@ var (
 )
 
 var (
-	supportedCNIPlugins        = sets.NewString(kubermaticv1.CNIPluginTypeCanal.String(), kubermaticv1.CNIPluginTypeCilium.String(), kubermaticv1.CNIPluginTypeNone.String())
+	// supportedCNIPlugins contains a lis of all currently supported CNI Plugin types.
+	supportedCNIPlugins = sets.NewString(
+		kubermaticv1.CNIPluginTypeCanal.String(),
+		kubermaticv1.CNIPluginTypeCilium.String(),
+		kubermaticv1.CNIPluginTypeNone.String(),
+	)
+	// supportedCNIPluginVersions contains a list of all currently supported CNI versions for each CNI type.
+	// Only supported versions are available for selection in KKP UI.
 	supportedCNIPluginVersions = map[kubermaticv1.CNIPluginType]sets.String{
-		kubermaticv1.CNIPluginTypeCanal:  sets.NewString("v3.8", "v3.19", "v3.20", "v3.21"),
+		kubermaticv1.CNIPluginTypeCanal:  sets.NewString("v3.19", "v3.20", "v3.21"),
 		kubermaticv1.CNIPluginTypeCilium: sets.NewString("v1.11"),
 		kubermaticv1.CNIPluginTypeNone:   sets.NewString(""),
+	}
+	// deprecatedCNIPluginVersions contains a list of deprecated CNI versions for each CNI type.
+	// Deprecated versions are not available for selection in KKP UI, but are still accepted
+	// by the validation webhook for backward compatibility.
+	deprecatedCNIPluginVersions = map[kubermaticv1.CNIPluginType]sets.String{
+		kubermaticv1.CNIPluginTypeCanal: sets.NewString("v3.8"),
 	}
 )
 
@@ -60,7 +77,34 @@ func GetSupportedCNIPluginVersions(cniPluginType kubermaticv1.CNIPluginType) (se
 	return versions, nil
 }
 
+// GetAllowedCNIPluginVersions returns all allowed CNI versions for a CNI type (supported + deprecated)
+func GetAllowedCNIPluginVersions(cniPluginType kubermaticv1.CNIPluginType) (sets.String, error) {
+	versions, err := GetSupportedCNIPluginVersions(cniPluginType)
+	if err != nil {
+		return sets.NewString(), err
+	}
+	if deprecated, ok := deprecatedCNIPluginVersions[cniPluginType]; ok {
+		versions.Insert(deprecated.List()...)
+	}
+	return versions, nil
+}
+
 // GetDefaultCNIPluginVersion returns the default CNI versions for a CNI type, empty string if no default version set
 func GetDefaultCNIPluginVersion(cniPluginType kubermaticv1.CNIPluginType) string {
 	return defaultCNIPluginVersion[cniPluginType]
+}
+
+// IsSupportedCNIPluginTypeAndVersion returns true if the given CNI plugin is of supported type and version
+func IsSupportedCNIPluginTypeAndVersion(cni *kubermaticv1.CNIPluginSettings) bool {
+	if cni == nil {
+		return false
+	}
+	versions, ok := supportedCNIPluginVersions[cni.Type]
+	if !ok {
+		return false
+	}
+	if versions.Has(cni.Version) {
+		return true
+	}
+	return false
 }

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -203,9 +203,19 @@ func (h *AdmissionHandler) mutateUpdate(oldCluster, newCluster *kubermaticv1.Clu
 		}
 	}
 
-	// This part handles CNI upgrade from unspecified (= very old) CNI version to the default Canal version.
-	// This upgrade is necessary for k8s versions >= 1.22, where v1beta1 CRDs are not supported anymore.
+	// For backward compatibility, if CNIPlugin is not set (possible only for clusters started before KKP v2.18 release),
+	// explicitly set it to the last Canal CNI version supported by KKP before v2.18.
 	if newCluster.Spec.CNIPlugin == nil {
+		newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
+			Type:    kubermaticv1.CNIPluginTypeCanal,
+			Version: cni.CanalCNILastUnspecifiedVersion,
+		}
+	}
+	// This part handles CNI upgrade from unsupported CNI version to the default Canal version.
+	// This upgrade is necessary for k8s versions >= 1.22, where v1beta1 CRDs used in old Canal version (v3.8)
+	// are not supported anymore.
+	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal &&
+		newCluster.Spec.CNIPlugin.Version == cni.CanalCNILastUnspecifiedVersion {
 		upgradeConstraint, err := semver.NewConstraint(">= 1.22")
 		if err != nil {
 			return fmt.Errorf("parsing CNI upgrade constraint failed: %v", err)

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -441,8 +441,8 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				defaultPatches,
 				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]interface{}{
-					"type":    "canal",
-					"version": "v3.21",
+					"type":    string(kubermaticv1.CNIPluginTypeCanal),
+					"version": cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 				}),
 			),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains several CNI versioning & webhooks enhancements:

 - Adds a list of deprecated CNI plugin versions that we still allow for backward compatibility, but don't want to offer for selection in KKP UI when creating new clusters.
 - Makes Canal v3.8 deprecated.
 - Defines `CanalCNILastUnspecifiedVersion` - the last Canal CNI version applied in KKP user-clusters started before KKP v2.18 release (v3.8)
 - If `cluster.spec.cniPlugin` is not set on an existing cluster, it will be set to `CanalCNILastUnspecifiedVersion` by the mutation webhook on the next update, so that KKP UI works properly and upgrade from the UI is possible.
 - Allows upgrading from the deprecated CNI version even without labeling the cluster with `unsafe-cni-upgrade` label. This upgrade was manually tested and should work fine. It is also automatically trigerred when upgrading k8s version to `>= 1.22`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8526 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
