### PR TITLE
bump konnectivity version to v0.0.27

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -52,7 +52,7 @@ func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrit
 	return func() (string, reconciling.DeploymentCreator) {
 		const (
 			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-			version = "v0.0.26"
+			version = "v0.0.27"
 		)
 
 		return resources.KonnectivityDeploymentName, func(ds *appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -43,7 +43,7 @@ var (
 func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Container, error) {
 	const (
 		name    = "k8s-artifacts-prod/kas-network-proxy/proxy-server"
-		version = "v0.0.26"
+		version = "v0.0.27"
 	)
 
 	return &corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrading to v0.0.27 because konnectivity-network-proxy has a memory leak. https://github.com/kubernetes/kubernetes/pull/107037



```release-note
NONE
```
