### PR TITLE
enable auto backups/restore for multiple backups destinations

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
@@ -90,12 +90,12 @@ func BackupContainersConfigMapCreator(cfg *operatorv1alpha1.KubermaticConfigurat
 			c.Data[cleanupContainerKey] = cfg.Spec.SeedController.BackupCleanupContainer
 
 			if cfg.Spec.SeedController.BackupStoreContainer == strings.TrimSpace(defaults.DefaultBackupStoreContainer) &&
-				seed.Spec.BackupRestore != nil {
+				(seed.Spec.BackupRestore != nil || seed.Spec.EtcdBackupRestore != nil) {
 				c.Data[storeContainerKey] = strings.TrimSpace(defaults.DefaultNewBackupStoreContainer)
 				log.Debugw("Defaulting field", "field", "seedController.backupRestoreContainer")
 			}
 
-			if seed.Spec.BackupRestore != nil {
+			if seed.Spec.BackupRestore != nil || seed.Spec.EtcdBackupRestore != nil {
 				if cfg.Spec.SeedController.BackupDeleteContainer == "" {
 					cfg.Spec.SeedController.BackupDeleteContainer = strings.TrimSpace(defaults.DefaultNewBackupDeleteContainer)
 					log.Debugw("Defaulting field", "field", "seedController.backupDeleteContainer")

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -80,13 +80,13 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions kubermat
 				fmt.Sprintf("-backup-container=/opt/backup/%s", storeContainerKey),
 			}
 
-			if seed.Spec.BackupRestore == nil {
+			if seed.Spec.BackupRestore == nil && seed.Spec.EtcdBackupRestore == nil {
 				args = append(args, fmt.Sprintf("-cleanup-container=/opt/backup/%s", cleanupContainerKey))
 			} else if !cfg.Spec.SeedController.BackupRestore.Enabled || cfg.Spec.SeedController.BackupCleanupContainer != "" {
 				args = append(args, fmt.Sprintf("-cleanup-container=/opt/backup/%s", cleanupContainerKey))
 			}
 
-			if cfg.Spec.SeedController.BackupRestore.Enabled || seed.Spec.BackupRestore != nil {
+			if cfg.Spec.SeedController.BackupRestore.Enabled || seed.Spec.BackupRestore != nil || seed.Spec.EtcdBackupRestore != nil {
 				args = append(args, "-enable-etcd-backups-restores")
 				args = append(args, fmt.Sprintf("-backup-delete-container=/opt/backup/%s", deleteContainerKey))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

adds logic to enable automatic etcd backups when multiple backups destinations are used

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8532 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
