### PR TITLE
Enhance CNI/networking addons handling

### DIFF
--- a/addons/kube-proxy/clusterrolebinding.yaml
+++ b/addons/kube-proxy/clusterrolebinding.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if ne .Cluster.Network.ProxyMode "ebpf" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -25,4 +24,3 @@ subjects:
 - kind: ServiceAccount
   name: kube-proxy
   namespace: kube-system
-{{ end }}

--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if ne .Cluster.Network.ProxyMode "ebpf" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -79,4 +78,3 @@ data:
     - name: default
       user:
         tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-{{ end }}

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if ne .Cluster.Network.ProxyMode "ebpf" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -83,4 +82,3 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - operator: Exists
-{{ end }}

--- a/addons/kube-proxy/serviceaccount.yaml
+++ b/addons/kube-proxy/serviceaccount.yaml
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if ne .Cluster.Network.ProxyMode "ebpf" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-proxy
   namespace: kube-system
-{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhances handling of CNI addons to address the following issues:

- When CNI settings (e.g. version) change, it may take up to 5 minutes until the CNI addon will start reconciliation, so the change is not immediate. This PR makes sure that the reconciliation starts right after CNI settings change.
- All CNI addons are being installed into the user cluster namespace in Seed, even if they are not necessary (e.g. you would always find both `cilium` and `canal` Addon CRs there, even when only one of them is actually in use). Whether or not some addon finally will be applied into the user cluster is managed at various places, either in the addon controller or in the addon manifests. This PR unifies it - the addon installer controller is the right place, so that unused addon CRs are not even deployed into the user cluster namespace in the Seed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8537 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
