### PR TITLE
Fix GetAllowedCNIPluginVersions handling

### DIFF
--- a/pkg/version/cni/version.go
+++ b/pkg/version/cni/version.go
@@ -79,14 +79,15 @@ func GetSupportedCNIPluginVersions(cniPluginType kubermaticv1.CNIPluginType) (se
 
 // GetAllowedCNIPluginVersions returns all allowed CNI versions for a CNI type (supported + deprecated)
 func GetAllowedCNIPluginVersions(cniPluginType kubermaticv1.CNIPluginType) (sets.String, error) {
-	versions, err := GetSupportedCNIPluginVersions(cniPluginType)
+	supported, err := GetSupportedCNIPluginVersions(cniPluginType)
 	if err != nil {
 		return sets.NewString(), err
 	}
+	all := sets.NewString(supported.List()...)
 	if deprecated, ok := deprecatedCNIPluginVersions[cniPluginType]; ok {
-		versions.Insert(deprecated.List()...)
+		all.Insert(deprecated.List()...)
 	}
-	return versions, nil
+	return all, nil
 }
 
 // GetDefaultCNIPluginVersion returns the default CNI versions for a CNI type, empty string if no default version set

--- a/pkg/version/cni/version.go
+++ b/pkg/version/cni/version.go
@@ -83,11 +83,11 @@ func GetAllowedCNIPluginVersions(cniPluginType kubermaticv1.CNIPluginType) (sets
 	if err != nil {
 		return sets.NewString(), err
 	}
-	all := sets.NewString(supported.List()...)
+	allowed := sets.NewString(supported.List()...)
 	if deprecated, ok := deprecatedCNIPluginVersions[cniPluginType]; ok {
-		all.Insert(deprecated.List()...)
+		allowed.Insert(deprecated.List()...)
 	}
-	return all, nil
+	return allowed, nil
 }
 
 // GetDefaultCNIPluginVersion returns the default CNI versions for a CNI type, empty string if no default version set


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes handling of `GetAllowedCNIPluginVersions`, which was incorrectly mutating `supportedCNIPlugins` + add an unit test covering the case which uncovered this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
