### PR TITLE
Disable network policies for kube-system

### DIFF
--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -177,11 +177,6 @@ func (h *AdmissionHandler) mutateCreate(newCluster *kubermaticv1.Cluster) error 
 		newCluster.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] = true
 	}
 
-	// Network policies for kube-system are deployed by default
-	if _, ok := newCluster.Spec.Features[kubermaticv1.KubeSystemNetworkPolicies]; !ok {
-		newCluster.Spec.Features[kubermaticv1.KubeSystemNetworkPolicies] = true
-	}
-
 	return nil
 }
 

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -261,7 +261,6 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/prometheus/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
-				jsonpatch.NewOperation("add", "/spec/features/kubeSystemNetworkPolicies", true),
 				jsonpatch.NewOperation("replace", "/spec/exposeStrategy", string(defaults.DefaultExposeStrategy)),
 			},
 		},
@@ -316,7 +315,6 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", resources.EBPFProxyMode),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", true),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
-				jsonpatch.NewOperation("add", "/spec/features/kubeSystemNetworkPolicies", true),
 			),
 		},
 		{
@@ -399,7 +397,6 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				defaultPatches,
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
-				jsonpatch.NewOperation("add", "/spec/features/kubeSystemNetworkPolicies", true),
 			),
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable network policies for kube-system due to issues with cilium

```release-note
NONE
```
