### PR TITLE
fix bad error message on misconfigured gce datacenter in seed yaml file

### DIFF
--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -218,7 +218,10 @@ func CloudConfig(
 		}
 
 		tag := fmt.Sprintf("kubernetes-cluster-%s", cluster.Name)
-		localZone := dc.Spec.GCP.Region + "-" + dc.Spec.GCP.ZoneSuffixes[0]
+		localZone := ""
+		if len(dc.Spec.GCP.ZoneSuffixes) > 0 {
+			localZone = dc.Spec.GCP.Region + "-" + dc.Spec.GCP.ZoneSuffixes[0]
+		}
 
 		// By default, all GCP clusters are assumed to be the in the same zone. If the control plane
 		// and worker nodes are not it the same zone (localZone), the GCP cloud controller fails

--- a/pkg/resources/cloudconfig/configmap_test.go
+++ b/pkg/resources/cloudconfig/configmap_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudconfig
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -300,6 +301,27 @@ func TestOpenStackCloudConfig(t *testing.T) {
 				t.Errorf("cloud-config differs from the expected one: %s", diff)
 			}
 		})
+	}
+}
+
+func TestGCPCloudConfigEmptyLocalZone(t *testing.T) {
+	cluster := &kubermaticv1.Cluster{
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: kubermaticv1.CloudSpec{
+				GCP: &kubermaticv1.GCPCloudSpec{},
+			},
+		},
+	}
+	datacenter := &kubermaticv1.Datacenter{
+		Spec: kubermaticv1.DatacenterSpec{
+			GCP: &kubermaticv1.DatacenterSpecGCP{ZoneSuffixes: []string{}},
+		},
+	}
+	credentials := resources.Credentials{}
+	credentials.GCP.ServiceAccount = base64.StdEncoding.EncodeToString([]byte(`{"project_id":"foo"}`))
+	_, err := CloudConfig(cluster, datacenter, credentials)
+	if err != nil {
+		t.Fatalf("Error trying to get cloud-config: %v", err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Hubert Ströbitzer <hubert@kubermatic.com>

**What this PR does / why we need it**:

On having not filled out the zones in the seed yaml file on gcp we get the following (misleading) error message

> runtime error: index out of range [0] with length 0 [recovered] panic: runtime error: index out of range [0] with length 0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #7203 

**Special notes for your reviewer**:

**Documentation**:

**Does this PR introduce a user-facing change?**:
```release-note
fix bad error message on misconfigured gce datacenter in seed yaml file
```
