### PR TITLE
always use installer in deploy.sh

### DIFF
--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -33,7 +33,6 @@ if [[ ! -f "$2" ]]; then
 fi
 
 VALUES_FILE="$(realpath "$2")"
-DEPLOY_MINIO=${DEPLOY_MINIO:-true}
 DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 
 cd $(dirname "$0")/../..
@@ -122,33 +121,26 @@ kubermatic)
   fi
 
   # Kubermatic
-  if [[ "${1}" = "master" ]]; then
-    echodate "Running Kubermatic Installer..."
+  clusterType="$1"
 
-    # --force must be given because the Chart versions have not necessarily changed.
-    ./_build/kubermatic-installer deploy \
-      --storageclass copy-default \
-      --config "$KUBERMATIC_CONFIG" \
-      --helm-values "$VALUES_FILE" \
-      --migrate-upstream-cert-manager \
-      --force
+  echodate "Running Kubermatic Installer..."
 
-    # We might have not configured IAP which results in nothing being deployed. This triggers https://github.com/helm/helm/issues/4295 and marks this as failed
-    # We hack around this by grepping for a string that is mandatory in the values file of IAP
-    # to determine if its configured, because am empty chart leads to Helm doing weird things
-    if grep -q discovery_url ${VALUES_FILE}; then
+  # --force must be given because the Chart versions have not necessarily changed.
+  ./_build/kubermatic-installer deploy "kubermatic-$clusterType" \
+    --storageclass copy-default \
+    --config "$KUBERMATIC_CONFIG" \
+    --helm-values "$VALUES_FILE" \
+    --migrate-upstream-cert-manager \
+    --force
+
+  if [[ "$clusterType" = "master" ]]; then
+    # We might have not configured IAP, which results in nothing being deployed. This triggers
+    # https://github.com/helm/helm/issues/4295 and marks this as failed.
+    if [ $(yq read "$VALUES_FILE" --length 'iap.deployments') -gt 0 ]; then
       deploy "iap" "iap" charts/iap/
     else
-      echodate "Skipping IAP deployment because discovery_url is unset in values file"
+      echodate "Skipping IAP chart because no deployments are defined in Helm values file."
     fi
-  else
-    echodate "Installing Kubermatic CRDs into seed cluster..."
-    retry 3 kubectl apply --filename charts/kubermatic-operator/crd/
-  fi
-
-  if [[ "${DEPLOY_MINIO}" = true ]]; then
-    deploy "minio" "minio" charts/minio/
-    deploy "s3-exporter" "kube-system" charts/s3-exporter/
   fi
   ;;
 esac


### PR DESCRIPTION
**What this PR does / why we need it**:
Since #8552 the installer can now properly setup seeds. We should use it to ensure it works.

This PR also fixes the broken deployment check for the IAP chart. Since we moved to oauth2-proxy for the IAP, there is no `discovery_url` at all anymore. The only reason we still deployed is because our own values for the dev system still contained the dicovery_url. :grin: 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
