### PR TITLE
Fix creation of ClusterRole in cert-manager chart

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: cert-manager
-version: 2.0.4
+version: 2.0.5
 appVersion: v1.5.2
 description: A Helm chart for cert-manager
 keywords:

--- a/charts/cert-manager/templates/cert-manager-rbac.yaml
+++ b/charts/cert-manager/templates/cert-manager-rbac.yaml
@@ -417,6 +417,7 @@ rules:
     resources: ["challenges", "orders"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
 
+---
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a missing document separator between two consecutive ClusterRole
definitions, which prevented the creation of the ClusterRole
'cert-manager-edit'.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Create missing ClusterRole 'cert-manager-edit' for cert-manager
```
