### PR TITLE
Change cert-manager's upgrade procedure

### DIFF
--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -519,6 +519,8 @@ func preparePreV21CertManagerDeployment(
 		issuer.SetResourceVersion("")
 		issuer.SetUID("")
 		issuer.SetSelfLink("")
+		issuer.SetLabels(map[string]string{})
+		issuer.SetAnnotations(map[string]string{})
 
 		if err := kubeClient.Create(ctx, &issuer); err != nil {
 			logger.Warnf("Failed to restore ClusterIssuer: %v\n\nUse backup_%s_%s.yaml file to restore.", err, CertManagerReleaseName, now)


### PR DESCRIPTION
**What this PR does / why we need it**:
It's safer to just remove old cert-manager installation and keep only the clusterIssuers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7899 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
cert-manager's upgrade will reinstall the chart cleanly, existing ClusterIssuers created by a helm chart will be recreated
```
