### PR TITLE
use embedded upstream CRDs for gatekeeper CRD installation

### DIFF
--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -31,7 +31,8 @@ boilerplate \
   -exclude pkg/resources/certificates/triple/triple.go \
   -exclude pkg/resources/etcd/testdata \
   -exclude pkg/ee \
-  -exclude charts/kubermatic-operator/crd
+  -exclude charts/kubermatic-operator/crd \
+  -exclude pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static
 
 echodate "Checking Kubermatic EE licenses..."
 boilerplate \

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
@@ -17,53 +17,54 @@ limitations under the License.
 package gatekeeper
 
 import (
+	_ "embed"
+
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-const (
-	configAPIGroup                        = "config.gatekeeper.sh"
-	configAPIVersion                      = "v1alpha1"
-	constraintTemplateAPIGroup            = "templates.gatekeeper.sh"
-	constraintTemplateAPIVersion          = "v1beta1"
-	statusAPIGroup                        = "status.gatekeeper.sh"
-	constraintPodStatusAPIVersion         = "v1beta1"
-	constraintTemplatePodStatusAPIVersion = "v1beta1"
-	mutatorPodStatusAPIVersion            = "v1beta1"
-	mutatorPodStatusAPIGroup              = "status.gatekeeper.sh"
-	assignAPIGroup                        = "mutations.gatekeeper.sh"
-	assignAPIVersion                      = "v1alpha1"
-	assignMetadataAPIGroup                = "mutations.gatekeeper.sh"
-	assignMetadataAPIVersion              = "v1alpha1"
+var (
+	//go:embed static/config-customresourcedefinition.yaml
+	configYAML string
+
+	//go:embed static/constrainttemplate-customresourcedefinition.yaml
+	constraintTemplateYAML string
+
+	//go:embed static/constrainttemplatepodstatus-customresourcedefinition.yaml
+	constraintTemplatePodStatusYAML string
+
+	//go:embed static/constraintpodstatus-customresourcedefinition.yaml
+	constraintPodStatusYAML string
+
+	//go:embed static/mutatorpodstatus-customresourcedefinition.yaml
+	mutatorPodStatusYAML string
+
+	//go:embed static/assign-customresourcedefinition.yaml
+	assignYAML string
+
+	//go:embed static/assignmetadata-customresourcedefinition.yaml
+	assignMetadataYAML string
 )
 
 // ConfigCRDCreator returns the gatekeeper config CRD definition
 func ConfigCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConfigCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Annotations = map[string]string{"controller-gen.kubebuilder.io/version": "v0.5.2"}
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes"}
-			crd.Spec.Group = configAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    configAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(configYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.NamespaceScoped
-			crd.Spec.Names.Kind = "Config"
-			crd.Spec.Names.ListKind = "ConfigList"
-			crd.Spec.Names.Plural = "configs"
-			crd.Spec.Names.Singular = "config"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}
@@ -74,42 +75,18 @@ func ConfigCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 func ConstraintTemplateCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConstraintTemplateCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Annotations = map[string]string{"controller-gen.kubebuilder.io/version": "v0.5.2"}
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes", "controller-tools.k8s.io": "1.0"}
-			crd.Spec.Group = constraintTemplateAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    constraintTemplateAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
-				{
-					Name:    "v1alpha1",
-					Served:  true,
-					Storage: false,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(constraintTemplateYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.ClusterScoped
-			crd.Spec.Names.Kind = "ConstraintTemplate"
-			crd.Spec.Names.Plural = "constrainttemplates"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}
@@ -120,27 +97,18 @@ func ConstraintTemplateCRDCreator() reconciling.NamedCustomResourceDefinitionCre
 func ConstraintPodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConstraintPodStatusCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes"}
-			crd.Spec.Group = statusAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    constraintPodStatusAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(constraintPodStatusYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.NamespaceScoped
-			crd.Spec.Names.Kind = "ConstraintPodStatus"
-			crd.Spec.Names.Plural = "constraintpodstatuses"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}
@@ -151,27 +119,18 @@ func ConstraintPodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCr
 func ConstraintTemplatePodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConstraintTemplatePodStatusCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes"}
-			crd.Spec.Group = statusAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    constraintTemplatePodStatusAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(constraintTemplatePodStatusYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.NamespaceScoped
-			crd.Spec.Names.Kind = "ConstraintTemplatePodStatus"
-			crd.Spec.Names.Plural = "constrainttemplatepodstatuses"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}
@@ -181,28 +140,18 @@ func ConstraintTemplatePodStatusCRDCreator() reconciling.NamedCustomResourceDefi
 func MutatorPodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperMutatorPodStatusCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Annotations = map[string]string{"controller-gen.kubebuilder.io/version": "v0.5.2"}
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes"}
-			crd.Spec.Group = mutatorPodStatusAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    mutatorPodStatusAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(mutatorPodStatusYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.NamespaceScoped
-			crd.Spec.Names.Kind = "MutatorPodStatus"
-			crd.Spec.Names.Plural = "mutatorpodstatuses"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}
@@ -212,28 +161,18 @@ func MutatorPodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCreat
 func AssignCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperAssignCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Annotations = map[string]string{"controller-gen.kubebuilder.io/version": "v0.5.2"}
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes"}
-			crd.Spec.Group = assignAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    assignAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(assignYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.ClusterScoped
-			crd.Spec.Names.Kind = "Assign"
-			crd.Spec.Names.Plural = "assign"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}
@@ -243,28 +182,18 @@ func AssignCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 func AssignMetadataCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperAssignMetadataCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			crd.Annotations = map[string]string{"controller-gen.kubebuilder.io/version": "v0.5.2"}
-			crd.Labels = map[string]string{"gatekeeper.sh/system": "yes"}
-			crd.Spec.Group = assignMetadataAPIGroup
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    assignMetadataAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.Unmarshal([]byte(assignMetadataYAML), &fileCRD)
+			if err != nil {
+				return nil, err
 			}
-			crd.Spec.Scope = apiextensionsv1.ClusterScoped
-			crd.Spec.Names.Kind = "AssignMetadata"
-			crd.Spec.Names.Plural = "assignmetadata"
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
 
 			return crd, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source: https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
@@ -1,0 +1,208 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assign.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: Assign
+    listKind: AssignList
+    plural: assign
+    singular: assign
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Assign is the Schema for the assign API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AssignSpec defines the desired state of Assign
+              properties:
+                applyTo:
+                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+                  items:
+                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    properties:
+                      groups:
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                      versions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                location:
+                  type: string
+                match:
+                  description: Match selects objects to apply mutations to.
+                  properties:
+                    excludedNamespaces:
+                      items:
+                        type: string
+                      type: array
+                    kinds:
+                      items:
+                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        properties:
+                          apiGroups:
+                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            items:
+                              type: string
+                            type: array
+                          kinds:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    labelSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    namespaceSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                    scope:
+                      description: ResourceScope is an enum defining the different scopes available to a custom resource
+                      type: string
+                  type: object
+                parameters:
+                  properties:
+                    assign:
+                      description: Assign.value holds the value to be assigned
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    assignIf:
+                      description: once https://github.com/kubernetes-sigs/controller-tools/pull/528 is merged, we can use an actual object
+                      type: object
+                    pathTests:
+                      items:
+                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate"
+                        properties:
+                          condition:
+                            description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                            enum:
+                              - MustExist
+                              - MustNotExist
+                            type: string
+                          subPath:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              description: AssignStatus defines the observed state of Assign
+              properties:
+                byPod:
+                  items:
+                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+                    properties:
+                      enforced:
+                        type: boolean
+                      errors:
+                        items:
+                          description: MutatorError represents a single error caught while adding a mutator to a system
+                          properties:
+                            message:
+                              type: string
+                          required:
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        type: string
+                      mutatorUID:
+                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                      operations:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assignmetadata-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assignmetadata-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assignmetadata-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assignmetadata-customresourcedefinition.yaml
@@ -1,0 +1,173 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assignmetadata.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: AssignMetadata
+    listKind: AssignMetadataList
+    plural: assignmetadata
+    singular: assignmetadata
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: AssignMetadata is the Schema for the assignmetadata API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AssignMetadataSpec defines the desired state of AssignMetadata
+              properties:
+                location:
+                  type: string
+                match:
+                  description: Match selects objects to apply mutations to.
+                  properties:
+                    excludedNamespaces:
+                      items:
+                        type: string
+                      type: array
+                    kinds:
+                      items:
+                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        properties:
+                          apiGroups:
+                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            items:
+                              type: string
+                            type: array
+                          kinds:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    labelSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    namespaceSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                    scope:
+                      description: ResourceScope is an enum defining the different scopes available to a custom resource
+                      type: string
+                  type: object
+                parameters:
+                  properties:
+                    assign:
+                      description: Assign.value holds the value to be assigned
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              type: object
+            status:
+              description: AssignMetadataStatus defines the observed state of AssignMetadata
+              properties:
+                byPod:
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                  items:
+                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+                    properties:
+                      enforced:
+                        type: boolean
+                      errors:
+                        items:
+                          description: MutatorError represents a single error caught while adding a mutator to a system
+                          properties:
+                            message:
+                              type: string
+                          required:
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        type: string
+                      mutatorUID:
+                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                      operations:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
@@ -1,0 +1,102 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: configs.config.gatekeeper.sh
+spec:
+  group: config.gatekeeper.sh
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: configs
+    singular: config
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Config is the Schema for the configs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConfigSpec defines the desired state of Config
+              properties:
+                match:
+                  description: Configuration for namespace exclusion
+                  items:
+                    properties:
+                      excludedNamespaces:
+                        items:
+                          type: string
+                        type: array
+                      processes:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                readiness:
+                  description: Configuration for readiness tracker
+                  properties:
+                    statsEnabled:
+                      type: boolean
+                  type: object
+                sync:
+                  description: Configuration for syncing k8s objects
+                  properties:
+                    syncOnly:
+                      description: If non-empty, only entries on this list will be replicated into OPA
+                      items:
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                validation:
+                  description: Configuration for validation
+                  properties:
+                    traces:
+                      description: List of requests to trace. Both "user" and "kinds" must be specified
+                      items:
+                        properties:
+                          dump:
+                            description: Also dump the state of OPA with the trace. Set to `All` to dump everything.
+                            type: string
+                          kind:
+                            description: Only trace requests of the following GroupVersionKind
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          user:
+                            description: Only trace requests from the specified user
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              description: ConfigStatus defines the observed state of Config
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
@@ -1,0 +1,66 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: constraintpodstatuses.status.gatekeeper.sh
+spec:
+  group: status.gatekeeper.sh
+  names:
+    kind: ConstraintPodStatus
+    listKind: ConstraintPodStatusList
+    plural: constraintpodstatuses
+    singular: constraintpodstatus
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ConstraintPodStatus is the Schema for the constraintpodstatuses API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            status:
+              description: ConstraintPodStatusStatus defines the observed state of ConstraintPodStatus
+              properties:
+                constraintUID:
+                  description: Storing the constraint UID allows us to detect drift, such as when a constraint has been recreated after its CRD was deleted out from under it, interrupting the watch
+                  type: string
+                enforced:
+                  type: boolean
+                errors:
+                  items:
+                    description: Error represents a single error caught while adding a constraint to OPA
+                    properties:
+                      code:
+                        type: string
+                      location:
+                        type: string
+                      message:
+                        type: string
+                    required:
+                      - code
+                      - message
+                    type: object
+                  type: array
+                id:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                operations:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
@@ -1,0 +1,197 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: constrainttemplates.templates.gatekeeper.sh
+spec:
+  group: templates.gatekeeper.sh
+  names:
+    kind: ConstraintTemplate
+    listKind: ConstraintTemplateList
+    plural: constrainttemplates
+    singular: constrainttemplate
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ConstraintTemplate is the Schema for the constrainttemplates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+              properties:
+                crd:
+                  properties:
+                    spec:
+                      properties:
+                        names:
+                          properties:
+                            kind:
+                              type: string
+                            shortNames:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        validation:
+                          properties:
+                            openAPIV3Schema:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                  type: object
+                targets:
+                  items:
+                    properties:
+                      libs:
+                        items:
+                          type: string
+                        type: array
+                      rego:
+                        type: string
+                      target:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+              properties:
+                byPod:
+                  items:
+                    description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
+                    properties:
+                      errors:
+                        items:
+                          description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                          properties:
+                            code:
+                              type: string
+                            location:
+                              type: string
+                            message:
+                              type: string
+                          required:
+                            - code
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        description: a unique identifier for the pod that wrote the status
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                created:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ConstraintTemplate is the Schema for the constrainttemplates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+              properties:
+                crd:
+                  properties:
+                    spec:
+                      properties:
+                        names:
+                          properties:
+                            kind:
+                              type: string
+                            shortNames:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        validation:
+                          properties:
+                            openAPIV3Schema:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                  type: object
+                targets:
+                  items:
+                    properties:
+                      libs:
+                        items:
+                          type: string
+                        type: array
+                      rego:
+                        type: string
+                      target:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+              properties:
+                byPod:
+                  items:
+                    description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
+                    properties:
+                      errors:
+                        items:
+                          description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                          properties:
+                            code:
+                              type: string
+                            location:
+                              type: string
+                            message:
+                              type: string
+                          required:
+                            - code
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        description: a unique identifier for the pod that wrote the status
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                created:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: constrainttemplatepodstatuses.status.gatekeeper.sh
+spec:
+  group: status.gatekeeper.sh
+  names:
+    kind: ConstraintTemplatePodStatus
+    listKind: ConstraintTemplatePodStatusList
+    plural: constrainttemplatepodstatuses
+    singular: constrainttemplatepodstatus
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            status:
+              description: ConstraintTemplatePodStatusStatus defines the observed state of ConstraintTemplatePodStatus
+              properties:
+                errors:
+                  items:
+                    description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                    properties:
+                      code:
+                        type: string
+                      location:
+                        type: string
+                      message:
+                        type: string
+                    required:
+                      - code
+                      - message
+                    type: object
+                  type: array
+                id:
+                  description: 'Important: Run "make" to regenerate code after modifying this file'
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                operations:
+                  items:
+                    type: string
+                  type: array
+                templateUID:
+                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: mutatorpodstatuses.status.gatekeeper.sh
+spec:
+  group: status.gatekeeper.sh
+  names:
+    kind: MutatorPodStatus
+    listKind: MutatorPodStatusList
+    plural: mutatorpodstatuses
+    singular: mutatorpodstatus
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: MutatorPodStatus is the Schema for the mutationpodstatuses API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            status:
+              description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+              properties:
+                enforced:
+                  type: boolean
+                errors:
+                  items:
+                    description: MutatorError represents a single error caught while adding a mutator to a system
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                    type: object
+                  type: array
+                id:
+                  type: string
+                mutatorUID:
+                  description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                operations:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
@@ -1,3 +1,5 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -32,7 +32,7 @@ import (
 
 func init() {
 	// Kubernetes Objects can be deeper than the default 10 levels.
-	deep.MaxDepth = 20
+	deep.MaxDepth = 25
 	deep.LogErrors = true
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
uses embedded upstream gatekeeper CRDs for gatekeeper installation on user clusters, instead of the current way of having them in code. This will make them easier to mantain

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7971 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
