### PR TITLE
fix nodeport proxy e2e test

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1182,7 +1182,7 @@ presubmits:
   #########################################################
 
   - name: pre-kubermatic-nodeport-proxy-e2e
-    run_if_changed: "(cmd/nodeport-proxy/|pkg/controller/operator/seed/nodeportproxy/|pkg/controller/nodeport-proxy|.prow.yaml)"
+    run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/pkg/test/e2e/nodeport-proxy/deployer.go
+++ b/pkg/test/e2e/nodeport-proxy/deployer.go
@@ -81,6 +81,9 @@ func (d *Deployer) SetUp() error {
 		},
 		Spec: operatorv1alpha1.KubermaticConfigurationSpec{
 			FeatureGates: sets.NewString(features.TunnelingExposeStrategy),
+			UserCluster: operatorv1alpha1.KubermaticUserClusterConfiguration{
+				EtcdVolumeSize: "500Mi",
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
E2E test for nodeport proxy is broken. It did not run because `run_if_changed` is too strict in prow.yaml. This pr fixes it. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```