### PR TITLE
[release/v2.18] Upgrade etcd to 3.5.1 for Kubernetes 1.22+

### DIFF
--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -351,7 +351,7 @@ func ImageTag(c *kubermaticv1.Cluster) string {
 		return "v3.4.3"
 	}
 
-	return "v3.5.0"
+	return "v3.5.1"
 }
 
 func computeReplicas(data etcdStatefulSetCreatorData, set *appsv1.StatefulSet) int32 {

--- a/pkg/resources/test/fixtures/cronjob-aws-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.0
+            image: gcr.io/etcd-development/etcd:v3.5.1
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -341,7 +341,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -335,7 +335,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -335,7 +335,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -335,7 +335,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
@@ -95,7 +95,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.0
+        image: gcr.io/etcd-development/etcd:v3.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of #8559 into `release/v2.18`. KKP 2.18 uses etcd 3.5 for Kubernetes versions >= 1.22, but does not use the 3.5 client library (as `master` does), so a manual change was necessary.

To repeat #8559, etcd 3.5.0 had some bugs around internal representation of cluster state, and 3.5.1 is supposed to fix this. #8558 reported a problem that matches upstream issues supposedly solved by 3.5.1. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to #8558

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Upgrade etcd to 3.5.1 for Kubernetes 1.22 (and higher)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>