### PR TITLE
update etcd launcher e2e test with multiple backups

### DIFF
--- a/hack/ci/testdata/backup_s3_creds.yaml
+++ b/hack/ci/testdata/backup_s3_creds.yaml
@@ -19,12 +19,3 @@ metadata:
 data:
   ACCESS_KEY_ID: RlhjRDdzMHRGT1B1VHY2amFaQVJKRG91YzJIYWw4RTA=
   SECRET_ACCESS_KEY: d2RFWkdUbmhrZ0JEVERldGFIRnVpenMzcHdYSHZXVHM=
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: s3-settings
-  namespace: kube-system
-data:
-  BUCKET_NAME: kkpbackupe2e
-  ENDPOINT: minio.minio.svc.cluster.local:9000

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -29,9 +29,14 @@ metadata:
   labels:
     worker-name: "__BUILD_ID__"
 spec:
-  backupRestore:
-    s3BucketName: kkpbackupe2e
-    s3Endpoint: minio.minio.svc.cluster.local:9000
+  etcdBackupRestore:
+    destinations:
+      minio:
+        bucketName: kkpbackupe2e
+        endpoint: minio.minio.svc.cluster.local:9000
+        credentials:
+          namespace: kube-system
+          name: backup-s3
   country: Germany
   location: Hamburg
   kubeconfig:

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -47,8 +47,9 @@ var (
 )
 
 const (
-	scaleUpCount   = 5
-	scaleDownCount = 3
+	scaleUpCount           = 5
+	scaleDownCount         = 3
+	minioBackupDestination = "minio"
 )
 
 func TestBackup(t *testing.T) {
@@ -203,7 +204,7 @@ func createBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.Cl
 				APIVersion:      cluster.APIVersion,
 				ResourceVersion: cluster.ResourceVersion,
 			},
-			Destination: "minio",
+			Destination: minioBackupDestination,
 		},
 	}
 
@@ -235,7 +236,7 @@ func restoreBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.C
 				ResourceVersion: cluster.ResourceVersion,
 			},
 			BackupName:  backup.Status.CurrentBackups[0].BackupName,
-			Destination: "minio",
+			Destination: minioBackupDestination,
 		},
 	}
 

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -203,6 +203,7 @@ func createBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.Cl
 				APIVersion:      cluster.APIVersion,
 				ResourceVersion: cluster.ResourceVersion,
 			},
+			Destination: "minio",
 		},
 	}
 

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -235,6 +235,7 @@ func restoreBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.C
 				ResourceVersion: cluster.ResourceVersion,
 			},
 			BackupName: backup.Status.CurrentBackups[0].BackupName,
+			Destination: "minio",
 		},
 	}
 

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -234,7 +234,7 @@ func restoreBackup(ctx context.Context, t *testing.T, client ctrlruntimeclient.C
 				APIVersion:      cluster.APIVersion,
 				ResourceVersion: cluster.ResourceVersion,
 			},
-			BackupName: backup.Status.CurrentBackups[0].BackupName,
+			BackupName:  backup.Status.CurrentBackups[0].BackupName,
 			Destination: "minio",
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the etcd launcher e2e tests with new backups which support multiple destinations


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
