### PR TITLE
Another round of CRD sync

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.37
+version: 0.3.38
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -739,6 +739,12 @@ spec:
                     required:
                     - billingCycle
                     type: object
+                  providerName:
+                    description: ProviderName is the name of the cloud provider used
+                      for this cluster. This must match the given provider spec (e.g.
+                      if the providerName is "aws", then the AWSCloudSpec must be
+                      set)
+                    type: string
                   vsphere:
                     description: VSphereCloudSpec specifies access data to VSphere
                       cloud.
@@ -829,6 +835,7 @@ spec:
                     type: object
                 required:
                 - dc
+                - providerName
                 type: object
               clusterNetwork:
                 description: ClusterNetworkingConfig specifies the different networking

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -710,6 +710,12 @@ spec:
                     required:
                     - billingCycle
                     type: object
+                  providerName:
+                    description: ProviderName is the name of the cloud provider used
+                      for this cluster. This must match the given provider spec (e.g.
+                      if the providerName is "aws", then the AWSCloudSpec must be
+                      set)
+                    type: string
                   vsphere:
                     description: VSphereCloudSpec specifies access data to VSphere
                       cloud.
@@ -800,6 +806,7 @@ spec:
                     type: object
                 required:
                 - dc
+                - providerName
                 type: object
               clusterNetwork:
                 description: ClusterNetworkingConfig specifies the different networking

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -607,6 +607,11 @@ type CloudSpec struct {
 	// DatacenterName where the users 'cloud' lives in.
 	DatacenterName string `json:"dc"`
 
+	// ProviderName is the name of the cloud provider used for this cluster.
+	// This must match the given provider spec (e.g. if the providerName is
+	// "aws", then the AWSCloudSpec must be set)
+	ProviderName string `json:"providerName"`
+
 	Fake         *FakeCloudSpec         `json:"fake,omitempty"`
 	Digitalocean *DigitaloceanCloudSpec `json:"digitalocean,omitempty"`
 	BringYourOwn *BringYourOwnCloudSpec `json:"bringyourown,omitempty"`

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -404,6 +404,7 @@ func convertClusterSpec(old kubermaticv1.ClusterSpec) newv1.ClusterSpec {
 	result := newv1.ClusterSpec{
 		Cloud: newv1.CloudSpec{
 			DatacenterName: old.Cloud.DatacenterName,
+			ProviderName:   old.Cloud.ProviderName,
 
 			// Azure, VSphere and Openstack need special treatment further down
 			AWS:          (*newv1.AWSCloudSpec)(old.Cloud.AWS),


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to keep new OpenAPI v3 CRDs in sync with our old schemaless-CRD types.

PRs to sync:
* #8352

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
