### PR TITLE
Add worker-cluster-kubeconfig flag for machine-controller webhooks

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/admission.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/admission.go
@@ -181,7 +181,7 @@ func OperatingSystemConfigValidatingWebhookConfigurationCreator(cfg *operatorv1a
 			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
 			sideEffects := admissionregistrationv1.SideEffectClassNone
-			scope := admissionregistrationv1.ClusterScope
+			scope := admissionregistrationv1.AllScopes
 
 			ca, err := common.WebhookCABundle(cfg, client)
 			if err != nil {
@@ -234,7 +234,7 @@ func OperatingSystemProfileValidatingWebhookConfigurationCreator(cfg *operatorv1
 			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
 			sideEffects := admissionregistrationv1.SideEffectClassNone
-			scope := admissionregistrationv1.ClusterScope
+			scope := admissionregistrationv1.AllScopes
 
 			ca, err := common.WebhookCABundle(cfg, client)
 			if err != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -399,6 +399,8 @@ func (r *Reconciler) ensureServiceAccounts(ctx context.Context, c *kubermaticv1.
 	namedServiceAccountCreatorGetters := []reconciling.NamedServiceAccountCreatorGetter{
 		etcd.ServiceAccountCreator,
 		usercluster.ServiceAccountCreator,
+		machinecontroller.ServiceAccountCreator,
+		machinecontroller.WebhookServiceAccountCreator,
 	}
 
 	if c.Spec.EnableOperatingSystemManager {
@@ -415,6 +417,7 @@ func (r *Reconciler) ensureServiceAccounts(ctx context.Context, c *kubermaticv1.
 func (r *Reconciler) ensureRoles(ctx context.Context, c *kubermaticv1.Cluster) error {
 	namedRoleCreatorGetters := []reconciling.NamedRoleCreatorGetter{
 		usercluster.RoleCreator,
+		machinecontroller.WebhookRoleCreator,
 	}
 
 	if c.Spec.EnableOperatingSystemManager {
@@ -431,6 +434,7 @@ func (r *Reconciler) ensureRoles(ctx context.Context, c *kubermaticv1.Cluster) e
 func (r *Reconciler) ensureRoleBindings(ctx context.Context, c *kubermaticv1.Cluster) error {
 	namedRoleBindingCreatorGetters := []reconciling.NamedRoleBindingCreatorGetter{
 		usercluster.RoleBindingCreator,
+		machinecontroller.WebhookRoleBindingCreator,
 	}
 
 	if c.Spec.EnableOperatingSystemManager {

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -149,7 +149,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 					Command: []string{"/usr/local/bin/machine-controller"},
 					Args:    getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime, data.Cluster().Spec.EnableOperatingSystemManager),
 					Env: append(envVars, corev1.EnvVar{
-						Name:  "KUBECONFIG",
+						Name:  "PROBER_KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
 					}),
 					LivenessProbe: &corev1.Probe{
@@ -180,6 +180,9 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 					},
 				},
 			}
+
+			dep.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, controllerResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)

--- a/pkg/resources/machinecontroller/rbac.go
+++ b/pkg/resources/machinecontroller/rbac.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinecontroller
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	serviceAccountName        = "kubermatic-machine-controller"
+	webhookServiceAccountName = "kubermatic-machine-controller-webhook"
+	webhookRoleName           = "kubermatic:machine-controller-webhook"
+	webhookRoleBindingName    = "kubermatic:machine-controller-webhook"
+)
+
+func ServiceAccountCreator() (string, reconciling.ServiceAccountCreator) {
+	return serviceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+		return sa, nil
+	}
+}
+
+func WebhookServiceAccountCreator() (string, reconciling.ServiceAccountCreator) {
+	return webhookServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+		return sa, nil
+	}
+}
+func WebhookRoleCreator() (string, reconciling.RoleCreator) {
+	return webhookRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
+		r.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"operatingsystemmanager.k8c.io"},
+				Resources: []string{"operatingsystemprofiles"},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+			},
+		}
+		return r, nil
+	}
+}
+
+func WebhookRoleBindingCreator() (string, reconciling.RoleBindingCreator) {
+	return webhookRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+		rb.RoleRef = rbacv1.RoleRef{
+			Name:     webhookRoleName,
+			Kind:     "Role",
+			APIGroup: rbacv1.GroupName,
+		}
+		rb.Subjects = []rbacv1.Subject{
+			{
+				Kind: rbacv1.ServiceAccountKind,
+				Name: webhookServiceAccountName,
+			},
+		}
+		return rb, nil
+	}
+}

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -52,7 +52,7 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	Tag  = "v0.3.4"
+	Tag  = "v0.3.5"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -52,7 +52,7 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	Tag  = "v0.3.2"
+	Tag  = "v0.3.4"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -59,8 +59,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -90,7 +90,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -105,6 +105,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -59,8 +59,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -90,7 +90,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -105,6 +105,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -59,8 +59,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -90,7 +90,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -105,6 +105,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -59,8 +59,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -90,7 +90,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -105,6 +105,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -59,8 +59,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -90,7 +90,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -105,6 +105,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -59,8 +59,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -90,7 +90,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -105,6 +105,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -51,8 +51,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +82,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -106,6 +106,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -97,6 +97,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -51,8 +51,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +82,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -106,6 +106,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -97,6 +97,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -51,8 +51,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +82,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -106,6 +106,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -97,6 +97,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -53,8 +53,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -84,7 +84,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -108,6 +108,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -99,6 +99,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -53,8 +53,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -84,7 +84,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -108,6 +108,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -99,6 +99,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -53,8 +53,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -84,7 +84,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -108,6 +108,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -99,6 +99,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -110,6 +110,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -64,8 +64,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -95,7 +95,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -119,6 +119,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -64,8 +64,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -95,7 +95,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -119,6 +119,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -110,6 +110,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -110,6 +110,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -64,8 +64,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -95,7 +95,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -119,6 +119,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -64,8 +64,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -95,7 +95,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -119,6 +119,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -110,6 +110,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -110,6 +110,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -64,8 +64,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -95,7 +95,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -119,6 +119,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -64,8 +64,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -95,7 +95,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -119,6 +119,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -110,6 +110,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -103,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -57,8 +57,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -88,7 +88,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -112,6 +112,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -57,8 +57,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -88,7 +88,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -112,6 +112,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
@@ -60,7 +60,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -103,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -103,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -57,8 +57,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -88,7 +88,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -112,6 +112,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -57,8 +57,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -88,7 +88,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -112,6 +112,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller.yaml
@@ -60,7 +60,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -103,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -103,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -57,8 +57,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -88,7 +88,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -112,6 +112,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -57,8 +57,8 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
-          value: /etc/kubernetes/kubeconfig/kubeconfig
+        - name: PROBER_KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
           failureThreshold: 8
@@ -88,7 +88,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
+        - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
         - mountPath: /tmp/cert
@@ -112,6 +112,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
@@ -60,7 +60,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -103,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig
         secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add worker-cluster-kubeconfig flag for machine-controller webhooks

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
