### PR TITLE
Improve handling of KUBECONFIG in http-prober

### DIFF
--- a/cmd/http-prober/release.sh
+++ b/cmd/http-prober/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ver=v0.3.2
+ver=v0.3.3
 
 set -euox pipefail
 

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	tag                = "v0.3.2"
+	tag                = "v0.3.3"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -117,7 +117,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 					Command: []string{"/usr/local/bin/webhook"},
 					Args:    args,
 					Env: append(envVars, corev1.EnvVar{
-						Name:  "KUBECONFIG",
+						Name:  "PROBER_KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
 					}),
 					ReadinessProbe: &corev1.Probe{

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -202,7 +202,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
@@ -202,7 +202,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -202,7 +202,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
@@ -99,7 +99,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-externalCloudProvider.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -196,7 +196,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        - name: KUBECONFIG
+        - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.41.0
         livenessProbe:
@@ -106,7 +106,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -158,7 +158,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -172,7 +172,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.2
+        image: quay.io/kubermatic/http-prober:v0.3.3
         name: copy-http-prober
         resources: {}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the behavior of `http-prober` wait for CRD functionality. Previously, it relied specifically on `KUBECONFIG` env variable for path to kubeconfig. with the current changes it will try to resolve kubeconfig in the following order, based on precedence:

```text
1. PROBER_KUBECONFIG env variable
2. KUBECONFIG env variable
3. -kubeconfig flag
4. In-cluster config if running inside a cluster
5. $HOME/.kube/config if exists.
```

We now need to use in-cluster and external cluster's kube config within the same container. For machine-controller webhooks, previously using `KUBECONFIG` env variable was sufficient since we only required the user cluster's kubeconfig. But now it also needs to load in-cluster config for seed/master cluster. By specifying `KUBECONFIG` at a container level we can't fetch in-cluster config using https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/config/config.go#L59

As a work-around we updated it to have a dedicated env variable `PROBER_KUBECONFIG` to avoid any conflicts if multiple configs are required within the same context.

**NOTE:** This shouldn't break anything for the existing workflows since `KUBECONFIG` env variable still provides the same functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
