### PR TITLE
Fix external cluster kubeconfig status check

### DIFF
--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -914,7 +914,7 @@ func convertClusterToAPIWithStatus(ctx context.Context, clusterProvider provider
 
 	// check kubeconfig access. Skip during reconciling state
 	_, err := clusterProvider.GetVersion(internalCluster)
-	if err != nil && apiCluster.Status.State != apiv2.RECONCILING {
+	if err != nil && apiCluster.Status.State == apiv2.RUNNING {
 		apiCluster.Status = apiv2.ExternalClusterStatus{
 			State:         apiv2.ERROR,
 			StatusMessage: fmt.Sprintf("can't access cluster via kubeconfig, check the privilidges, %v", err),


### PR DESCRIPTION
Signed-off-by: Harshita <imharshita@github.com>

**What this PR does / why we need it**: Fix external cluster kubeconfig status check

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8626

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
