### PR TITLE
Check usercluster compatibility prior to KKP upgrades

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -303,7 +303,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		opt.SeedsGetter = seedsGetter
 		opt.SeedClientGetter = provider.SeedClientGetterFactory(seedKubeconfigGetter)
 
-		logger.Info("🩺 Validating existing installation…")
+		logger.Info("🚦 Validating existing installation…")
 
 		if errs := kubermaticStack.ValidateState(appContext, opt); errs != nil {
 			logger.Error("⛔ Cannot proceed with the installation:")
@@ -314,6 +314,8 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 
 			return errors.New("preflight checks have failed")
 		}
+
+		logger.Info("✅ Existing installation is valid.")
 
 		logger.Infof("🛫 Deploying %s…", kubermaticStack.Name())
 

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -186,7 +186,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			return fmt.Errorf("unknown stack %q specified", stackName)
 		}
 
-		logger.WithFields(fields).Info("🛫 Initializing installer…")
+		logger.WithFields(fields).Info("🚀 Initializing installer…")
 
 		// load config files
 		if len(kubeconfig) == 0 {
@@ -303,7 +303,19 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		opt.SeedsGetter = seedsGetter
 		opt.SeedClientGetter = provider.SeedClientGetterFactory(seedKubeconfigGetter)
 
-		logger.Infof("🧩 Deploying %s…", kubermaticStack.Name())
+		logger.Info("🩺 Validating existing installation…")
+
+		if errs := kubermaticStack.ValidateState(appContext, opt); errs != nil {
+			logger.Error("⛔ Cannot proceed with the installation:")
+
+			for _, e := range errs {
+				subLogger.Errorf("%v", e)
+			}
+
+			return errors.New("preflight checks have failed")
+		}
+
+		logger.Infof("🛫 Deploying %s…", kubermaticStack.Name())
 
 		if err := kubermaticStack.Deploy(appContext, opt); err != nil {
 			return err

--- a/pkg/install/stack/common/validation.go
+++ b/pkg/install/stack/common/validation.go
@@ -17,10 +17,97 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/install/stack"
 )
+
+func ValidateAllUserClustersAreCompatible(ctx context.Context, seed *kubermaticv1.Seed, opt *stack.DeployOptions) []error {
+	var errs []error
+
+	// we need the actual, effective versioning configuration, which most users will
+	// probably not override
+	defaulted, err := defaults.DefaultConfiguration(opt.KubermaticConfiguration, zap.NewNop().Sugar())
+	if err != nil {
+		return append(errs, fmt.Errorf("failed to apply default values to the KubermaticConfiguration: %w", err))
+	}
+
+	// create client into seed
+	seedClient, err := opt.SeedClientGetter(seed)
+	if err != nil {
+		return append(errs, fmt.Errorf("failed to create client for Seed cluster %q: %w", seed.Name, err))
+	}
+
+	// list all userclusters
+	clusters := kubermaticv1.ClusterList{}
+	if err := seedClient.List(ctx, &clusters); err != nil {
+		return append(errs, fmt.Errorf("failed to list user clusters on Seed %q: %w", seed.Name, err))
+	}
+
+	configuredVersions := defaulted.Spec.Versions.Kubernetes
+	upgradeConstraints := []*semver.Constraints{}
+
+	// do not parse and check the validity of constraints for each usercluster, but just once
+	for i, update := range configuredVersions.Updates {
+		// only consider automated updates, otherwise we might accept an unsupported
+		// cluster that is never manually updated
+		if update.Automatic == nil || !*update.Automatic {
+			continue
+		}
+
+		from, err := semver.NewConstraint(update.From)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("`from` constraint %q for update rule %d is invalid: %w", update.From, i, err))
+			continue
+		}
+
+		upgradeConstraints = append(upgradeConstraints, from)
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// check that each cluster still matches the configured versions
+	for _, cluster := range clusters.Items {
+		clusterVersion := cluster.Spec.Version.Semver()
+		validVersion := false
+
+		// is this version still straight up supported?
+		for _, configured := range configuredVersions.Versions {
+			if configured.Equal(clusterVersion) {
+				validVersion = true
+				break
+			}
+		}
+
+		if validVersion {
+			continue
+		}
+
+		// is an upgrade path defined from the current version to something else?
+		for _, update := range upgradeConstraints {
+			if update.Check(clusterVersion) {
+				validVersion = true
+				break
+			}
+		}
+
+		if !validVersion {
+			errs = append(errs, fmt.Errorf("cluster %s (version %s) on Seed %s would not be supported anymore", cluster.Name, clusterVersion, seed.Name))
+		}
+	}
+
+	return errs
+}
 
 func ValidateRandomSecret(value string, path string) error {
 	if value == "" {

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -24,10 +24,12 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
+
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
 	"k8c.io/kubermatic/v2/pkg/log"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -73,6 +73,8 @@ func NewStack() stack.Stack {
 	return &MasterStack{}
 }
 
+var _ stack.Stack = &MasterStack{}
+
 func (*MasterStack) Name() string {
 	return "KKP master stack"
 }

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -17,22 +17,115 @@ limitations under the License.
 package kubermaticmaster
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
+
+func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+	var errs []error
+
+	// we need the actual, effective versioning configuration, which most users will
+	// probably not override
+	defaulted, err := defaults.DefaultConfiguration(opt.KubermaticConfiguration, zap.NewNop().Sugar())
+	if err != nil {
+		return append(errs, fmt.Errorf("failed to apply default values to the KubermaticConfiguration: %w", err))
+	}
+
+	allSeeds, err := opt.SeedsGetter()
+	if err != nil {
+		return append(errs, fmt.Errorf("failed to list Seeds: %w", err))
+	}
+
+	configuredVersions := defaulted.Spec.Versions.Kubernetes
+	upgradeConstraints := []*semver.Constraints{}
+
+	// do not parse and check the validity of constraints for each usercluster, but just once
+	for i, update := range configuredVersions.Updates {
+		// only consider automated updates, otherwise we might accept an unsupported
+		// cluster that is never manually updated
+		if update.Automatic == nil || !*update.Automatic {
+			continue
+		}
+
+		from, err := semver.NewConstraint(update.From)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("`from` constraint %q for update rule %d is invalid: %w", update.From, i, err))
+			continue
+		}
+
+		upgradeConstraints = append(upgradeConstraints, from)
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	for seedName, seed := range allSeeds {
+		opt.Logger.WithField("seed", seedName).Info("Checking seed cluster…")
+
+		// create client into seed
+		seedClient, err := opt.SeedClientGetter(seed)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to create client for Seed cluster %q: %w", seedName, err))
+			continue
+		}
+
+		// list all userclusters
+		clusters := kubermaticv1.ClusterList{}
+		if err := seedClient.List(ctx, &clusters); err != nil {
+			errs = append(errs, fmt.Errorf("failed to list user clusters on Seed %q: %w", seedName, err))
+			continue
+		}
+
+		// check that each cluster still matches the configured versions
+		for _, cluster := range clusters.Items {
+			clusterVersion := cluster.Spec.Version.Semver()
+			validVersion := false
+
+			// is this version still straight up supported?
+			for _, configured := range configuredVersions.Versions {
+				if configured.Equal(clusterVersion) {
+					validVersion = true
+					break
+				}
+			}
+
+			if validVersion {
+				continue
+			}
+
+			// is an upgrade path defined from the current version to something else?
+			for _, update := range upgradeConstraints {
+				if update.Check(clusterVersion) {
+					validVersion = true
+					break
+				}
+			}
+
+			if !validVersion {
+				errs = append(errs, fmt.Errorf("cluster %s (version %s) on Seed %s would not be supported anymore", cluster.Name, clusterVersion, seedName))
+			}
+		}
+	}
+
+	return errs
+}
 
 func (*MasterStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, opt stack.DeployOptions, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
 	kubermaticFailures := validateKubermaticConfiguration(config)

--- a/pkg/install/stack/kubermatic-master/validation_test.go
+++ b/pkg/install/stack/kubermatic-master/validation_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubermaticmaster
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	"k8s.io/utils/pointer"
+)
+
+func TestClusterVersionIsConfigured(t *testing.T) {
+	testcases := []struct {
+		name       string
+		version    *semver.Version
+		versions   operatorv1alpha1.KubermaticVersioningConfiguration
+		configured bool
+	}{
+		{
+			name:    "version is directly supported",
+			version: semver.MustParse("1.0.0"),
+			versions: operatorv1alpha1.KubermaticVersioningConfiguration{
+				Versions: []*semver.Version{
+					semver.MustParse("1.0.0"),
+				},
+			},
+			configured: true,
+		},
+		{
+			name:    "version is not configured",
+			version: semver.MustParse("1.0.0"),
+			versions: operatorv1alpha1.KubermaticVersioningConfiguration{
+				Versions: []*semver.Version{
+					semver.MustParse("2.0.0"),
+				},
+			},
+			configured: false,
+		},
+		{
+			name:    "update constraint matches because it's auto update",
+			version: semver.MustParse("1.0.0"),
+			versions: operatorv1alpha1.KubermaticVersioningConfiguration{
+				Updates: []operatorv1alpha1.Update{
+					{
+						From:      "1.0.0",
+						To:        "2.0.0",
+						Automatic: pointer.Bool(true),
+					},
+				},
+			},
+			configured: true,
+		},
+		{
+			name:    "constraint expression matches",
+			version: semver.MustParse("1.2.3"),
+			versions: operatorv1alpha1.KubermaticVersioningConfiguration{
+				Updates: []operatorv1alpha1.Update{
+					{
+						From:      "1.2.*",
+						To:        "2.0.0",
+						Automatic: pointer.Bool(true),
+					},
+				},
+			},
+			configured: true,
+		},
+		{
+			name:    "update constraint does not match because it's no auto update",
+			version: semver.MustParse("1.0.0"),
+			versions: operatorv1alpha1.KubermaticVersioningConfiguration{
+				Updates: []operatorv1alpha1.Update{
+					{
+						From:      "1.0.0",
+						To:        "2.0.0",
+						Automatic: pointer.Bool(false),
+					},
+				},
+			},
+			configured: false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			config := operatorv1alpha1.KubermaticConfiguration{
+				Spec: operatorv1alpha1.KubermaticConfigurationSpec{
+					Versions: operatorv1alpha1.KubermaticVersionsConfiguration{
+						Kubernetes: testcase.versions,
+					},
+				},
+			}
+
+			constraints, err := getAutoUpdateConstraints(&config)
+			if err != nil {
+				t.Fatalf("Failed to determine update constraints: %v", err)
+			}
+
+			configured := clusterVersionIsConfigured(testcase.version, &config, constraints)
+			if configured != testcase.configured {
+				if testcase.configured {
+					t.Fatalf("Expected %q to be supported, but it is not.", testcase.version)
+				} else {
+					t.Fatalf("Expected %q to not be supported, but it is.", testcase.version)
+				}
+			}
+		})
+	}
+}

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -57,6 +57,8 @@ func NewStack() stack.Stack {
 	return &SeedStack{}
 }
 
+var _ stack.Stack = &SeedStack{}
+
 func (*SeedStack) Name() string {
 	return "KKP seed stack"
 }

--- a/pkg/install/stack/kubermatic-seed/validation.go
+++ b/pkg/install/stack/kubermatic-seed/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubermaticseed
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -26,6 +27,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/install/stack/common"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
+
+func (m *SeedStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+	return nil
+}
 
 func (*SeedStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, opt stack.DeployOptions, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
 	helmFailures := validateHelmValues(helmValues)

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -23,6 +23,7 @@ import (
 
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
+	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -52,6 +53,9 @@ type DeployOptions struct {
 	// only the KKP CRDs. cert-manager CRDs will for example always use the
 	// ChartsDirectory instead.
 	KubermaticCRDDirectory string
+
+	SeedsGetter      provider.SeedsGetter
+	SeedClientGetter provider.SeedClientGetter
 
 	Logger                             *logrus.Entry
 	EnableCertManagerV2Migration       bool

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -69,5 +69,6 @@ type DeployOptions struct {
 type Stack interface {
 	Name() string
 	ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, opt DeployOptions, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error)
+	ValidateState(ctx context.Context, opt DeployOptions) []error
 	Deploy(ctx context.Context, opt DeployOptions) error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds another stage to the installation process, a "preflight" stage. Previously we only validated the given configuration files, now we also probe the target cluster and ensure that it's good to go. The first check for this preflight stage is to ensure that all userclusters are still covered by the version configuration.

This check runs on the **master** cluster, even though userclusters of course live on seed clusters. But

1. when doing `kubermatic-installer deploy kubermatic-seed`, the installer does not know which Seed is the current one (this only applies to shared master+seed setups)
2. The installer doesn't actually install any KKP stuff into seeds, the KKP operator is responsible for this. And it does that from the master cluster. It therefore makes more sense to validate the master (and collect all Seeds there and check them) and not the seeds.

**Which issue(s) this PR fixes**:
Fixes #7314

**Does this PR introduce a user-facing change?**:
```release-note
KKP Installer will now check that all userclusters match the given versioning configuration prior to upgrading KKP. This ensures no userclusters are suddenly "orphaned" and incompatible with KKP.
```
