### PR TITLE
fix bad metering Docker image

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -39,7 +39,7 @@ import (
 )
 
 func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryDocker) + "/kubermatic/metering:v0.6"
+	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v0.6"
 }
 
 func getMinioImage(overwriter registry.WithOverwriteFunc) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
I broke this by accident in #8615.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
