### PR TITLE
Prevent KKP PDBs from blocking node rotations

### DIFF
--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -166,7 +166,13 @@ func APIPDBCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.Na
 
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return name, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+			// To prevent the PDB from blocking node rotations, we accept
+			// 0 minAvailable if the replica count is only 1.
+			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
 			min := intstr.FromInt(1)
+			if cfg.Spec.API.Replicas != nil && *cfg.Spec.API.Replicas < 2 {
+				min = intstr.FromInt(0)
+			}
 
 			pdb.Spec.MinAvailable = &min
 			pdb.Spec.Selector = &metav1.LabelSelector{

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -123,7 +123,13 @@ func MasterControllerManagerPDBCreator(cfg *operatorv1alpha1.KubermaticConfigura
 
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return name, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+			// To prevent the PDB from blocking node rotations, we accept
+			// 0 minAvailable if the replica count is only 1.
+			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
 			min := intstr.FromInt(1)
+			if cfg.Spec.MasterController.Replicas != nil && *cfg.Spec.MasterController.Replicas < 2 {
+				min = intstr.FromInt(0)
+			}
 
 			pdb.Spec.MinAvailable = &min
 			pdb.Spec.Selector = &metav1.LabelSelector{

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -98,7 +98,13 @@ func UIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, versions
 func UIPDBCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedPodDisruptionBudgetCreatorGetter {
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return "kubermatic-dashboard", func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+			// To prevent the PDB from blocking node rotations, we accept
+			// 0 minAvailable if the replica count is only 1.
+			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
 			min := intstr.FromInt(1)
+			if cfg.Spec.UI.Replicas != nil && *cfg.Spec.UI.Replicas < 2 {
+				min = intstr.FromInt(0)
+			}
 
 			pdb.Spec.MinAvailable = &min
 			pdb.Spec.Selector = &metav1.LabelSelector{

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -257,7 +257,13 @@ func SeedControllerManagerPDBCreator(cfg *operatorv1alpha1.KubermaticConfigurati
 
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return name, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+			// To prevent the PDB from blocking node rotations, we accept
+			// 0 minAvailable if the replica count is only 1.
+			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
 			min := intstr.FromInt(1)
+			if cfg.Spec.SeedController.Replicas != nil && *cfg.Spec.SeedController.Replicas < 2 {
+				min = intstr.FromInt(0)
+			}
 
 			pdb.Spec.MinAvailable = &min
 			pdb.Spec.Selector = &metav1.LabelSelector{


### PR DESCRIPTION
**What this PR does / why we need it**:
With `replicas=1` (our default), a PDB with `minAvailable=1` will block node rotations. This PR adds a simple fix for that.

The underlying reason why we default to just 1 replica is that our webhooks are part of the controller-managers and only the leader starts the webhook server. That's why in #5616 we reduced the default to 1 replica.

Once #8566 is merged, the webhook will live in its own pod and the controller-managers can safely be scaled up by default. Given that users can still choose to use just 1 replica means that even then we still have to make the PDB work in that usecase. Hence why I applied this fix to the API/UI deployments as well, which were never part of the webhook-leader problem.

**Which issue(s) this PR fixes**:
Fixes #8068, fixes #7110

**Does this PR introduce a user-facing change?**:
```release-note
Fix PodDisruptionBudgets for master/seed-controller-manager blocking node rotations.
```
