### PR TITLE
Remove metering Deployment/CronJob when feature is disabled

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -273,10 +273,8 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *operatorv1alph
 		return err
 	}
 
-	if seed.Spec.Metering != nil && seed.Spec.Metering.Enabled {
-		if err := metering.ReconcileMeteringResources(ctx, client, cfg, seed); err != nil {
-			return err
-		}
+	if err := metering.ReconcileMeteringResources(ctx, client, cfg, seed); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures no active components remain when metering is disabled. For simplicity (no, not because I'm lazy) we keep the metadata-only elements like RBAC in case the admin re-enables the feature in the future.

**Which issue(s) this PR fixes**:
Fixes #7828

**Does this PR introduce a user-facing change?**:
```release-note
Fix disabling metering not having any effect.
```
