### PR TITLE
Improve GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,17 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating KKP
+labels: kind/bug
+---
+
+### What happened?
+
+### What should happen?
+
+### How to reproduce?
+
+### Environment
+
+- KKP Version:
+- Shared or separate master/seed clusters?:
+- Master/seed cluster provider:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,9 @@
+---
+name: Feature Request
+about: Suggest a new or improved feature
+labels: kind/feature
+---
+
+### What would you like to be added? / User Story
+
+### Acceptance criteria

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
-**What this PR does / why we need it**:
+**What does this PR do / Why do we need it**:
 
-**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+**Does this PR close any issues?**:
+<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->:
 Fixes #
 
 **Special notes for your reviewer**:
@@ -9,9 +10,9 @@ Fixes #
 <!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
 
 **Does this PR introduce a user-facing change?**:
-<!--  Write your release note:
+<!-- Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
-2. If  no release note is required, just write "NONE".
+2. If no release note is required, just write "NONE".
 -->
 ```release-note
 ```

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,3 +1,0 @@
-**User Story**
-
-**Acceptance criteria**


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes our issue templates more useful and usable. Our dashboard is already leading the way with theirs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
