### PR TITLE
fix vsphere periodic tests failure

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -960,7 +960,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
     decorate: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
+    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -1004,7 +1004,7 @@ presubmits:
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
     decorate: true
     optional: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
+    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -1050,7 +1050,7 @@ presubmits:
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
     decorate: true
     optional: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
+    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -392,7 +392,7 @@ spec:
       volumes:
         - name: vsphere-config-volume
           secret:
-            secretName: vsphere-config-secret
+            secretName: cloud-config-csi
         - name: socket-dir
           emptyDir: {}
 ---

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -300,7 +300,7 @@ spec:
             - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
               value: 3m
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/cloud/csi-vsphere.conf"
+              value: "/etc/cloud/config"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -251,6 +251,9 @@ spec:
         #  effect: NoExecute
         #  tolerationSeconds: 30
       dnsPolicy: "Default"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: csi-attacher
           image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.3.0
@@ -420,6 +423,9 @@ spec:
       serviceAccountName: vsphere-csi-node
       hostNetwork: true
       dnsPolicy: "ClusterFirstWithHostNet"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: node-driver-registrar
           image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.3.0

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -355,7 +355,7 @@ spec:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/cloud/csi-vsphere.conf"
+              value: "/etc/cloud/config"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -40,6 +40,8 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
+// comment to trigger CI
+
 const (
 	folderCleanupFinalizer = "kubermatic.io/cleanup-vsphere-folder"
 )

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -40,8 +40,6 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
-// comment to trigger CI
-
 const (
 	folderCleanupFinalizer = "kubermatic.io/cleanup-vsphere-folder"
 )


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Investigate and fix vSphere e2e tests failures.

**Does this PR close any issues?**:
Fixes #

**Special notes for your reviewer**:
Changes:
* Vsphere CSI addon folder now triggers vsphere e2e tests (to spot these kind of issues as fast as possible in the future)
* Fixed Typo in the mounted secret (the secret wasn't mounted because not found)
* Added seccomp profile to pass the seccomp conformance tests (just copied and past from all other addons)

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
