### PR TITLE
Recocile aks irrespective of state

### DIFF
--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -187,9 +187,9 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Extern
 				r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 				return reconcile.Result{}, err
 			}
-			// reconcile to update kubeconfig for cases like starting a stopped cluster
-			return reconcile.Result{RequeueAfter: time.Minute * 2}, nil
 		}
+		// reconcile to update kubeconfig for cases like starting a stopped cluster
+		return reconcile.Result{RequeueAfter: time.Minute * 2}, nil
 	}
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Signed-off-by: Harshita <imharshita@github.com>

**What does this PR do / Why do we need it**: Reconcile azure kubernetes cluster irrespective of cluster state.
This change is necessary in order to get updated kubeconfig for an already imported aks cluster, in case the cluster is starting from a stopped state or it becomes healthy after a failed state.
Since these state changes doesnt affect the cluster crd, so reconcile  requeue time needs to be set

**Does this PR close any issues?**:
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
