### PR TITLE
Fix metric names for MinIO Grafana dashboard

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.5.6
+version: 1.5.7
 appVersion: 8.1.2
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/dashboards/minio/overview.json
+++ b/charts/monitoring/grafana/dashboards/minio/overview.json
@@ -68,7 +68,7 @@
       "pluginVersion": "6.5.2",
       "targets": [
         {
-          "expr": "minio_disk_storage_used_bytes / minio_disk_storage_total_bytes * 100",
+          "expr": "disk_storage_used{app=\"minio\"} / disk_storage_total{app=\"minio\"} * 100",
           "instant": true,
           "refId": "A"
         }
@@ -122,7 +122,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "minio_disk_storage_available_bytes",
+          "expr": "disk_storage_available{app=\"minio\"}",
           "interval": "$interval",
           "legendFormat": "available",
           "refId": "A"
@@ -232,12 +232,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(minio_network_sent_bytes_total[$interval])",
+          "expr": "rate(s3_tx_bytes_total{app=\"minio\"}[$interval])",
           "legendFormat": "sent",
           "refId": "A"
         },
         {
-          "expr": "rate(minio_network_received_bytes_total[$interval])",
+          "expr": "rate(s3_rx_bytes_total{app=\"minio\"}[$interval])",
           "legendFormat": "received",
           "refId": "B"
         }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Because the metrics exposed by MinIO were refactored as part of pull
request [8003](https://github.com/minio/minio/pull/8003), the Grafana dashboard for MinIO did no longer
display any metrics.

Therefore the dashboard was updated to use the new metrics as outlined
in their [migration guide](https://github.com/Praveenrajmani/minio/blob/9ff7af2dfbc14d971fd3ce8fd02ae32b4252e6d4/docs/metrics/prometheus/README.md#migration-guide-for-the-new-set-of-metrics). Since we run a standalone MinIO server, the
panel 'Network Traffic' only takes the values for the current server
instance into account.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Grafana dashboard for MinIO to display the correct Prometheus metrics
```
