### PR TITLE
fix allowed registry parameters

### DIFF
--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -201,7 +201,7 @@ func allowedRegistryConstraintCreatorGetter(regSet sets.String) reconciling.Name
 			ct.Spec.ConstraintType = AllowedRegistryCTName
 			ct.Spec.Disabled = regSet.Len() == 0
 
-			jsonRegSet, err := json.Marshal(regSet)
+			jsonRegSet, err := json.Marshal(regSet.List())
 			if err != nil {
 				return nil, fmt.Errorf("error marshalling registry set: %v", err)
 			}

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -251,7 +251,7 @@ func genWRConstraint(registrySet sets.String) *kubermaticv1.Constraint {
 	ct.Name = allowedregistrycontroller.AllowedRegistryCTName
 	ct.Namespace = testNamespace
 
-	jsonRegSet, _ := json.Marshal(registrySet)
+	jsonRegSet, _ := json.Marshal(registrySet.List())
 
 	ct.Spec = kubermaticv1.ConstraintSpec{
 		ConstraintType: allowedregistrycontroller.AllowedRegistryCTName,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The parameters in the resulting allowed registry list were wrongly parsed into JSON, causing the resulting Constraint not to work properly.

**Does this PR close any issues?**:
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8704

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix for AllowedRegistry Constraint parameters being badly parsed, causing the Constraint not to work.
```
