### PR TITLE
base64 encode kubeconfig when read from secret credential

### DIFF
--- a/pkg/handler/common/provider/kubevirt.go
+++ b/pkg/handler/common/provider/kubevirt.go
@@ -86,8 +86,7 @@ func getKvKubeConfigFromCredentials(ctx context.Context, projectProvider provide
 	if err != nil {
 		return "", err
 	}
-	return kvKubeconfig, nil
-
+	return base64.StdEncoding.EncodeToString([]byte(kvKubeconfig)), nil
 }
 
 func KubeVirtVMIPresets(kubeconfig string) (apiv2.VirtualMachineInstancePresetList, error) {


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
As we changed line 44 in pkg/handler/common/provider/kubevirt.go to have only base64 encoded kubeconfigs, it made the endpoints (list vmflavors and list storageclasses) fail.
Even though the kubeconfig is base64 encoded in the credential secret, 
in `kubeconfig, err = secretKeySelector(cloud.Kubevirt.CredentialsReference, resources.KubevirtKubeConfig)` -> the kubeconfig is returned decoded.

It lead to bug #8719

2 options: 
- 1:  we change back line 44 to go back to something like 
`	config, err := base64.StdEncoding.DecodeString(kubeconfig)
	if err != nil {
		// if the decoding failed, the kubeconfig is sent already decoded without the need of decoding it,
		// for example the value has been read from Vault during the ci tests, which is saved as json format.
		config = []byte(kubeconfig)
	}
`
- 2 we leave line 44 and base64 the kubeconfig read from the secret 

I chose option 2 here. We can discuss this choice.


**Does this PR close any issues?**:
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8719

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
