### PR TITLE
Update Grafana dashboards

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.5.5
+version: 1.5.6
 appVersion: 8.1.2
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/dashboards/go/processes.json
+++ b/charts/monitoring/grafana/dashboards/go/processes.json
@@ -264,7 +264,7 @@
       ],
       "targets": [
         {
-          "expr": "count by (namespace, pod, version) (go_info)",
+          "expr": "count by (namespace, pod, version) (go_info{namespace!=\"\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/charts/monitoring/grafana/dashboards/kubermatic/machine-controller.json
+++ b/charts/monitoring/grafana/dashboards/kubermatic/machine-controller.json
@@ -229,7 +229,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kube_node_info{cluster=~\"$cluster\"}) by (cluster)",
+          "expr": "sum(job:kube_node_info:count{cluster=~\"$cluster\"}) by (cluster)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ cluster }}",

--- a/charts/monitoring/grafana/dashboards/kubermatic/user-clusters.json
+++ b/charts/monitoring/grafana/dashboards/kubermatic/user-clusters.json
@@ -10,6 +10,11 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -37,57 +42,7 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 0,
-        "y": 1
-      },
-      "id": 5,
-      "interval": null,
-      "legend": {
-        "percentage": true,
-        "percentageDecimals": null,
-        "show": true,
-        "values": true
-      },
-      "legendType": "Right side",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "options": {},
-      "pieType": "donut",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "expr": "count by (type) (count by (name, type) (kubermatic_cluster_info))",
-          "instant": true,
-          "legendFormat": "{{ type }}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Cluster Types",
-      "transparent": true,
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "breakPoint": "50%",
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "$datasource",
-      "decimals": 0,
-      "editable": true,
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
+        "x": 4,
         "y": 1
       },
       "id": 14,
@@ -101,7 +56,6 @@
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
-      "options": {},
       "pieType": "donut",
       "strokeWidth": 1,
       "targets": [
@@ -136,7 +90,7 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 16,
+        "x": 12,
         "y": 1
       },
       "id": 15,
@@ -150,7 +104,6 @@
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
-      "options": {},
       "pieType": "donut",
       "strokeWidth": 1,
       "targets": [
@@ -176,6 +129,12 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -184,6 +143,7 @@
         "x": 0,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": false,
@@ -199,9 +159,10 @@
       "links": [],
       "nullPointMode": "null as zero",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -211,10 +172,12 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "count by (type) (count by (name, type) (kubermatic_cluster_info))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ type }}",
+          "legendFormat": "{{ type }} clusters",
           "refId": "A"
         }
       ],
@@ -268,6 +231,12 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -276,6 +245,7 @@
         "x": 8,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 13,
       "legend": {
         "avg": false,
@@ -291,9 +261,10 @@
       "links": [],
       "nullPointMode": "null as zero",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -360,6 +331,12 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -368,6 +345,7 @@
         "x": 16,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 18,
       "legend": {
         "avg": false,
@@ -383,9 +361,10 @@
       "links": [],
       "nullPointMode": "null as zero",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -447,6 +426,11 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -455,7 +439,7 @@
       },
       "id": 9,
       "panels": [],
-      "title": "Kubernetes",
+      "title": "Kubernetes Releases",
       "type": "row"
     },
     {
@@ -486,7 +470,6 @@
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
-      "options": {},
       "pieType": "donut",
       "strokeWidth": 1,
       "targets": [
@@ -533,7 +516,6 @@
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
-      "options": {},
       "pieType": "donut",
       "strokeWidth": 1,
       "targets": [
@@ -559,6 +541,12 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -567,6 +555,7 @@
         "x": 8,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -582,9 +571,10 @@
       "links": [],
       "nullPointMode": "null as zero",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -651,6 +641,12 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -659,6 +655,7 @@
         "x": 16,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -674,9 +671,10 @@
       "links": [],
       "nullPointMode": "null as zero",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -687,297 +685,6 @@
       "targets": [
         {
           "expr": "count by (master_version) (count by (name, master_version) (kubermatic_cluster_info{type=\"kubernetes\"}))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ master_version }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Release History",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "id": 17,
-      "panels": [],
-      "title": "OpenShift",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "breakPoint": "50%",
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "$datasource",
-      "editable": true,
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 0,
-        "y": 27
-      },
-      "id": 19,
-      "interval": null,
-      "legend": {
-        "show": true,
-        "values": false
-      },
-      "legendType": "Right side",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "options": {},
-      "pieType": "donut",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "expr": "count by (master_version) (count by (name, master_version) (count by (name, master_version) (label_replace(kubermatic_cluster_info{type=\"openshift\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\"))))",
-          "instant": true,
-          "legendFormat": "{{ master_version }}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Minor Releases",
-      "transparent": true,
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "breakPoint": "50%",
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "$datasource",
-      "editable": true,
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 4,
-        "y": 27
-      },
-      "id": 20,
-      "interval": null,
-      "legend": {
-        "show": true,
-        "values": false
-      },
-      "legendType": "Right side",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "options": {},
-      "pieType": "donut",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "expr": "count by (master_version) (count by (name, master_version) (kubermatic_cluster_info{type=\"openshift\"}))",
-          "instant": true,
-          "legendFormat": "{{ master_version }}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Releases",
-      "transparent": true,
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 27
-      },
-      "id": 21,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "count by (master_version) (count by (name, master_version) (label_replace(kubermatic_cluster_info{type=\"openshift\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\")))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ master_version }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Minor Release History",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 27
-      },
-      "id": 22,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "count by (master_version) (count by (name, master_version) (kubermatic_cluster_info{type=\"openshift\"}))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ master_version }}",
@@ -1029,13 +736,15 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 19,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {},
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Data Source",

--- a/charts/monitoring/grafana/dashboards/kubernetes/kubelets-overview.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/kubelets-overview.json
@@ -10,6 +10,11 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -32,12 +37,14 @@
       "description": "",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 47,
       "legend": {
         "avg": false,
@@ -52,7 +59,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -122,12 +133,14 @@
       "description": "",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 8,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 50,
       "legend": {
         "avg": false,
@@ -142,7 +155,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -211,12 +228,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 16,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 46,
       "legend": {
         "avg": false,
@@ -231,7 +250,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -292,6 +315,11 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -315,12 +343,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 0,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 2,
       "interval": "",
       "legend": {
@@ -338,7 +368,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -349,9 +383,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kubelet_pod_worker_duration_seconds{instance=~\"$node\",quantile=\"0.9\",operation_type=~\"$operations\"}[5m])) by (instance)",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_pod_worker_duration_seconds_bucket{instance=~\"$node\",operation_type=~\"$operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "refId": "D"
@@ -411,12 +447,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 6,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 51,
       "interval": "",
       "legend": {
@@ -434,7 +472,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -444,9 +486,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kubelet_cgroup_manager_duration_seconds{instance=~\"$node\",quantile=\"0.9\",operation_type=~\"$operations\"}[5m])) by (instance)",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{instance=~\"$node\",operation_type=~\"$operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "refId": "D"
@@ -506,12 +550,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 12,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 52,
       "interval": "",
       "legend": {
@@ -529,7 +575,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -539,9 +589,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kubelet_runtime_operations_duration_seconds{instance=~\"$node\",quantile=\"0.9\",operation_type=~\"$operations\"}[5m])) by (instance)",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{instance=~\"$node\",operation_type=~\"$operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "refId": "D"
@@ -601,12 +653,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 18,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 53,
       "interval": "",
       "legend": {
@@ -624,7 +678,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -634,9 +692,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kubelet_pleg_relist_duration_seconds{instance=~\"$node\",quantile=\"0.9\",operation_type=~\"$operations\"}[5m])) by (instance)",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{instance=~\"$node\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "refId": "D"
@@ -686,6 +746,11 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -719,16 +784,17 @@
         "y": 20
       },
       "heatmap": {},
+      "hideZeroBuckets": false,
       "highlightCards": true,
       "id": 57,
       "legend": {
         "show": false
       },
       "links": [],
-      "minSpan": 8,
+      "maxPerRow": 3,
       "repeat": "node",
       "repeatDirection": "h",
-      "scopedVars": {},
+      "reverseYBuckets": false,
       "targets": [
         {
           "expr": "sum(increase(rest_client_request_duration_seconds_bucket{job=\"kubelet\",instance=\"$node\"}[5m])) by (le)",
@@ -768,15 +834,19 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {},
+        "description": null,
+        "error": null,
         "hide": 0,
+        "includeAll": false,
         "label": null,
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -790,65 +860,49 @@
         "current": {},
         "datasource": "$datasource",
         "definition": "label_values(node_boot_time_seconds, node_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Node",
         "multi": true,
         "name": "node",
         "options": [],
-        "query": "label_values(node_boot_time_seconds, node_name)",
+        "query": {
+          "query": "label_values(node_boot_time_seconds, node_name)",
+          "refId": "prometheus-node-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
         "allValue": null,
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
+        "datasource": "${datasource}",
+        "definition": "label_values({__name__=~\"kubelet_.+?_duration_seconds_bucket\",operation_type!=\"\"}, operation_type)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Operations",
         "multi": true,
         "name": "operations",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "create",
-            "value": "create"
-          },
-          {
-            "selected": false,
-            "text": "update",
-            "value": "update"
-          },
-          {
-            "selected": false,
-            "text": "sync",
-            "value": "sync"
-          },
-          {
-            "selected": false,
-            "text": "kill",
-            "value": "kill"
-          }
-        ],
-        "query": "create,update,sync,kill",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"kubelet_.+?_duration_seconds_bucket\",operation_type!=\"\"}, operation_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
@@ -885,5 +939,5 @@
   "timezone": "",
   "title": "Kubelets Overview",
   "uid": "ZJ1iOSemz",
-  "version": 12
+  "version": 1
 }

--- a/charts/monitoring/grafana/dashboards/kubernetes/kubelets-overview.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/kubelets-overview.json
@@ -939,5 +939,5 @@
   "timezone": "",
   "title": "Kubelets Overview",
   "uid": "ZJ1iOSemz",
-  "version": 1
+  "version": 13
 }

--- a/charts/monitoring/grafana/dashboards/kubernetes/kubelets.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/kubelets.json
@@ -9,6 +9,11 @@
   "links": [],
   "panels": [
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -29,12 +34,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 47,
       "legend": {
         "avg": false,
@@ -49,7 +56,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -118,12 +129,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 46,
       "legend": {
         "avg": false,
@@ -138,7 +151,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -219,12 +236,14 @@
         "y": 1
       },
       "heatmap": {},
+      "hideZeroBuckets": false,
       "highlightCards": true,
       "id": 49,
       "legend": {
         "show": false
       },
       "links": [],
+      "reverseYBuckets": false,
       "targets": [
         {
           "expr": "sum(increase(rest_client_request_duration_seconds_bucket{job=\"kubelet\",instance=\"$node\"}[5m])) by (le)",
@@ -264,6 +283,11 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -287,12 +311,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 2,
       "interval": "",
       "legend": {
@@ -309,412 +335,49 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
+      "maxPerRow": 4,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeat": null,
+      "repeat": "pod_worker_operations",
+      "repeatDirection": "h",
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"create\"}",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{instance=\"$node\",operation_type=\"$pod_worker_operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "99th percentile",
           "refId": "A"
         },
         {
-          "expr": "max(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_pod_worker_duration_seconds_bucket{instance=\"$node\",operation_type=\"$pod_worker_operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"create\"}",
-          "format": "time_series",
-          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "90th percentile",
-          "refId": "D"
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Creates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 10
-      },
-      "id": 20,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Updates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 10
-      },
-      "id": 21,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Syncs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 10
-      },
-      "id": 22,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pod_worker_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pod_worker_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Kills",
+      "title": "$pod_worker_operations",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -754,6 +417,11 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -777,12 +445,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 27,
       "interval": "",
       "legend": {
@@ -800,410 +470,47 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
+      "repeat": "cgroup_manager_operations",
+      "repeatDirection": "h",
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"create\"}",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{instance=\"$node\",operation_type=\"$cgroup_manager_operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "99th percentile",
           "refId": "A"
         },
         {
-          "expr": "max(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{instance=\"$node\",operation_type=\"$cgroup_manager_operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"create\"}",
-          "format": "time_series",
-          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "90th percentile",
-          "refId": "D"
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Creates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 18
-      },
-      "id": 28,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Updates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 18
-      },
-      "id": 29,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Syncs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 18
-      },
-      "id": 30,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_cgroup_manager_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_cgroup_manager_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Kills",
+      "title": "$cgroup_manager_operations",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1243,6 +550,11 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1264,14 +576,17 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "description": "",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 0,
         "y": 26
       },
+      "hiddenSeries": false,
       "id": 33,
       "interval": "",
       "legend": {
@@ -1289,410 +604,47 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
+      "repeat": "runtime_operations",
+      "repeatDirection": "h",
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"create\"}",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{instance=\"$node\",operation_type=\"$runtime_operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "99th percentile",
           "refId": "A"
         },
         {
-          "expr": "max(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{instance=\"$node\",operation_type=\"$runtime_operations\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"create\"}",
-          "format": "time_series",
-          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "90th percentile",
-          "refId": "D"
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Creates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 26
-      },
-      "id": 34,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Updates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 26
-      },
-      "id": 35,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Syncs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 26
-      },
-      "id": 36,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_runtime_operations_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_runtime_operations_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Kills",
+      "title": "$runtime_operations",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1732,11 +684,16 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 61
       },
       "id": 38,
       "panels": [],
@@ -1755,12 +712,14 @@
       "datasource": "$datasource",
       "editable": true,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 12,
         "x": 0,
-        "y": 34
+        "y": 62
       },
+      "hiddenSeries": false,
       "id": 39,
       "interval": "",
       "legend": {
@@ -1778,7 +737,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "8.1.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1788,400 +751,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"create\"}",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{instance=\"$node\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "99th percentile",
           "refId": "A"
         },
         {
-          "expr": "max(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.9, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{instance=\"$node\"}[5m])) by (instance, le))",
           "format": "time_series",
           "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"create\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"create\"}",
-          "format": "time_series",
-          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "90th percentile",
-          "refId": "D"
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Creates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 34
-      },
-      "id": 40,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"update\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"update\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Updates",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 34
-      },
-      "id": 41,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"sync\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"sync\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Syncs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {
-        "load 15m": "#ffffffff",
-        "load 1m": "#e24d42",
-        "load 5m": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 34
-      },
-      "id": 42,
-      "interval": "",
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.99\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "99th percentile",
-          "refId": "A"
-        },
-        {
-          "expr": "max(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "max",
-          "refId": "B"
-        },
-        {
-          "expr": "min(kubelet_pleg_relist_duration_seconds{instance=\"$node\",operation_type=\"kill\"})",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "min",
-          "refId": "C"
-        },
-        {
-          "expr": "kubelet_pleg_relist_duration_seconds{instance=\"$node\",quantile=\"0.9\",operation_type=\"kill\"}",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "90th percentile",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Kills",
+      "title": "Relists",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2221,15 +815,19 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {},
+        "description": null,
+        "error": null,
         "hide": 0,
+        "includeAll": false,
         "label": null,
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -2243,22 +841,95 @@
         "current": {},
         "datasource": "$datasource",
         "definition": "label_values(node_boot_time_seconds, node_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Node",
         "multi": false,
         "name": "node",
         "options": [],
-        "query": "label_values(node_boot_time_seconds, node_name)",
+        "query": {
+          "query": "label_values(node_boot_time_seconds, node_name)",
+          "refId": "prometheus-node-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${datasource}",
+        "definition": "label_values(kubelet_runtime_operations_duration_seconds_bucket, operation_type)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "runtime_operations",
+        "options": [],
+        "query": {
+          "query": "label_values(kubelet_runtime_operations_duration_seconds_bucket, operation_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${datasource}",
+        "definition": "label_values(kubelet_pod_worker_duration_seconds_bucket, operation_type)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "pod_worker_operations",
+        "options": [],
+        "query": {
+          "query": "label_values(kubelet_pod_worker_duration_seconds_bucket, operation_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${datasource}",
+        "definition": "label_values(kubelet_cgroup_manager_duration_seconds_bucket, operation_type)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "cgroup_manager_operations",
+        "options": [],
+        "query": {
+          "query": "label_values(kubelet_cgroup_manager_duration_seconds_bucket, operation_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -2295,5 +966,5 @@
   "timezone": "",
   "title": "Kubelets",
   "uid": "p4ynSSeik",
-  "version": 6
+  "version": 1
 }

--- a/charts/monitoring/grafana/dashboards/kubernetes/kubelets.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/kubelets.json
@@ -966,5 +966,5 @@
   "timezone": "",
   "title": "Kubelets",
   "uid": "p4ynSSeik",
-  "version": 1
+  "version": 7
 }

--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -321,6 +321,11 @@ groups:
     labels:
       severity: warning
 
+  - record: job:kube_node_info:count
+    expr: count(kube_node_info)
+    labels:
+      kubermatic: federate
+
 - name: kubernetes-absent
   rules:
   - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
@@ -531,6 +531,11 @@ data:
         labels:
           severity: warning
 
+      - record: job:kube_node_info:count
+        expr: count(kube_node_info)
+        labels:
+          kubermatic: federate
+
     - name: kubernetes-absent
       rules:
       - alert: KubernetesApiserverDown


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR cleans up a few issues in our Grafana dashboards:

* scraping the kube-apiserver produces a go_info metric, but without namespace/pod name on GKE; those go_info metrics lead to an empty line in our go version table which is now hidden
* the node count was not federated to the seed level Prometheus, so the node count metric on the machine-controller dashboard was broken
* one dashboard still had openshift leftovers
* the kubelet dashboards were broken (#8025)

**Does this PR close any issues?**:
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8025

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
