### PR TITLE
check if client can retrieve some data for connected cluster

### DIFF
--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -94,8 +94,13 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 
-			if _, err := clusterProvider.GenerateClient(cfg); err != nil {
+			cli, err := clusterProvider.GenerateClient(cfg)
+			if err != nil {
 				return nil, errors.NewBadRequest(fmt.Sprintf("cannot connect to the kubernetes cluster: %v", err))
+			}
+			// check if kubeconfig can automatically authenticate and get resources.
+			if err := cli.List(ctx, &corev1.PodList{}); err != nil {
+				return nil, errors.NewBadRequest(fmt.Sprintf("can not retrieve data, check your kubeconfig: %v", err))
 			}
 
 			newCluster := genExternalCluster(req.Body.Name, project.Name)


### PR DESCRIPTION
**What does this PR do / Why do we need it**: add additional kubeconfig check for the connected external cluster. This PR solves the problem when the `user` is missing in the kubeconfig. The client expects a user name and password for authentication and cause problem on the backend side.

**Does this PR close any issues?**:
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #


```release-note
NONE
```
