### PR TITLE
Remove Alert KubeAPILatencyHIGH from AlertManager.

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.10
+version: 2.4.11
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
@@ -45,26 +45,6 @@ groups:
           severity: critical
           resource: apiserver
           service: kubernetes
-      - alert: KubeAPILatencyHigh
-        annotations:
-          message: The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
-          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
-        expr: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
-        for: 10m
-        labels:
-          severity: warning
-          resource: apiserver
-          service: kubernetes
-      - alert: KubeAPILatencyHigh
-        annotations:
-          message: The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
-          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
-        expr: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
-        for: 10m
-        labels:
-          severity: critical
-          resource: apiserver
-          service: kubernetes
       - alert: KubeAPIErrorsHigh
         annotations:
           message: API server is returning errors for {{ $value }}% of requests.
@@ -73,6 +53,32 @@ groups:
           sum(rate(apiserver_request_total{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
             /
           sum(rate(apiserver_request_total{job="apiserver"}[5m])) without(instance, pod) * 100 > 10
+        for: 10m
+        labels:
+          severity: critical
+          resource: apiserver
+          service: kubernetes
+      - alert: KubeAPITerminatedRequests
+        annotations:
+          message: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
+          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
+        expr: |
+          sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
+            /
+          (sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
+        for: 5m
+        labels:
+          severity: warning
+          resource: apiserver
+          service: kubernetes
+      - alert: KubeAPITerminatedRequests
+        annotations:
+          message: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
+          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
+        expr: |
+          sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
+            /
+          (sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
         for: 10m
         labels:
           severity: critical

--- a/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -68,11 +68,13 @@ groups:
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
     expr: |
       sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
-        / 
+        /
       (sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
     for: 5m
     labels:
       severity: warning
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeAPITerminatedRequests
     annotations:
@@ -80,11 +82,13 @@ groups:
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
     expr: |
       sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
-        / 
+        /
       (sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
     for: 10m
     labels:
       severity: critical
+      resource: apiserver
+      service: kubernetes
 
   - alert: KubeAPIErrorsHigh
     annotations:

--- a/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -48,32 +48,6 @@ groups:
       resource: apiserver
       service: kubernetes
 
-  - alert: KubeAPILatencyHigh
-    annotations:
-      message:
-        The API server has a 99th percentile latency of {{ $value }} seconds
-        for {{ $labels.verb }} {{ $labels.resource }}.
-      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
-    expr: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
-    for: 10m
-    labels:
-      severity: warning
-      resource: apiserver
-      service: kubernetes
-
-  - alert: KubeAPILatencyHigh
-    annotations:
-      message:
-        The API server has a 99th percentile latency of {{ $value }} seconds
-        for {{ $labels.verb }} {{ $labels.resource }}.
-      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
-    expr: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
-    for: 10m
-    labels:
-      severity: critical
-      resource: apiserver
-      service: kubernetes
-
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.

--- a/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -62,6 +62,30 @@ groups:
       resource: apiserver
       service: kubernetes
 
+  - alert: KubeAPITerminatedRequests
+    annotations:
+      message: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
+      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
+    expr: |
+      sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m]))
+        / 
+      (  sum(rate(apiserver_request_total{%(kubeApiserverSelector)s}[10m])) + sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m])) ) > 0.20
+    for: 5m
+    labels:
+      severity: warning
+
+  - alert: KubeAPITerminatedRequests
+    annotations:
+      message: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
+      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
+    expr: |
+      sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m]))
+        / 
+      (  sum(rate(apiserver_request_total{%(kubeApiserverSelector)s}[10m])) + sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m])) ) > 0.20
+    for: 10m
+    labels:
+      severity: critical
+
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.

--- a/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -67,9 +67,9 @@ groups:
       message: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
     expr: |
-      sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m]))
+      sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
         / 
-      (  sum(rate(apiserver_request_total{%(kubeApiserverSelector)s}[10m])) + sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m])) ) > 0.20
+      (sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
     for: 5m
     labels:
       severity: warning
@@ -79,9 +79,9 @@ groups:
       message: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubeapiterminatedrequests
     expr: |
-      sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m]))
+      sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
         / 
-      (  sum(rate(apiserver_request_total{%(kubeApiserverSelector)s}[10m])) + sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m])) ) > 0.20
+      (sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
This PR removes an alert KubeAPILatencyHIGH from kubermatic chart as it has been removed from  kubernetes-mixin and replaced by KubeAPITerminatedRequests.
https://github.com/kubermatic/kubermatic/issues/7373
https://github.com/kubermatic/kubermatic/issues/7914
https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/alerts/kube_apiserver.libsonnet#L107


Signed-off-by: vishnuegknr <vishnuegknr@gmail>

**What does this PR do / Why do we need it**:
* This PR will remove an alert which is obsolete.

**Does this PR close any issues?**:
*  #7373 and fixes #7914
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:
*  This PR is created to remove the alert which is obsolete and added new alert which has been replaced the old one.

**Documentation**:
*  https://github.com/kubermatic/kubermatic/issues/7373
*  https://github.com/kubermatic/kubermatic/issues/7914
*  https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/alerts/kube_apiserver.libsonnet#L107

<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
*  No, this will only remove one alert and add new alert.
```release-note
Prometheus alert KubeAPILatencyHIGH has been replaced with KubeAPITerminatedRequests, which is more reliable.
```
