### PR TITLE
Fix reconciling using recreate strategy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 **What does this PR do / Why do we need it**:
 
-**Does this PR close any issues?**:
-<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
+**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
 Fixes #
 
 **Special notes for your reviewer**:

--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -123,6 +123,11 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 		if err := client.Delete(ctx, obj.DeepCopyObject().(ctrlruntimeclient.Object)); err != nil {
 			return fmt.Errorf("failed to delete object %T %q: %v", obj, namespacedName.String(), err)
 		}
+
+		obj.SetResourceVersion("")
+		obj.SetUID("")
+		obj.SetGeneration(0)
+
 		if err := client.Create(ctx, obj); err != nil {
 			return fmt.Errorf("failed to create object %T %q: %v", obj, namespacedName.String(), err)
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
When using Delete+Create to reconcile a resource, we should ensure that metadata like UID/resourceVersion are not set, otherwise the kube-apiserver will reject the operation with something like

> EnsureObject returned an error while none was expected: failed to create object *v1.ConfigMap "default/test": resourceVersion can not be set for Create requests

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #6912

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
