### PR TITLE
Fix Konnectivity agent authentication with apiserver network polices

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -477,7 +477,9 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			apiserver.EctdAllowCreator(c),
 			apiserver.MachineControllerWebhookCreator(c),
 		}
-		if !data.IsKonnectivityEnabled() {
+		if data.IsKonnectivityEnabled() {
+			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, apiserver.ClusterExternalAddrAllowCreator(c))
+		} else {
 			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters,
 				apiserver.OpenVPNServerAllowCreator(c),
 				apiserver.MetricsServerAllowCreator(c),

--- a/pkg/resources/konnectivity/deletion.go
+++ b/pkg/resources/konnectivity/deletion.go
@@ -20,6 +20,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,6 +48,12 @@ func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.KonnectivityProxyTLSSecretName,
+				Namespace: namespace,
+			},
+		},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.NetworkPolicyClusterExternalAddrAllow,
 				Namespace: namespace,
 			},
 		},

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -735,6 +735,7 @@ const (
 	NetworkPolicyOpenVPNServerAllow            = "openvpn-server-allow"
 	NetworkPolicyMachineControllerWebhookAllow = "machine-controller-webhook-allow"
 	NetworkPolicyMetricsServerAllow            = "metrics-server-allow"
+	NetworkPolicyClusterExternalAddrAllow      = "cluster-external-addr-allow"
 	NetworkPolicyOIDCIssuerAllow               = "oidc-issuer-allow"
 )
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
APIserver network policies prevent Konnectivity agent authentication. This PR adds a network policy that allows konnectivity-server (running as a sidecar in the apiserver pods) to reach the cluster external apiserver endpoint (used as service-account-issuer) to validate konnectivity-agent authentication token.

**Does this PR close any issues?**:
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8718 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
