### PR TITLE
allow to enable debug logging of the usercluster-ctrl-mgr

### DIFF
--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -124,6 +124,9 @@ type ClusterSpec struct {
 	// PauseReason is the reason why the cluster is no being managed.
 	PauseReason string `json:"pauseReason,omitempty"`
 
+	// DebugLog enables more verbose logging by KKP's usercluster-controller-manager.
+	DebugLog bool `json:"debugLog,omitempty"`
+
 	// Optional component specific overrides
 	ComponentsOverride ComponentSettings `json:"componentsOverride"`
 

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -143,6 +143,10 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				fmt.Sprintf("-node-local-dns-cache=%t", data.NodeLocalDNSCacheEnabled()),
 			}, getNetworkArgs(data)...)
 
+			if data.Cluster().Spec.DebugLog {
+				args = append(args, "-log-debug=true")
+			}
+
 			if data.IsKonnectivityEnabled() {
 				args = append(args, "-konnectivity-enabled=true")
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR makes it possible to enable debug logging for individual userclusters. Since this is much more useful than having a global configuration flag, I would consider this to fully solve #8734. Since this controller-manager is not really a Kubernetes component, I chose to not use the ComponentsOverride stuff for this.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8734

**Does this PR introduce a user-facing change?**:
```release-note
Add `spec.debugLog` field to `Cluster` objects to toggle the verbose log on the usercluster-controller-manager.
```
