### PR TITLE
Fix reconcile loop for vSphere CSI ValidatingWebhookConfiguration

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -89,6 +89,9 @@ func main() {
 	// Set the logger used by sigs.k8s.io/controller-runtime
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog))
 
+	// make sure the logging flags actually affect the global (deprecated) logger instance
+	kubermaticlog.Logger = log
+
 	versions := kubermatic.NewDefaultVersions()
 	cli.Hello(log, "Seed Controller-Manager", logOpts.Debug, &versions)
 

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -143,12 +143,14 @@ func main() {
 	flag.StringVar(&runOp.konnectivityServerHost, "konnectivity-server-host", "", "Konnectivity Server host.")
 	flag.IntVar(&runOp.konnectivityServerPort, "konnectivity-server-port", 6443, "Konnectivity Server port.")
 	flag.BoolVar(&runOp.enableOperatingSystemManager, "operating-system-manager-enabled", false, "Enable Operating System Manager, this only enables deployment of OSM resources.")
-
 	flag.Parse()
 
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog))
+
+	// make sure the logging flags actually affect the global (deprecated) logger instance
+	kubermaticlog.Logger = log
 
 	versions := kubermatic.NewDefaultVersions()
 	cli.Hello(log, "User-Cluster Controller-Manager", logOpts.Debug, &versions)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/csi-migration/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/csi-migration/webhook.go
@@ -24,6 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -32,20 +33,29 @@ func ValidatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace, 
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return name, func(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
+			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
-			validatingWebhookConfiguration.Name = name
-			validatingWebhookConfiguration.Namespace = namespace
+			scope := admissionregistrationv1.AllScopes
+
 			validatingWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name: name,
+					Name:                    name,
+					AdmissionReviewVersions: []string{"v1"},
+					MatchPolicy:             &matchPolicy,
+					FailurePolicy:           &failurePolicy,
+					SideEffects:             &sideEffect,
+					TimeoutSeconds:          pointer.Int32Ptr(30),
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						Service: &admissionregistrationv1.ServiceReference{
 							Namespace: namespace,
 							Name:      resources.CSIMigrationWebhookName,
 							Path:      pointer.String("/validate"),
+							Port:      pointer.Int32Ptr(443),
 						},
 						CABundle: triple.EncodeCertPEM(caCert),
 					},
+					NamespaceSelector: &metav1.LabelSelector{},
+					ObjectSelector:    &metav1.LabelSelector{},
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{
@@ -59,6 +69,7 @@ func ValidatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace, 
 								Resources: []string{
 									"storageclasses",
 								},
+								Scope: &scope,
 							},
 							Operations: []admissionregistrationv1.OperationType{
 								admissionregistrationv1.Create,
@@ -66,9 +77,6 @@ func ValidatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace, 
 							},
 						},
 					},
-					SideEffects:             &sideEffect,
-					AdmissionReviewVersions: []string{"v1"},
-					FailurePolicy:           &failurePolicy,
 				},
 			}
 

--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -159,7 +159,10 @@ func waitUntilUpdateIsInCacheConditionFunc(
 			klog.Errorf("failed retrieving object %T %s while waiting for the cache to contain our latest changes: %v", currentObj, namespacedName, err)
 			return false, nil
 		}
-		// Check if the object from the store differs the old object
+
+		// Check if the object from the store differs the old object;
+		// We are waiting for the resourceVersion/generation to change
+		// and for this new version to be then present in our cache.
 		if !DeepEqual(currentObj.(metav1.Object), oldObj.(metav1.Object)) {
 			return true, nil
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We had a reconcile loop for the webhook, at least because we forgot to set the service port.

> 2022-01-17T15:20:14.767+0100    debug   reconciling/compare.go:62       Object differs from generated one       {"type": "*v1.ValidatingWebhookConfiguration", "namespace": "", "name": "validation.csi.vsphere.vmware.com", "diff": ["Webhooks.slice[0].ClientConfig.Service.Port: <nil pointer> != int32"]}

This error was however invisible, even with enabled debug logging, because we forgot to update the global Logger instance based on the given CLI flags. That is why this PR also changes the seed-ctrl-mgr.

With regards to the other fields (NamespaceSelector, MatchPolicy), I am not 100% sure if we would need to specify them, but our other creators already do and this is the safe approach.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8715

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix vSphere clusters getting stuck after CSI migration due to bad ValidatingWebhookConfiguration reconciling.
```
