### PR TITLE
[release/v2.18] Fix reconcile loop for vSphere CSI ValidatingWebhookConfiguration (#8738)

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	// Set the logger used by sigs.k8s.io/controller-runtime
 	ctrlruntimelog.Log = ctrlruntimelog.NewDelegatingLogger(zapr.NewLogger(rawLog).WithName("controller_runtime"))
-	
+
 	// make sure the logging flags actually affect the global (deprecated) logger instance
 	kubermaticlog.Logger = log
 

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -86,6 +86,9 @@ func main() {
 
 	// Set the logger used by sigs.k8s.io/controller-runtime
 	ctrlruntimelog.Log = ctrlruntimelog.NewDelegatingLogger(zapr.NewLogger(rawLog).WithName("controller_runtime"))
+	
+	// make sure the logging flags actually affect the global (deprecated) logger instance
+	kubermaticlog.Logger = log
 
 	electionName := controllerName + "-leader-election"
 	if options.workerName != "" {

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -140,6 +140,9 @@ func main() {
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 
+	// make sure the logging flags actually affect the global (deprecated) logger instance
+	kubermaticlog.Logger = log
+
 	versions := kubermatic.NewDefaultVersions()
 	cli.Hello(log, "User-Cluster Controller-Manager", logOpts.Debug, &versions)
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/csi-migration/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/csi-migration/webhook.go
@@ -24,6 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -32,20 +33,29 @@ func ValidatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace, 
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return name, func(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
+			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
-			validatingWebhookConfiguration.Name = name
-			validatingWebhookConfiguration.Namespace = namespace
+			scope := admissionregistrationv1.AllScopes
+
 			validatingWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name: name,
+					Name:                    name,
+					AdmissionReviewVersions: []string{"v1"},
+					MatchPolicy:             &matchPolicy,
+					FailurePolicy:           &failurePolicy,
+					SideEffects:             &sideEffect,
+					TimeoutSeconds:          pointer.Int32Ptr(30),
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						Service: &admissionregistrationv1.ServiceReference{
 							Namespace: namespace,
 							Name:      resources.CSIMigrationWebhookName,
 							Path:      pointer.String("/validate"),
+							Port:      pointer.Int32Ptr(443),
 						},
 						CABundle: triple.EncodeCertPEM(caCert),
 					},
+					NamespaceSelector: &metav1.LabelSelector{},
+					ObjectSelector:    &metav1.LabelSelector{},
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{
@@ -59,6 +69,7 @@ func ValidatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace, 
 								Resources: []string{
 									"storageclasses",
 								},
+								Scope: &scope,
 							},
 							Operations: []admissionregistrationv1.OperationType{
 								admissionregistrationv1.Create,
@@ -66,9 +77,6 @@ func ValidatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace, 
 							},
 						},
 					},
-					SideEffects:             &sideEffect,
-					AdmissionReviewVersions: []string{"v1"},
-					FailurePolicy:           &failurePolicy,
 				},
 			}
 

--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -154,7 +154,10 @@ func waitUntilUpdateIsInCacheConditionFunc(
 			klog.Errorf("failed retrieving object %T %s while waiting for the cache to contain our latest changes: %v", currentObj, namespacedName, err)
 			return false, nil
 		}
-		// Check if the object from the store differs the old object
+
+		// Check if the object from the store differs the old object;
+		// We are waiting for the resourceVersion/generation to change
+		// and for this new version to be then present in our cache.
 		if !DeepEqual(currentObj.(metav1.Object), oldObj.(metav1.Object)) {
 			return true, nil
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Backport #8738 into this release branch.

**Does this PR introduce a user-facing change?**:
```release-note
Fix vSphere clusters getting stuck after CSI migration due to bad ValidatingWebhookConfiguration reconciling.
```
