### PR TITLE
use owner references to cleanup seed-level RBAC instead of manual work

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2340,7 +2340,8 @@ const (
 	SeedUserProjectBindingCleanupFinalizer = "kubermatic.io/cleanup-seed-user-project-bindings"
 	// SeedUserCleanupFinalizer indicates that Kubermatic Users on the seed clusters need cleanup
 	SeedUserCleanupFinalizer = "kubermatic.io/cleanup-seed-users"
-	// ClusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup
+	// ClusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup.
+	// This finalizer is deprecated and should not be used anymore since we migrated to using owner references for cleanup.
 	ClusterRoleBindingsCleanupFinalizer = "kubermatic.io/cleanup-cluster-role-bindings"
 	// ClusterTemplateSeedCleanupFinalizer indicates that synced cluster template on seed clusters need cleanup
 	ClusterTemplateSeedCleanupFinalizer = "kubermatic.io/cleanup-seed-cluster-template"

--- a/pkg/clusterdeletion/clusterrolebindings.go
+++ b/pkg/clusterdeletion/clusterrolebindings.go
@@ -22,24 +22,15 @@ import (
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/resources/usercluster"
 
-	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// cleanupClusterRoleBindings is deprecated and should be removed in KKP 2.20+, because
+// nowadays we use owner references for cleanup and this manual step is not needed anymore.
 func (d *Deletion) cleanupClusterRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer) {
 		return nil
-	}
-
-	toDelete := &rbacv1.ClusterRoleBinding{}
-	toDelete.Name = usercluster.GenClusterRoleBindingName(cluster.Status.NamespaceName)
-	if err := d.seedClient.Delete(ctx, toDelete); err != nil {
-		if !kerrors.IsNotFound(err) {
-			return err
-		}
 	}
 
 	oldCluster := cluster.DeepCopy()

--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -152,7 +152,6 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, log *zap.Sugar
 	}
 
 	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.InClusterLBCleanupFinalizer)
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.InClusterPVCleanupFinalizer)
+	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.InClusterLBCleanupFinalizer, kubermaticapiv1.InClusterPVCleanupFinalizer)
 	return d.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -33,7 +33,8 @@ const (
 
 func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// Create the namespace
-	if err := r.ensureNamespaceExists(ctx, cluster); err != nil {
+	namespace, err := r.ensureNamespaceExists(ctx, cluster)
+	if err != nil {
 		return nil, err
 	}
 
@@ -53,7 +54,7 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 	}
 
 	// Deploy & Update master components for Kubernetes
-	res, err := r.ensureResourcesAreDeployed(ctx, cluster)
+	res, err := r.ensureResourcesAreDeployed(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -83,9 +84,6 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 
 	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.KubermaticConstraintCleanupFinalizer) {
 		finalizers = append(finalizers, kubermaticapiv1.KubermaticConstraintCleanupFinalizer)
-	}
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer) {
-		finalizers = append(finalizers, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer)
 	}
 
 	if len(finalizers) > 0 {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -451,9 +451,9 @@ func (r *Reconciler) ensureRoleBindings(ctx context.Context, c *kubermaticv1.Clu
 	return nil
 }
 
-func (r *Reconciler) ensureClusterRoles(ctx context.Context, namespace *corev1.Namespace) error {
+func (r *Reconciler) ensureClusterRoles(ctx context.Context) error {
 	namedClusterRoleCreatorGetters := []reconciling.NamedClusterRoleCreatorGetter{
-		usercluster.ClusterRole(namespace),
+		usercluster.ClusterRole(),
 	}
 	if err := reconciling.ReconcileClusterRoles(ctx, namedClusterRoleCreatorGetters, "", r.Client); err != nil {
 		return fmt.Errorf("failed to ensure Cluster Roles: %v", err)
@@ -717,7 +717,7 @@ func (r *Reconciler) ensureRBAC(ctx context.Context, cluster *kubermaticv1.Clust
 		return err
 	}
 
-	if err := r.ensureClusterRoles(ctx, namespace); err != nil {
+	if err := r.ensureClusterRoles(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -137,12 +137,6 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 	// This is used as basis to sync the clusters address which we in turn do
 	// before creating any deployments.
 	namespace := &corev1.Namespace{
-		// explicitly set TypeMeta because we need them for setting owner references
-		// and in a real-life scenario, the type meta is always set
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Namespace",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testCluster.Status.NamespaceName,
 		},
@@ -180,6 +174,14 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 	}
 	if err := mgr.GetClient().Create(ctx, caBundleConfigMap); err != nil {
 		t.Fatalf("failed to create the CA bundle: %v", err)
+	}
+
+	// explicitly set TypeMeta because we need them for setting owner references
+	// and in a real-life scenario, the type meta is always set;
+	// set this *afte* the Create() call, which would remove the TypeMeta for some reason.
+	namespace.TypeMeta = metav1.TypeMeta{
+		Kind:       "Namespace",
+		APIVersion: "v1",
 	}
 
 	// Status must be set *after* the Service has been created, because

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -216,11 +216,11 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		userClusterConnProvider: new(testUserClusterConnectionProvider),
 	}
 
-	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
+	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster, namespace); err != nil {
 		t.Fatalf("Initial resource deployment failed, this indicates that some resources are invalid. Error: %v", err)
 	}
 
-	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
+	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster, namespace); err != nil {
 		t.Fatalf("The second resource reconciliation failed, indicating we don't properly default some fields. Check the `Object differs from generated one` error for the object for which we timed out. Original error: %v", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -137,6 +137,12 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 	// This is used as basis to sync the clusters address which we in turn do
 	// before creating any deployments.
 	namespace := &corev1.Namespace{
+		// explicitly set TypeMeta because we need them for setting owner references
+		// and in a real-life scenario, the type meta is always set
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testCluster.Status.NamespaceName,
 		},

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -102,10 +102,9 @@ func RoleBindingCreator() (string, reconciling.RoleBindingCreator) {
 	}
 }
 
-func ClusterRole(namespace *corev1.Namespace) reconciling.NamedClusterRoleCreatorGetter {
+func ClusterRole() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return roleName, func(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			r.OwnerReferences = []metav1.OwnerReference{genOwnerReference(namespace)}
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"kubermatic.k8s.io"},

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -101,28 +102,32 @@ func RoleBindingCreator() (string, reconciling.RoleBindingCreator) {
 	}
 }
 
-func ClusterRoleCreator() (string, reconciling.ClusterRoleCreator) {
-	return roleName, func(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-		r.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"kubermatic.k8s.io"},
-				Resources: []string{"clusters"},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-					"patch",
-					"update",
+func ClusterRole(namespace *corev1.Namespace) reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return roleName, func(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			r.OwnerReferences = []metav1.OwnerReference{genOwnerReference(namespace)}
+			r.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"kubermatic.k8s.io"},
+					Resources: []string{"clusters"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+						"patch",
+						"update",
+					},
 				},
-			},
+			}
+			return r, nil
 		}
-		return r, nil
 	}
 }
 
-func ClusterRoleBinding(namespace string) reconciling.NamedClusterRoleBindingCreatorGetter {
+func ClusterRoleBinding(namespace *corev1.Namespace) reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return GenClusterRoleBindingName(namespace), func(rb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			rb.OwnerReferences = []metav1.OwnerReference{genOwnerReference(namespace)}
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     roleName,
 				Kind:     "ClusterRole",
@@ -132,7 +137,7 @@ func ClusterRoleBinding(namespace string) reconciling.NamedClusterRoleBindingCre
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      serviceAccountName,
-					Namespace: namespace,
+					Namespace: namespace.Name,
 				},
 			}
 			return rb, nil
@@ -140,6 +145,20 @@ func ClusterRoleBinding(namespace string) reconciling.NamedClusterRoleBindingCre
 	}
 }
 
-func GenClusterRoleBindingName(targetNamespace string) string {
-	return fmt.Sprintf("%s-%s", roleBindingName, targetNamespace)
+// genOwnerReference returns an owner ref pointing to the cluster namespace. This
+// ensures that when a cluster is deleted, the ClusterRole/Binding are deleted automatically
+// *after* the cluster namespace is gone. Previously, we manually deleted them, but
+// this could lead to cases where the usercluster-ctrl-mgr is still running and
+// producing errors because it cannot access Cluster objects anymore.
+func genOwnerReference(namespace *corev1.Namespace) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: namespace.APIVersion,
+		Kind:       namespace.Kind,
+		Name:       namespace.Name,
+		UID:        namespace.UID,
+	}
+}
+
+func GenClusterRoleBindingName(targetNamespace *corev1.Namespace) string {
+	return fmt.Sprintf("%s-%s", roleBindingName, targetNamespace.Name)
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
During cleanup, we remove the ClusterRole/Binding too early, leading to the usercluster-ctrl-mgr logging errors (see linked issue). This PR changes the cleanup procedure to use owner references instead. Thankfully, namespaces are not namespaced (^^), so we can set owner refs to the cluster namespace. This means that the RBAC stuff is deleted only after the cluster namespace is gone, which should be when the usercluster-ctrl-mgr pod is also already gone.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #7832

**Does this PR introduce a user-facing change?**:
```release-note
Fix clusters being occasionally stuck in deletion because seed-level RBAC resources were deleted too early.
```
