### PR TITLE
Update flatcar controller to support removal of resources

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -83,7 +83,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err := r.List(ctx, &nodeList,
 		ctrlruntimeclient.MatchingLabels{nodelabelerapi.DistributionLabelKey: nodelabelerapi.FlatcarLabelValue},
 	); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list nodes: %v", err)
+		return reconcile.Result{}, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
 	// filter out any Flatcar nodes that are already being deleted
@@ -96,11 +96,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 	if len(nodes) == 0 {
 		if err := r.cleanupUpdateOperatorResources(ctx); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to clean up UpdateOperator resources: %v", err)
+			return reconcile.Result{}, fmt.Errorf("failed to clean up UpdateOperator resources: %w", err)
 		}
 	} else {
 		if err := r.reconcileUpdateOperatorResources(ctx); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to reconcile the UpdateOperator resources: %v", err)
+			return reconcile.Result{}, fmt.Errorf("failed to reconcile the UpdateOperator resources: %w", err)
 		}
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/delete.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/delete.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func EnsureAllDeleted(ctx context.Context, client ctrlruntimeclient.Client) error {
+	objects := []ctrlruntimeclient.Object{
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AgentDaemonSetName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      OperatorDeploymentName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: OperatorClusterRoleBindingName,
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: AgentClusterRoleBindingName,
+			},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: OperatorClusterRoleName,
+			},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: AgentClusterRoleName,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      OperatorServiceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AgentServiceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+	}
+
+	for _, object := range objects {
+		if err := ensureDeleted(ctx, client, object); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureDeleted(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) error {
+	if err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+		// error is 'not found', we're done here
+		return nil
+	}
+
+	return client.Delete(ctx, obj)
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -92,17 +92,6 @@ func OperatorDeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc,
 				},
 			}
 
-			dep.Spec.Template.Spec.Tolerations = []corev1.Toleration{
-				{
-					Effect:   corev1.TaintEffectNoSchedule,
-					Operator: corev1.TolerationOpExists,
-				},
-				{
-					Effect:   corev1.TaintEffectNoExecute,
-					Operator: corev1.TolerationOpExists,
-				},
-			}
-
 			return dep, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -57,9 +56,6 @@ func OperatorDeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc,
 			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			dep.Spec.Template.ObjectMeta.Labels = labels
 			dep.Spec.Template.Spec.ServiceAccountName = OperatorServiceAccountName
-
-			// The operator should only run on Flatcar nodes
-			dep.Spec.Template.Spec.NodeSelector = map[string]string{nodelabelerapi.DistributionLabelKey: nodelabelerapi.FlatcarLabelValue}
 
 			env := []corev1.EnvVar{
 				{

--- a/pkg/controller/util/predicate/predicate.go
+++ b/pkg/controller/util/predicate/predicate.go
@@ -44,7 +44,7 @@ func Factory(filter func(o ctrlruntimeclient.Object) bool) predicate.Funcs {
 	}
 }
 
-// MultiFactory returns a predicate func tha tapplies the given filter functions
+// MultiFactory returns a predicate func that applies the given filter functions
 // to the respective events for CREATE, UPDATE and DELETE. For UPDATE events, the
 // filter is applied to both the old and new object and OR's the result.
 func MultiFactory(createFilter func(o ctrlruntimeclient.Object) bool, updateFilter func(o ctrlruntimeclient.Object) bool, deleteFilter func(o ctrlruntimeclient.Object) bool) predicate.Funcs {

--- a/pkg/controller/util/predicate/predicate.go
+++ b/pkg/controller/util/predicate/predicate.go
@@ -44,6 +44,23 @@ func Factory(filter func(o ctrlruntimeclient.Object) bool) predicate.Funcs {
 	}
 }
 
+// MultiFactory returns a predicate func tha tapplies the given filter functions
+// to the respective events for CREATE, UPDATE and DELETE. For UPDATE events, the
+// filter is applied to both the old and new object and OR's the result.
+func MultiFactory(createFilter func(o ctrlruntimeclient.Object) bool, updateFilter func(o ctrlruntimeclient.Object) bool, deleteFilter func(o ctrlruntimeclient.Object) bool) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return createFilter(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return updateFilter(e.ObjectOld) || updateFilter(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return deleteFilter(e.Object)
+		},
+	}
+}
+
 // ByNamespace returns a predicate func that only includes objects in the given namespace.
 func ByNamespace(namespace string) predicate.Funcs {
 	return Factory(func(o ctrlruntimeclient.Object) bool {
@@ -72,4 +89,9 @@ func ByLabel(key, value string) predicate.Funcs {
 		}
 		return false
 	})
+}
+
+// TrueFilter is a helper filter implementation that always returns true, e.g. for use with MultiFactory.
+func TrueFilter(_ ctrlruntimeclient.Object) bool {
+	return true
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR updates the flatcar controller in `user-cluster-controller-manager` to remove `flatcar-update-{operator,agent}` related resources when no Flatcar node is in the cluster. That way, no leftover resources linger when a Flatcar `MachineDeployment` is added and removed later on.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8708

**Special notes for your reviewer**:
- The predicate has been removed because we want to check the conditions against all nodes, not only the one caught by the controller loop. Node changes merely act as a trigger now.
- The check if a node is unschedulable has been removed as both DaemonSet and Deployment ignore ANY taints. Flatcar nodes that are marked as unschedulable can therefore still run the update-agent.
- The node selector has been removed from the Deployment because the update-operator does not _require_ to run on Flatcar nodes (it does not interact with the underlying node; it just coordinates the agent actions via the Kubernetes API) and blocks draining the last remaining Flatcar Node of a `MachineDeployment` (as any taint is ignored, that includes the taint repelling Pods from unschedulable Nodes). This way, the update-operator can be drained and started on another Node in the cluster, and then be removed when the last Flatcar Node is successfully removed.
- The "catch-all" tolerations have been removed from the `flatcar-update-operator` Deployment. Putting those on Deployments is problematic because it prevents node drains from succeeding. Other, similar resources like `calico-kube-controllers` don't have those tolerations either.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unused flatcar update resources are removed when no Flatcar `Nodes` are in a user cluster
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
