### PR TITLE
make k8s dashboard version depend on usercluster version

### DIFF
--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -23,6 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/semver"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,8 +51,7 @@ var (
 const (
 	name      = resources.KubernetesDashboardDeploymentName
 	imageName = "kubernetesui/dashboard"
-	tag       = "v2.4.0"
-	// Namespace used by Dashboard to find required resources.
+	// Namespace used by dashboard to find required resources.
 	Namespace     = "kubernetes-dashboard"
 	ContainerPort = 9090
 	AppLabel      = resources.AppLabelKey + "=" + name
@@ -82,6 +82,11 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 				return nil, fmt.Errorf("failed to create pod labels: %w", err)
 			}
 
+			containers, err := getContainers(data, dep.Spec.Template.Spec.Containers)
+			if err != nil {
+				return nil, err
+			}
+
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 				Labels: podLabels,
 			}
@@ -89,7 +94,7 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Volumes = volumes
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
-			dep.Spec.Template.Spec.Containers = getContainers(data, dep.Spec.Template.Spec.Containers)
+			dep.Spec.Template.Spec.Containers = containers
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
@@ -107,7 +112,7 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 	}
 }
 
-func getContainers(data kubernetesDashboardData, existingContainers []corev1.Container) []corev1.Container {
+func getContainers(data kubernetesDashboardData, existingContainers []corev1.Container) ([]corev1.Container, error) {
 	// We must do some hoops there because SecurityContext.RunAsGroup
 	// does not exit in all Kubernetes versions. We must keep it if it
 	// exists but never set it ourselves. The APIServer defaults
@@ -119,6 +124,12 @@ func getContainers(data kubernetesDashboardData, existingContainers []corev1.Con
 	securityContext.RunAsUser = pointer.Int64Ptr(1001)
 	securityContext.ReadOnlyRootFilesystem = pointer.BoolPtr(true)
 	securityContext.AllowPrivilegeEscalation = pointer.BoolPtr(false)
+
+	tag, err := getDashboardVersion(data.Cluster().Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	return []corev1.Container{{
 		Name:            name,
 		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryDocker), imageName, tag),
@@ -146,7 +157,7 @@ func getContainers(data kubernetesDashboardData, existingContainers []corev1.Con
 			},
 		},
 		SecurityContext: securityContext,
-	}}
+	}}, nil
 }
 
 func getVolumes() []corev1.Volume {
@@ -165,4 +176,13 @@ func getVolumes() []corev1.Volume {
 			},
 		},
 	}
+}
+
+func getDashboardVersion(clusterVersion semver.Semver) (string, error) {
+	// check the GitHub releases for find compat info on the dashboard:
+	// https://github.com/kubernetes/dashboard/releases
+
+	// v2.4.0 is the latest version and supports Kubernetes 1.20/1.21;
+	// there is no official release to support 1.22+ yet.
+	return "v2.4.0", nil
 }

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -182,7 +182,16 @@ func getDashboardVersion(clusterVersion semver.Semver) (string, error) {
 	// check the GitHub releases for find compat info on the dashboard:
 	// https://github.com/kubernetes/dashboard/releases
 
-	// v2.4.0 is the latest version and supports Kubernetes 1.20/1.21;
-	// there is no official release to support 1.22+ yet.
-	return "v2.4.0", nil
+	switch clusterVersion.MajorMinor() {
+	case "1.20":
+		return "v2.4.0", nil
+	case "1.21":
+		return "v2.4.0", nil
+	case "1.22":
+		return "v2.5.0", nil
+	case "1.23":
+		return "v2.5.0", nil
+	default:
+		return "", fmt.Errorf("no compatible version defined for Kubernetes %q", clusterVersion.MajorMinor())
+	}
 }

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
@@ -50,7 +50,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.4.0
+        image: docker.io/kubernetesui/dashboard:v2.5.0
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The dashboard depends on the cluster version. This PR makes it dynamic, even though there currently is only 1 realistic useful release (2.4.0). KKP doesn't support anything <1.20 and there is no dashboard release with 1.22+ support yet. So in the end, the dynamic version is currently always the same :D

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8196

**Does this PR introduce a user-facing change?**:
```release-note
The version of the installed Kubernetes dashboard now depends on the usercluster version.
```
