### PR TITLE
update kube-state-metrics to 2.3.0

### DIFF
--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -48,7 +48,7 @@ var (
 
 const (
 	name    = "kube-state-metrics"
-	version = "v2.2.3"
+	version = "v2.3.0"
 )
 
 // DeploymentCreator returns the function to create and update the kube-state-metrics deployment

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.3.0 contains a few fixes, but nothing important for us.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update kube-state-metrics to 2.3.0
```
