### PR TITLE
Update Cluster objects when Azure resources are found after retries

### DIFF
--- a/pkg/provider/cloud/azure/availability_set.go
+++ b/pkg/provider/cloud/azure/availability_set.go
@@ -74,9 +74,7 @@ func reconcileAvailabilitySet(ctx context.Context, clients *ClientSet, location 
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.AvailabilitySet = cluster.Spec.Cloud.Azure.AvailabilitySet
-		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerAvailabilitySet) {
-			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerAvailabilitySet)
-		}
+		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerAvailabilitySet)
 	})
 }
 

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -185,22 +185,6 @@ func (a *Azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(cluster, FinalizerResourceGroup) {
-		logger.Infow("deleting resource group", "resourceGroup", cluster.Spec.Cloud.Azure.ResourceGroup)
-		if err := deleteResourceGroup(a.ctx, clientSet, cluster.Spec.Cloud); err != nil {
-			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
-				return cluster, fmt.Errorf("failed to delete resource group %q: %v", cluster.Spec.Cloud.Azure.ResourceGroup, err)
-			}
-		}
-
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerResourceGroup)
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	if kuberneteshelper.HasFinalizer(cluster, FinalizerAvailabilitySet) {
 		logger.Infow("deleting availability set", "availabilitySet", cluster.Spec.Cloud.Azure.AvailabilitySet)
 		if err := deleteAvailabilitySet(a.ctx, clientSet, cluster.Spec.Cloud); err != nil {
@@ -211,6 +195,22 @@ func (a *Azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerAvailabilitySet)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerResourceGroup) {
+		logger.Infow("deleting resource group", "resourceGroup", cluster.Spec.Cloud.Azure.ResourceGroup)
+		if err := deleteResourceGroup(a.ctx, clientSet, cluster.Spec.Cloud); err != nil {
+			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
+				return cluster, fmt.Errorf("failed to delete resource group %q: %v", cluster.Spec.Cloud.Azure.ResourceGroup, err)
+			}
+		}
+
+		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerResourceGroup)
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -54,7 +54,7 @@ func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location st
 			// this is a special case; because we cannot determine if a resource group was created by
 			// the controller or not, we only add the finalizer if by the beginning of this loop, the
 			// name was not set. Otherwise we risk deleting a resource group we do not own.
-			if name == "" && !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerResourceGroup) {
+			if name == "" {
 				kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
 			}
 		})
@@ -66,9 +66,7 @@ func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location st
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
-		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerResourceGroup) {
-			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
-		}
+		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
 	})
 }
 

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -34,6 +34,8 @@ func resourceGroupName(cluster *kubermaticv1.Cluster) string {
 }
 
 func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location string, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	name := cluster.Spec.Cloud.Azure.ResourceGroup
+
 	if cluster.Spec.Cloud.Azure.ResourceGroup == "" {
 		cluster.Spec.Cloud.Azure.ResourceGroup = resourceGroupName(cluster)
 	}
@@ -47,16 +49,26 @@ func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location st
 	// of the resource. Since there is nothing in the resource group we could compare to eventually reconcile, we
 	// skip all of that and return early if we found a resource group during our API call earlier.
 	if !isNotFound(resourceGroup.Response) {
-		return cluster, nil
+		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+			updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
+			// this is a special case; because we cannot determine if a resource group was created by
+			// the controller or not, we only add the finalizer if by the beginning of this loop, the
+			// name was not set. Otherwise we risk deleting a resource group we do not own.
+			if name == "" && !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerResourceGroup) {
+				kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
+			}
+		})
 	}
 
 	if err = ensureResourceGroup(ctx, clients.Groups, cluster.Spec.Cloud, location, cluster.Name); err != nil {
-		return cluster, err
+		return nil, err
 	}
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
-		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
+		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerResourceGroup) {
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
+		}
 	})
 }
 

--- a/pkg/provider/cloud/azure/route_table.go
+++ b/pkg/provider/cloud/azure/route_table.go
@@ -53,7 +53,7 @@ func reconcileRouteTable(ctx context.Context, clients *ClientSet, location strin
 			// this is a special case; because we cannot determine if a route table was created by
 			// the controller or not, we only add the finalizer if by the beginning of this loop, the
 			// name was not set. Otherwise we risk deleting a route table we do not own.
-			if name == "" && !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerRouteTable) {
+			if name == "" {
 				kuberneteshelper.AddFinalizer(updatedCluster, FinalizerRouteTable)
 			}
 		})

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -40,13 +40,15 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 
 	securityGroup, err := clients.SecurityGroups.Get(ctx, cluster.Spec.Cloud.Azure.ResourceGroup, cluster.Spec.Cloud.Azure.SecurityGroup, "")
 	if err != nil && !isNotFound(securityGroup.Response) {
-		return cluster, err
+		return nil, err
 	}
 
 	// if we found a security group, we can check for the ownership tag to determine
 	// if the referenced security group is owned by this cluster and should be reconciled
 	if !isNotFound(securityGroup.Response) && !hasOwnershipTag(securityGroup.Tags, cluster) {
-		return cluster, nil
+		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+			updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
+		})
 	}
 
 	lowPort, highPort := kubermaticresources.NewTemplateDataBuilder().
@@ -68,18 +70,18 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 	//
 	// Attributes we check:
 	// - defined security rules
-	if securityGroup.SecurityGroupPropertiesFormat != nil && securityGroup.SecurityGroupPropertiesFormat.SecurityRules != nil &&
-		compareSecurityRules(*securityGroup.SecurityGroupPropertiesFormat.SecurityRules, *target.SecurityGroupPropertiesFormat.SecurityRules) {
-		return cluster, nil
-	}
-
-	if err := ensureSecurityGroup(ctx, clients, cluster.Spec.Cloud, target); err != nil {
-		return cluster, err
+	if !(securityGroup.SecurityGroupPropertiesFormat != nil && securityGroup.SecurityGroupPropertiesFormat.SecurityRules != nil &&
+		compareSecurityRules(*securityGroup.SecurityGroupPropertiesFormat.SecurityRules, *target.SecurityGroupPropertiesFormat.SecurityRules)) {
+		if err := ensureSecurityGroup(ctx, clients, cluster.Spec.Cloud, target); err != nil {
+			return cluster, err
+		}
 	}
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
-		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSecurityGroup)
+		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerSecurityGroup) {
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSecurityGroup)
+		}
 	})
 }
 

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -79,9 +79,7 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
-		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerSecurityGroup) {
-			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSecurityGroup)
-		}
+		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSecurityGroup)
 	})
 }
 

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -78,9 +78,7 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
-		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerSubnet) {
-			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSubnet)
-		}
+		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSubnet)
 	})
 }
 

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -57,28 +57,30 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 	// VNET isn't owned by KKP, we should not try to reconcile subnets and
 	// return early
 	if !isNotFound(subnet.Response) && !hasOwnershipTag(vnet.Tags, cluster) {
-		return cluster, nil
+		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+			updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
+		})
 	}
 
 	target := targetSubnet(cluster.Spec.Cloud)
 
-	// check for attributes of the existing subnet and return early if all values are already
+	// check for attributes of the existing subnet and skip ensuring if all values are already
 	// as expected. Since there are a lot of pointers in the network.Subnet struct, we need to
 	// do a lot of "!= nil" checks so this does not panic.
 	//
 	// Attributes we check:
 	// - Subnet CIDR
-	if subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefix != nil && *subnet.SubnetPropertiesFormat.AddressPrefix == *target.SubnetPropertiesFormat.AddressPrefix {
-		return cluster, nil
-	}
-
-	if err := ensureSubnet(ctx, clients, cluster.Spec.Cloud, target); err != nil {
-		return cluster, err
+	if !(subnet.SubnetPropertiesFormat != nil && subnet.SubnetPropertiesFormat.AddressPrefix != nil && *subnet.SubnetPropertiesFormat.AddressPrefix == *target.SubnetPropertiesFormat.AddressPrefix) {
+		if err := ensureSubnet(ctx, clients, cluster.Spec.Cloud, target); err != nil {
+			return nil, err
+		}
 	}
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
-		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSubnet)
+		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerSubnet) {
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSubnet)
+		}
 	})
 }
 

--- a/pkg/provider/cloud/azure/vnet.go
+++ b/pkg/provider/cloud/azure/vnet.go
@@ -72,9 +72,7 @@ func reconcileVNet(ctx context.Context, clients *ClientSet, location string, clu
 
 	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.VNetName = cluster.Spec.Cloud.Azure.VNetName
-		if !kuberneteshelper.HasFinalizer(updatedCluster, FinalizerVNet) {
-			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerVNet)
-		}
+		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerVNet)
 	})
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
When Azure was slow to respond to initial attempts to create resources (we noticed for resource group, but the problem exists for all resources), the passed context would time out and the reconcile would fail. The next retry would then discover that the resource exists, so it was under the impression it didn't need to do anything and could return early.

Unfortunately, we still might need to update the cloud spec with resource names and finalizers, as the initial try could have succeeded in creating the resource, but timed out for whatever reason before updating the `Cluster` object. This PR considers that situation.


**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8753

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
