### PR TITLE
make error message more readable

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -119,7 +119,7 @@ func (r *userGrafanaReconciler) Reconcile(ctx context.Context, request reconcile
 	}
 
 	if err := r.userGrafanaController.ensureGrafanaUser(ctx, user); err != nil {
-		return reconcile.Result{}, fmt.Errorf("unable to add grafana user : %w", err)
+		return reconcile.Result{}, fmt.Errorf("unable to add grafana user: %w", err)
 	}
 	return reconcile.Result{}, nil
 }
@@ -201,8 +201,11 @@ func (r *userGrafanaController) ensureGrafanaUser(ctx context.Context, user *kub
 	grafanaUser := &grafanasdk.User{}
 	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(grafanaUser); err != nil || grafanaUser.ID == 0 {
-		return fmt.Errorf("unable to decode response : %w", err)
+	if err := decoder.Decode(grafanaUser); err != nil {
+		return fmt.Errorf("unable to decode response: %w", err)
+	}
+	if grafanaUser.ID == 0 {
+		return fmt.Errorf("user %q was not found", user.Spec.Email)
 	}
 
 	// delete user from default org


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This prevents the ugly

> {"level":"error","time":"2022-01-19T16:46:38.483Z","logger":"controller.kubermatic_mla_controller","caller":"controller/controller.go:317","msg":"Reconciler error","name":"test-terraform-nrcch","namespace":"","error":"unable to add grafana user : unable to decode response : %!w(<nil>)"}

I am not sure what exactly happens in the `ensureGrafanaUser` function at the beginning, but this change should be safe.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
