### PR TITLE
Fix Konnectivity/OpenVPN switching with Tunneling expose strategy

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -99,7 +99,7 @@ func ConfigMapCreator(cfg Config) reconciling.NamedConfigMapCreatorGetter {
 			if err != nil {
 				return nil, err
 			}
-			cm.Data["envoy.yaml"] = b.String()
+			cm.Data[resources.EnvoyAgentConfigFileName] = b.String()
 
 			return cm, nil
 		}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -599,6 +599,7 @@ const (
 
 const (
 	EnvoyAgentConfigMapName                    = "envoy-agent"
+	EnvoyAgentConfigFileName                   = "envoy.yaml"
 	EnvoyAgentDaemonSetName                    = "envoy-agent"
 	EnvoyAgentCreateInterfaceInitContainerName = "create-dummy-interface"
 	EnvoyAgentAssignAddressInitContainerName   = "assign-address"

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -125,7 +125,7 @@ func (a *AgentConfig) newAgentConfigMap(ns string) *corev1.ConfigMap {
 
 // newAgnhostPod returns a pod returns the manifest of the agent pod.
 func (a *AgentConfig) newAgentPod(ns string) *corev1.Pod {
-	agentName, createDs := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions, registry.GetOverwriteFunc(""))()
+	agentName, createDs := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions, "", registry.GetOverwriteFunc(""))()
 	// TODO: errors should never be thrown here
 	ds, _ := createDs(&appsv1.DaemonSet{})
 	// We don't need the init containers in this context.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fixes switching between Konnectivity and OpenVPN with Tunneling expose strategy by adding a config hash annotation to the envoy-agent daemonset, to ensure that the envoy-agent is restarted when the config changes.

Also fixes the envoy config when Konnectivity is enabled - it that case the config should not contain the listener for openvpn-server (before this change, it would contain it with the bind port == 0, which is not valid - even though it is harmless).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
