### PR TITLE
Fix vsphere csi driver update immutability

### DIFF
--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -31,7 +31,10 @@ metadata:
   name: csi.vsphere.vmware.com
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
 ---
 kind: ServiceAccount
 apiVersion: v1


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
CSI driver settiings are immutable and cannot be updated. Therefore we need to ensure to use the same parameters as used in previous versions:

https://github.com/kubermatic/kubermatic/blob/release/v2.18/addons/csi/vsphere/driver.yaml

```
failed to reconcile Addon "csi": failed to deploy the addon manifests into the cluster: failed to execute '/usr/local/bin/kubectl-1.22 --kubeconfig /tmp/cluster-kxvx8tmclm-addon-csi-kubeconfig apply --prune --filename /tmp/cluster-kxvx8tmclm-csi.yaml --selector kubermatic-addon=csi' for addon csi of cluster kxvx8tmclm: exit status 1 serviceaccount/vsphere-csi-controller unchanged clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role unchanged clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding unchanged serviceaccount/vsphere-csi-node unchanged clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role unchanged clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding unchanged role.rbac.authorization.k8s.io/vsphere-csi-node-role unchanged rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding unchanged configmap/internal-feature-states.csi.vsphere.vmware.com unchanged service/vsphere-csi-controller unchanged deployment.apps/vsphere-csi-controller unchanged daemonset.apps/vsphere-csi-node unchanged The CSIDriver "csi.vsphere.vmware.com" is invalid: * spec.podInfoOnMount: Invalid value: false: field is immutable * spec.volumeLifecycleModes: Invalid value: []storage.VolumeLifecycleMode{"Persistent"}: field is immutable 
```



```release-note
NONE
```
