### PR TITLE
use ca-bundle in vsphere csi driver

### DIFF
--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -317,12 +317,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
             - mountPath: /csi
               name: socket-dir
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
+              readOnly: true
           ports:
             - name: healthz
               containerPort: 9808
@@ -372,9 +377,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
               readOnly: true
         - name: csi-provisioner
           image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v3.0.0
@@ -401,6 +411,9 @@ spec:
             secretName: cloud-config-csi
         - name: socket-dir
           emptyDir: {}
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -483,6 +496,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
               value: "1"
+            - name: SSL_CERT_FILE
+              value: "/etc/kubermatic/certs/ca-bundle.pem"
           securityContext:
             privileged: true
             capabilities:
@@ -502,6 +517,9 @@ spec:
               mountPath: /sys/block
             - name: sys-devices-dir
               mountPath: /sys/devices
+            - mountPath: /etc/kubermatic/certs
+              name: ca-bundle
+              readOnly: true
           ports:
             - name: healthz
               containerPort: 9808
@@ -546,6 +564,9 @@ spec:
           hostPath:
             path: /sys/devices
             type: Directory
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
       tolerations:
         - effect: NoExecute
           operator: Exists


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

ca-bundle usage got lost during csi update. This pr adds it again.


```release-note
Fix not referencing a custom CA bundle in vSphere CSI driver (regression from 2.18)
```
