### PR TITLE
Bump kube-state-metrics and VPA to new image location

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.73
+version: 1.1.74
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 deprecated: true

--- a/charts/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/charts/kubermatic/templates/vpa-updater-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         args:
         - "--address=:8943"
         # If a container was killed by a OOM trigger an update.
-        - "--evict-after-oom-treshold=30m0s"
+        - "--evict-after-oom-threshold=30m0s"
         - "--updater-interval=10m0s"
         - "--logtostderr"
         resources:

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -26,8 +26,8 @@ kubeStateMetrics:
 
   resizer:
     image:
-      repository: gcr.io/google_containers/addon-resizer
-      tag: '1.8.4' # is still the recommended version
+      repository: k8s.gcr.io/autoscaling/addon-resizer
+      tag: '1.8.14'
     resources:
       requests:
         cpu: 50m

--- a/cmd/node-resource-documenter/documenter_test.go
+++ b/cmd/node-resource-documenter/documenter_test.go
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: 'gcr.io/google_containers/kubernetes-dashboard-amd64:v1.10.1'
+        image: 'docker.io/kubernetesui/dashboard:v2.4.0'
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -485,7 +485,7 @@ spec:
   verticalPodAutoscaler:
     admissionController:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: gcr.io/google_containers/vpa-admission-controller
+      dockerRepository: k8s.gcr.io/autoscaling/vpa-admission-controller
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Limits describes the maximum amount of compute resources allowed.
@@ -502,7 +502,7 @@ spec:
           memory: 32Mi
     recommender:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: gcr.io/google_containers/vpa-recommender
+      dockerRepository: k8s.gcr.io/autoscaling/vpa-recommender
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Limits describes the maximum amount of compute resources allowed.
@@ -519,7 +519,7 @@ spec:
           memory: 512Mi
     updater:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: gcr.io/google_containers/vpa-updater
+      dockerRepository: k8s.gcr.io/autoscaling/vpa-updater
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Limits describes the maximum amount of compute resources allowed.

--- a/pkg/controller/operator/common/vpa/updater.go
+++ b/pkg/controller/operator/common/vpa/updater.go
@@ -66,7 +66,7 @@ func UpdaterDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, version
 					Command: []string{"/updater"},
 					Args: []string{
 						fmt.Sprintf("--address=:%d", updaterPort),
-						"--evict-after-oom-treshold=30m",
+						"--evict-after-oom-threshold=30m",
 						"--updater-interval=10m",
 						"--logtostderr",
 					},

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -48,9 +48,9 @@ const (
 	DefaultControllerManagerReplicas              = 1
 	DefaultSchedulerReplicas                      = 1
 	DefaultExposeStrategy                         = kubermaticv1.ExposeStrategyNodePort
-	DefaultVPARecommenderDockerRepository         = "gcr.io/google_containers/vpa-recommender"
-	DefaultVPAUpdaterDockerRepository             = "gcr.io/google_containers/vpa-updater"
-	DefaultVPAAdmissionControllerDockerRepository = "gcr.io/google_containers/vpa-admission-controller"
+	DefaultVPARecommenderDockerRepository         = "k8s.gcr.io/autoscaling/vpa-recommender"
+	DefaultVPAUpdaterDockerRepository             = "k8s.gcr.io/autoscaling/vpa-updater"
+	DefaultVPAAdmissionControllerDockerRepository = "k8s.gcr.io/autoscaling/vpa-admission-controller"
 	DefaultEnvoyDockerRepository                  = "docker.io/envoyproxy/envoy-alpine"
 	DefaultUserClusterScrapeAnnotationPrefix      = "monitoring.kubermatic.io"
 	DefaultMaximumParallelReconciles              = 10

--- a/pkg/version/kubermatic/versions.go
+++ b/pkg/version/kubermatic/versions.go
@@ -49,7 +49,7 @@ func NewDefaultVersions() Versions {
 		KubermaticCommit:  gitHash,
 		Kubermatic:        kubermaticDockerTag,
 		UI:                uiDockerTag,
-		VPA:               "0.5.0",
+		VPA:               "0.9.2",
 		Envoy:             "v1.17.1",
 		KubermaticEdition: edition.KubermaticEdition,
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #5773

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Vertical Pod Autoscaler (VPA) to 0.9.2
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
