### PR TITLE
Merge mandatory verify Prow jobs into one job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-6
         command:
         - make
         args:
@@ -39,8 +39,36 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
 
-  - name: pre-kubermatic-verify
+  - name: pre-kubermatic-test-integration
     run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/integration-tests:5-0
+        command:
+        - make
+        args:
+        - test-integration
+        # docker-in-docker (for localstack) needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+
+  - name: pre-kubermatic-verify
+    always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     path_alias: k8c.io/kubermatic
@@ -48,126 +76,13 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-6
         command:
-        - make
-        args:
-        - verify
+        - ./hack/ci/verify.sh
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-
-  - name: pre-kubermatic-verify-charts
-    run_if_changed: "^charts/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:2.0.0
-        command:
-        - "./hack/ci/verify-chart-versions.sh"
-        resources:
-          requests:
-            memory: 128Mi
-            cpu: 50m
-          limits:
-            memory: 256Mi
-            cpu: 250m
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-
-  - name: pre-kubermatic-verify-shfmt
-    run_if_changed: "^hack/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: docker.io/mvdan/shfmt:v3.2.1
-        command:
-        - "/bin/shfmt"
-      #   -l        list files whose formatting differs from shfmt's
-      #   -d        error with a diff when the formatting differs
-      #   -i uint   indent: 0 for tabs (default), >0 for number of spaces
-        args:
-        - "-l"
-        - "-sr"
-        - "-i"
-        - "2"
-        - "-d"
-        - "hack"
-        resources:
-          requests:
-            memory: 32Mi
-            cpu: 50m
-          limits:
-            memory: 256Mi
-            cpu: 250m
-
-  - name: pre-kubermatic-verify-kubermatic-chart
-    run_if_changed: "^(cmd|codegen|hack|pkg|charts)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
-        command:
-        - "./hack/verify-kubermatic-chart.sh"
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 250m
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-
-  - name: pre-kubermatic-verify-grafana-dashboards
-    run_if_changed: "^charts/monitoring/grafana/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:2.0.0
-        command:
-        - "./hack/verify-grafana-dashboards.sh"
-        resources:
-          requests:
-            memory: 64Mi
-            cpu: 50m
-          limits:
-            memory: 128Mi
-            cpu: 250m
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-
-  - name: pre-kubermatic-verify-docs
-    run_if_changed: "^(cmd|codegen|hack|pkg|docs)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
-        command:
-        - "./hack/verify-docs.sh"
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 1
+            memory: 2Gi
+            cpu: 2
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -189,43 +104,6 @@ presubmits:
           requests:
             memory: 10Gi
             cpu: 3
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-
-  - name: pre-kubermatic-spellcheck
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
-        command:
-        - make
-        args:
-        - spellcheck
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 0.5
-
-  - name: pre-kubermatic-dependencies
-    run_if_changed: "^(cmd/|codegen/|hack/|pkg/|go.mod|go.sum)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
-        command:
-        - make
-        args:
-        - check-dependencies
-        resources:
-          requests:
-            memory: 256Mi
-            cpu: 1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -252,22 +130,6 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
 
-  - name: pre-kubermatic-license-validation
-    run_if_changed: "^go.(mod|sum)$"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
-        command:
-        - ./hack/verify-licenses.sh
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 1
-
   - name: pre-kubermatic-verify-boilerplate
     always_run: true
     decorate: true
@@ -284,38 +146,6 @@ presubmits:
             memory: 256Mi
             cpu: 100m
 
-  - name: pre-kubermatic-prometheus-rules-validation
-    run_if_changed: "charts/monitoring"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:2.0.0
-        command:
-        - ./hack/verify-prometheus-rules.sh
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-
-  - name: pre-kubermatic-user-cluster-prometheus-config-validation
-    run_if_changed: "pkg/resources/prometheus"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
-        command:
-        - "./hack/ci/verify-user-cluster-prometheus-configs.sh"
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-      imagePullSecrets:
-      - name: quay
-
   - name: pre-kubermatic-simulate-github-release
     run_if_changed: "hack/ci/github-release.sh"
     decorate: true
@@ -324,7 +154,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-6
         command:
         - ./hack/ci/test-github-release.sh
         resources:
@@ -343,7 +173,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -367,7 +197,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -387,6 +217,7 @@ presubmits:
   #########################################################
   # Base Kubernetes Tests (AWS, Flatcar)
   #########################################################
+
   - name: pre-kubermatic-e2e-aws-ubuntu-1.20
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
@@ -403,7 +234,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -444,7 +275,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -485,7 +316,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -526,7 +357,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -573,7 +404,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -619,7 +450,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -662,7 +493,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -710,7 +541,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -753,7 +584,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -796,7 +627,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -839,7 +670,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -884,7 +715,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -929,7 +760,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -974,7 +805,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1018,7 +849,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1064,7 +895,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1110,7 +941,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1154,7 +985,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1202,7 +1033,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         imagePullPolicy: Always
         command:
         - "./hack/ci/run-api-e2e.sh"
@@ -1243,7 +1074,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
@@ -1280,7 +1111,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         imagePullPolicy: Always
         command:
         - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -1311,7 +1142,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -1348,7 +1179,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         imagePullPolicy: Always
         command:
         - ./hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -1377,7 +1208,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -1408,7 +1239,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode
@@ -1421,34 +1252,6 @@ presubmits:
           limits:
             memory: 4Gi
             cpu: 2
-
-  - name: pre-kubermatic-test-integration
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/integration-tests:5-0
-        command:
-        - make
-        args:
-        - test-integration
-        # docker-in-docker (for localstack) needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
 
   #########################################################
   # User cluster MLA e2e tests
@@ -1468,7 +1271,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script is used as a presubmit to check that Helm chart versions
+### have been updated if charts have been modified. Without the Prow env
+### vars, this script won't run properly.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+EXIT_CODE=0
+
+try() {
+  local title="$1"
+  shift
+
+  heading "$title"
+  echo -e "$@\n"
+
+  start_time=$(date +%s)
+
+  set +e
+  $@
+  exitCode=$?
+  set -e
+
+  elapsed_time=$(($(date +%s) - $start_time))
+  TEST_NAME="$title" write_junit $exitCode "$elapsed_time"
+
+  if [[ $exitCode -eq 0 ]]; then
+    echo -e "\n[${elapsed_time}s] SUCCESS :)"
+  else
+    echo -e "\n[${elapsed_time}s] FAILED."
+    EXIT_CODE=1
+  fi
+
+  git reset --hard --quiet
+  git clean --force
+
+  echo
+}
+
+try "Verify code generation" make verify
+try "Spellcheck" make spellcheck
+try "Verify go.mod" make check-dependencies
+try "Verify chart versions" ./hack/ci/verify-chart-versions.sh
+try "Verify legacy kubermatic chart" ./hack/verify-kubermatic-chart.sh
+try "Verify generated documentation" ./hack/verify-docs.sh
+try "Verify license compatibility" ./hack/verify-licenses.sh
+try "Verify Grafana dashboards" ./hack/verify-grafana-dashboards.sh
+try "Verify Prometheus rules" ./hack/verify-prometheus-rules.sh
+try "Verify User Cluster Prometheus rules" ./hack/ci/verify-user-cluster-prometheus-configs.sh
+
+# -l        list files whose formatting differs from shfmt's
+# -d        error with a diff when the formatting differs
+# -i uint   indent: 0 for tabs (default), >0 for number of spaces
+try "shfmt" shfmt -l -sr -i 2 -d hack
+
+exit $EXIT_CODE

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -391,3 +391,19 @@ start_docker_daemon() {
   retry 5 docker stats --no-stream
   echodate "Docker became ready"
 }
+
+repeat() {
+  local end=$1
+  local str="${2:-=}"
+
+  for i in $(seq 1 $end); do
+    echo -n "${str}"
+  done
+}
+
+heading() {
+  local title="$@"
+  echo "$title"
+  repeat ${#title} "="
+  echo
+}

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -89,15 +89,15 @@ write_junit() {
     errors=1
     failure='<failure type="Failure">Step failed</failure>'
   fi
-  TEST_NAME="[Kubermatic] ${TEST_NAME#\[Kubermatic\] }"
-  cat << EOF > ${ARTIFACTS}/junit.$(echo $TEST_NAME | sed 's/ /_/g').xml
+  TEST_CLASS="${TEST_CLASS:-Kubermatic}"
+  cat << EOF > ${ARTIFACTS}/junit.$(echo $TEST_NAME | sed 's/ /_/g' | tr '[:upper:]' '[:lower:]').xml
 <?xml version="1.0" ?>
 <testsuites>
-    <testsuite errors="$errors" failures="$errors" name="$TEST_NAME" tests="1">
-        <testcase classname="$TEST_NAME" name="$TEST_NAME" time="$duration">
-          $failure
-        </testcase>
-    </testsuite>
+  <testsuite errors="$errors" failures="$errors" name="$TEST_CLASS" tests="1">
+    <testcase classname="$TEST_CLASS" name="$TEST_NAME" time="$duration">
+      $failure
+    </testcase>
+  </testsuite>
 </testsuites>
 EOF
 }

--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -41,23 +41,84 @@ groups:
     labels:
       kubermatic: federate
 
-- name: kubermatic.machine_controller
+- name: kubermatic.etcd
   rules:
-  - record: job:machine_controller_errors_total:rate5m
-    expr: rate(machine_controller_errors_total[5m])
-    labels:
-      kubermatic: federate
-
-  - alert: KubernetesAdmissionWebhookHighRejectionRate
+  - alert: EtcdInsufficientMembers
     annotations:
-      message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-    expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-    for: 5m
+      message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+    expr: |
+      sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+    for: 15m
+    labels:
+      severity: critical
+
+  - alert: EtcdNoLeader
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+    expr: |
+      etcd_server_has_leader{job="etcd"} == 0
+    for: 15m
+    labels:
+      severity: critical
+
+  - alert: EtcdHighNumberOfLeaderChanges
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+    expr: |
+      rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+    for: 15m
     labels:
       severity: warning
 
-- name: kubermatic.etcd
-  rules:
+  - alert: EtcdGRPCRequestsSlow
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+    expr: |
+      histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+      > 0.15
+    for: 10m
+    labels:
+      severity: critical
+
+  - alert: EtcdMemberCommunicationSlow
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+    expr: |
+      histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+      > 0.15
+    for: 10m
+    labels:
+      severity: warning
+
+  - alert: EtcdHighNumberOfFailedProposals
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+    expr: |
+      rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+    for: 15m
+    labels:
+      severity: warning
+
+  - alert: EtcdHighFsyncDurations
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+    expr: |
+      histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+      > 0.5
+    for: 10m
+    labels:
+      severity: warning
+
+  - alert: EtcdHighCommitDurations
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+    expr: |
+      histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+      > 0.25
+    for: 10m
+    labels:
+      severity: warning
+
   - record: job:etcd_server_has_leader:sum
     expr: sum(etcd_server_has_leader)
     labels:
@@ -195,6 +256,14 @@ groups:
     labels:
       severity: warning
 
+  - alert: KubernetesAdmissionWebhookHighRejectionRate
+    annotations:
+      message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+    expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+    for: 5m
+    labels:
+      severity: warning
+
   - record: job:machine_controller_errors_total:rate5m
     expr: rate(machine_controller_errors_total[5m])
     labels:
@@ -209,84 +278,6 @@ groups:
     expr: sum(machine_controller_machines)
     labels:
       kubermatic: federate
-
-- name: etcd
-  rules:
-  - alert: EtcdInsufficientMembers
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-    expr: |
-      sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-    for: 15m
-    labels:
-      severity: critical
-
-  - alert: EtcdNoLeader
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-    expr: |
-      etcd_server_has_leader{job="etcd"} == 0
-    for: 15m
-    labels:
-      severity: critical
-
-  - alert: EtcdHighNumberOfLeaderChanges
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-    expr: |
-      rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-    for: 15m
-    labels:
-      severity: warning
-
-  - alert: EtcdGRPCRequestsSlow
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-    expr: |
-      histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-      > 0.15
-    for: 10m
-    labels:
-      severity: critical
-
-  - alert: EtcdMemberCommunicationSlow
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-    expr: |
-      histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-      > 0.15
-    for: 10m
-    labels:
-      severity: warning
-
-  - alert: EtcdHighNumberOfFailedProposals
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-    expr: |
-      rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-    for: 15m
-    labels:
-      severity: warning
-
-  - alert: EtcdHighFsyncDurations
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-    expr: |
-      histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-      > 0.5
-    for: 10m
-    labels:
-      severity: warning
-
-  - alert: EtcdHighCommitDurations
-    annotations:
-      message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-    expr: |
-      histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-      > 0.25
-    for: 10m
-    labels:
-      severity: warning
 
 - name: process.filedescriptors
   rules:

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
@@ -251,23 +251,84 @@ data:
         labels:
           kubermatic: federate
 
-    - name: kubermatic.machine_controller
+    - name: kubermatic.etcd
       rules:
-      - record: job:machine_controller_errors_total:rate5m
-        expr: rate(machine_controller_errors_total[5m])
-        labels:
-          kubermatic: federate
-
-      - alert: KubernetesAdmissionWebhookHighRejectionRate
+      - alert: EtcdInsufficientMembers
         annotations:
-          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
-        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
-        for: 5m
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
         labels:
           severity: warning
 
-    - name: kubermatic.etcd
-      rules:
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:
@@ -405,6 +466,14 @@ data:
         labels:
           severity: warning
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
       - record: job:machine_controller_errors_total:rate5m
         expr: rate(machine_controller_errors_total[5m])
         labels:
@@ -419,84 +488,6 @@ data:
         expr: sum(machine_controller_machines)
         labels:
           kubermatic: federate
-
-    - name: etcd
-      rules:
-      - alert: EtcdInsufficientMembers
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
-        expr: |
-          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdNoLeader
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
-        expr: |
-          etcd_server_has_leader{job="etcd"} == 0
-        for: 15m
-        labels:
-          severity: critical
-
-      - alert: EtcdHighNumberOfLeaderChanges
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
-        expr: |
-          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdGRPCRequestsSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
-          > 0.15
-        for: 10m
-        labels:
-          severity: critical
-
-      - alert: EtcdMemberCommunicationSlow
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
-          > 0.15
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighNumberOfFailedProposals
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
-        expr: |
-          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
-        for: 15m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighFsyncDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.5
-        for: 10m
-        labels:
-          severity: warning
-
-      - alert: EtcdHighCommitDurations
-        annotations:
-          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        expr: |
-          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
-          > 0.25
-        for: 10m
-        labels:
-          severity: warning
 
     - name: process.filedescriptors
       rules:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a suggestion, not sure how it will work out. I got tired from the many different and seemingly randomly structured `verify-` jobs and would like to see how a single, monolithic verify job could work.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
