### PR TITLE
Drop unused test values from cert-manager

### DIFF
--- a/charts/cert-manager/test/default.yaml
+++ b/charts/cert-manager/test/default.yaml
@@ -13,9 +13,3 @@
 # limitations under the License.
 
 cert-manager:
-  clusterIssuers:
-    letsencrypt-prod:
-      email: dev@kubermatic.com
-
-    letsencrypt-staging:
-      email: dev@kubermatic.com


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Support for `clusterIssuers` was dropped from the helm chart thus it does not make sense to keep those in test values.

As you can see from the output, there is nothing being produced based on these values.

**Special notes for your reviewer**: N/A

**Documentation**: N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
