### PR TITLE
apiserver network policy: allow all egress DNS traffic from apiserver

### DIFF
--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -111,11 +111,7 @@ func DNSAllowCreator(c *kubermaticv1.Cluster, data *resources.TemplateData) reco
 						resources.AppLabelKey: name,
 					},
 				},
-			}
-
-			if data.IsKonnectivityEnabled() {
-				// allow all egress DNS traffic
-				np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
@@ -128,25 +124,8 @@ func DNSAllowCreator(c *kubermaticv1.Cluster, data *resources.TemplateData) reco
 							},
 						},
 					},
-				}
-			} else {
-				// allow egress traffic to the custom DNS resolver
-				np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
-					{
-						To: []networkingv1.NetworkPolicyPeer{
-							{
-								PodSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										resources.AppLabelKey: "dns-resolver",
-										"cluster":             c.ObjectMeta.Name,
-									},
-								},
-							},
-						},
-					},
-				}
+				},
 			}
-
 			return np, nil
 		}
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It seems that in some specific environments (see https://github.com/kubermatic/kubermatic/issues/8682) apiserver network policy for dns-resolver may not work as expected for the apiserver init container. More generic policy allowing TCP/UDP dst port 53 seems to be working better and also matches with what we need for Konnectivity.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8682 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix apiserver network policy: allow all egress DNS traffic from the apiserver.
```
