### PR TITLE
Remove host from swagger, bump version and sync to docs

### DIFF
--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -19,8 +19,7 @@ limitations under the License.
 // This spec describes possible operations which can be made against the Kubermatic Kubernetes Platform API.
 //
 //     Schemes: https
-//     Host: dev.kubermatic.io
-//     Version: 2.18
+//     Version: 2.20
 //
 //     Consumes:
 //     - application/json

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -12,9 +12,8 @@
   "info": {
     "description": "This spec describes possible operations which can be made against the Kubermatic Kubernetes Platform API.",
     "title": "Kubermatic Kubernetes Platform API",
-    "version": "2.18"
+    "version": "2.20"
   },
-  "host": "dev.kubermatic.io",
   "paths": {
     "/api/projects/{project_id}/clusters/{cluster_id}/sshkeys/{key_id}": {
       "delete": {

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -42,6 +42,7 @@ mkdir -p content/kubermatic/master/data
 cp ../docs/zz_generated.seed.yaml content/kubermatic/master/data/seed.yaml
 cp ../docs/zz_generated.kubermaticConfiguration.yaml content/kubermatic/master/data/kubermaticConfiguration.yaml
 cp ../docs/zz_generated.addondata.go.txt content/kubermatic/master/data/addondata.go
+cp ../cmd/kubermatic-api/swagger.json content/kubermatic/master/data/swagger.json
 
 # re-create Prometheus runbook
 make runbook

--- a/pkg/test/e2e/utils/apiclient/client/kubermatic_kubernetes_platform_api_client.go
+++ b/pkg/test/e2e/utils/apiclient/client/kubermatic_kubernetes_platform_api_client.go
@@ -61,7 +61,7 @@ var Default = NewHTTPClient(nil)
 const (
 	// DefaultHost is the default Host
 	// found in Meta (info) section of spec file
-	DefaultHost string = "dev.kubermatic.io"
+	DefaultHost string = "localhost"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
 	DefaultBasePath string = "/"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Our generated `swagger.json` hardcodes `dev.kubermatic.io` as host. That seems like a really bad idea, as the swagger UI available from the KKP dashboard will not work properly with this set. Also bumping the API version to be in line with the upcoming KKP version.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8177

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
https://github.com/kubermatic/docs/pull/928

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>

