### PR TITLE
added a resource restore check to etcd backup e2e tests

### DIFF
--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -50,6 +50,7 @@ const (
 	scaleUpCount           = 5
 	scaleDownCount         = 3
 	minioBackupDestination = "minio"
+	namespaceName          = "backup-test"
 )
 
 func TestBackup(t *testing.T) {
@@ -96,11 +97,34 @@ func TestBackup(t *testing.T) {
 		t.Fatalf("failed to get cluster: %v", err)
 	}
 
+	t.Log("creating client for user cluster...")
+	userClient, err := testClient.GetUserClusterClient(datacenter, project.ID, apiCluster.ID)
+	if err != nil {
+		t.Fatalf("error creating user cluster client: %v", err)
+	}
+
+	// Create a resource on the cluster so that we can see that the backup works
+	testNamespace := &corev1.Namespace{}
+	testNamespace.Name = namespaceName
+	err = userClient.Create(ctx, testNamespace)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+	t.Log("created test namespace")
+
 	// create etcd backup that will be restored later
 	err, backup := createBackup(ctx, t, client, cluster)
 	if err != nil {
 		t.Fatalf("failed to create etcd backup: %v", err)
 	}
+	t.Log("created etcd backup")
+
+	// delete the test resource
+	err = userClient.Delete(ctx, testNamespace)
+	if err != nil {
+		t.Fatalf("failed to delete test namespace: %v", err)
+	}
+	t.Log("deleted test namespace")
 
 	// enable etcd-launcher feature after creating a backup
 	if err := enableLauncher(ctx, t, client, cluster); err != nil {
@@ -112,6 +136,15 @@ func TestBackup(t *testing.T) {
 	if err := restoreBackup(ctx, t, client, cluster, backup); err != nil {
 		t.Fatalf("failed to restore etcd backup: %v", err)
 	}
+	t.Log("restored etcd backup")
+
+	// check if resource was restored
+	restoredNamespace := &corev1.Namespace{}
+	err = userClient.Get(ctx, types.NamespacedName{Name: namespaceName}, restoredNamespace)
+	if err != nil {
+		t.Fatalf("failed to get restored test namespace: %v", err)
+	}
+	t.Log("deleted namespace was restored by backup")
 
 	t.Log("tests succeeded")
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds a check resource restore check for the e2e backup test.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8785 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
