### PR TITLE
Make hack/update-docs.sh work on macOS

### DIFF
--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -28,14 +28,16 @@ dummy=kubermaticNoOmitPlease
 # temporarily create a vendor folder
 go mod vendor
 
+sed="sed"; [ "$(command -v gsed)" ] && sed="gsed"
+
 # remove omitempty tags from structs so that genyaml will not skip fields
-sed -i "s/,omitempty/,$dummy/g" pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go vendor/k8s.io/api/core/v1/*.go
+$sed -i "s/,omitempty/,$dummy/g" pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go vendor/k8s.io/api/core/v1/*.go
 
 # there are some fields that we do actually want to ignore
-sed -i 's/omitgenyaml/omitempty/g' pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go
+$sed -i 's/omitgenyaml/omitempty/g' pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go
 
 go run cmd/example-yaml-generator/main.go . docs
 
 # revert our changes
-sed -i 's/omitempty/omitgenyaml/g' pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go
-sed -i "s/,$dummy/,omitempty/g" pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go vendor/k8s.io/api/core/v1/*.go
+$sed -i 's/omitempty/omitgenyaml/g' pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go
+$sed -i "s/,$dummy/,omitempty/g" pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go vendor/k8s.io/api/core/v1/*.go

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -28,7 +28,8 @@ dummy=kubermaticNoOmitPlease
 # temporarily create a vendor folder
 go mod vendor
 
-sed="sed"; [ "$(command -v gsed)" ] && sed="gsed"
+sed="sed"
+[ "$(command -v gsed)" ] && sed="gsed"
 
 # remove omitempty tags from structs so that genyaml will not skip fields
 $sed -i "s/,omitempty/,$dummy/g" pkg/crd/kubermatic/v1/*.go pkg/crd/operator/v1alpha1/*.go vendor/k8s.io/api/core/v1/*.go


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

What it says on the title. Makes `hack/update-docs.sh` aware of `gsed` if present on the local system, which allows running the script on macOS. Volume mounts are either performing badly or do not work at all for containerisation solutions on macOS, so running the script without `NO_CONTAINERIZE=1` works well in general, and just needs a few little tweaks to be more cross-platform compatible.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
