### PR TITLE
Add name to rulegroup spec

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -26138,6 +26138,10 @@
           },
           "x-go-name": "Data"
         },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
         "type": {
           "$ref": "#/definitions/RuleGroupType"
         }

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -208,6 +208,7 @@ type ClusterTemplateInstance struct {
 // RuleGroup represents a rule group of recording and alerting rules.
 // swagger:model RuleGroup
 type RuleGroup struct {
+	Name string `json:"name"`
 	// contains the RuleGroup data. Ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group
 	Data []byte `json:"data"`
 	// the type of this ruleGroup applies to. It can be `Metrics`.

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1922,6 +1922,7 @@ func GenAdminRuleGroup(name, namespace string, ruleGroupType kubermaticv1.RuleGr
 
 func GenAPIRuleGroup(name string, ruleGroupType kubermaticv1.RuleGroupType) *apiv2.RuleGroup {
 	return &apiv2.RuleGroup{
+		Name: name,
 		Data: GenerateTestRuleGroupData(name),
 		Type: ruleGroupType,
 	}

--- a/pkg/handler/v2/rulegroup/rulegroup.go
+++ b/pkg/handler/v2/rulegroup/rulegroup.go
@@ -245,6 +245,7 @@ func convertInternalToAPIRuleGroups(ruleGroups []*kubermaticv1.RuleGroup) []*api
 
 func convertInternalToAPIRuleGroup(ruleGroup *kubermaticv1.RuleGroup) *apiv2.RuleGroup {
 	return &apiv2.RuleGroup{
+		Name: ruleGroup.ObjectMeta.Name,
 		Data: ruleGroup.Spec.Data,
 		Type: ruleGroup.Spec.RuleGroupType,
 	}

--- a/pkg/handler/v2/rulegroup_admin/rulegroup.go
+++ b/pkg/handler/v2/rulegroup_admin/rulegroup.go
@@ -183,6 +183,7 @@ func convertInternalToAPIRuleGroups(ruleGroups []*kubermaticv1.RuleGroup) []*api
 
 func convertInternalToAPIRuleGroup(ruleGroup *kubermaticv1.RuleGroup) *apiv2.RuleGroup {
 	return &apiv2.RuleGroup{
+		Name: ruleGroup.ObjectMeta.Name,
 		Data: ruleGroup.Spec.Data,
 		Type: ruleGroup.Spec.RuleGroupType,
 	}

--- a/pkg/test/e2e/utils/apiclient/models/rule_group.go
+++ b/pkg/test/e2e/utils/apiclient/models/rule_group.go
@@ -21,6 +21,9 @@ type RuleGroup struct {
 	// contains the RuleGroup data. Ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group
 	Data []uint8 `json:"data"`
 
+	// name
+	Name string `json:"name,omitempty"`
+
 	// type
 	Type RuleGroupType `json:"type,omitempty"`
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Right now to fill out a single name column in the ui, we will have to decode the data object to YAML, transform it to JSON, cast it to object to then finally get the name. To avoid this, the new field `name` has been added to the rulegroup spec.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
