### PR TITLE
retrieve of etcd backup secret by name fix

### DIFF
--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -57,7 +57,7 @@ func CreateOrUpdateEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter 
 		bc := convertAPIToInternalBackupCredentials(&req.Body.BackupCredentials)
 
 		// Update if already exists
-		_, err = backupCredentialsProvider.GetUnsecured()
+		_, err = backupCredentialsProvider.GetUnsecured(bc.Name)
 		if err != nil {
 			_, err = backupCredentialsProvider.CreateUnsecured(bc)
 			if err != nil {

--- a/pkg/provider/kubernetes/backupcredentials.go
+++ b/pkg/provider/kubernetes/backupcredentials.go
@@ -21,7 +21,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -61,10 +60,10 @@ func (p *BackupCredentialsProvider) CreateUnsecured(credentials *corev1.Secret) 
 	return credentials, err
 }
 
-func (p *BackupCredentialsProvider) GetUnsecured() (*corev1.Secret, error) {
+func (p *BackupCredentialsProvider) GetUnsecured(credentialName string) (*corev1.Secret, error) {
 	credentials := &corev1.Secret{}
 	err := p.clientPrivileged.Get(context.Background(), types.NamespacedName{
-		Name:      resources.EtcdRestoreS3CredentialsSecret,
+		Name:      credentialName,
 		Namespace: metav1.NamespaceSystem,
 	}, credentials)
 	return credentials, err

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1221,7 +1221,7 @@ type BackupCredentialsProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured() (*corev1.Secret, error)
+	GetUnsecured(credentialName string) (*corev1.Secret, error)
 
 	// UpdateUnsecured updates the backup credentials
 	//


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In the ETCD backup feature, the secret containing the credentials is retrieved by the API server and only if it doesn't exist, the new secret is created (with the specified name); otherwise, it is updated. Problem is that in environments having the legacy secret but in which the admin wants to exploit the multi-target feature, the API server fails in creating the new credential: the secret is retrieved by the legacy name, that exists, then the secret (with the multi-target naming) is updated, but it does not exist.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8838 

**Special notes for your reviewer**:
To experience this bug, in dev try to add a new backup target and edit the credential. The error that you'll get is `secrets "<target-name>-etcd-backup-credentials" not found`

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
