### PR TITLE
temporarily disable vsphere integration tests

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -72,7 +72,9 @@ echodate "Running integration tests..."
 # * Finding all files that contain the build tag via grep
 # * Extracting the dirname as the `go test` command doesn't play well with individual files as args
 # * Prefixing them with `./` as that's needed by `go test` as well
+# * Temporarily disabling vsphere tests until the test env is available again
 grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ |
   xargs dirname |
   sort -u |
+  grep -v vsphere |
   xargs -I ^ go test -tags "integration ${KUBERMATIC_EDITION:-ce}" -race ./^


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Our vCenter has been offline for quite some time and it's time to accept that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
