### PR TITLE
Do not run ICMP rules addition in Azure if we do not own the NSG

### DIFF
--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -395,6 +395,12 @@ func (a *Azure) AddICMPRulesIfRequired(cluster *kubermaticv1.Cluster) error {
 		return fmt.Errorf("failed to get security group %q: %w", azure.SecurityGroup, err)
 	}
 
+	// we do not want to add IMCP rules to a NSG we do not own;
+	// which is the case when a pre-provisioned NSG is configured.
+	if !hasOwnershipTag(sg.Tags, cluster) {
+		return nil
+	}
+
 	var hasDenyAllTCPRule, hasDenyAllUDPRule, hasICMPAllowAllRule bool
 	if sg.SecurityRules != nil {
 		for _, rule := range *sg.SecurityRules {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The ICMP migration runs unconditionally on an Azure NSG if `status.CloudMigrationRevision == 0`, which usually should not be the case, but can happen. This means it adds the new rules to pre-provisioned NSGs as well. This PR adds a simple ownership check, and makes the ICMP rules addition a no-op on non-owned NSGs.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfix
ICMP rules migration only runs on Azure NSGs created by KKP
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
