### PR TITLE
save more UIDs during CRD migration

### DIFF
--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -1204,7 +1204,7 @@ func cloneClusterTemplateResourcesInCluster(ctx context.Context, logger logrus.F
 
 		logger.WithField("resource", oldObject.GetName()).Debug("Duplicating ClusterTemplate…")
 
-		if err := ensureObject(ctx, client, &newObject, false); err != nil {
+		if err := ensureObject(ctx, client, &newObject, true); err != nil {
 			return 0, fmt.Errorf("failed to clone %s: %w", oldObject.Name, err)
 		}
 	}
@@ -1235,7 +1235,7 @@ func cloneClusterTemplateInstanceResourcesInCluster(ctx context.Context, logger 
 
 		logger.WithField("resource", oldObject.GetName()).Debug("Duplicating ClusterTemplateInstance…")
 
-		if err := ensureObject(ctx, client, &newObject, false); err != nil {
+		if err := ensureObject(ctx, client, &newObject, true); err != nil {
 			return 0, fmt.Errorf("failed to clone %s: %w", oldObject.Name, err)
 		}
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
As it turns out, some objects have ownerRefs pointing to ClusterTemplates/ClusterTemplateInstances. This means that during migration we need to save those UIDs as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
