### PR TITLE
Dissolve temporary SIG CRD

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,8 +46,3 @@ aliases:
   sig-virtualization:
     - mfranczy
     - moadqassem
-
-  # temporary SIG to oversee the API group migration
-  sig-crd:
-    - kron4eg
-    - xrstf

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -1,14 +1,13 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-crd
+  - sig-cluster-management
 
 reviewers:
-  - sig-crd
+  - sig-cluster-management
 
 labels:
   - sig/cluster-management
-  - sig/crd
 
 options:
   no_parent_owners: true


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
SIG CRD was introduced in #8078 to oversee the migration. Now that the migration has been completed, we can get rid of this SIG again. Nobody should need to touch pkg/crd/ anymore (and after 2.20 is released, it can be removed alltogether).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
