### PR TITLE
Configure docker registry for docker-in-docker and kind

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -18,328 +18,334 @@ presubmits:
   # unit tests
   #########################################################
 
-  # - name: pre-kubermatic-test
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-6
-  #       command:
-  #       - make
-  #       args:
-  #       - test
-  #       resources:
-  #         requests:
-  #           memory: 7Gi
-  #           cpu: 2
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-test
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-7
+        command:
+        - make
+        args:
+        - test
+        resources:
+          requests:
+            memory: 7Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-test-integration
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/integration-tests:5-0
-  #       command:
-  #       - make
-  #       args:
-  #       - test-integration
-  #       # docker-in-docker (for localstack) needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
-  #           cpu: 2
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-test-integration
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-docker-mirror: "true"
+      preset-vsphere: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/integration-tests:5-0
+        command:
+        - make
+        args:
+        - test-integration
+        # docker-in-docker (for localstack) needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify
-  #   always_run: true
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   path_alias: k8c.io/kubermatic
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-6
-  #       command:
-  #       - ./hack/ci/verify.sh
-  #       resources:
-  #         requests:
-  #           memory: 2Gi
-  #           cpu: 2
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-verify
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    path_alias: k8c.io/kubermatic
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-7
+        command:
+        - ./hack/ci/verify.sh
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-lint
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: golangci/golangci-lint:v1.43.0
-  #       command:
-  #       - make
-  #       args:
-  #       - lint
-  #       resources:
-  #         requests:
-  #           memory: 10Gi
-  #           cpu: 3
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-lint
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: golangci/golangci-lint:v1.43.0
+        command:
+        - make
+        args:
+        - lint
+        resources:
+          requests:
+            memory: 10Gi
+            cpu: 3
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-shellcheck
-  #   optional: true
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: koalaman/shellcheck-alpine:v0.7.0
-  #       command:
-  #       - sh
-  #       args:
-  #       - -c
-  #       - shellcheck --shell=bash $(find . -name '*.sh')
-  #       resources:
-  #         requests:
-  #           memory: 1Gi
-  #           cpu: 0.5
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-shellcheck
+    optional: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: koalaman/shellcheck-alpine:v0.7.0
+        command:
+        - sh
+        args:
+        - -c
+        - shellcheck --shell=bash $(find . -name '*.sh')
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 0.5
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify-boilerplate
-  #   always_run: true
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic-labs/boilerplate:v0.2.0
-  #       command:
-  #       - ./hack/verify-boilerplate.sh
-  #       resources:
-  #         requests:
-  #           memory: 256Mi
-  #           cpu: 100m
+  - name: pre-kubermatic-verify-boilerplate
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic-labs/boilerplate:v0.2.0
+        command:
+        - ./hack/verify-boilerplate.sh
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 100m
 
-  # - name: pre-kubermatic-simulate-github-release
-  #   run_if_changed: "hack/ci/github-release.sh"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-6
-  #       command:
-  #       - ./hack/ci/test-github-release.sh
-  #       resources:
-  #         requests:
-  #           memory: 3Gi
-  #           cpu: 2
+  - name: pre-kubermatic-simulate-github-release
+    run_if_changed: "hack/ci/github-release.sh"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-7
+        command:
+        - ./hack/ci/test-github-release.sh
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 2
 
-  # - name: pre-kubermatic-test-helm-charts
-  #   run_if_changed: "charts/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-docker-pull: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #         command:
-  #           - "./hack/ci/test-helm-charts.sh"
-  #         env:
-  #           - name: KUBERMATIC_EDITION
-  #             value: ee
-  #         securityContext:
-  #           privileged: true
-  #         resources:
-  #           requests:
-  #             memory: 4Gi
-  #             cpu: 2
-  #           limits:
-  #             memory: 6Gi
+  - name: pre-kubermatic-test-helm-charts
+    run_if_changed: "charts/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+          command:
+            - "./hack/ci/test-helm-charts.sh"
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi
 
-  # - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
-  #   decorate: true
-  #   always_run: false
-  #   run_if_changed: "cmd/user-ssh-keys-agent/"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       command:
-  #       - "./hack/ci/run-user-ssh-key-agent-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3
-  #         limits:
-  #           memory: 4Gi
-  #           cpu: 3
+  - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
+    decorate: true
+    always_run: false
+    run_if_changed: "cmd/user-ssh-keys-agent/"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-docker-mirror: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        command:
+        - "./hack/ci/run-user-ssh-key-agent-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3
+          limits:
+            memory: 4Gi
+            cpu: 3
 
-  # #########################################################
-  # # Base Kubernetes Tests (AWS, Flatcar)
-  # #########################################################
+  #########################################################
+  # Base Kubernetes Tests (AWS, Flatcar)
+  #########################################################
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.20
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.20.14"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.20
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.20.14"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.21
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.8"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.21
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.8"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-aws-ubuntu-1.22
-  #   decorate: true
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.22
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
   - name: pre-kubermatic-e2e-aws-ubuntu-1.22-ce
     decorate: true
@@ -359,7 +365,6 @@ presubmits:
     spec:
       containers:
       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
-        imagePullPolicy: Always
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -390,907 +395,926 @@ presubmits:
   # Extended Kubernetes Tests (various cloud providers, OS)
   #########################################################
 
-  # - name: pre-kubermatic-e2e-azure-ubuntu-1.22
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-azure: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: PROVIDER
-  #         value: "azure"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.22
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: PROVIDER
+          value: "azure"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.22
-  #   decorate: true
-  #   always_run: false
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "gcp"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.22
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "gcp"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.22-psp
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "gcp"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: KUBERMATIC_PSP_ENABLED
-  #         value: "true"
-  #       - name: ONLY_TEST_CREATION
-  #         value: "true"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.22-psp
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "gcp"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: KUBERMATIC_PSP_ENABLED
+          value: "true"
+        - name: ONLY_TEST_CREATION
+          value: "true"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-do-centos-1.22
-  #   decorate: true
-  #   always_run: false
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: DISTRIBUTIONS
-  #         value: centos
-  #       - name: PROVIDER
-  #         value: "digitalocean"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-do-centos-1.22
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: DISTRIBUTIONS
+          value: centos
+        - name: PROVIDER
+          value: "digitalocean"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-packet-ubuntu-1.22
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-packet: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "packet"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-packet-ubuntu-1.22
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-packet: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "packet"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-kubevirt-centos-1.22
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-kubevirt: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "kubevirt"
-  #       - name: DISTRIBUTIONS
-  #         value: centos
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-kubevirt-centos-1.22
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubevirt: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "kubevirt"
+        - name: DISTRIBUTIONS
+          value: centos
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-hetzner: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "hetzner"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-hetzner: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "hetzner"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-openstack-ubuntu-1.22
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "openstack"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-openstack-ubuntu-1.22
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-openstack-centos-1.22
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "openstack"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: DISTRIBUTIONS
-  #         value: centos
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-openstack-centos-1.22
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: DISTRIBUTIONS
+          value: centos
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
-  #   decorate: true
-  #   run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.8"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
+    decorate: true
+    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.8"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.8"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SCENARIO_OPTIONS
-  #         value: "custom-folder"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
+    decorate: true
+    optional: true
+    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.8"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SCENARIO_OPTIONS
+          value: "custom-folder"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.21.8"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: DISTRIBUTIONS
-  #         value: ubuntu
-  #       - name: SCENARIO_OPTIONS
-  #         value: "datastore-cluster"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
+    decorate: true
+    optional: true
+    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.21.8"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SCENARIO_OPTIONS
+          value: "datastore-cluster"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-nutanix-ubuntu-1.22
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "pkg/provider/cloud/nutanix"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-nutanix: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "nutanix"
-  #       - name: DISTRIBUTIONS
-  #         value: "ubuntu"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-nutanix-ubuntu-1.22
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/nutanix"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-nutanix: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "nutanix"
+        - name: DISTRIBUTIONS
+          value: "ubuntu"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-nutanix-centos-1.22
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "pkg/provider/cloud/nutanix"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-nutanix: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.22.5"
-  #       - name: PROVIDER
-  #         value: "nutanix"
-  #       - name: DISTRIBUTIONS
-  #         value: "centos"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/run-e2e-tests.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-nutanix-centos-1.22
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/nutanix"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-nutanix: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "nutanix"
+        - name: DISTRIBUTIONS
+          value: "centos"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # #########################################################
-  # # REST API e2e tests
-  # #########################################################
+  #########################################################
+  # REST API e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-api-e2e
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-openstack: "true"
-  #     preset-azure: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-gce: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       imagePullPolicy: Always
-  #       command:
-  #       - "./hack/ci/run-api-e2e.sh"
-  #       env:
-  #       - name: VERSION_TO_TEST
-  #         value: v1.22.5
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
+  - name: pre-kubermatic-api-e2e
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-openstack: "true"
+      preset-azure: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-gce: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        command:
+        - "./hack/ci/run-api-e2e.sh"
+        env:
+        - name: VERSION_TO_TEST
+          value: v1.22.5
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
 
-  # #########################################################
-  # # etcd-launcher e2e tests
-  # #########################################################
+  #########################################################
+  # etcd-launcher e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-etcd-launcher-e2e
-  #   run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       command:
-  #       - "./hack/ci/run-etcd-launcher-tests.sh"
-  #       env:
-  #       - name: VERSION_TO_TEST
-  #         value: v1.21.8
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
+  - name: pre-kubermatic-etcd-launcher-e2e
+    run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        command:
+        - "./hack/ci/run-etcd-launcher-tests.sh"
+        env:
+        - name: VERSION_TO_TEST
+          value: v1.21.8
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
 
-  # #########################################################
-  # # NodePort Proxy e2e tests
-  # #########################################################
+  #########################################################
+  # NodePort Proxy e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-nodeport-proxy-e2e
-  #   run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       imagePullPolicy: Always
-  #       command:
-  #       - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
+  - name: pre-kubermatic-nodeport-proxy-e2e
+    run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        command:
+        - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
 
-  # #########################################################
-  # # opa e2e tests
-  # #########################################################
+  #########################################################
+  # opa e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-opa-e2e
-  #   run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #         command:
-  #           - "./hack/ci/run-opa-e2e-tests.sh"
-  #         env:
-  #           - name: VERSION_TO_TEST
-  #             value: v1.22.5
-  #           - name: KUBERMATIC_EDITION
-  #             value: ee
-  #           - name: SERVICE_ACCOUNT_KEY
-  #             valueFrom:
-  #               secretKeyRef:
-  #                 name: e2e-ci
-  #                 key: serviceAccountSigningKey
-  #         securityContext:
-  #           privileged: true
-  #         resources:
-  #           requests:
-  #             memory: 4Gi
-  #             cpu: 2
-  #           limits:
-  #             memory: 6Gi
+  - name: pre-kubermatic-opa-e2e
+    run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+          command:
+            - "./hack/ci/run-opa-e2e-tests.sh"
+          env:
+            - name: VERSION_TO_TEST
+              value: v1.22.5
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi
 
-  # #########################################################
-  # # Expose Strategy e2e tests
-  # #########################################################
+  #########################################################
+  # Expose Strategy e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-expose-strategy-e2e
-  #   run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       imagePullPolicy: Always
-  #       command:
-  #       - ./hack/run-expose-strategy-e2e-test-in-kind.sh
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
+  - name: pre-kubermatic-expose-strategy-e2e
+    run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        command:
+        - ./hack/run-expose-strategy-e2e-test-in-kind.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
 
-  # #########################################################
-  # # external ccm migration e2e tests
-  # #########################################################
+  #########################################################
+  # external ccm migration e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-ccm-migration-e2e
-  #   run_if_changed: "(pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #         env:
-  #           - name: KUBERMATIC_EDITION
-  #             value: ce
-  #         command:
-  #           - ./hack/run-ccm-migration-e2e-test-in-kind.sh
-  #         # docker-in-docker needs privileged mode
-  #         securityContext:
-  #           privileged: true
-  #         resources:
-  #           requests:
-  #             memory: 4Gi
-  #             cpu: 3.5
-  #           limits:
-  #             memory: 4Gi
+  - name: pre-kubermatic-ccm-migration-e2e
+    run_if_changed: "(pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ce
+          command:
+            - ./hack/run-ccm-migration-e2e-test-in-kind.sh
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 4Gi
 
-  # #########################################################
-  # # misc
-  # #########################################################
+  #########################################################
+  # misc
+  #########################################################
 
-  # - name: pre-kubermatic-e2e-gcp-offline
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #       command:
-  #       - "./hack/ci/run-offline-test.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 2.5Gi
-  #           cpu: 500m
-  #         limits:
-  #           memory: 4Gi
-  #           cpu: 2
+  - name: pre-kubermatic-e2e-gcp-offline
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        command:
+        - "./hack/ci/run-offline-test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
 
-  # #########################################################
-  # # User cluster MLA e2e tests
-  # #########################################################
+  #########################################################
+  # User cluster MLA e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-mla-e2e
-  #   run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-  #         command:
-  #           - "./hack/ci/run-mla-e2e-tests.sh"
-  #         env:
-  #           - name: VERSION_TO_TEST
-  #             value: v1.22.5
-  #           - name: KUBERMATIC_EDITION
-  #             value: ee
-  #           - name: SERVICE_ACCOUNT_KEY
-  #             valueFrom:
-  #               secretKeyRef:
-  #                 name: e2e-ci
-  #                 key: serviceAccountSigningKey
-  #         securityContext:
-  #           privileged: true
-  #         resources:
-  #           requests:
-  #             memory: 14Gi
-  #             cpu: 4
-  #           limits:
-  #             memory: 18Gi
+  - name: pre-kubermatic-mla-e2e
+    run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+          command:
+            - "./hack/ci/run-mla-e2e-tests.sh"
+          env:
+            - name: VERSION_TO_TEST
+              value: v1.22.5
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 14Gi
+              cpu: 4
+            limits:
+              memory: 18Gi

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -18,328 +18,328 @@ presubmits:
   # unit tests
   #########################################################
 
-  - name: pre-kubermatic-test
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-6
-        command:
-        - make
-        args:
-        - test
-        resources:
-          requests:
-            memory: 7Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-test
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-6
+  #       command:
+  #       - make
+  #       args:
+  #       - test
+  #       resources:
+  #         requests:
+  #           memory: 7Gi
+  #           cpu: 2
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-test-integration
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/integration-tests:5-0
-        command:
-        - make
-        args:
-        - test-integration
-        # docker-in-docker (for localstack) needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-test-integration
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/integration-tests:5-0
+  #       command:
+  #       - make
+  #       args:
+  #       - test-integration
+  #       # docker-in-docker (for localstack) needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
+  #           cpu: 2
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    path_alias: k8c.io/kubermatic
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-6
-        command:
-        - ./hack/ci/verify.sh
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-verify
+  #   always_run: true
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   path_alias: k8c.io/kubermatic
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-6
+  #       command:
+  #       - ./hack/ci/verify.sh
+  #       resources:
+  #         requests:
+  #           memory: 2Gi
+  #           cpu: 2
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-lint
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: golangci/golangci-lint:v1.43.0
-        command:
-        - make
-        args:
-        - lint
-        resources:
-          requests:
-            memory: 10Gi
-            cpu: 3
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-lint
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: golangci/golangci-lint:v1.43.0
+  #       command:
+  #       - make
+  #       args:
+  #       - lint
+  #       resources:
+  #         requests:
+  #           memory: 10Gi
+  #           cpu: 3
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-shellcheck
-    optional: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: koalaman/shellcheck-alpine:v0.7.0
-        command:
-        - sh
-        args:
-        - -c
-        - shellcheck --shell=bash $(find . -name '*.sh')
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 0.5
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-shellcheck
+  #   optional: true
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: koalaman/shellcheck-alpine:v0.7.0
+  #       command:
+  #       - sh
+  #       args:
+  #       - -c
+  #       - shellcheck --shell=bash $(find . -name '*.sh')
+  #       resources:
+  #         requests:
+  #           memory: 1Gi
+  #           cpu: 0.5
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify-boilerplate
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic-labs/boilerplate:v0.2.0
-        command:
-        - ./hack/verify-boilerplate.sh
-        resources:
-          requests:
-            memory: 256Mi
-            cpu: 100m
+  # - name: pre-kubermatic-verify-boilerplate
+  #   always_run: true
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic-labs/boilerplate:v0.2.0
+  #       command:
+  #       - ./hack/verify-boilerplate.sh
+  #       resources:
+  #         requests:
+  #           memory: 256Mi
+  #           cpu: 100m
 
-  - name: pre-kubermatic-simulate-github-release
-    run_if_changed: "hack/ci/github-release.sh"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-6
-        command:
-        - ./hack/ci/test-github-release.sh
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 2
+  # - name: pre-kubermatic-simulate-github-release
+  #   run_if_changed: "hack/ci/github-release.sh"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-6
+  #       command:
+  #       - ./hack/ci/test-github-release.sh
+  #       resources:
+  #         requests:
+  #           memory: 3Gi
+  #           cpu: 2
 
-  - name: pre-kubermatic-test-helm-charts
-    run_if_changed: "charts/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-docker-pull: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-          command:
-            - "./hack/ci/test-helm-charts.sh"
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ee
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-            limits:
-              memory: 6Gi
+  # - name: pre-kubermatic-test-helm-charts
+  #   run_if_changed: "charts/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-docker-pull: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #         command:
+  #           - "./hack/ci/test-helm-charts.sh"
+  #         env:
+  #           - name: KUBERMATIC_EDITION
+  #             value: ee
+  #         securityContext:
+  #           privileged: true
+  #         resources:
+  #           requests:
+  #             memory: 4Gi
+  #             cpu: 2
+  #           limits:
+  #             memory: 6Gi
 
-  - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
-    decorate: true
-    always_run: false
-    run_if_changed: "cmd/user-ssh-keys-agent/"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        command:
-        - "./hack/ci/run-user-ssh-key-agent-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3
-          limits:
-            memory: 4Gi
-            cpu: 3
+  # - name: pre-kubermatic-test-user-ssh-key-agent-multiarch
+  #   decorate: true
+  #   always_run: false
+  #   run_if_changed: "cmd/user-ssh-keys-agent/"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       command:
+  #       - "./hack/ci/run-user-ssh-key-agent-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3
+  #         limits:
+  #           memory: 4Gi
+  #           cpu: 3
 
-  #########################################################
-  # Base Kubernetes Tests (AWS, Flatcar)
-  #########################################################
+  # #########################################################
+  # # Base Kubernetes Tests (AWS, Flatcar)
+  # #########################################################
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.20
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.20.14"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.20
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.20.14"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.21
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.8"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.21
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.8"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.22
-    decorate: true
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-ubuntu-1.22
+  #   decorate: true
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
   - name: pre-kubermatic-e2e-aws-ubuntu-1.22-ce
     decorate: true
@@ -388,907 +388,907 @@ presubmits:
   # Extended Kubernetes Tests (various cloud providers, OS)
   #########################################################
 
-  - name: pre-kubermatic-e2e-azure-ubuntu-1.22
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-azure: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: PROVIDER
-          value: "azure"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-azure-ubuntu-1.22
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-azure: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: PROVIDER
+  #         value: "azure"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.22
-    decorate: true
-    always_run: false
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "gcp"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.22
+  #   decorate: true
+  #   always_run: false
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "gcp"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.22-psp
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "gcp"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: KUBERMATIC_PSP_ENABLED
-          value: "true"
-        - name: ONLY_TEST_CREATION
-          value: "true"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.22-psp
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "gcp"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: KUBERMATIC_PSP_ENABLED
+  #         value: "true"
+  #       - name: ONLY_TEST_CREATION
+  #         value: "true"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-do-centos-1.22
-    decorate: true
-    always_run: false
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: DISTRIBUTIONS
-          value: centos
-        - name: PROVIDER
-          value: "digitalocean"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-do-centos-1.22
+  #   decorate: true
+  #   always_run: false
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: DISTRIBUTIONS
+  #         value: centos
+  #       - name: PROVIDER
+  #         value: "digitalocean"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-packet-ubuntu-1.22
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-packet: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "packet"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-packet-ubuntu-1.22
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-packet: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "packet"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-kubevirt-centos-1.22
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-kubevirt: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "kubevirt"
-        - name: DISTRIBUTIONS
-          value: centos
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-kubevirt-centos-1.22
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-kubevirt: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "kubevirt"
+  #       - name: DISTRIBUTIONS
+  #         value: centos
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-hetzner: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "hetzner"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-hetzner: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "hetzner"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-ubuntu-1.22
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "openstack"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-openstack-ubuntu-1.22
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "openstack"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-centos-1.22
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "openstack"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: DISTRIBUTIONS
-          value: centos
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-openstack-centos-1.22
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "openstack"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: DISTRIBUTIONS
+  #         value: centos
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
-    decorate: true
-    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.8"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21
+  #   decorate: true
+  #   run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.8"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
-    decorate: true
-    optional: true
-    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.8"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SCENARIO_OPTIONS
-          value: "custom-folder"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.8"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SCENARIO_OPTIONS
+  #         value: "custom-folder"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
-    decorate: true
-    optional: true
-    run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.21.8"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: DISTRIBUTIONS
-          value: ubuntu
-        - name: SCENARIO_OPTIONS
-          value: "datastore-cluster"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.21.8"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: DISTRIBUTIONS
+  #         value: ubuntu
+  #       - name: SCENARIO_OPTIONS
+  #         value: "datastore-cluster"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-nutanix-ubuntu-1.22
-    decorate: true
-    optional: true
-    run_if_changed: "pkg/provider/cloud/nutanix"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-nutanix: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "nutanix"
-        - name: DISTRIBUTIONS
-          value: "ubuntu"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-nutanix-ubuntu-1.22
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "pkg/provider/cloud/nutanix"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-nutanix: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "nutanix"
+  #       - name: DISTRIBUTIONS
+  #         value: "ubuntu"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-nutanix-centos-1.22
-    decorate: true
-    optional: true
-    run_if_changed: "pkg/provider/cloud/nutanix"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-nutanix: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
-        - name: PROVIDER
-          value: "nutanix"
-        - name: DISTRIBUTIONS
-          value: "centos"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/run-e2e-tests.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-nutanix-centos-1.22
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "pkg/provider/cloud/nutanix"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-nutanix: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.22.5"
+  #       - name: PROVIDER
+  #         value: "nutanix"
+  #       - name: DISTRIBUTIONS
+  #         value: "centos"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/run-e2e-tests.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  #########################################################
-  # REST API e2e tests
-  #########################################################
+  # #########################################################
+  # # REST API e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-api-e2e
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-openstack: "true"
-      preset-azure: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-gce: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        imagePullPolicy: Always
-        command:
-        - "./hack/ci/run-api-e2e.sh"
-        env:
-        - name: VERSION_TO_TEST
-          value: v1.22.5
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
+  # - name: pre-kubermatic-api-e2e
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-openstack: "true"
+  #     preset-azure: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-gce: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       imagePullPolicy: Always
+  #       command:
+  #       - "./hack/ci/run-api-e2e.sh"
+  #       env:
+  #       - name: VERSION_TO_TEST
+  #         value: v1.22.5
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
 
-  #########################################################
-  # etcd-launcher e2e tests
-  #########################################################
+  # #########################################################
+  # # etcd-launcher e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-etcd-launcher-e2e
-    run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        command:
-        - "./hack/ci/run-etcd-launcher-tests.sh"
-        env:
-        - name: VERSION_TO_TEST
-          value: v1.21.8
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
+  # - name: pre-kubermatic-etcd-launcher-e2e
+  #   run_if_changed: "(cmd/etcd-launcher/|pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       command:
+  #       - "./hack/ci/run-etcd-launcher-tests.sh"
+  #       env:
+  #       - name: VERSION_TO_TEST
+  #         value: v1.21.8
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
 
-  #########################################################
-  # NodePort Proxy e2e tests
-  #########################################################
+  # #########################################################
+  # # NodePort Proxy e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-nodeport-proxy-e2e
-    run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        imagePullPolicy: Always
-        command:
-        - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
+  # - name: pre-kubermatic-nodeport-proxy-e2e
+  #   run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       imagePullPolicy: Always
+  #       command:
+  #       - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
 
-  #########################################################
-  # opa e2e tests
-  #########################################################
+  # #########################################################
+  # # opa e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-opa-e2e
-    run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-          command:
-            - "./hack/ci/run-opa-e2e-tests.sh"
-          env:
-            - name: VERSION_TO_TEST
-              value: v1.22.5
-            - name: KUBERMATIC_EDITION
-              value: ee
-            - name: SERVICE_ACCOUNT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: e2e-ci
-                  key: serviceAccountSigningKey
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-            limits:
-              memory: 6Gi
+  # - name: pre-kubermatic-opa-e2e
+  #   run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #         command:
+  #           - "./hack/ci/run-opa-e2e-tests.sh"
+  #         env:
+  #           - name: VERSION_TO_TEST
+  #             value: v1.22.5
+  #           - name: KUBERMATIC_EDITION
+  #             value: ee
+  #           - name: SERVICE_ACCOUNT_KEY
+  #             valueFrom:
+  #               secretKeyRef:
+  #                 name: e2e-ci
+  #                 key: serviceAccountSigningKey
+  #         securityContext:
+  #           privileged: true
+  #         resources:
+  #           requests:
+  #             memory: 4Gi
+  #             cpu: 2
+  #           limits:
+  #             memory: 6Gi
 
-  #########################################################
-  # Expose Strategy e2e tests
-  #########################################################
+  # #########################################################
+  # # Expose Strategy e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-expose-strategy-e2e
-    run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        imagePullPolicy: Always
-        command:
-        - ./hack/run-expose-strategy-e2e-test-in-kind.sh
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
+  # - name: pre-kubermatic-expose-strategy-e2e
+  #   run_if_changed: "(cmd/nodeport-proxy/|pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       imagePullPolicy: Always
+  #       command:
+  #       - ./hack/run-expose-strategy-e2e-test-in-kind.sh
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
 
-  #########################################################
-  # external ccm migration e2e tests
-  #########################################################
+  # #########################################################
+  # # external ccm migration e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-ccm-migration-e2e
-    run_if_changed: "(pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ce
-          command:
-            - ./hack/run-ccm-migration-e2e-test-in-kind.sh
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 3.5
-            limits:
-              memory: 4Gi
+  # - name: pre-kubermatic-ccm-migration-e2e
+  #   run_if_changed: "(pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #         env:
+  #           - name: KUBERMATIC_EDITION
+  #             value: ce
+  #         command:
+  #           - ./hack/run-ccm-migration-e2e-test-in-kind.sh
+  #         # docker-in-docker needs privileged mode
+  #         securityContext:
+  #           privileged: true
+  #         resources:
+  #           requests:
+  #             memory: 4Gi
+  #             cpu: 3.5
+  #           limits:
+  #             memory: 4Gi
 
-  #########################################################
-  # misc
-  #########################################################
+  # #########################################################
+  # # misc
+  # #########################################################
 
-  - name: pre-kubermatic-e2e-gcp-offline
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-        command:
-        - "./hack/ci/run-offline-test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 2.5Gi
-            cpu: 500m
-          limits:
-            memory: 4Gi
-            cpu: 2
+  # - name: pre-kubermatic-e2e-gcp-offline
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #       command:
+  #       - "./hack/ci/run-offline-test.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 2.5Gi
+  #           cpu: 500m
+  #         limits:
+  #           memory: 4Gi
+  #           cpu: 2
 
-  #########################################################
-  # User cluster MLA e2e tests
-  #########################################################
+  # #########################################################
+  # # User cluster MLA e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-mla-e2e
-    run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
-          command:
-            - "./hack/ci/run-mla-e2e-tests.sh"
-          env:
-            - name: VERSION_TO_TEST
-              value: v1.22.5
-            - name: KUBERMATIC_EDITION
-              value: ee
-            - name: SERVICE_ACCOUNT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: e2e-ci
-                  key: serviceAccountSigningKey
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 14Gi
-              cpu: 4
-            limits:
-              memory: 18Gi
+  # - name: pre-kubermatic-mla-e2e
+  #   run_if_changed: "(go.mod|go.sum|pkg/|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+  #         command:
+  #           - "./hack/ci/run-mla-e2e-tests.sh"
+  #         env:
+  #           - name: VERSION_TO_TEST
+  #             value: v1.22.5
+  #           - name: KUBERMATIC_EDITION
+  #             value: ee
+  #           - name: SERVICE_ACCOUNT_KEY
+  #             valueFrom:
+  #               secretKeyRef:
+  #                 name: e2e-ci
+  #                 key: serviceAccountSigningKey
+  #         securityContext:
+  #           privileged: true
+  #         resources:
+  #           requests:
+  #             memory: 14Gi
+  #             cpu: 4
+  #           limits:
+  #             memory: 18Gi

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -359,6 +359,7 @@ presubmits:
     spec:
       containers:
       - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        imagePullPolicy: Always
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -347,6 +347,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
+      preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-vault: "true"
@@ -357,7 +358,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-6
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -24,7 +24,7 @@ fi
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
 export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 
-start_docker_daemon
+start_docker_daemon_ci
 
 # Prevent mtu-related timeouts
 echodate "Setting iptables rule to clamp mss to path mtu"

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -56,18 +56,12 @@ source <(k completion bash )
 source <(k completion bash | sed s/kubectl/k/g)
 EOF
 
-# Load kind image
-echodate "Loading kindest image"
-docker load --input /kindest.tar
-echodate "Loaded kindest image"
-
 # Create kind cluster
 TEST_NAME="Create kind cluster"
 echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 
 beforeKindCreate=$(nowms)
-export KIND_NODE_VERSION=v1.21.1
 
 # make the registry mirror available as a socket,
 # so we can mount it into the kind cluster
@@ -80,7 +74,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: "${KIND_CLUSTER_NAME}"
 nodes:
   - role: control-plane
-    image: "kindest/node:${KIND_NODE_VERSION}"
     extraMounts:
     - hostPath: /mirror
       containerPath: /mirror
@@ -91,7 +84,7 @@ containerdConfigPatches:
 EOF
 
 kind create cluster --config kind-config.yaml
-pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$KIND_NODE_VERSION\""
+pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate
 
 # unwrap the socket inside the kind cluster and make it available on a TCP port,
 # because containerd/Docker doesn't support sockets for mirrors.
@@ -137,4 +130,4 @@ if [ -z "${DISABLE_CLUSTER_EXPOSER:-}" ]; then
   echodate "Successfully set up iptables rules for nodeports"
 fi
 
-echodate "Kind cluster $KIND_CLUSTER_NAME using Kubernetes $KIND_NODE_VERSION is up and running."
+echodate "Kind cluster $KIND_CLUSTER_NAME is up and running."

--- a/hack/ci/setup-kubermatic-mla-in-kind.sh
+++ b/hack/ci/setup-kubermatic-mla-in-kind.sh
@@ -191,9 +191,15 @@ echodate "VPA is ready."
 
 appendTrap cleanup_kubermatic_clusters_in_kind EXIT
 
-TEST_NAME="Expose Dex and Kubermatic API"
 echodate "Exposing Dex and Kubermatic API to localhost..."
 kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 > /dev/null &
 kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 > /dev/null &
+
 hack/ci/setup-mla.sh
+
+echodate "Exposing Grafana to localhost..."
+kubectl port-forward --address 0.0.0.0 -n mla svc/grafana 3000:80 > /dev/null &
+kubectl port-forward --address 0.0.0.0 -n mla svc/cortex-alertmanager 3001:8080 > /dev/null &
+kubectl port-forward --address 0.0.0.0 -n mla svc/cortex-ruler 3002:8080 > /dev/null &
+kubectl port-forward --address 0.0.0.0 -n mla svc/loki-distributed-ruler 3003:3100 > /dev/null &
 echodate "Finished exposing components"

--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -56,12 +56,4 @@ sleep 5
 echodate "Waiting for MLA to deploy Seed components..."
 retry 8 check_all_deployments_ready mla
 
-TEST_NAME="Expose Grafana"
-echodate "Exposing Grafana to localhost..."
-kubectl port-forward --address 0.0.0.0 -n mla svc/grafana 3000:80 > /dev/null &
-kubectl port-forward --address 0.0.0.0 -n mla svc/cortex-alertmanager 3001:8080 > /dev/null &
-kubectl port-forward --address 0.0.0.0 -n mla svc/cortex-ruler 3002:8080 > /dev/null &
-kubectl port-forward --address 0.0.0.0 -n mla svc/loki-distributed-ruler 3003:3100 > /dev/null &
-echodate "Finished exposing components"
-
 echodate "MLA is ready."

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -374,6 +374,9 @@ docker_logs() {
 }
 
 start_docker_daemon() {
+  mkdir -p /etc/docker
+  echo '{"data-root":"/docker-graph"}' > /etc/docker/daemon.json
+
   if docker stats --no-stream > /dev/null 2>&1; then
     echodate "Not starting Docker again, it's already running."
     return

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -375,7 +375,10 @@ docker_logs() {
 
 start_docker_daemon() {
   mkdir -p /etc/docker
-  echo '{"data-root":"/docker-graph"}' > /etc/docker/daemon.json
+  echo '{
+    "data-root":"/docker-graph",
+    "registry-mirrors":["http://registry-mirror.registry.svc.cluster.local.:5001"]
+  }' > /etc/docker/daemon.json
 
   if docker stats --no-stream > /dev/null 2>&1; then
     echodate "Not starting Docker again, it's already running."

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -54,7 +54,7 @@ appendTrap clean_up EXIT
 
 # Only start docker daemon in CI envorinment.
 if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
-  start_docker_daemon
+  start_docker_daemon_ci
 fi
 
 cat << EOF > kind-config.yaml

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -32,7 +32,6 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.21.1}"
 KIND_PORT="${KIND_PORT-31000}"
 USER_CLUSTER_KUBERNETES_VERSION="${USER_CLUSTER_KUBERNETES_VERSION:-v1.20.2}"
 USER_CLUSTER_NAME="${USER_CLUSTER_NAME-$(head -3 /dev/urandom | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]' | cut -c -10)}"
@@ -72,7 +71,6 @@ EOF
 # setup Kind cluster
 time retry 5 kind create cluster \
   --name="${KIND_CLUSTER_NAME}" \
-  --image=kindest/node:"${KIND_NODE_VERSION}" \
   --config=kind-config.yaml
 kind export kubeconfig --name=${KIND_CLUSTER_NAME}
 

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -63,7 +63,7 @@ appendTrap clean_up EXIT
 
 # Only start docker daemon in CI envorinment.
 if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
-  start_docker_daemon
+  start_docker_daemon_ci
 fi
 
 # build Docker images

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -92,7 +92,7 @@ rm _build/kubermatic-installer
 make _build/kubermatic-installer
 
 # setup Kind cluster
-time retry 5 kind create cluster --name="${KIND_CLUSTER_NAME}" \
+time retry 5 kind create cluster --name="${KIND_CLUSTER_NAME}"
 kind export kubeconfig --name=${KIND_CLUSTER_NAME}
 
 # load nodeport-proxy image

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -44,7 +44,6 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.21.1}"
 USER_CLUSTER_KUBERNETES_VERSION="${USER_CLUSTER_KUBERNETES_VERSION:-v1.20.2}"
 KUBECONFIG="${KUBECONFIG:-"${HOME}/.kube/config"}"
 
@@ -93,9 +92,7 @@ rm _build/kubermatic-installer
 make _build/kubermatic-installer
 
 # setup Kind cluster
-time retry 5 kind create cluster \
-  --name="${KIND_CLUSTER_NAME}" \
-  --image=kindest/node:"${KIND_NODE_VERSION}"
+time retry 5 kind create cluster --name="${KIND_CLUSTER_NAME}" \
 kind export kubeconfig --name=${KIND_CLUSTER_NAME}
 
 # load nodeport-proxy image

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -39,7 +39,9 @@ LOCALSTACK_IMAGE="${LOCALSTACK_IMAGE:-localstack/localstack:$LOCALSTACK_TAG}"
 if [ -z "${SKIP_AWS_PROVIDER:-}" ]; then
   echodate "Setting up localstack container, set \$SKIP_AWS_PROVIDER to skip..."
 
-  start_docker_daemon
+  if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
+    start_docker_daemon_ci
+  fi
 
   containerName=kkp-localstack
 

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -27,7 +27,6 @@ DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.21.1}"
 
 type kind > /dev/null || fatal \
   "Kind is required to run this script, please refer to: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
@@ -51,7 +50,7 @@ make -C cmd/nodeport-proxy docker \
   TAG="${TAG}"
 
 # setup Kind cluster
-time retry 5 kind create cluster --name "${KIND_CLUSTER_NAME}" --image=kindest/node:"${KIND_NODE_VERSION}"
+time retry 5 kind create cluster --name "${KIND_CLUSTER_NAME}"
 # load nodeport-proxy image
 time retry 5 kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "$KIND_CLUSTER_NAME"
 # run tests

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -39,7 +39,7 @@ appendTrap clean_up EXIT
 
 # Only start docker daemon / download cache in CI envorinment.
 if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
-  start_docker_daemon
+  start_docker_daemon_ci
   make download-gocache
 fi
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR fixes the longstand problem that our CI-internal Docker registry mirror was not actually being used.

The CI nodes themselves are configured properly.

The docker-in-docker daemon that is used to start kind didn't know about the mirror, but now thanks to an improved `start-docker.sh` in the `build` image, we can easily configure it. This takes care of the `kindest/node` image, which was previously part of the `build` image (as a `tar` file). However, it turns out that the image is often out of sync (somehow?) and when doing a `kind create cluster`, the actual correct image is being pulled anyway (and before this PR, it's being pulled from docker.io).

Since this PR fixes the mirror config for the docker-in-docker daemon, the new `build` image does not contain a copy of the `kindest/node` image anymore. No more chances to get inconsistencies and 2 node images accidentally being loaded.

Going further, this PR also configures the mirror for kind's containerd daemon (the inner-inner-inner container runtime here). Since kind does not allow outgoing traffic and we cannot tweak `docker run` with kind, I chose to just use `socat` to tunnel the mirror via a socket and then mount the socket into the kind container. Inside the container another `socat` unwraps the socket, because containerd doesn't like to use sockets.

In a typical e2e test, socat maybe needs to handle .... 30? requests or so. Nothing too demanding. Seems pretty nice, though hacky, hence the large comments.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
