### PR TITLE
[release/v2.19] Fix auto upgrade from 1.19 to 1.20 (cherry-pick of #8821)

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -454,10 +454,12 @@ spec:
           # Automatic controls whether this update is executed automatically
           # for the worker nodes of all matching user clusters.
           automaticNodeUpdate: false
-          # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.20.*".
           from: 1.19.*
-          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-          to: 1.20.*
+          # To is the version to which an update is allowed.
+          # Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
+          # Can be a wildcard otherwise, e.g. "1.20.*".
+          to: 1.20.13
         - from: 1.20.*
           to: 1.20.*
         - automatic: true

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -336,7 +336,9 @@ type KubermaticVersioningConfiguration struct {
 type Update struct {
 	// From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
 	From string `json:"from,omitempty"`
-	// From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+	// To is the version to which an update is allowed.
+	// Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
+	// Can be a wildcard otherwise, e.g. "1.20.*".
 	To string `json:"to,omitempty"`
 	// Automatic controls whether this update is executed automatically
 	// for the control plane of all matching user clusters.

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -208,9 +208,10 @@ var (
 		Updates: []operatorv1alpha1.Update{
 			// ======= 1.19 =======
 			{
-				// Auto-upgrade unsupported clusters
+				// Auto-upgrade unsupported clusters.
+				// 'To' must not be a constraint, it has to be a specific version.
 				From:      "1.19.*",
-				To:        "1.20.*",
+				To:        "1.20.13",
 				Automatic: pointer.BoolPtr(true),
 			},
 

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -341,9 +341,11 @@ type KubermaticVersioningConfiguration struct {
 
 // Update represents an update option for a user cluster.
 type Update struct {
-	// From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+	// From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.20.*".
 	From string `json:"from,omitempty"`
-	// From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+	// To is the version to which an update is allowed.
+	// Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
+	// Can be a wildcard otherwise, e.g. "1.20.*".
 	To string `json:"to,omitempty"`
 	// Automatic controls whether this update is executed automatically
 	// for the control plane of all matching user clusters.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

What it says on the title. A manual cherry-pick of #8821 into `release/v2.19`, to fix auto upgrades.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8816

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Automatic upgrades from 1.19.* to 1.20.13 work as intended now
```
