### PR TITLE
Update example values and KKPConfig to respect OIDC settings

### DIFF
--- a/charts/kubermatic.example.ce.yaml
+++ b/charts/kubermatic.example.ce.yaml
@@ -46,9 +46,10 @@ spec:
     skipTokenIssuerTLSVerify: true
     tokenIssuer: https://cluster.example.dev/dex
 
-    # this must match the secret configured for the kubermatic client from
-    # the values.yaml.
-    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
+    # This must match the secret configured for the kubermaticIssuer client from
+    # the dex clients in values.yaml.
+    # Needed if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting
+    issuerClientSecret: <dex-kubermatic-issuer-oauth-secret-here>
 
     # these need to be randomly generated. Those can be generated on the
     # shell using:

--- a/charts/kubermatic.example.ee.yaml
+++ b/charts/kubermatic.example.ee.yaml
@@ -56,9 +56,10 @@ spec:
     skipTokenIssuerTLSVerify: true
     tokenIssuer: https://cluster.example.dev/dex
 
-    # this must match the secret configured for the kubermatic client from
-    # the values.yaml.
-    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
+    # This must match the secret configured for the kubermaticIssuer client from
+    # the dex clients in values.yaml.
+    # Needed if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting
+    issuerClientSecret: <dex-kubermatic-issuer-oauth-secret-here>
 
     # these need to be randomly generated. Those can be generated on the
     # shell using:

--- a/charts/values.example.ce.yaml
+++ b/charts/values.example.ce.yaml
@@ -32,6 +32,19 @@ dex:
     - https://cluster.example.dev
     - https://cluster.example.dev/projects
 
+  # The "kubermaticIssuer" client is used for providing OIDC access to User Clusters.
+  # This configuration is optional, used if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting.
+  # More about this configuration at https://docs.kubermatic.com/kubermatic/master/tutorials_howtos/oidc_provider_configuration/share-_clusters_via_delegated_oidc_authentication/
+  - id: kubermaticIssuer
+    name: Kubermatic OIDC Issuer
+    # Generate a secure secret key
+    # Those can be generated on the shell using:
+    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    secret: <a-random-key>
+    RedirectURIs:
+      # ensure the URLs below use the dex.ingress.host configured above
+      - https://cluster.example.dev/api/v1/kubeconfig
+
   # Depending on your chosen login method, you need to configure either an OAuth provider like
   # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
   # for an overview over all available connectors.

--- a/charts/values.example.ee.yaml
+++ b/charts/values.example.ee.yaml
@@ -32,6 +32,19 @@ dex:
     - https://cluster.example.dev
     - https://cluster.example.dev/projects
 
+    # The "kubermaticIssuer" client is used for providing OIDC access to User Clusters.
+    # This configuration is optional, used if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting.
+    # More about this configuration at https://docs.kubermatic.com/kubermatic/master/tutorials_howtos/oidc_provider_configuration/share-_clusters_via_delegated_oidc_authentication/
+  - id: kubermaticIssuer
+    name: Kubermatic OIDC Issuer
+    # Generate a secure secret key
+    # Those can be generated on the shell using:
+    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    secret: <a-random-key>
+    RedirectURIs:
+      # ensure the URLs below use the dex.ingress.host configured above
+      - https://cluster.example.dev/api/v1/kubeconfig
+
   # Depending on your chosen login method, you need to configure either an OAuth provider like
   # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
   # for an overview over all available connectors.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
There were a misleading steps in the example values around the configuration of dex clients and KKPConfiguration.

Value of `issuerClientSecret` belongs to the issuer == used for accessing kubeconfig of user clusters via OIDC authentication.

And thus is actually not needed if users don't use that option.

It was discovered during the investigation of related issue - https://github.com/kubermatic/kubermatic/issues/8723.

Right now the situation was misleading because `issuerClientSecret` is not connected with the usage of `kubermatic` client (that is used for access KKP dahboard).

**Does this PR close any issues?**:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
No updates in docs needed.

**Does this PR introduce a user-facing change?**:
```release-note
Update example values and KubermaticConfiguration to respect OIDC settings
```
