### PR TITLE
[release/v2.18] apiserver network policy: allow all egress DNS traffic from apiserver

### DIFF
--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -99,8 +99,8 @@ func DNSAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCrea
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return "dns-allow", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			dnsPort := intstr.FromInt(53)
-			protoUdp := corev1.ProtocolUDP
-			protoTcp := corev1.ProtocolTCP
+			protoUDP := corev1.ProtocolUDP
+			protoTCP := corev1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
@@ -115,11 +115,11 @@ func DNSAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCrea
 					{
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoUdp,
+								Protocol: &protoUDP,
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &dnsPort,
 							},
 						},


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
This is a manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/8788

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8682 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix apiserver network policy: allow all egress DNS traffic from the apiserver.
```
