### PR TITLE
Fix Azure cloud spec defaulting and required fields

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.4.0
+version: 0.4.1
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -361,7 +361,6 @@ spec:
                       vnetResourceGroup:
                         type: string
                     required:
-                    - assignAvailabilitySet
                     - availabilitySet
                     - loadBalancerSKU
                     - resourceGroup

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -329,7 +329,6 @@ spec:
                       vnetResourceGroup:
                         type: string
                     required:
-                    - assignAvailabilitySet
                     - availabilitySet
                     - loadBalancerSKU
                     - resourceGroup

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -607,8 +607,9 @@ spec:
                             allowed. Wildcards are allowed, e.g. "1.18.*".
                           type: string
                         to:
-                          description: From is the version to which an update is allowed.
-                            Wildcards are allowed, e.g. "1.18.*".
+                          description: To is the version to which an update is allowed.
+                            Must be a valid version if `automatic` is set to true,
+                            e.g. "1.20.13". Can be a wildcard otherwise, e.g. "1.20.*".
                           type: string
                       type: object
                     type: array

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -681,7 +681,7 @@ type AzureCloudSpec struct {
 	RouteTableName          string `json:"routeTable"`
 	SecurityGroup           string `json:"securityGroup"`
 	NodePortsAllowedIPRange string `json:"nodePortsAllowedIPRange,omitempty"`
-	AssignAvailabilitySet   *bool  `json:"assignAvailabilitySet"`
+	AssignAvailabilitySet   *bool  `json:"assignAvailabilitySet,omitempty"`
 	AvailabilitySet         string `json:"availabilitySet"`
 	// LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used
 	LoadBalancerSKU LBSKU `json:"loadBalancerSKU"` //nolint:tagliatelle

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -304,6 +304,14 @@ func (a *Azure) reconcileCluster(cluster *kubermaticv1.Cluster, update provider.
 }
 
 func (a *Azure) DefaultCloudSpec(cloud *kubermaticv1.CloudSpec) error {
+	if cloud.Azure == nil {
+		return fmt.Errorf("no Azure cloud spec found")
+	}
+
+	if cloud.Azure.LoadBalancerSKU == "" {
+		cloud.Azure.LoadBalancerSKU = kubermaticv1.AzureBasicLBSKU
+	}
+
 	return nil
 }
 

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -305,7 +305,7 @@ func (a *Azure) reconcileCluster(cluster *kubermaticv1.Cluster, update provider.
 
 func (a *Azure) DefaultCloudSpec(cloud *kubermaticv1.CloudSpec) error {
 	if cloud.Azure == nil {
-		return fmt.Errorf("no Azure cloud spec found")
+		return errors.New("no Azure cloud spec found")
 	}
 
 	if cloud.Azure.LoadBalancerSKU == "" {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The new CRDs do validation differently/better. The CRD migration covered setting the `LoadBalancerSKU` field here: https://github.com/kubermatic/kubermatic/blob/e9e21912831361f4d8f88924fbd76355838cdaae/pkg/install/crdmigration/clones.go#L798-L804

For new clusters, this field needs to be defaulted, because otherwise creation will fail with this error:

```
Cluster.kubermatic.k8c.io "x9hm4dws5j" is invalid: spec.cloud.azure.loadBalancerSKU: Unsupported value: "": supported values: "standard", "basic"
```

In addition, some other changes to the Azure spec are necessary.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8857 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
