### PR TITLE
fix seed-controller not being able to create usercluster ClusterRoleBinding

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -253,6 +253,14 @@ func (r *Reconciler) ensureNamespaceExists(ctx context.Context, cluster *kuberma
 		return nil, fmt.Errorf("failed to create Namespace %s: %w", cluster.Status.NamespaceName, err)
 	}
 
+	// Creating() an object does not set the type meta, in fact it _resets_ it.
+	// Since the namespace is later used to build an owner reference, we must ensure
+	// type meta is set properly.
+	ns.TypeMeta = metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+	}
+
 	return ns, nil
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

> {"level":"info","time":"2022-02-03T13:49:24.487Z","caller":"conformance-tests/runner.go:1608","msg":"ERROR","scenario":"aws-ubuntu-1.20.14","cluster":"tscfkr8pw4","EventType":"Warning","Number":1,"Reason":"ReconcilingError","Message":"failed to reconcile cluster: failed to ensure Cluster Role Bindings: failed to ensure ClusterRoleBinding /kubermatic:usercluster-controller-manager-cluster-tscfkr8pw4: failed to create *v1.ClusterRoleBinding '/kubermatic:usercluster-controller-manager-cluster-tscfkr8pw4': [ClusterRoleBinding.rbac.authorization.k8s.io](http://clusterrolebinding.rbac.authorization.k8s.io/) \"kubermatic:usercluster-controller-manager-cluster-tscfkr8pw4\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": kind must not be empty]","Source":"kubermatic_kubernetes_controller"}

When using the namespace to build the owner ref, the typemeta needs to be set. However `Create()` does not set it. In fact, `Create()` even _removes_ any TypeMeta that would be on the object.

This PR ensures that TypeMeta is set properly.

**Does this PR introduce a user-facing change?**:
```release-note
Fix bad owner references for ClusterRoleBindings
```
