### PR TITLE
extend verify-codegen to cover CRDs

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -19,42 +19,13 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-TEMPDIR=_tmp
-PKG_DIFFROOT=pkg
-TMP_PKG_DIFFROOT="$TEMPDIR/pkg"
-CHARTS_DIFFROOT=charts
-TMP_CHARTS_DIFFROOT="$TEMPDIR/charts"
-
-cleanup() {
-  rm -rf "$TEMPDIR"
-}
-trap "cleanup" EXIT SIGINT
-
-cleanup
-
-mkdir -p "${TMP_PKG_DIFFROOT}" "${TMP_CHARTS_DIFFROOT}"
-cp -a "${PKG_DIFFROOT}"/* "${TMP_PKG_DIFFROOT}"
-cp -a "${CHARTS_DIFFROOT}"/* "${TMP_CHARTS_DIFFROOT}"
-
-# This will update both generated code and the CRDs for *.k8c.io,
-# but until those new CRDs are live, we only diff pkg/. We have
-# to restore the CRDs afterwards, so that other verify-* scripts
-# do not get confused when they `git diff`.
+# This will update both generated code and the CRDs for *.k8c.io
 ./hack/update-codegen.sh
 
-# restore CRDs
-cp -a "${TMP_CHARTS_DIFFROOT}"/* "${CHARTS_DIFFROOT}"
-
-echodate "Diffing ${PKG_DIFFROOT} against freshly generated codegen"
-ret=0
-diff -Naupr "${PKG_DIFFROOT}" "${TMP_PKG_DIFFROOT}" || ret=$?
-
-# restore pkg
-cp -a "${TMP_PKG_DIFFROOT}"/* "${PKG_DIFFROOT}"
-
-if [[ $ret -eq 0 ]]; then
-  echodate "${PKG_DIFFROOT} up to date."
-else
-  echodate "${PKG_DIFFROOT} is out of date. Please run hack/update-codegen.sh"
+echodate "Diffing..."
+if ! git diff --exit-code pkg charts; then
+  echodate "The generated code / CRDs are out of date. Please run hack/update-codegen.sh."
   exit 1
 fi
+
+echodate "Generated code is in-sync."


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
As promised in the TODO comment, it's now time to also verify the CRDs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
