### PR TITLE
Consider Hetzner network set by cluster spec

### DIFF
--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -46,7 +46,7 @@ func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluste
 		return !isOTC(dc.Spec.Openstack) && OpenStackCloudControllerSupported(cluster.Spec.Version)
 
 	case cluster.Spec.Cloud.Hetzner != nil:
-		return dc.Spec.Hetzner.Network != ""
+		return cluster.Spec.Cloud.Hetzner.Network != "" || dc.Spec.Hetzner.Network != ""
 
 	case cluster.Spec.Cloud.VSphere != nil:
 		supported, err := version.IsSupported(cluster.Spec.Version.Semver(), kubermaticv1.VSphereCloudProvider, incompatibilities, kubermaticv1.ExternalCloudProviderCondition)

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -279,10 +279,16 @@ func getHetznerProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc
 		network = dc.Spec.Hetzner.Network
 	}
 
+	networks := []providerconfig.ConfigVarString{}
+
+	if network != "" {
+		networks = append(networks, providerconfig.ConfigVarString{Value: network})
+	}
+
 	config := hetzner.RawConfig{
 		Datacenter: providerconfig.ConfigVarString{Value: dc.Spec.Hetzner.Datacenter},
 		Location:   providerconfig.ConfigVarString{Value: dc.Spec.Hetzner.Location},
-		Networks:   []providerconfig.ConfigVarString{{Value: network}},
+		Networks:   networks,
 		ServerType: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Hetzner.Type},
 	}
 

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -269,10 +269,20 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 }
 
 func getHetznerProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	network := nodeSpec.Cloud.Hetzner.Network
+	// fall back to network defined in cluster spec
+	if network == "" {
+		network = c.Spec.Cloud.Hetzner.Network
+	}
+	// fall back to network defined in datacenter spec
+	if network == "" {
+		network = dc.Spec.Hetzner.Network
+	}
+
 	config := hetzner.RawConfig{
 		Datacenter: providerconfig.ConfigVarString{Value: dc.Spec.Hetzner.Datacenter},
 		Location:   providerconfig.ConfigVarString{Value: dc.Spec.Hetzner.Location},
-		Networks:   []providerconfig.ConfigVarString{{Value: dc.Spec.Hetzner.Network}},
+		Networks:   []providerconfig.ConfigVarString{{Value: network}},
 		ServerType: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Hetzner.Type},
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

#6588 introduced a `network` field for Hetzner on various levels (datacenter and cluster spec). The description suggests that the field on the cluster spec takes precedence over the datacenter field.

Unfortunately, it looks like the implementation back then did not consider the field on the cluster spec level for the generated `MachineDeployments` and only applied the datacenter-level value.

This can result in `MachineDeployments` failing to deploy if the datacenter value is not given or set to an empty string, or a mismatch from the network that is defined in CCM settings (as that does consider the cluster spec value):

https://github.com/kubermatic/kubermatic/blob/e234573f6cd2c52e948ddc681f56cc79046ce036/pkg/resources/cloudcontroller/hetzner.go#L79-L82

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8868

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If a network is set in the Hetzner cluster spec, it is now correctly applied to generated machines
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>