### PR TITLE
Change required fields on Nutanix preset spec

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.5.0
+version: 0.5.1
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -253,22 +253,32 @@ spec:
               nutanix:
                 properties:
                   clusterName:
+                    description: ClusterName is the Nutanix cluster to deploy resources
+                      and nodes to.
                     type: string
                   datacenter:
                     type: string
                   enabled:
                     type: boolean
                   password:
+                    description: Password is the password corresponding to the provided
+                      user.
                     type: string
                   projectName:
+                    description: ProjectName is the optional Nutanix project to use.
+                      If none is given, no project will be used.
                     type: string
                   proxyURL:
+                    description: ProxyURL is used to optionally configure a HTTP proxy
+                      to access Nutanix Prism Central.
                     type: string
                   username:
+                    description: Username is the username to access the Nutanix Prism
+                      Central API.
                     type: string
                 required:
+                - clusterName
                 - password
-                - proxyURL
                 - username
                 type: object
               openstack:

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -290,11 +290,17 @@ func (s Anexia) IsValid() bool {
 type Nutanix struct {
 	ProviderPreset `json:",inline"`
 
-	ProxyURL string `json:"proxyURL"`
+	// ProxyURL is used to optionally configure a HTTP proxy to access Nutanix Prism Central.
+	ProxyURL string `json:"proxyURL,omitempty"`
+	// Username is the username to access the Nutanix Prism Central API.
 	Username string `json:"username"`
+	// Password is the password corresponding to the provided user.
 	Password string `json:"password"`
 
-	ClusterName string `json:"clusterName,omitempty"`
+	// ClusterName is the Nutanix cluster to deploy resources and nodes to.
+	ClusterName string `json:"clusterName"`
+	// ProjectName is the optional Nutanix project to use. If none is given,
+	// no project will be used.
 	ProjectName string `json:"projectName,omitempty"`
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

After discussion with @maciaszczykm, this improves the field requirement for the Nutanix spec in `Presets`. A proxy URL is only needed in certain network architectures, and the cluster name is always needed (because if a preset is selected in the UI, no separate data can be given).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
