### PR TITLE
Fixing linter complains about frontal commas

### DIFF
--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -39,7 +39,7 @@ const (
 
 // Addon specifies a add-on.
 type Addon struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   AddonSpec   `json:"spec,omitempty"`
@@ -76,7 +76,7 @@ type AddonSpec struct {
 
 // AddonList is a list of addons.
 type AddonList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []Addon `json:"items"`

--- a/pkg/apis/kubermatic/v1/addon_config.go
+++ b/pkg/apis/kubermatic/v1/addon_config.go
@@ -27,7 +27,7 @@ import (
 
 // AddonConfig specifies addon configuration.
 type AddonConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec AddonConfigSpec `json:"spec,omitempty"`
@@ -67,7 +67,7 @@ type AddonFormControl struct {
 
 // AddonConfigList is a list of addon configs.
 type AddonConfigList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []AddonConfig `json:"items"`

--- a/pkg/apis/kubermatic/v1/admission_plugin.go
+++ b/pkg/apis/kubermatic/v1/admission_plugin.go
@@ -28,7 +28,7 @@ import (
 
 // AdmissionPluginList is the type representing a AdmissionPluginList.
 type AdmissionPluginList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// List of Admission Plugins
@@ -41,7 +41,7 @@ type AdmissionPluginList struct {
 
 // AdmissionPlugin is the type representing a AdmissionPlugin.
 type AdmissionPlugin struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec AdmissionPluginSpec `json:"spec,omitempty"`

--- a/pkg/apis/kubermatic/v1/alertmanager.go
+++ b/pkg/apis/kubermatic/v1/alertmanager.go
@@ -35,7 +35,7 @@ const (
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 type Alertmanager struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   AlertmanagerSpec   `json:"spec,omitempty"`
@@ -52,7 +52,7 @@ type AlertmanagerSpec struct {
 // +kubebuilder:object:root=true
 
 type AlertmanagerList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []Alertmanager `json:"items"`

--- a/pkg/apis/kubermatic/v1/allowed_registry.go
+++ b/pkg/apis/kubermatic/v1/allowed_registry.go
@@ -34,7 +34,7 @@ const (
 
 // AllowedRegistry is the object representing an allowed registry.
 type AllowedRegistry struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec AllowedRegistrySpec `json:"spec,omitempty"`
@@ -52,7 +52,7 @@ type AllowedRegistrySpec struct {
 
 // AllowedRegistryList specifies a list of allowed registries.
 type AllowedRegistryList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []AllowedRegistry `json:"items"`

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -89,7 +89,7 @@ var ProtectedClusterLabels = sets.NewString(WorkerNameLabelKey, ProjectIDLabelKe
 
 // Cluster is the object representing a cluster.
 type Cluster struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec    ClusterSpec    `json:"spec,omitempty"`
@@ -102,7 +102,7 @@ type Cluster struct {
 
 // ClusterList specifies a list of clusters.
 type ClusterList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []Cluster `json:"items"`
@@ -486,14 +486,14 @@ type ComponentSettings struct {
 }
 
 type APIServerSettings struct {
-	DeploymentSettings `json:",inline"`
+	DeploymentSettings `json:"inline"`
 
 	EndpointReconcilingDisabled *bool  `json:"endpointReconcilingDisabled,omitempty"`
 	NodePortRange               string `json:"nodePortRange,omitempty"`
 }
 
 type ControllerSettings struct {
-	DeploymentSettings     `json:",inline"`
+	DeploymentSettings     `json:"inline"`
 	LeaderElectionSettings `json:"leaderElection,omitempty"`
 }
 

--- a/pkg/apis/kubermatic/v1/cluster_template_instance.go
+++ b/pkg/apis/kubermatic/v1/cluster_template_instance.go
@@ -36,7 +36,7 @@ const (
 
 // ClusterTemplateInstance is the object representing a cluster template instance.
 type ClusterTemplateInstance struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ClusterTemplateInstanceSpec `json:"spec,omitempty"`
@@ -55,7 +55,7 @@ type ClusterTemplateInstanceSpec struct {
 
 // ClusterTemplateInstanceList specifies a list of cluster template instances.
 type ClusterTemplateInstanceList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []ClusterTemplateInstance `json:"items"`

--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -51,7 +51,7 @@ const (
 
 // ClusterTemplate is the object representing a cluster template.
 type ClusterTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	ClusterLabels          map[string]string       `json:"clusterLabels,omitempty"`
@@ -66,7 +66,7 @@ type ClusterTemplate struct {
 
 // ClusterTemplateList specifies a list of cluster templates.
 type ClusterTemplateList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []ClusterTemplate `json:"items"`

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -55,7 +55,7 @@ const (
 
 // KubermaticConfiguration is the configuration required for running Kubermatic.
 type KubermaticConfiguration struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec KubermaticConfigurationSpec `json:"spec,omitempty"`
@@ -407,7 +407,7 @@ type KubermaticProxyConfiguration struct {
 
 // KubermaticConfigurationList is a collection of KubermaticConfigurations.
 type KubermaticConfigurationList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []KubermaticConfiguration `json:"items"`

--- a/pkg/apis/kubermatic/v1/constraint.go
+++ b/pkg/apis/kubermatic/v1/constraint.go
@@ -37,7 +37,7 @@ const (
 
 // Constraint specifies a kubermatic wrapper for the gatekeeper constraints.
 type Constraint struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ConstraintSpec `json:"spec,omitempty"`
@@ -111,7 +111,7 @@ type Kind struct {
 
 // ConstraintList specifies a list of constraints.
 type ConstraintList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []Constraint `json:"items"`

--- a/pkg/apis/kubermatic/v1/constraint_template.go
+++ b/pkg/apis/kubermatic/v1/constraint_template.go
@@ -38,7 +38,7 @@ const (
 
 // ConstraintTemplate is the object representing a kubermatic wrapper for a gatekeeper constraint template.
 type ConstraintTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ConstraintTemplateSpec `json:"spec,omitempty"`
@@ -64,7 +64,7 @@ type ConstraintTemplateSelector struct {
 
 // ConstraintTemplateList specifies a list of constraint templates.
 type ConstraintTemplateList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []ConstraintTemplate `json:"items"`

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -92,7 +92,7 @@ func IsProviderSupported(name string) bool {
 
 // SeedDatacenterList is the type representing a SeedDatacenterList.
 type SeedList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// List of seeds
@@ -105,7 +105,7 @@ type SeedList struct {
 
 // Seed is the type representing a SeedDatacenter.
 type Seed struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec SeedSpec `json:"spec"`
@@ -529,7 +529,7 @@ func (p *ProxySettings) Merge(dst *ProxySettings) {
 type NodeSettings struct {
 	// Optional: Proxy settings for the Nodes in this datacenter.
 	// Defaults to the Proxy settings of the seed.
-	ProxySettings `json:",inline"`
+	ProxySettings `json:"inline"`
 	// Optional: These image registries will be configured as insecure
 	// on the container runtime.
 	InsecureRegistries []string `json:"insecureRegistries,omitempty"`

--- a/pkg/apis/kubermatic/v1/etcd_backup_config.go
+++ b/pkg/apis/kubermatic/v1/etcd_backup_config.go
@@ -48,7 +48,7 @@ const (
 
 // EtcdBackupConfig specifies a add-on.
 type EtcdBackupConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   EtcdBackupConfigSpec   `json:"spec,omitempty"`
@@ -80,7 +80,7 @@ type EtcdBackupConfigSpec struct {
 
 // EtcdBackupConfigList is a list of etcd backup configs.
 type EtcdBackupConfigList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []EtcdBackupConfig `json:"items"`

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -51,7 +51,7 @@ type EtcdRestorePhase string
 
 // EtcdRestore specifies a add-on.
 type EtcdRestore struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   EtcdRestoreSpec   `json:"spec,omitempty"`
@@ -81,7 +81,7 @@ type EtcdRestoreSpec struct {
 
 // EtcdRestoreList is a list of etcd restores.
 type EtcdRestoreList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []EtcdRestore `json:"items"`

--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -41,7 +41,7 @@ const (
 
 // ExternalCluster is the object representing an external kubernetes cluster.
 type ExternalCluster struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ExternalClusterSpec `json:"spec,omitempty"`
@@ -52,7 +52,7 @@ type ExternalCluster struct {
 
 // ExternalClusterList specifies a list of external kubernetes clusters.
 type ExternalClusterList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []ExternalCluster `json:"items"`

--- a/pkg/apis/kubermatic/v1/mla_admin_settings.go
+++ b/pkg/apis/kubermatic/v1/mla_admin_settings.go
@@ -35,7 +35,7 @@ const (
 // MLAAdminSetting is the object representing cluster-specific administrator settings
 // for KKP user cluster MLA (monitoring, logging & alerting) stack.
 type MLAAdminSetting struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec MLAAdminSettingSpec `json:"spec,omitempty"`
@@ -92,7 +92,7 @@ type LoggingRateLimitSettings struct {
 // MLAAdminSettingList specifies a list of administrtor settings for KKP
 // user cluster MLA (monitoring, logging & alerting) stack.
 type MLAAdminSettingList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []MLAAdminSetting `json:"items"`

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -26,7 +26,7 @@ import (
 
 // PresetList is the type representing a PresetList.
 type PresetList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// List of presets
@@ -39,7 +39,7 @@ type PresetList struct {
 
 // Preset is the type representing a Preset.
 type Preset struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec PresetSpec `json:"spec"`
@@ -94,7 +94,7 @@ func (s ProviderPreset) IsEnabled() bool {
 }
 
 type Digitalocean struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	// Token is used to authenticate with the DigitalOcean API.
 	Token string `json:"token"`
@@ -105,7 +105,7 @@ func (s Digitalocean) IsValid() bool {
 }
 
 type Hetzner struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	// Token is used to authenticate with the Hetzner API.
 	Token string `json:"token"`
@@ -122,7 +122,7 @@ func (s Hetzner) IsValid() bool {
 }
 
 type Azure struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	TenantID       string `json:"tenantID"`
 	SubscriptionID string `json:"subscriptionID"`
@@ -147,7 +147,7 @@ func (s Azure) IsValid() bool {
 }
 
 type VSphere struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -163,7 +163,7 @@ func (s VSphere) IsValid() bool {
 }
 
 type AWS struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	AccessKeyID     string `json:"accessKeyID"`
 	SecretAccessKey string `json:"secretAccessKey"`
@@ -183,7 +183,7 @@ func (s AWS) IsValid() bool {
 }
 
 type Openstack struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	UseToken bool `json:"useToken,omitempty"`
 
@@ -219,7 +219,7 @@ func (s Openstack) IsValid() bool {
 }
 
 type Packet struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	APIKey    string `json:"apiKey"`
 	ProjectID string `json:"projectID"`
@@ -232,7 +232,7 @@ func (s Packet) IsValid() bool {
 }
 
 type GCP struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	ServiceAccount string `json:"serviceAccount"`
 
@@ -245,7 +245,7 @@ func (s GCP) IsValid() bool {
 }
 
 type Fake struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	Token string `json:"token"`
 }
@@ -255,7 +255,7 @@ func (s Fake) IsValid() bool {
 }
 
 type Kubevirt struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	Kubeconfig string `json:"kubeconfig"`
 }
@@ -265,7 +265,7 @@ func (s Kubevirt) IsValid() bool {
 }
 
 type Alibaba struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	AccessKeyID     string `json:"accessKeyID"`
 	AccessKeySecret string `json:"accessKeySecret"`
@@ -277,7 +277,7 @@ func (s Alibaba) IsValid() bool {
 }
 
 type Anexia struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	// Token is used to authenticate with the Anexia API.
 	Token string `json:"token"`
@@ -288,7 +288,7 @@ func (s Anexia) IsValid() bool {
 }
 
 type Nutanix struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	ProxyURL string `json:"proxyURL"`
 	Username string `json:"username"`
@@ -303,7 +303,7 @@ func (s Nutanix) IsValid() bool {
 }
 
 type GKE struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	ServiceAccount string `json:"serviceAccount"`
 }
@@ -313,7 +313,7 @@ func (s GKE) IsValid() bool {
 }
 
 type EKS struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	AccessKeyID     string `json:"accessKeyID"`
 	SecretAccessKey string `json:"secretAccessKey"`
@@ -327,7 +327,7 @@ func (s EKS) IsValid() bool {
 }
 
 type AKS struct {
-	ProviderPreset `json:",inline"`
+	ProviderPreset `json:"inline"`
 
 	TenantID       string `json:"tenantID"`
 	SubscriptionID string `json:"subscriptionID"`

--- a/pkg/apis/kubermatic/v1/project.go
+++ b/pkg/apis/kubermatic/v1/project.go
@@ -54,7 +54,7 @@ const (
 
 // Project is the type describing a project.
 type Project struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   ProjectSpec   `json:"spec,omitempty"`
@@ -76,7 +76,7 @@ type ProjectStatus struct {
 
 // ProjectList is a collection of projects.
 type ProjectList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []Project `json:"items"`

--- a/pkg/apis/kubermatic/v1/rulegroup.go
+++ b/pkg/apis/kubermatic/v1/rulegroup.go
@@ -34,7 +34,7 @@ const (
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 type RuleGroup struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec RuleGroupSpec `json:"spec,omitempty"`
@@ -64,7 +64,7 @@ const (
 // +kubebuilder:object:root=true
 
 type RuleGroupList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []RuleGroup `json:"items"`

--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -29,7 +29,7 @@ const GlobalSettingsName = "globalsettings"
 
 // KubermaticSetting is the type representing a KubermaticSetting.
 type KubermaticSetting struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec SettingSpec `json:"spec,omitempty"`
@@ -101,7 +101,7 @@ type MlaOptions struct {
 
 // KubermaticSettingList is a list of settings.
 type KubermaticSettingList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []KubermaticSetting `json:"items"`

--- a/pkg/apis/kubermatic/v1/sshkeys.go
+++ b/pkg/apis/kubermatic/v1/sshkeys.go
@@ -37,7 +37,7 @@ const (
 
 // UserSSHKey specifies a users UserSSHKey.
 type UserSSHKey struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec SSHKeySpec `json:"spec,omitempty"`
@@ -82,7 +82,7 @@ func (sk *UserSSHKey) AddToCluster(clustername string) {
 
 // UserSSHKeyList specifies a users UserSSHKey.
 type UserSSHKeyList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []UserSSHKey `json:"items"`

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -42,7 +42,7 @@ const (
 
 // User specifies a user.
 type User struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   UserSpec   `json:"spec,omitempty"`
@@ -81,7 +81,7 @@ type UserSettings struct {
 
 // UserList is a list of users.
 type UserList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []User `json:"items"`

--- a/pkg/apis/kubermatic/v1/user_project_binding.go
+++ b/pkg/apis/kubermatic/v1/user_project_binding.go
@@ -40,7 +40,7 @@ const (
 // UserProjectBinding specifies a binding between a user and a project
 // This resource is used by the user management to manipulate members of the given project.
 type UserProjectBinding struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:"inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec UserProjectBindingSpec `json:"spec,omitempty"`
@@ -58,7 +58,7 @@ type UserProjectBindingSpec struct {
 
 // UserProjectBindingList is a list of users.
 type UserProjectBindingList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:"inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []UserProjectBinding `json:"items"`


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
For some reason linter started to complain about frontal commas. This PR removes such occurrences. 

**Special notes for your reviewer**:
Both me and @zreigz have experienced this issue. This has to be something new as @zreigz hasn't experienced this in the morning.
<img width="1236" alt="Screenshot 2022-02-04 at 14 48 09" src="https://user-images.githubusercontent.com/9121459/152539668-e9a93dab-fbad-4c9b-ae8e-562298973e75.png">

```release-note
NONE
```

Signed-off-by: Patryk Przekwas <patryk@kubermatic.com>