### PR TITLE
update integration test binaries to 1.23.3

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -48,7 +48,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/integration-tests:5-0
+      - image: quay.io/kubermatic/integration-tests:5-1
         command:
         - make
         args:

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+FROM quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
 LABEL maintainer="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating
-ENV KUBE_VERSION=1.21.4
+ENV KUBE_VERSION=1.23.3
 
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \

--- a/hack/images/integration-tests/release.sh
+++ b/hack/images/integration-tests/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/integration-tests
 VERSION=5
-BUILD_SUFFIX=0
+BUILD_SUFFIX=1
 
 docker build --no-cache --pull -t "$REPOSITORY:$VERSION-$BUILD_SUFFIX" .
 docker push "$REPOSITORY:$VERSION-$BUILD_SUFFIX"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is primarily to update the base image, which has better support for Docker registry mirrors in its `start-docker.sh`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
