### PR TITLE
fix AWS cloud provider cleanup sometimes getting stuck when cleaning up tags

### DIFF
--- a/pkg/provider/cloud/aws/tags.go
+++ b/pkg/provider/cloud/aws/tags.go
@@ -136,10 +136,12 @@ func cleanUpTags(client ec2iface.EC2API, cluster *kubermaticv1.Cluster) error {
 	}
 
 	// remove tag
-	_, err = client.DeleteTags(&ec2.DeleteTagsInput{
-		Resources: resourceIDs,
-		Tags:      []*ec2.Tag{tag},
-	})
+	if len(resourceIDs) > 0 {
+		_, err = client.DeleteTags(&ec2.DeleteTagsInput{
+			Resources: resourceIDs,
+			Tags:      []*ec2.Tag{tag},
+		})
+	}
 
 	return err
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This fixes the rare case were all resources have been cleaned up already, but the finalizer was still stuck, leading to

> {"level":"error","time":"2022-02-04T14:46:35.780Z","logger":"controller.kubermatic_cloud_controller","caller":"controller/controller.go:317","msg":"Reconciler error","name":"jmh6qqjgg7","namespace":"","error":"failed cloud provider cleanup: failed to clean up tags: InvalidParameterValue: Value (  ) for parameter resourceId is invalid. Null/empty value for resourceId is invalid\n\tstatus code: 400, request id: 8edbfe54-2ca5-4dc9-9277-f0fcbde4597b","errorCauses":[{"error":"failed cloud provider cleanup: failed to clean up tags: InvalidParameterValue: Value (  ) for parameter resourceId is invalid. Null/empty value for resourceId is invalid\n\tstatus code: 400, request id: 8edbfe54-2ca5-4dc9-9277-f0fcbde4597b"}]}

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix AWS cloud provider cleanup sometimes getting stuck when cleaning up tags
```
