### PR TITLE
fix finalizer names

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2336,46 +2336,46 @@ type ReportURL string
 
 const (
 	// NodeDeletionFinalizer indicates that the nodes still need cleanup.
-	NodeDeletionFinalizer = "kubermatic.io/delete-nodes"
+	NodeDeletionFinalizer = "kubermatic.k8c.io/delete-nodes"
 	// InClusterPVCleanupFinalizer indicates that the PVs still need cleanup.
-	InClusterPVCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-pv"
+	InClusterPVCleanupFinalizer = "kubermatic.k8c.io/cleanup-in-cluster-pv"
 	// InClusterLBCleanupFinalizer indicates that the LBs still need cleanup.
-	InClusterLBCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-lb"
+	InClusterLBCleanupFinalizer = "kubermatic.k8c.io/cleanup-in-cluster-lb"
 	// CredentialsSecretsCleanupFinalizer indicates that secrets for credentials still need cleanup.
-	CredentialsSecretsCleanupFinalizer = "kubermatic.io/cleanup-credentials-secrets"
+	CredentialsSecretsCleanupFinalizer = "kubermatic.k8c.io/cleanup-credentials-secrets"
 	// UserClusterRoleCleanupFinalizer indicates that user cluster role still need cleanup.
-	UserClusterRoleCleanupFinalizer = "kubermatic.io/user-cluster-role"
+	UserClusterRoleCleanupFinalizer = "kubermatic.k8c.io/user-cluster-role"
 	// ExternalClusterKubeconfigCleanupFinalizer indicates that secrets for kubeconfig still need cleanup.
-	ExternalClusterKubeconfigCleanupFinalizer = "kubermatic.io/cleanup-kubeconfig-secret"
+	ExternalClusterKubeconfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeconfig-secret"
 	// EtcdBackConfigCleanupFinalizer indicates that EtcdBackupConfigs for the cluster still need cleanup.
-	EtcdBackupConfigCleanupFinalizer = "kubermatic.io/cleanup-etcdbackupconfigs"
+	EtcdBackupConfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-etcdbackupconfigs"
 	// GatekeeperConstraintTemplateCleanupFinalizer indicates that synced gatekeeper Constraint Templates on user cluster need cleanup.
-	GatekeeperConstraintTemplateCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-constraint-templates"
+	GatekeeperConstraintTemplateCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-constraint-templates"
 	// GatekeeperSeedConstraintTemplateCleanupFinalizer indicates that synced gatekeeper Constraint Templates on seed clusters need cleanup.
-	GatekeeperSeedConstraintTemplateCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-master-constraint-templates"
+	GatekeeperSeedConstraintTemplateCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-master-constraint-templates"
 	// GatekeeperSeedConstraintCleanupFinalizer indicates that synced gatekeeper Constraint on seed clusters need cleanup.
-	GatekeeperSeedConstraintCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-seed-constraint"
+	GatekeeperSeedConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-seed-constraint"
 	// GatekeeperConstraintCleanupFinalizer indicates that gatkeeper constraints on the user cluster need cleanup.
-	GatekeeperConstraintCleanupFinalizer = "kubermatic.io/cleanup-gatekeeper-constraints"
+	GatekeeperConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-constraints"
 	// KubermaticUserClusterNsDefaultConstraintCleanupFinalizer indicates that kubermatic constraints on the user cluster namespace need cleanup.
-	KubermaticUserClusterNsDefaultConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-usercluster-ns-default-constraints"
+	KubermaticUserClusterNsDefaultConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-usercluster-ns-default-constraints"
 	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup.
-	KubermaticConstraintCleanupFinalizer = "kubermatic.io/cleanup-kubermatic-constraints"
+	KubermaticConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-constraints"
 	// SeedProjectCleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup.
-	SeedProjectCleanupFinalizer = "kubermatic.io/cleanup-seed-projects"
+	SeedProjectCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-projects"
 	// SeedUserProjectBindingCleanupFinalizer indicates that Kubermatic UserProjectBindings on the seed clusters need cleanup.
-	SeedUserProjectBindingCleanupFinalizer = "kubermatic.io/cleanup-seed-user-project-bindings"
+	SeedUserProjectBindingCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-user-project-bindings"
 	// SeedUserCleanupFinalizer indicates that Kubermatic Users on the seed clusters need cleanup.
-	SeedUserCleanupFinalizer = "kubermatic.io/cleanup-seed-users"
+	SeedUserCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-users"
 	// ClusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup.
 	// This finalizer is deprecated and should not be used anymore since we migrated to using owner references for cleanup.
-	ClusterRoleBindingsCleanupFinalizer = "kubermatic.io/cleanup-cluster-role-bindings"
+	ClusterRoleBindingsCleanupFinalizer = "kubermatic.k8c.io/cleanup-cluster-role-bindings"
 	// ClusterTemplateSeedCleanupFinalizer indicates that synced cluster template on seed clusters need cleanup.
-	ClusterTemplateSeedCleanupFinalizer = "kubermatic.io/cleanup-seed-cluster-template"
+	ClusterTemplateSeedCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-cluster-template"
 	// AllowedRegistryCleanupFinalizer indicates that allowed registry Constraints need to be cleaned up.
-	AllowedRegistryCleanupFinalizer = "kubermatic.io/cleanup-allowed-registry"
+	AllowedRegistryCleanupFinalizer = "kubermatic.k8c.io/cleanup-allowed-registry"
 	// ClusterTemplateSeedCleanupFinalizer indicates that cluster template instance on seed clusters need cleanup.
-	SeedClusterTemplateInstanceFinalizer = "kubermatic.io/cleanup-seed-cluster-template-instance"
+	SeedClusterTemplateInstanceFinalizer = "kubermatic.k8c.io/cleanup-seed-cluster-template-instance"
 )
 
 const (

--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	deletedLBAnnotationName = "kubermatic.io/cleaned-up-loadbalancers"
+	deletedLBAnnotationName = "kubermatic.k8c.io/cleaned-up-loadbalancers"
 )
 
 func New(seedClient ctrlruntimeclient.Client, userClusterClientGetter func() (ctrlruntimeclient.Client, error), etcdBackupRestoreController bool) *Deletion {

--- a/pkg/controller/master-controller-manager/rbac/sync_project.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	CleanupFinalizerName = "kubermatic.io/controller-manager-rbac-cleanup"
+	CleanupFinalizerName = "kubermatic.k8c.io/controller-manager-rbac-cleanup"
 )
 
 func (c *projectController) sync(ctx context.Context, key ctrlruntimeclient.ObjectKey) error {

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -125,7 +125,7 @@ func TestEnsureProjectInitialized(t *testing.T) {
 			projectToSync: test.CreateProject("thunderball", test.CreateUser("James Bond")),
 			expectedProject: func() *kubermaticv1.Project {
 				project := test.CreateProject("thunderball", test.CreateUser("James Bond"))
-				project.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				project.Finalizers = []string{"kubermatic.k8c.io/controller-manager-rbac-cleanup"}
 				return project
 			}(),
 		},
@@ -1412,7 +1412,7 @@ func TestEnsureProjectOwner(t *testing.T) {
 			existingUser:           test.CreateUser("James Bond"),
 			expectedBindings: func() []kubermaticv1.UserProjectBinding {
 				binding := test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond")))
-				binding.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding.Finalizers = []string{"kubermatic.k8c.io/controller-manager-rbac-cleanup"}
 				binding.ObjectMeta.Name = ""
 				binding.ResourceVersion = ""
 				return []kubermaticv1.UserProjectBinding{*binding}
@@ -1473,11 +1473,11 @@ func TestEnsureProjectOwner(t *testing.T) {
 			existingUser: test.CreateUser("James Bond"),
 			expectedBindings: func() []kubermaticv1.UserProjectBinding {
 				binding := test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond")))
-				binding.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding.Finalizers = []string{"kubermatic.k8c.io/controller-manager-rbac-cleanup"}
 				binding.ObjectMeta.Name = ""
 				binding.ResourceVersion = ""
 				binding2 := test.CreateExpectedOwnerBinding("Batman", test.CreateProject("thunderball", test.CreateUser("Batman")))
-				binding2.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding2.Finalizers = []string{"kubermatic.k8c.io/controller-manager-rbac-cleanup"}
 				binding2.ObjectMeta.Name = ""
 				binding2.ResourceVersion = ""
 				return []kubermaticv1.UserProjectBinding{*binding, *binding2}
@@ -1532,11 +1532,11 @@ func TestEnsureProjectOwner(t *testing.T) {
 			existingUser: test.CreateUser("James Bond"),
 			expectedBindings: func() []kubermaticv1.UserProjectBinding {
 				binding := test.CreateExpectedOwnerBinding("James Bond", test.CreateProject("thunderball", test.CreateUser("James Bond")))
-				binding.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding.Finalizers = []string{"kubermatic.k8c.io/controller-manager-rbac-cleanup"}
 				binding.ObjectMeta.Name = ""
 				binding.ResourceVersion = ""
 				binding2 := test.CreateExpectedOwnerBinding("Batman", test.CreateProject("thunderball", test.CreateUser("Batman")))
-				binding2.Finalizers = []string{"kubermatic.io/controller-manager-rbac-cleanup"}
+				binding2.Finalizers = []string{"kubermatic.k8c.io/controller-manager-rbac-cleanup"}
 				binding2.ObjectMeta.Name = ""
 				binding2.ResourceVersion = ""
 				return []kubermaticv1.UserProjectBinding{*binding, *binding2}

--- a/pkg/controller/master-controller-manager/seed-sync/controller.go
+++ b/pkg/controller/master-controller-manager/seed-sync/controller.go
@@ -45,7 +45,7 @@ const (
 
 	// CleanupFinalizer is put on Seed CRs to facilitate proper
 	// cleanup when a Seed is deleted.
-	CleanupFinalizer = "kubermatic.io/cleanup-seed-sync"
+	CleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-sync"
 )
 
 // Add creates a new Seed-Sync controller and sets up Watches.

--- a/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
@@ -48,7 +48,7 @@ import (
 const (
 	ControllerName = "usersshkeys_synchronizer"
 
-	UserSSHKeysClusterIDsCleanupFinalizer = "kubermatic.io/cleanup-usersshkeys-cluster-ids"
+	UserSSHKeysClusterIDsCleanupFinalizer = "kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids"
 )
 
 // Reconciler is a controller which is responsible for managing clusters.

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -70,7 +70,7 @@ const (
 	// cronJobPrefix defines the prefix used for all backup cronjob names.
 	cronJobPrefix = "etcd-backup"
 	// cleanupFinalizer defines the name for the finalizer to ensure we cleanup after we deleted a cluster.
-	cleanupFinalizer = "kubermatic.io/cleanup-backups"
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-backups"
 	// backupCleanupJobLabel defines the label we use on all cleanup jobs.
 	backupCleanupJobLabel = "kubermatic-etcd-backup-cleaner"
 	// clusterEnvVarKey defines the environment variable key for the cluster name.

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -63,7 +63,7 @@ const (
 	ControllerName = "kubermatic_etcd_backup_controller"
 
 	// DeleteAllBackupsFinalizer indicates that the backups still need to be deleted in the backend.
-	DeleteAllBackupsFinalizer = "kubermatic.io/delete-all-backups"
+	DeleteAllBackupsFinalizer = "kubermatic.k8c.io/delete-all-backups"
 
 	// BackupConfigNameLabelKey is the label key which should be used to name the BackupConfig a job belongs to.
 	BackupConfigNameLabelKey = "backupConfig"

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -54,12 +54,12 @@ const (
 	ControllerName = "kubermatic_etcd_restore_controller"
 
 	// FinishRestoreFinalizer indicates that the restore is rebuilding the etcd statefulset.
-	FinishRestoreFinalizer = "kubermatic.io/finish-restore"
+	FinishRestoreFinalizer = "kubermatic.k8c.io/finish-restore"
 
 	// ActiveRestoreAnnotationName is the cluster annotation that records the EtcdRestore resource that's currently
 	// being restored into the cluster, if any. This is also used for mutual exclusion, i.e. to make sure that not
 	// more than one EtcdRestore resource is active for the cluster at the same time.
-	ActiveRestoreAnnotationName = "kubermatic.io/active-restore"
+	ActiveRestoreAnnotationName = "kubermatic.k8c.io/active-restore"
 )
 
 // Reconciler stores necessary components that are required to restore etcd backups.

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -50,7 +50,7 @@ import (
 )
 
 const (
-	alertmanagerFinalizer        = "kubermatic.io/alertmanager"
+	alertmanagerFinalizer        = "kubermatic.k8c.io/alertmanager"
 	AlertmanagerConfigEndpoint   = "/api/v1/alerts"
 	AlertmanagerTenantHeaderName = "X-Scope-OrgID"
 )

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -42,7 +42,7 @@ type cleaner interface {
 
 const (
 	ControllerName     = "kubermatic_mla_controller"
-	mlaFinalizer       = "kubermatic.io/mla"
+	mlaFinalizer       = "kubermatic.k8c.io/mla"
 	defaultOrgID       = 1
 	GrafanaUserKey     = "admin-user"
 	GrafanaPasswordKey = "admin-password"

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	ruleGroupFinalizer             = "kubermatic.io/rule-group"
+	ruleGroupFinalizer             = "kubermatic.k8c.io/rule-group"
 	MetricsRuleGroupConfigEndpoint = "/api/v1/rules"
 	LogRuleGroupConfigEndpoint     = "/loki/api/v1/rules"
 	RuleGroupTenantHeaderName      = "X-Scope-OrgID"

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -947,7 +947,7 @@ func GenProject(name string, phase kubermaticv1.ProjectPhase, creationTime time.
 func GenDefaultProject() *kubermaticv1.Project {
 	user := GenDefaultUser()
 	oRef := metav1.OwnerReference{
-		APIVersion: "kubermatic.io/v1",
+		APIVersion: "kubermatic.k8c.io/v1",
 		Kind:       "User",
 		UID:        user.UID,
 		Name:       user.Name,

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -61,7 +61,7 @@ func TestRenameProjectEndpoint(t *testing.T) {
 
 	oRef := func(user *kubermaticv1.User) metav1.OwnerReference {
 		return metav1.OwnerReference{
-			APIVersion: "kubermatic.io/v1",
+			APIVersion: "kubermatic.k8c.io/v1",
 			Kind:       "User",
 			UID:        user.UID,
 			Name:       user.Name,

--- a/pkg/provider/cloud/aws/provider.go
+++ b/pkg/provider/cloud/aws/provider.go
@@ -32,15 +32,15 @@ const (
 
 	regionAnnotationKey = "kubermatic.io/aws-region"
 
-	cleanupFinalizer = "kubermatic.io/cleanup-aws"
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-aws"
 
 	// The individual finalizers are deprecated and not used for newly reconciled
 	// clusters, where the single cleanupFinalizer is enough.
 
-	securityGroupCleanupFinalizer    = "kubermatic.io/cleanup-aws-security-group"
-	instanceProfileCleanupFinalizer  = "kubermatic.io/cleanup-aws-instance-profile"
-	controlPlaneRoleCleanupFinalizer = "kubermatic.io/cleanup-aws-control-plane-role"
-	tagCleanupFinalizer              = "kubermatic.io/cleanup-aws-tags"
+	securityGroupCleanupFinalizer    = "kubermatic.k8c.io/cleanup-aws-security-group"
+	instanceProfileCleanupFinalizer  = "kubermatic.k8c.io/cleanup-aws-instance-profile"
+	controlPlaneRoleCleanupFinalizer = "kubermatic.k8c.io/cleanup-aws-control-plane-role"
+	tagCleanupFinalizer              = "kubermatic.k8c.io/cleanup-aws-tags"
 
 	authFailure = "AuthFailure"
 )

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -38,17 +38,17 @@ const (
 	clusterTagKey = "cluster"
 
 	// FinalizerSecurityGroup will instruct the deletion of the security group.
-	FinalizerSecurityGroup = "kubermatic.io/cleanup-azure-security-group"
+	FinalizerSecurityGroup = "kubermatic.k8c.io/cleanup-azure-security-group"
 	// FinalizerRouteTable will instruct the deletion of the route table.
-	FinalizerRouteTable = "kubermatic.io/cleanup-azure-route-table"
+	FinalizerRouteTable = "kubermatic.k8c.io/cleanup-azure-route-table"
 	// FinalizerSubnet will instruct the deletion of the subnet.
-	FinalizerSubnet = "kubermatic.io/cleanup-azure-subnet"
+	FinalizerSubnet = "kubermatic.k8c.io/cleanup-azure-subnet"
 	// FinalizerVNet will instruct the deletion of the virtual network.
-	FinalizerVNet = "kubermatic.io/cleanup-azure-vnet"
+	FinalizerVNet = "kubermatic.k8c.io/cleanup-azure-vnet"
 	// FinalizerResourceGroup will instruct the deletion of the resource group.
-	FinalizerResourceGroup = "kubermatic.io/cleanup-azure-resource-group"
+	FinalizerResourceGroup = "kubermatic.k8c.io/cleanup-azure-resource-group"
 	// FinalizerAvailabilitySet will instruct the deletion of the availability set.
-	FinalizerAvailabilitySet = "kubermatic.io/cleanup-azure-availability-set"
+	FinalizerAvailabilitySet = "kubermatic.k8c.io/cleanup-azure-availability-set"
 
 	denyAllTCPSecGroupRuleName   = "deny_all_tcp"
 	denyAllUDPSecGroupRuleName   = "deny_all_udp"

--- a/pkg/provider/cloud/gcp/provider.go
+++ b/pkg/provider/cloud/gcp/provider.go
@@ -44,10 +44,10 @@ import (
 const (
 	DefaultNetwork                   = "global/networks/default"
 	computeAPIEndpoint               = "https://www.googleapis.com/compute/v1/"
-	firewallSelfCleanupFinalizer     = "kubermatic.io/cleanup-gcp-firewall-self"
-	firewallICMPCleanupFinalizer     = "kubermatic.io/cleanup-gcp-firewall-icmp"
-	firewallNodePortCleanupFinalizer = "kubermatic.io/cleanup-gcp-firewall-nodeport"
-	routesCleanupFinalizer           = "kubermatic.io/cleanup-gcp-routes"
+	firewallSelfCleanupFinalizer     = "kubermatic.k8c.io/cleanup-gcp-firewall-self"
+	firewallICMPCleanupFinalizer     = "kubermatic.k8c.io/cleanup-gcp-firewall-icmp"
+	firewallNodePortCleanupFinalizer = "kubermatic.k8c.io/cleanup-gcp-firewall-nodeport"
+	routesCleanupFinalizer           = "kubermatic.k8c.io/cleanup-gcp-routes"
 
 	k8sNodeRouteTag          = "k8s-node-route"
 	k8sNodeRoutePrefixRegexp = "kubernetes-.*"

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -38,7 +38,7 @@ const (
 	categoryDescription = "automatically created by KKP"
 	categoryValuePrefix = "kubernetes-"
 
-	categoryCleanupFinalizer = "kubermatic.io/cleanup-nutanix-categories"
+	categoryCleanupFinalizer = "kubermatic.k8c.io/cleanup-nutanix-categories"
 )
 
 type Nutanix struct {

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -47,19 +47,19 @@ import (
 
 const (
 	// SecurityGroupCleanupFinalizer will instruct the deletion of the security group.
-	SecurityGroupCleanupFinalizer = "kubermatic.io/cleanup-openstack-security-group"
+	SecurityGroupCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-security-group"
 	// OldNetworkCleanupFinalizer will instruct the deletion of all network components. Router, Network, Subnet
 	// Deprecated: Got split into dedicated finalizers.
-	OldNetworkCleanupFinalizer = "kubermatic.io/cleanup-openstack-network"
+	OldNetworkCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-network"
 
 	// NetworkCleanupFinalizer will instruct the deletion of the network.
-	NetworkCleanupFinalizer = "kubermatic.io/cleanup-openstack-network-v2"
+	NetworkCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-network-v2"
 	// SubnetCleanupFinalizer will instruct the deletion of the subnet.
-	SubnetCleanupFinalizer = "kubermatic.io/cleanup-openstack-subnet-v2"
+	SubnetCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-subnet-v2"
 	// RouterCleanupFinalizer will instruct the deletion of the router.
-	RouterCleanupFinalizer = "kubermatic.io/cleanup-openstack-router-v2"
+	RouterCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-router-v2"
 	// RouterSubnetLinkCleanupFinalizer will instruct the deletion of the link between the router and the subnet.
-	RouterSubnetLinkCleanupFinalizer = "kubermatic.io/cleanup-openstack-router-subnet-link-v2"
+	RouterSubnetLinkCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-router-subnet-link-v2"
 )
 
 type getClientFunc func(cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error)

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	folderCleanupFinalizer = "kubermatic.io/cleanup-vsphere-folder"
+	folderCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-folder"
 )
 
 // Provider represents the vsphere provider.

--- a/pkg/provider/kubernetes/util_test.go
+++ b/pkg/provider/kubernetes/util_test.go
@@ -43,7 +43,7 @@ const (
 	TestFakeToken = "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6IjEiLCJleHAiOjE2NDk3NDg4NTYsImlhdCI6MTU1NTA1NDQ1NiwibmJmIjoxNTU1MDU0NDU2LCJwcm9qZWN0X2lkIjoiMSIsInRva2VuX2lkIjoiMSJ9.Q4qxzOaCvUnWfXneY654YiQjUTd_Lsmw56rE17W2ouo"
 
 	// TestFakeFinalizer is a dummy finalizer with no special meaning.
-	TestFakeFinalizer = "test.kubermatic.io/dummy"
+	TestFakeFinalizer = "test.kubermatic.k8c.io/dummy"
 )
 
 type fakeJWTTokenGenerator struct {
@@ -155,7 +155,7 @@ func genProject(name string, phase kubermaticv1.ProjectPhase, creationTime time.
 func genDefaultProject() *kubermaticv1.Project {
 	user := genDefaultUser()
 	oRef := metav1.OwnerReference{
-		APIVersion: "kubermatic.io/v1",
+		APIVersion: "kubermatic.k8c.io/v1",
 		Kind:       "User",
 		UID:        user.UID,
 		Name:       user.Name,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
During the CRD migration, we normalize the existing finalizers: https://github.com/kubermatic/kubermatic/blob/release/v2.20/pkg/install/crdmigration/clones.go#L389-L395 -- yet I forgot to actually update all the constants for the finalizers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
