### PR TITLE
Update Multus to v3.8.1, enable Multus auto-configuration

### DIFF
--- a/addons/multus/daemonset.yaml
+++ b/addons/multus/daemonset.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-multus-ds-amd64
+  name: kube-multus-ds
   namespace: kube-system
   labels:
     tier: node
@@ -35,18 +35,18 @@ spec:
         name: multus
     spec:
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: '{{ Registry "docker.io" }}/nfvpe/multus:v3.6'
+        image: '{{ Registry "ghcr.io" }}/k8snetworkplumbingwg/multus-cni:v3.8.1'
         command: ["/entrypoint.sh"]
         args:
-        - "--multus-conf-file=/tmp/multus-conf/00-multus.conflist"
+        - "--multus-conf-file=auto"
         - "--cni-version=0.3.1"
         resources:
           requests:
@@ -62,8 +62,23 @@ spec:
           mountPath: /host/etc/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
-        - name: multus-cfg
-          mountPath: /tmp/multus-conf
+      initContainers:
+        - name: install-multus-binary
+          image: '{{ Registry "ghcr.io" }}/k8snetworkplumbingwg/multus-cni:v3.8.1'
+          command:
+            - "cp"
+            - "/usr/src/multus-cni/bin/multus"
+            - "/host/opt/cni/bin/multus"
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "15Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
@@ -72,9 +87,3 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
-        - name: multus-cfg
-          configMap:
-            name: multus-cni-config
-            items:
-            - key: cni-conf.json
-              path: 00-multus.conflist


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Updates Multus addon in KKP and makes it more usable by enabling Multus auto-configuration.
This makes Multus usable with Canal CNI in KKP. Multus compatibility with CIlium CNI will be solved in a separate PR.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8897 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Multus to v3.8.1, enable Multus auto-configuration.
```
