### PR TITLE
Do not reference Nutanix cluster in API path and fix subnet filtering by project name

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17304,7 +17304,7 @@
         }
       }
     },
-    "/api/v2/providers/nutanix/{dc}/{cluster_name}/subnets": {
+    "/api/v2/providers/nutanix/{dc}/subnets": {
       "get": {
         "description": "List subnets from Nutanix",
         "produces": [

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17213,12 +17213,12 @@
           },
           {
             "type": "string",
-            "name": "Username",
+            "name": "NutanixUsername",
             "in": "header"
           },
           {
             "type": "string",
-            "name": "Password",
+            "name": "NutanixPassword",
             "in": "header"
           },
           {
@@ -17269,12 +17269,12 @@
           },
           {
             "type": "string",
-            "name": "Username",
+            "name": "NutanixUsername",
             "in": "header"
           },
           {
             "type": "string",
-            "name": "Password",
+            "name": "NutanixPassword",
             "in": "header"
           },
           {
@@ -17325,12 +17325,12 @@
           },
           {
             "type": "string",
-            "name": "Username",
+            "name": "NutanixUsername",
             "in": "header"
           },
           {
             "type": "string",
-            "name": "Password",
+            "name": "NutanixPassword",
             "in": "header"
           },
           {
@@ -17345,17 +17345,15 @@
           },
           {
             "type": "string",
-            "x-go-name": "ClusterName",
-            "name": "cluster_name",
-            "in": "path",
+            "name": "NutanixCluster",
+            "in": "header",
             "required": true
           },
           {
             "type": "string",
-            "x-go-name": "ProjectName",
             "description": "Project query parameter. Can be omitted to query subnets without project scope",
-            "name": "project_name",
-            "in": "query"
+            "name": "NutanixProject",
+            "in": "header"
           }
         ],
         "responses": {

--- a/pkg/handler/v2/provider/nutanix.go
+++ b/pkg/handler/v2/provider/nutanix.go
@@ -260,7 +260,7 @@ func NutanixSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credential := preset.Spec.Nutanix; credential != nil {
-				//creds.ProxyURL = credential.ProxyURL
+				creds.ProxyURL = credential.ProxyURL
 				creds.Username = credential.Username
 				creds.Password = credential.Password
 				cluster = credential.ClusterName

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -622,7 +622,7 @@ func (r Routing) RegisterV2(mux *mux.Router, metrics common.ServerMetrics) {
 		Handler(r.listNutanixProjects())
 
 	mux.Methods(http.MethodGet).
-		Path("/providers/nutanix/{dc}/{cluster_name}/subnets").
+		Path("/providers/nutanix/{dc}/subnets").
 		Handler(r.listNutanixSubnets())
 
 	// Define a set of endpoints for preset management

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -3861,7 +3861,7 @@ func (r Routing) listNutanixProjects() http.Handler {
 	)
 }
 
-// swagger:route GET /api/v2/providers/nutanix/{dc}/{cluster_name}/subnets nutanix listNutanixSubnets
+// swagger:route GET /api/v2/providers/nutanix/{dc}/subnets nutanix listNutanixSubnets
 //
 // List subnets from Nutanix
 //

--- a/pkg/provider/cloud/nutanix/api.go
+++ b/pkg/provider/cloud/nutanix/api.go
@@ -17,7 +17,6 @@ limitations under the License.
 package nutanix
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_clusters_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_clusters_parameters.go
@@ -62,14 +62,14 @@ type ListNutanixClustersParams struct {
 	// Credential.
 	Credential *string
 
-	// Password.
-	Password *string
+	// NutanixPassword.
+	NutanixPassword *string
+
+	// NutanixUsername.
+	NutanixUsername *string
 
 	// ProxyURL.
 	ProxyURL *string
-
-	// Username.
-	Username *string
 
 	/* Dc.
 
@@ -141,15 +141,26 @@ func (o *ListNutanixClustersParams) SetCredential(credential *string) {
 	o.Credential = credential
 }
 
-// WithPassword adds the password to the list nutanix clusters params
-func (o *ListNutanixClustersParams) WithPassword(password *string) *ListNutanixClustersParams {
-	o.SetPassword(password)
+// WithNutanixPassword adds the nutanixPassword to the list nutanix clusters params
+func (o *ListNutanixClustersParams) WithNutanixPassword(nutanixPassword *string) *ListNutanixClustersParams {
+	o.SetNutanixPassword(nutanixPassword)
 	return o
 }
 
-// SetPassword adds the password to the list nutanix clusters params
-func (o *ListNutanixClustersParams) SetPassword(password *string) {
-	o.Password = password
+// SetNutanixPassword adds the nutanixPassword to the list nutanix clusters params
+func (o *ListNutanixClustersParams) SetNutanixPassword(nutanixPassword *string) {
+	o.NutanixPassword = nutanixPassword
+}
+
+// WithNutanixUsername adds the nutanixUsername to the list nutanix clusters params
+func (o *ListNutanixClustersParams) WithNutanixUsername(nutanixUsername *string) *ListNutanixClustersParams {
+	o.SetNutanixUsername(nutanixUsername)
+	return o
+}
+
+// SetNutanixUsername adds the nutanixUsername to the list nutanix clusters params
+func (o *ListNutanixClustersParams) SetNutanixUsername(nutanixUsername *string) {
+	o.NutanixUsername = nutanixUsername
 }
 
 // WithProxyURL adds the proxyURL to the list nutanix clusters params
@@ -161,17 +172,6 @@ func (o *ListNutanixClustersParams) WithProxyURL(proxyURL *string) *ListNutanixC
 // SetProxyURL adds the proxyUrl to the list nutanix clusters params
 func (o *ListNutanixClustersParams) SetProxyURL(proxyURL *string) {
 	o.ProxyURL = proxyURL
-}
-
-// WithUsername adds the username to the list nutanix clusters params
-func (o *ListNutanixClustersParams) WithUsername(username *string) *ListNutanixClustersParams {
-	o.SetUsername(username)
-	return o
-}
-
-// SetUsername adds the username to the list nutanix clusters params
-func (o *ListNutanixClustersParams) SetUsername(username *string) {
-	o.Username = username
 }
 
 // WithDC adds the dc to the list nutanix clusters params
@@ -201,10 +201,18 @@ func (o *ListNutanixClustersParams) WriteToRequest(r runtime.ClientRequest, reg 
 		}
 	}
 
-	if o.Password != nil {
+	if o.NutanixPassword != nil {
 
-		// header param Password
-		if err := r.SetHeaderParam("Password", *o.Password); err != nil {
+		// header param NutanixPassword
+		if err := r.SetHeaderParam("NutanixPassword", *o.NutanixPassword); err != nil {
+			return err
+		}
+	}
+
+	if o.NutanixUsername != nil {
+
+		// header param NutanixUsername
+		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
 			return err
 		}
 	}
@@ -213,14 +221,6 @@ func (o *ListNutanixClustersParams) WriteToRequest(r runtime.ClientRequest, reg 
 
 		// header param ProxyURL
 		if err := r.SetHeaderParam("ProxyURL", *o.ProxyURL); err != nil {
-			return err
-		}
-	}
-
-	if o.Username != nil {
-
-		// header param Username
-		if err := r.SetHeaderParam("Username", *o.Username); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_projects_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_projects_parameters.go
@@ -62,14 +62,14 @@ type ListNutanixProjectsParams struct {
 	// Credential.
 	Credential *string
 
-	// Password.
-	Password *string
+	// NutanixPassword.
+	NutanixPassword *string
+
+	// NutanixUsername.
+	NutanixUsername *string
 
 	// ProxyURL.
 	ProxyURL *string
-
-	// Username.
-	Username *string
 
 	/* Dc.
 
@@ -141,15 +141,26 @@ func (o *ListNutanixProjectsParams) SetCredential(credential *string) {
 	o.Credential = credential
 }
 
-// WithPassword adds the password to the list nutanix projects params
-func (o *ListNutanixProjectsParams) WithPassword(password *string) *ListNutanixProjectsParams {
-	o.SetPassword(password)
+// WithNutanixPassword adds the nutanixPassword to the list nutanix projects params
+func (o *ListNutanixProjectsParams) WithNutanixPassword(nutanixPassword *string) *ListNutanixProjectsParams {
+	o.SetNutanixPassword(nutanixPassword)
 	return o
 }
 
-// SetPassword adds the password to the list nutanix projects params
-func (o *ListNutanixProjectsParams) SetPassword(password *string) {
-	o.Password = password
+// SetNutanixPassword adds the nutanixPassword to the list nutanix projects params
+func (o *ListNutanixProjectsParams) SetNutanixPassword(nutanixPassword *string) {
+	o.NutanixPassword = nutanixPassword
+}
+
+// WithNutanixUsername adds the nutanixUsername to the list nutanix projects params
+func (o *ListNutanixProjectsParams) WithNutanixUsername(nutanixUsername *string) *ListNutanixProjectsParams {
+	o.SetNutanixUsername(nutanixUsername)
+	return o
+}
+
+// SetNutanixUsername adds the nutanixUsername to the list nutanix projects params
+func (o *ListNutanixProjectsParams) SetNutanixUsername(nutanixUsername *string) {
+	o.NutanixUsername = nutanixUsername
 }
 
 // WithProxyURL adds the proxyURL to the list nutanix projects params
@@ -161,17 +172,6 @@ func (o *ListNutanixProjectsParams) WithProxyURL(proxyURL *string) *ListNutanixP
 // SetProxyURL adds the proxyUrl to the list nutanix projects params
 func (o *ListNutanixProjectsParams) SetProxyURL(proxyURL *string) {
 	o.ProxyURL = proxyURL
-}
-
-// WithUsername adds the username to the list nutanix projects params
-func (o *ListNutanixProjectsParams) WithUsername(username *string) *ListNutanixProjectsParams {
-	o.SetUsername(username)
-	return o
-}
-
-// SetUsername adds the username to the list nutanix projects params
-func (o *ListNutanixProjectsParams) SetUsername(username *string) {
-	o.Username = username
 }
 
 // WithDC adds the dc to the list nutanix projects params
@@ -201,10 +201,18 @@ func (o *ListNutanixProjectsParams) WriteToRequest(r runtime.ClientRequest, reg 
 		}
 	}
 
-	if o.Password != nil {
+	if o.NutanixPassword != nil {
 
-		// header param Password
-		if err := r.SetHeaderParam("Password", *o.Password); err != nil {
+		// header param NutanixPassword
+		if err := r.SetHeaderParam("NutanixPassword", *o.NutanixPassword); err != nil {
+			return err
+		}
+	}
+
+	if o.NutanixUsername != nil {
+
+		// header param NutanixUsername
+		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
 			return err
 		}
 	}
@@ -213,14 +221,6 @@ func (o *ListNutanixProjectsParams) WriteToRequest(r runtime.ClientRequest, reg 
 
 		// header param ProxyURL
 		if err := r.SetHeaderParam("ProxyURL", *o.ProxyURL); err != nil {
-			return err
-		}
-	}
-
-	if o.Username != nil {
-
-		// header param Username
-		if err := r.SetHeaderParam("Username", *o.Username); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_subnets_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_subnets_parameters.go
@@ -62,29 +62,29 @@ type ListNutanixSubnetsParams struct {
 	// Credential.
 	Credential *string
 
-	// Password.
-	Password *string
+	// NutanixCluster.
+	NutanixCluster string
+
+	// NutanixPassword.
+	NutanixPassword *string
+
+	/* NutanixProject.
+
+	   Project query parameter. Can be omitted to query subnets without project scope
+	*/
+	NutanixProject *string
+
+	// NutanixUsername.
+	NutanixUsername *string
 
 	// ProxyURL.
 	ProxyURL *string
-
-	// Username.
-	Username *string
-
-	// ClusterName.
-	ClusterName string
 
 	/* Dc.
 
 	   KKP Datacenter to use for endpoint
 	*/
 	DC string
-
-	/* ProjectName.
-
-	   Project query parameter. Can be omitted to query subnets without project scope
-	*/
-	ProjectName *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -150,15 +150,48 @@ func (o *ListNutanixSubnetsParams) SetCredential(credential *string) {
 	o.Credential = credential
 }
 
-// WithPassword adds the password to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) WithPassword(password *string) *ListNutanixSubnetsParams {
-	o.SetPassword(password)
+// WithNutanixCluster adds the nutanixCluster to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) WithNutanixCluster(nutanixCluster string) *ListNutanixSubnetsParams {
+	o.SetNutanixCluster(nutanixCluster)
 	return o
 }
 
-// SetPassword adds the password to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) SetPassword(password *string) {
-	o.Password = password
+// SetNutanixCluster adds the nutanixCluster to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) SetNutanixCluster(nutanixCluster string) {
+	o.NutanixCluster = nutanixCluster
+}
+
+// WithNutanixPassword adds the nutanixPassword to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) WithNutanixPassword(nutanixPassword *string) *ListNutanixSubnetsParams {
+	o.SetNutanixPassword(nutanixPassword)
+	return o
+}
+
+// SetNutanixPassword adds the nutanixPassword to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) SetNutanixPassword(nutanixPassword *string) {
+	o.NutanixPassword = nutanixPassword
+}
+
+// WithNutanixProject adds the nutanixProject to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) WithNutanixProject(nutanixProject *string) *ListNutanixSubnetsParams {
+	o.SetNutanixProject(nutanixProject)
+	return o
+}
+
+// SetNutanixProject adds the nutanixProject to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) SetNutanixProject(nutanixProject *string) {
+	o.NutanixProject = nutanixProject
+}
+
+// WithNutanixUsername adds the nutanixUsername to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) WithNutanixUsername(nutanixUsername *string) *ListNutanixSubnetsParams {
+	o.SetNutanixUsername(nutanixUsername)
+	return o
+}
+
+// SetNutanixUsername adds the nutanixUsername to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) SetNutanixUsername(nutanixUsername *string) {
+	o.NutanixUsername = nutanixUsername
 }
 
 // WithProxyURL adds the proxyURL to the list nutanix subnets params
@@ -172,28 +205,6 @@ func (o *ListNutanixSubnetsParams) SetProxyURL(proxyURL *string) {
 	o.ProxyURL = proxyURL
 }
 
-// WithUsername adds the username to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) WithUsername(username *string) *ListNutanixSubnetsParams {
-	o.SetUsername(username)
-	return o
-}
-
-// SetUsername adds the username to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) SetUsername(username *string) {
-	o.Username = username
-}
-
-// WithClusterName adds the clusterName to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) WithClusterName(clusterName string) *ListNutanixSubnetsParams {
-	o.SetClusterName(clusterName)
-	return o
-}
-
-// SetClusterName adds the clusterName to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) SetClusterName(clusterName string) {
-	o.ClusterName = clusterName
-}
-
 // WithDC adds the dc to the list nutanix subnets params
 func (o *ListNutanixSubnetsParams) WithDC(dc string) *ListNutanixSubnetsParams {
 	o.SetDC(dc)
@@ -203,17 +214,6 @@ func (o *ListNutanixSubnetsParams) WithDC(dc string) *ListNutanixSubnetsParams {
 // SetDC adds the dc to the list nutanix subnets params
 func (o *ListNutanixSubnetsParams) SetDC(dc string) {
 	o.DC = dc
-}
-
-// WithProjectName adds the projectName to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) WithProjectName(projectName *string) *ListNutanixSubnetsParams {
-	o.SetProjectName(projectName)
-	return o
-}
-
-// SetProjectName adds the projectName to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) SetProjectName(projectName *string) {
-	o.ProjectName = projectName
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -232,10 +232,31 @@ func (o *ListNutanixSubnetsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		}
 	}
 
-	if o.Password != nil {
+	// header param NutanixCluster
+	if err := r.SetHeaderParam("NutanixCluster", o.NutanixCluster); err != nil {
+		return err
+	}
 
-		// header param Password
-		if err := r.SetHeaderParam("Password", *o.Password); err != nil {
+	if o.NutanixPassword != nil {
+
+		// header param NutanixPassword
+		if err := r.SetHeaderParam("NutanixPassword", *o.NutanixPassword); err != nil {
+			return err
+		}
+	}
+
+	if o.NutanixProject != nil {
+
+		// header param NutanixProject
+		if err := r.SetHeaderParam("NutanixProject", *o.NutanixProject); err != nil {
+			return err
+		}
+	}
+
+	if o.NutanixUsername != nil {
+
+		// header param NutanixUsername
+		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
 			return err
 		}
 	}
@@ -248,39 +269,9 @@ func (o *ListNutanixSubnetsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		}
 	}
 
-	if o.Username != nil {
-
-		// header param Username
-		if err := r.SetHeaderParam("Username", *o.Username); err != nil {
-			return err
-		}
-	}
-
-	// path param cluster_name
-	if err := r.SetPathParam("cluster_name", o.ClusterName); err != nil {
-		return err
-	}
-
 	// path param dc
 	if err := r.SetPathParam("dc", o.DC); err != nil {
 		return err
-	}
-
-	if o.ProjectName != nil {
-
-		// query param project_name
-		var qrProjectName string
-
-		if o.ProjectName != nil {
-			qrProjectName = *o.ProjectName
-		}
-		qProjectName := qrProjectName
-		if qProjectName != "" {
-
-			if err := r.SetQueryParam("project_name", qProjectName); err != nil {
-				return err
-			}
-		}
 	}
 
 	if len(res) > 0 {

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_subnets_responses.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_subnets_responses.go
@@ -55,7 +55,7 @@ type ListNutanixSubnetsOK struct {
 }
 
 func (o *ListNutanixSubnetsOK) Error() string {
-	return fmt.Sprintf("[GET /api/v2/providers/nutanix/{dc}/{cluster_name}/subnets][%d] listNutanixSubnetsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /api/v2/providers/nutanix/{dc}/subnets][%d] listNutanixSubnetsOK  %+v", 200, o.Payload)
 }
 func (o *ListNutanixSubnetsOK) GetPayload() models.NutanixSubnetList {
 	return o.Payload
@@ -94,7 +94,7 @@ func (o *ListNutanixSubnetsDefault) Code() int {
 }
 
 func (o *ListNutanixSubnetsDefault) Error() string {
-	return fmt.Sprintf("[GET /api/v2/providers/nutanix/{dc}/{cluster_name}/subnets][%d] listNutanixSubnets default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /api/v2/providers/nutanix/{dc}/subnets][%d] listNutanixSubnets default  %+v", o._statusCode, o.Payload)
 }
 func (o *ListNutanixSubnetsDefault) GetPayload() *models.ErrorResponse {
 	return o.Payload

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/nutanix_client.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/nutanix_client.go
@@ -126,7 +126,7 @@ func (a *Client) ListNutanixSubnets(params *ListNutanixSubnetsParams, authInfo r
 	op := &runtime.ClientOperation{
 		ID:                 "listNutanixSubnets",
 		Method:             "GET",
-		PathPattern:        "/api/v2/providers/nutanix/{dc}/{cluster_name}/subnets",
+		PathPattern:        "/api/v2/providers/nutanix/{dc}/subnets",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

This adjusts the KKP API endpoints for Nutanix to feedback from @maciaszczykm. It also fixes the filtering by project name, which was incorrectly using the project reference that a subnet is created in (I'm not even sure that is possible).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not reference Nutanix cluster in KKP API endpoint path for subnets
```
