### PR TITLE
Use correct header 'NutanixProxyURL' for swagger generation

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17318,7 +17318,7 @@
           },
           {
             "type": "string",
-            "name": "ProxyURL",
+            "name": "NutanixProxyURL",
             "in": "header"
           },
           {
@@ -17374,7 +17374,7 @@
           },
           {
             "type": "string",
-            "name": "ProxyURL",
+            "name": "NutanixProxyURL",
             "in": "header"
           },
           {
@@ -17430,7 +17430,7 @@
           },
           {
             "type": "string",
-            "name": "ProxyURL",
+            "name": "NutanixProxyURL",
             "in": "header"
           },
           {

--- a/pkg/handler/v2/provider/nutanix.go
+++ b/pkg/handler/v2/provider/nutanix.go
@@ -46,8 +46,8 @@ type NutanixCommonReq struct {
 	NutanixPassword string
 
 	// in: header
-	// name: ProxyURL
-	ProxyURL string
+	// name: NutanixProxyURL
+	NutanixProxyURL string
 
 	// in: header
 	// name: Credential
@@ -93,7 +93,7 @@ func DecodeNutanixCommonReq(c context.Context, r *http.Request) (interface{}, er
 
 	req.NutanixUsername = r.Header.Get("NutanixUsername")
 	req.NutanixPassword = r.Header.Get("NutanixPassword")
-	req.ProxyURL = r.Header.Get("NutanixProxyURL")
+	req.NutanixProxyURL = r.Header.Get("NutanixProxyURL")
 	req.Credential = r.Header.Get("Credential")
 
 	dc, ok := mux.Vars(r)["dc"]
@@ -143,7 +143,7 @@ func NutanixClusterEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 		req := request.(NutanixCommonReq)
 
 		creds := providercommon.NutanixCredentials{
-			ProxyURL: req.ProxyURL,
+			ProxyURL: req.NutanixProxyURL,
 			Username: req.NutanixUsername,
 			Password: req.NutanixPassword,
 		}
@@ -192,7 +192,7 @@ func NutanixProjectEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 		req := request.(NutanixCommonReq)
 
 		creds := providercommon.NutanixCredentials{
-			ProxyURL: req.ProxyURL,
+			ProxyURL: req.NutanixProxyURL,
 			Username: req.NutanixUsername,
 			Password: req.NutanixPassword,
 		}
@@ -241,7 +241,7 @@ func NutanixSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 		req := request.(NutanixSubnetReq)
 
 		creds := providercommon.NutanixCredentials{
-			ProxyURL: req.ProxyURL,
+			ProxyURL: req.NutanixProxyURL,
 			Username: req.NutanixUsername,
 			Password: req.NutanixPassword,
 		}

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_clusters_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_clusters_parameters.go
@@ -65,11 +65,11 @@ type ListNutanixClustersParams struct {
 	// NutanixPassword.
 	NutanixPassword *string
 
+	// NutanixProxyURL.
+	NutanixProxyURL *string
+
 	// NutanixUsername.
 	NutanixUsername *string
-
-	// ProxyURL.
-	ProxyURL *string
 
 	/* Dc.
 
@@ -152,6 +152,17 @@ func (o *ListNutanixClustersParams) SetNutanixPassword(nutanixPassword *string) 
 	o.NutanixPassword = nutanixPassword
 }
 
+// WithNutanixProxyURL adds the nutanixProxyURL to the list nutanix clusters params
+func (o *ListNutanixClustersParams) WithNutanixProxyURL(nutanixProxyURL *string) *ListNutanixClustersParams {
+	o.SetNutanixProxyURL(nutanixProxyURL)
+	return o
+}
+
+// SetNutanixProxyURL adds the nutanixProxyUrl to the list nutanix clusters params
+func (o *ListNutanixClustersParams) SetNutanixProxyURL(nutanixProxyURL *string) {
+	o.NutanixProxyURL = nutanixProxyURL
+}
+
 // WithNutanixUsername adds the nutanixUsername to the list nutanix clusters params
 func (o *ListNutanixClustersParams) WithNutanixUsername(nutanixUsername *string) *ListNutanixClustersParams {
 	o.SetNutanixUsername(nutanixUsername)
@@ -161,17 +172,6 @@ func (o *ListNutanixClustersParams) WithNutanixUsername(nutanixUsername *string)
 // SetNutanixUsername adds the nutanixUsername to the list nutanix clusters params
 func (o *ListNutanixClustersParams) SetNutanixUsername(nutanixUsername *string) {
 	o.NutanixUsername = nutanixUsername
-}
-
-// WithProxyURL adds the proxyURL to the list nutanix clusters params
-func (o *ListNutanixClustersParams) WithProxyURL(proxyURL *string) *ListNutanixClustersParams {
-	o.SetProxyURL(proxyURL)
-	return o
-}
-
-// SetProxyURL adds the proxyUrl to the list nutanix clusters params
-func (o *ListNutanixClustersParams) SetProxyURL(proxyURL *string) {
-	o.ProxyURL = proxyURL
 }
 
 // WithDC adds the dc to the list nutanix clusters params
@@ -209,18 +209,18 @@ func (o *ListNutanixClustersParams) WriteToRequest(r runtime.ClientRequest, reg 
 		}
 	}
 
-	if o.NutanixUsername != nil {
+	if o.NutanixProxyURL != nil {
 
-		// header param NutanixUsername
-		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
+		// header param NutanixProxyURL
+		if err := r.SetHeaderParam("NutanixProxyURL", *o.NutanixProxyURL); err != nil {
 			return err
 		}
 	}
 
-	if o.ProxyURL != nil {
+	if o.NutanixUsername != nil {
 
-		// header param ProxyURL
-		if err := r.SetHeaderParam("ProxyURL", *o.ProxyURL); err != nil {
+		// header param NutanixUsername
+		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_projects_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_projects_parameters.go
@@ -65,11 +65,11 @@ type ListNutanixProjectsParams struct {
 	// NutanixPassword.
 	NutanixPassword *string
 
+	// NutanixProxyURL.
+	NutanixProxyURL *string
+
 	// NutanixUsername.
 	NutanixUsername *string
-
-	// ProxyURL.
-	ProxyURL *string
 
 	/* Dc.
 
@@ -152,6 +152,17 @@ func (o *ListNutanixProjectsParams) SetNutanixPassword(nutanixPassword *string) 
 	o.NutanixPassword = nutanixPassword
 }
 
+// WithNutanixProxyURL adds the nutanixProxyURL to the list nutanix projects params
+func (o *ListNutanixProjectsParams) WithNutanixProxyURL(nutanixProxyURL *string) *ListNutanixProjectsParams {
+	o.SetNutanixProxyURL(nutanixProxyURL)
+	return o
+}
+
+// SetNutanixProxyURL adds the nutanixProxyUrl to the list nutanix projects params
+func (o *ListNutanixProjectsParams) SetNutanixProxyURL(nutanixProxyURL *string) {
+	o.NutanixProxyURL = nutanixProxyURL
+}
+
 // WithNutanixUsername adds the nutanixUsername to the list nutanix projects params
 func (o *ListNutanixProjectsParams) WithNutanixUsername(nutanixUsername *string) *ListNutanixProjectsParams {
 	o.SetNutanixUsername(nutanixUsername)
@@ -161,17 +172,6 @@ func (o *ListNutanixProjectsParams) WithNutanixUsername(nutanixUsername *string)
 // SetNutanixUsername adds the nutanixUsername to the list nutanix projects params
 func (o *ListNutanixProjectsParams) SetNutanixUsername(nutanixUsername *string) {
 	o.NutanixUsername = nutanixUsername
-}
-
-// WithProxyURL adds the proxyURL to the list nutanix projects params
-func (o *ListNutanixProjectsParams) WithProxyURL(proxyURL *string) *ListNutanixProjectsParams {
-	o.SetProxyURL(proxyURL)
-	return o
-}
-
-// SetProxyURL adds the proxyUrl to the list nutanix projects params
-func (o *ListNutanixProjectsParams) SetProxyURL(proxyURL *string) {
-	o.ProxyURL = proxyURL
 }
 
 // WithDC adds the dc to the list nutanix projects params
@@ -209,18 +209,18 @@ func (o *ListNutanixProjectsParams) WriteToRequest(r runtime.ClientRequest, reg 
 		}
 	}
 
-	if o.NutanixUsername != nil {
+	if o.NutanixProxyURL != nil {
 
-		// header param NutanixUsername
-		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
+		// header param NutanixProxyURL
+		if err := r.SetHeaderParam("NutanixProxyURL", *o.NutanixProxyURL); err != nil {
 			return err
 		}
 	}
 
-	if o.ProxyURL != nil {
+	if o.NutanixUsername != nil {
 
-		// header param ProxyURL
-		if err := r.SetHeaderParam("ProxyURL", *o.ProxyURL); err != nil {
+		// header param NutanixUsername
+		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_subnets_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/nutanix/list_nutanix_subnets_parameters.go
@@ -74,11 +74,11 @@ type ListNutanixSubnetsParams struct {
 	*/
 	NutanixProject *string
 
+	// NutanixProxyURL.
+	NutanixProxyURL *string
+
 	// NutanixUsername.
 	NutanixUsername *string
-
-	// ProxyURL.
-	ProxyURL *string
 
 	/* Dc.
 
@@ -183,6 +183,17 @@ func (o *ListNutanixSubnetsParams) SetNutanixProject(nutanixProject *string) {
 	o.NutanixProject = nutanixProject
 }
 
+// WithNutanixProxyURL adds the nutanixProxyURL to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) WithNutanixProxyURL(nutanixProxyURL *string) *ListNutanixSubnetsParams {
+	o.SetNutanixProxyURL(nutanixProxyURL)
+	return o
+}
+
+// SetNutanixProxyURL adds the nutanixProxyUrl to the list nutanix subnets params
+func (o *ListNutanixSubnetsParams) SetNutanixProxyURL(nutanixProxyURL *string) {
+	o.NutanixProxyURL = nutanixProxyURL
+}
+
 // WithNutanixUsername adds the nutanixUsername to the list nutanix subnets params
 func (o *ListNutanixSubnetsParams) WithNutanixUsername(nutanixUsername *string) *ListNutanixSubnetsParams {
 	o.SetNutanixUsername(nutanixUsername)
@@ -192,17 +203,6 @@ func (o *ListNutanixSubnetsParams) WithNutanixUsername(nutanixUsername *string) 
 // SetNutanixUsername adds the nutanixUsername to the list nutanix subnets params
 func (o *ListNutanixSubnetsParams) SetNutanixUsername(nutanixUsername *string) {
 	o.NutanixUsername = nutanixUsername
-}
-
-// WithProxyURL adds the proxyURL to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) WithProxyURL(proxyURL *string) *ListNutanixSubnetsParams {
-	o.SetProxyURL(proxyURL)
-	return o
-}
-
-// SetProxyURL adds the proxyUrl to the list nutanix subnets params
-func (o *ListNutanixSubnetsParams) SetProxyURL(proxyURL *string) {
-	o.ProxyURL = proxyURL
 }
 
 // WithDC adds the dc to the list nutanix subnets params
@@ -253,18 +253,18 @@ func (o *ListNutanixSubnetsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		}
 	}
 
-	if o.NutanixUsername != nil {
+	if o.NutanixProxyURL != nil {
 
-		// header param NutanixUsername
-		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
+		// header param NutanixProxyURL
+		if err := r.SetHeaderParam("NutanixProxyURL", *o.NutanixProxyURL); err != nil {
 			return err
 		}
 	}
 
-	if o.ProxyURL != nil {
+	if o.NutanixUsername != nil {
 
-		// header param ProxyURL
-		if err := r.SetHeaderParam("ProxyURL", *o.ProxyURL); err != nil {
+		// header param NutanixUsername
+		if err := r.SetHeaderParam("NutanixUsername", *o.NutanixUsername); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The code was reading the `NutanixProxyURL` header, but swagger was advertising `ProxyURL`. This PR fixes the swagger definition and use `NutanixProxyURL` too.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
