### PR TITLE
Make Cilium non-exclusive CNI for compatibility with Multus

### DIFF
--- a/addons/cilium/cilium.yaml
+++ b/addons/cilium/cilium.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Generated from:
-#   helm template cilium cilium/cilium --version 1.11.0 --namespace kube-system --set operator.replicas=1 \
+#   helm template cilium cilium/cilium --version 1.11.0 --namespace kube-system --set cni.exclusive=false --set operator.replicas=1 \
 #     --set hubble.tls.auto.method=cronJob --set hubble.relay.enabled=true --set hubble.ui.enabled=true \
 #     --set kubeProxyReplacement=strict --set k8sServiceHost=CHANGEME --set k8sServicePort=CHANGEME
 #
@@ -558,7 +558,7 @@ spec:
               command:
               - "/cni-install.sh"
               - "--enable-debug=false"
-              - "--cni-exclusive=true"
+              - "--cni-exclusive=false"
           preStop:
             exec:
               command:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR makes Multus compatible with Cilium by running Cilium as a non-exclusive CNI, which means it will NOT remove `/etc/cni/net.d` cofig files of other CNIs upon each Cilium pod (re)start.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8898 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make Cilium non-exclusive CNI for compatibility with Multus.
```
