### PR TITLE
Increase metering image version

### DIFF
--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -198,7 +198,7 @@ mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
 						"-c",
 						`mc config host add s3 $S3_ENDPOINT $ACCESS_KEY_ID $SECRET_ACCESS_KEY
 mc mb --ignore-existing s3/$S3_BUCKET
-while true; do mc mirror --overwrite /metering-data s3/$S3_BUCKET; sleep 300; done`,
+while true; do mc mirror --overwrite /metering-data s3/$S3_BUCKET || exit 1; sleep 300; done`,
 					},
 					Image:           getMinioImage(getRegistry),
 					ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -42,7 +42,7 @@ import (
 )
 
 func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v0.6"
+	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v0.7"
 }
 
 func getMinioImage(overwriter registry.WithOverwriteFunc) string {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Update metering image version to include changes to API groups for KKP 2.20 (https://github.com/kubermatic/metering/pull/89).
Also exit metering minio containers if the mirror fails, so that errors don't go unnoticed (https://github.com/kubermatic/metering/issues/85). This has already been changed in the helm chart (https://github.com/kubermatic/metering/pull/88).

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
