### PR TITLE
Set constraint parameters to schemaless

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.5.2
+version: 0.5.3
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
@@ -182,12 +182,6 @@ spec:
                     type: string
                 type: object
               parameters:
-                additionalProperties:
-                  description: RawMessage is a raw encoded JSON value. It implements
-                    Marshaler and Unmarshaler and can be used to delay JSON decoding
-                    or precompute a JSON encoding.
-                  format: byte
-                  type: string
                 description: "Parameters specifies the parameters used by the constraint
                   template REGO. It supports both the legacy rawJSON parameters, in
                   which all the parameters are set in a JSON string, and regular parameters
@@ -195,7 +189,7 @@ spec:
                   syncing to the user cluster, the other parameters are ignored Example
                   with rawJSON parameters: \n parameters:   rawJSON: '{\"labels\":[\"gatekeeper\"]}'
                   \n And with regular parameters: \n parameters:   labels: [\"gatekeeper\"]"
-                type: object
+                x-kubernetes-preserve-unknown-fields: true
               selector:
                 description: Selector specifies the cluster selection filters
                 properties:

--- a/pkg/apis/kubermatic/v1/constraint.go
+++ b/pkg/apis/kubermatic/v1/constraint.go
@@ -51,9 +51,6 @@ type ConstraintSpec struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// Match contains the constraint to resource matching data
 	Match Match `json:"match,omitempty"`
-	// +kubebuilder:validation:Schemaless
-	// +kubebuilder:pruning:PreserveUnknownFields
-	//
 	// Parameters specifies the parameters used by the constraint template REGO.
 	// It supports both the legacy rawJSON parameters, in which all the parameters are set in a JSON string, and regular
 	// parameters like in Gatekeeper Constraints.
@@ -68,6 +65,8 @@ type ConstraintSpec struct {
 	// parameters:
 	//   labels: ["gatekeeper"]
 	//
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Parameters Parameters `json:"parameters,omitempty"`
 	// Selector specifies the cluster selection filters
 	Selector ConstraintSelector `json:"selector,omitempty"`

--- a/pkg/apis/kubermatic/v1/constraint.go
+++ b/pkg/apis/kubermatic/v1/constraint.go
@@ -51,6 +51,9 @@ type ConstraintSpec struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// Match contains the constraint to resource matching data
 	Match Match `json:"match,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	//
 	// Parameters specifies the parameters used by the constraint template REGO.
 	// It supports both the legacy rawJSON parameters, in which all the parameters are set in a JSON string, and regular
 	// parameters like in Gatekeeper Constraints.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Makes Constraint Parameters schemaless as it can in reality be many different types, depending on the Constraint Template.


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
