### PR TITLE
Only clean up Nutanix project category value if no resources present

### DIFF
--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -179,6 +179,10 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 				},
 			})
 
+			if err != nil {
+				return err
+			}
+
 			// no results mean it is safe to clean up this category value.
 			if len(query.Results) == 0 {
 				if err = client.Prism.V3.DeleteCategoryValue(ProjectCategoryName, projectID); err != nil {

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -164,8 +164,42 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 			if nutanixError.Code != http.StatusNotFound {
 				return err
 			}
-		} else if err = client.Prism.V3.DeleteCategoryValue(ProjectCategoryName, projectID); err != nil {
-			return err
+		} else {
+			// we need to make sure that no resources are attached
+			// to the project category before trying to delete it.
+			query, err := client.Prism.V3.GetCategoryQuery(&nutanixv3.CategoryQueryInput{
+				UsageType:        pointer.String("APPLIED_TO"),
+				GroupMemberCount: pointer.Int64(0),
+				CategoryFilter: &nutanixv3.CategoryFilter{
+					Type:     pointer.String("CATEGORIES_MATCH_ANY"),
+					KindList: []*string{},
+					Params: map[string][]string{
+						ProjectCategoryName: {projectID},
+					},
+				},
+			})
+
+			// no results mean it is safe to clean up this category value.
+			if len(query.Results) == 0 {
+				if err = client.Prism.V3.DeleteCategoryValue(ProjectCategoryName, projectID); err != nil {
+					return err
+				}
+			} else {
+				// we will loop over the results and see if any of them match our category for the cluster.
+				// if we hit a matching resource, an error is returned, as there is some leftover resource.
+				// other entities not linked to our cluster are fine and can be ignored.
+				for _, result := range query.Results {
+					if result != nil {
+						for _, entity := range result.EntityAnyReferenceList {
+							if entity != nil {
+								if val, ok := entity.Categories[ClusterCategoryName]; ok && val == CategoryValue(cluster.Name) {
+									return fmt.Errorf("entities associated with category '%s=%s' still exist", ClusterCategoryName, CategoryValue(cluster.Name))
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

This improves the logic around deleting the project category value. If a second cluster is created in the same KKP project, this will cause problems as there are leftover resources. If that is the case (resources outside of our user cluster), cleanup should be skipped. If we find resources owned by this cluster in our query result, something is wrong and an error is thrown.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
