### PR TITLE
Wait for 'quorum' before checking backup in etcd-launcher restore test

### DIFF
--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -138,6 +138,8 @@ func TestBackup(t *testing.T) {
 	}
 	t.Log("restored etcd backup")
 
+	waitForQuorum(t)
+
 	// check if resource was restored
 	restoredNamespace := &corev1.Namespace{}
 	err = userClient.Get(ctx, types.NamespacedName{Name: namespaceName}, restoredNamespace)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The etcd-launcher backup/restore test was improved in #8815, so it actually checks for a resource. However, the test case is quite flaky (see job history: https://public-prow.loodse.com/job-history/gs/prow-dev-public-data/pr-logs/directory/pre-kubermatic-etcd-launcher-e2e) because the code is attempting to read the namespace too fast. That results in errors like this one:

```
etcd_test.go:145: failed to get restored test namespace: Get "https://bhqnnkhp76.kubermatic.worker.ci.k8c.io:30570/api/v1/namespaces/backup-test": dial tcp 54.194.246.235:30570: connect: connection refused
```

 I've added another `waitForQuorum(t)` call here to give the apiserver time to be up and running again.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>