### PR TITLE
Fix an issue with the websocket usage when running api locally

### DIFF
--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -40,12 +40,14 @@ limitations under the License.
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -697,4 +699,13 @@ func (rl *responseLogger) Write(data []byte) (int, error) {
 func (rl *responseLogger) WriteHeader(statusCode int) {
 	rl.statusCode = statusCode
 	rl.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (rl *responseLogger) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := rl.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("hijack not supported")
+	}
+
+	return h.Hijack()
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It was impossible to use the WebSocket when starting the API locally as by default the debug flag is set to `true` and the custom response writer did not implement the required `Hijack` method.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
