### PR TITLE
hack/ci/setup-mla.sh: Create Grafana dashboard ConfigMaps before installing Grafana

### DIFF
--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -40,8 +40,8 @@ git clone "$URL" "$tempdir"
   cd "$tempdir"
   helm --namespace mla upgrade --atomic --create-namespace --install mla-secrets charts/mla-secrets --values config/mla-secrets/values.yaml
   helm --namespace mla upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
-  helm --namespace mla upgrade --atomic --create-namespace --install grafana charts/grafana --values config/grafana/values.yaml
   kubectl apply -f dashboards/
+  helm --namespace mla upgrade --atomic --create-namespace --install grafana charts/grafana --values config/grafana/values.yaml
   kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
   helm dependency update charts/cortex # need that to store memcached in charts directory
   helm --namespace mla upgrade --atomic --create-namespace --install consul charts/consul --values config/consul/values.yaml


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

https://github.com/kubermatic/mla/commit/dcef63e068dde4fc392890d6b3ed210965ab43fd changes the dependency logic required to successfully deploy Grafana (by making the `grafana` values depend on `ConfigMaps` also living in the MLA repository), but the setup script wasn't changed to accommodate that. The `grafana` Helm release is stuck because of that:

```
Warning  FailedMount  0s (x7 over 32s)  kubelet            MountVolume.SetUp failed for volume "dashboards-kubermatic" : configmap "grafana-dashboards-kkp-kubernetes" not found
Warning  FailedMount  0s (x7 over 32s)  kubelet            MountVolume.SetUp failed for volume "dashboards-kubernetes" : configmap "grafana-dashboards-kubernetes-overview" not found
```

I guess the `hack/deploy-seed.sh` script in kubermatic/mla needs a fix as well, but this will (hopefully) fix the KKP e2e testing.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
