### PR TITLE
fix panic in installer

### DIFF
--- a/pkg/install/helm/cli_test.go
+++ b/pkg/install/helm/cli_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func TestGuessReleaseVersion(t *testing.T) {
+	testcases := []struct {
+		input           string
+		expectedVersion *semver.Version
+		expectedChart   string
+	}{
+		{
+			input:           "foo",
+			expectedVersion: nil,
+			expectedChart:   "",
+		},
+		{
+			input:           "foo-bar",
+			expectedVersion: nil,
+			expectedChart:   "",
+		},
+		{
+			input:           "foo-1.2.3",
+			expectedVersion: semver.MustParse("1.2.3"),
+			expectedChart:   "foo",
+		},
+		{
+			input:           "foo-bar-1.2.3",
+			expectedVersion: semver.MustParse("1.2.3"),
+			expectedChart:   "foo-bar",
+		},
+		{
+			input:           "foo-bar-super-long-release-name-1.2.3",
+			expectedVersion: semver.MustParse("1.2.3"),
+			expectedChart:   "foo-bar-super-long-release-name",
+		},
+		{
+			input:           "foo-bar-super-long-release-name-1.2.3-suffix-really-long",
+			expectedVersion: semver.MustParse("1.2.3-suffix-really-long"),
+			expectedChart:   "foo-bar-super-long-release-name",
+		},
+		{
+			input:           "this-is-not-a-version",
+			expectedVersion: nil,
+			expectedChart:   "",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.input, func(t *testing.T) {
+			version, chart, err := guessChartName(testcase.input)
+			if testcase.expectedVersion == nil && err == nil {
+				t.Fatalf("Expected an error, but got version %v and chart %q.", version, chart)
+			}
+			if testcase.expectedVersion != nil {
+				if !version.Equal(testcase.expectedVersion) {
+					t.Fatalf("Expected version %v, but got version %v.", testcase.expectedVersion, version)
+				}
+
+				if testcase.expectedChart != chart {
+					t.Fatalf("Expected chart %q, but got chart %q.", testcase.expectedChart, chart)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Since #8877, we have release versions like "v9.9.9-deadbeefdeadbeef". This confused the old code to parse Helm's weird and useless "chart" value, which is "<release name>-<version>", e.g. `nginx-ingress-controller-v9.9.9-e9ec91bdf64b21ba53ba36aad9ff6c09571eed71`.

This PR improves the parsing under the assumption that release name musn't always equal chart name, e.g.

```json
  {
    "name": "telemetry1",
    "namespace": "telemetry-system",
    "revision": "1",
    "updated": "2021-09-08 13:56:18.90332735 +0530 +0530",
    "status": "deployed",
    "chart": "telemetry-v0.1.3",
    "app_version": "v0.1.0"
  },
  {
    "name": "service-gw-server",
    "namespace": "monitoring-external",
    "revision": "10",
    "updated": "2021-07-14 15:36:18.761949448 +0200 CEST",
    "status": "deployed",
    "chart": "service-gateway-0.1.3",
    "app_version": "2.5.2"
  },
```

Would have been super nice of Helm if they just include the version and chart name as dedicated fields, so people wouldn't have to do string parsing, but Helm's CLI is always ...... special.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
