### PR TITLE
Use metering image with updated KKP dependencies (v2.20.0-alpha.0)

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -42,7 +42,7 @@ import (
 )
 
 func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v0.7"
+	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:6edff18"
 }
 
 func getMinioImage(overwriter registry.WithOverwriteFunc) string {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Bumping KKP dependencies in metering image to v2.20.0-alpha.0.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cherry-pick release/v2.20
/cc @xrstf
