### PR TITLE
Use new version of the Anexia Cloud Controller Manager

### DIFF
--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -63,10 +63,11 @@ func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDepl
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:0.1.0",
+					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:1.1.3-kubermatic",
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",
+						fmt.Sprintf("--cluster-name=%s", data.Cluster().Spec.HumanReadableName),
 						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 					},
 					Env: []corev1.EnvVar{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

* This PR updates the Anexia cloud controller manager to use the version 1.1.3
** Now supports service of type loadbalancer
** contains bug fixes

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia - update the cloud controller version manager (v1.1.3) to support services of type load balancer
```
