### PR TITLE
Add darwin-arm64 (M1 Macs) to release platforms

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -40,7 +40,7 @@ export GIT_TAG="${GIT_TAG:-$(git describe --tags --exact-match)}"
 export GIT_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 export GIT_HEAD="${GIT_HEAD:-$(git rev-parse HEAD)}"
 export GIT_REPO="${GIT_REPO:-kubermatic/kubermatic}"
-export RELEASE_PLATFORMS="${RELEASE_PLATFORMS:-linux-amd64 darwin-amd64 windows-amd64}"
+export RELEASE_PLATFORMS="${RELEASE_PLATFORMS:-linux-amd64 darwin-amd64 darwin-arm64 windows-amd64}"
 
 # By default, this script is used to released tagged revisions,
 # for which a matching tag must exist in the dashboard repository.


### PR DESCRIPTION
Signed-off-by: Marvin Beckers <marvin@kubermatic.com>

**What does this PR do / Why do we need it**:

Most new Macs shipped as of today are `arm64`-based with their M1 chips. Let's add support for `darwin-arm64` as release platform, as `darwin-amd64` will eventually go away.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8197

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add darwin-arm64 to platforms supported by release binaries
```
