### PR TITLE
Upgrade gatekeeper to 3.6.0

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
@@ -57,10 +57,10 @@ spec:
                         type: object
                       validation:
                         default:
-                          legacySchema: true
+                          legacySchema: false
                         properties:
                           legacySchema:
-                            default: true
+                            default: false
                             type: boolean
                           openAPIV3Schema:
                             type: object

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -20578,7 +20578,7 @@
           "x-go-name": "ObservedGeneration"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "CNIPluginSettings": {
       "type": "object",
@@ -21431,7 +21431,7 @@
           "x-go-name": "Created"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "ControlPlaneMetrics": {
       "description": "ControlPlaneMetrics defines a metric for the user cluster control plane resources",
@@ -21469,7 +21469,7 @@
           "x-go-name": "Message"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "CreateClusterSpec": {
       "description": "CreateClusterSpec is the structure that is used to create cluster with its initial node deployment",

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -20626,7 +20626,7 @@
           "$ref": "#/definitions/CRDSpec"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "CRDSpec": {
       "type": "object",
@@ -20638,7 +20638,7 @@
           "$ref": "#/definitions/Validation"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "CentOSSpec": {
       "type": "object",
@@ -24700,7 +24700,7 @@
           "x-go-name": "ShortNames"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "Namespace": {
       "description": "Namespace defines namespace",
@@ -27163,7 +27163,7 @@
           "x-go-name": "Target"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "Time": {
       "description": "Programs using times should typically store and pass them as values,\nnot pointers. That is, time variables and struct fields should be of\ntype time.Time, not *time.Time.\n\nA Time value can be used by multiple goroutines simultaneously except\nthat the methods GobDecode, UnmarshalBinary, UnmarshalJSON and\nUnmarshalText are not concurrency-safe.\n\nTime instants can be compared using the Before, After, and Equal methods.\nThe Sub method subtracts two instants, producing a Duration.\nThe Add method adds a Time and a Duration, producing a Time.\n\nThe zero value of type Time is January 1, year 1, 00:00:00.000000000 UTC.\nAs this time is unlikely to come up in practice, the IsZero method gives\na simple way of detecting a time that has not been initialized explicitly.\n\nEach Time has associated with it a Location, consulted when computing the\npresentation form of the time, such as in the Format, Hour, and Year methods.\nThe methods Local, UTC, and In return a Time with a specific location.\nChanging the location in this way changes only the presentation; it does not\nchange the instant in time being denoted and therefore does not affect the\ncomputations described in earlier paragraphs.\n\nRepresentations of a Time value saved by the GobEncode, MarshalBinary,\nMarshalJSON, and MarshalText methods store the Time.Location's offset, but not\nthe location name. They therefore lose information about Daylight Saving Time.\n\nIn addition to the required “wall clock” reading, a Time may contain an optional\nreading of the current process's monotonic clock, to provide additional precision\nfor comparison or subtraction.\nSee the “Monotonic Clocks” section in the package documentation for details.\n\nNote that the Go == operator compares not just the time instant but also the\nLocation and the monotonic clock reading. Therefore, Time values should not\nbe used as map or database keys without first guaranteeing that the\nidentical Location has been set for all values, which can be achieved\nthrough use of the UTC or Local method, and that the monotonic clock reading\nhas been stripped by setting t = t.Round(0). In general, prefer t.Equal(u)\nto t == u, since t.Equal uses the most accurate comparison available and\ncorrectly handles the case when only one of its arguments has a monotonic\nclock reading.",
@@ -27470,7 +27470,7 @@
       "type": "object",
       "properties": {
         "legacySchema": {
-          "description": "+kubebuilder:default=true",
+          "description": "+kubebuilder:default=false",
           "type": "boolean",
           "x-go-name": "LegacySchema"
         },
@@ -27478,7 +27478,7 @@
           "$ref": "#/definitions/JSONSchemaProps"
         }
       },
-      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+      "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
     },
     "ValidationRule": {
       "type": "object",

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/collectors"

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -25,11 +25,12 @@ import (
 	"os"
 
 	"github.com/go-logr/zapr"
-	gatekeeperv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/collectors"
@@ -133,8 +134,8 @@ func main() {
 	if err := clusterv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
-	if err := gatekeeperv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", gatekeeperv1beta1.SchemeGroupVersion), zap.Error(err))
+	if err := constrainttemplatesv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatalw("Failed to register scheme", zap.Stringer("api", constrainttemplatesv1.SchemeGroupVersion), zap.Error(err))
 	}
 	if err := kubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", kubermaticv1.SchemeGroupVersion), zap.Error(err))

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -158,8 +158,8 @@ func main() {
 			},
 			{
 				ResourceName:       "ConstraintTemplate",
-				ImportAlias:        "gatekeeperv1beta1",
-				ResourceImportPath: "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1",
+				ImportAlias:        "gatekeeperv1",
+				ResourceImportPath: "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1",
 			},
 			{
 				ResourceName:     "ConstraintTemplate",

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v2
 
 import (
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -31,8 +31,8 @@ import (
 type ConstraintTemplate struct {
 	Name string `json:"name"`
 
-	Spec   kubermaticv1.ConstraintTemplateSpec `json:"spec"`
-	Status v1beta1.ConstraintTemplateStatus    `json:"status"`
+	Spec   kubermaticv1.ConstraintTemplateSpec            `json:"spec"`
+	Status constrainttemplatesv1.ConstraintTemplateStatus `json:"status"`
 }
 
 // Constraint represents a gatekeeper Constraint

--- a/pkg/apis/kubermatic/v1/constraint_template.go
+++ b/pkg/apis/kubermatic/v1/constraint_template.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -46,8 +46,8 @@ type ConstraintTemplate struct {
 
 // ConstraintTemplateSpec is the object representing the gatekeeper constraint template spec and kubermatic related spec.
 type ConstraintTemplateSpec struct {
-	CRD      v1beta1.CRD                `json:"crd,omitempty"`
-	Targets  []v1beta1.Target           `json:"targets,omitempty"`
+	CRD      v1.CRD                `json:"crd,omitempty"`
+	Targets  []v1.Target           `json:"targets,omitempty"`
 	Selector ConstraintTemplateSelector `json:"selector,omitempty"`
 }
 

--- a/pkg/apis/kubermatic/v1/constraint_template.go
+++ b/pkg/apis/kubermatic/v1/constraint_template.go
@@ -46,8 +46,8 @@ type ConstraintTemplate struct {
 
 // ConstraintTemplateSpec is the object representing the gatekeeper constraint template spec and kubermatic related spec.
 type ConstraintTemplateSpec struct {
-	CRD      v1.CRD                `json:"crd,omitempty"`
-	Targets  []v1.Target           `json:"targets,omitempty"`
+	CRD      v1.CRD                     `json:"crd,omitempty"`
+	Targets  []v1.Target                `json:"targets,omitempty"`
 	Selector ConstraintTemplateSelector `json:"selector,omitempty"`
 }
 

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -24,7 +24,7 @@ package v1
 import (
 	"encoding/json"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1526,7 +1526,7 @@ func (in *ConstraintTemplateSpec) DeepCopyInto(out *ConstraintTemplateSpec) {
 	in.CRD.DeepCopyInto(&out.CRD)
 	if in.Targets != nil {
 		in, out := &in.Targets, &out.Targets
-		*out = make([]v1beta1.Target, len(*in))
+		*out = make([]templatesv1.Target, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -144,13 +144,13 @@ func genConstraintTemplate(name string, deleted bool) *kubermaticv1.ConstraintTe
 
 func genCTSpec() kubermaticv1.ConstraintTemplateSpec {
 	return kubermaticv1.ConstraintTemplateSpec{
-		CRD: v1beta1.CRD{
-			Spec: v1beta1.CRDSpec{
-				Names: v1beta1.Names{
+		CRD: constrainttemplatev1.CRD{
+			Spec: constrainttemplatev1.CRDSpec{
+				Names: constrainttemplatev1.Names{
 					Kind:       "labelconstraint",
 					ShortNames: []string{"lc"},
 				},
-				Validation: &v1beta1.Validation{
+				Validation: &constrainttemplatev1.Validation{
 					OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
 						Properties: map[string]apiextensionv1.JSONSchemaProps{
 							"labels": {
@@ -166,7 +166,7 @@ func genCTSpec() kubermaticv1.ConstraintTemplateSpec {
 				},
 			},
 		},
-		Targets: []v1beta1.Target{
+		Targets: []constrainttemplatev1.Target{
 			{
 				Target: "admission.k8s.gatekeeper.sh",
 				Rego: `

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -139,7 +139,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 		}
 
 		err := r.syncAllClusters(ctx, log, constraintTemplate, func(userClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
-			err := userClusterClient.Delete(ctx, &v1beta1.ConstraintTemplate{
+			err := userClusterClient.Delete(ctx, &v1.ConstraintTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: constraintTemplate.Name,
 				},
@@ -220,9 +220,9 @@ func (r *reconciler) syncAllClusters(
 
 func constraintTemplateCreatorGetter(kubeCT *kubermaticv1.ConstraintTemplate) reconciling.NamedConstraintTemplateCreatorGetter {
 	return func() (string, reconciling.ConstraintTemplateCreator) {
-		return kubeCT.Name, func(ct *v1beta1.ConstraintTemplate) (*v1beta1.ConstraintTemplate, error) {
+		return kubeCT.Name, func(ct *v1.ConstraintTemplate) (*v1.ConstraintTemplate, error) {
 			ct.Name = kubeCT.Name
-			ct.Spec = v1beta1.ConstraintTemplateSpec{
+			ct.Spec = v1.ConstraintTemplateSpec{
 				CRD:     kubeCT.Spec.CRD,
 				Targets: kubeCT.Spec.Targets,
 			}

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -46,7 +46,7 @@ import (
 const ctName = "requiredlabels"
 
 func TestReconcile(t *testing.T) {
-	sch, err := v1beta1.SchemeBuilder.Build()
+	sch, err := constrainttemplatev1.SchemeBuilder.Build()
 	if err != nil {
 		t.Fatalf("building gatekeeper scheme failed: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestReconcile(t *testing.T) {
 				t.Fatalf("reconciling failed: %v", err)
 			}
 
-			ct := &v1beta1.ConstraintTemplate{}
+			ct := &constrainttemplatev1.ConstraintTemplate{}
 			err := tc.userClient.Get(ctx, request.NamespacedName, ct)
 			if tc.expectedGetErrStatus != "" {
 				if err == nil {
@@ -152,7 +152,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func TestDeleteWhenCTOnUserClusterIsMissing(t *testing.T) {
-	sch, err := v1beta1.SchemeBuilder.Build()
+	sch, err := constrainttemplatev1.SchemeBuilder.Build()
 	if err != nil {
 		t.Fatalf("building gatekeeper scheme failed: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestDeleteWhenCTOnUserClusterIsMissing(t *testing.T) {
 		t.Fatalf("reconciling failed: %v", err)
 	}
 
-	err = userClient.Get(ctx, request.NamespacedName, &v1beta1.ConstraintTemplate{})
+	err = userClient.Get(ctx, request.NamespacedName, &constrainttemplatev1.ConstraintTemplate{})
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -211,10 +211,10 @@ func genConstraintTemplate(name string, deleted bool) *kubermaticv1.ConstraintTe
 	return ct
 }
 
-func genGKConstraintTemplate(name string) *v1beta1.ConstraintTemplate {
-	ct := &v1beta1.ConstraintTemplate{}
+func genGKConstraintTemplate(name string) *constrainttemplatev1.ConstraintTemplate {
+	ct := &constrainttemplatev1.ConstraintTemplate{}
 	ct.Name = name
-	ct.Spec = v1beta1.ConstraintTemplateSpec{
+	ct.Spec = constrainttemplatev1.ConstraintTemplateSpec{
 		CRD:     genCTSpec().CRD,
 		Targets: genCTSpec().Targets,
 	}
@@ -224,13 +224,13 @@ func genGKConstraintTemplate(name string) *v1beta1.ConstraintTemplate {
 
 func genCTSpec() kubermaticv1.ConstraintTemplateSpec {
 	return kubermaticv1.ConstraintTemplateSpec{
-		CRD: v1beta1.CRD{
-			Spec: v1beta1.CRDSpec{
-				Names: v1beta1.Names{
+		CRD: constrainttemplatev1.CRD{
+			Spec: constrainttemplatev1.CRDSpec{
+				Names: constrainttemplatev1.Names{
 					Kind:       "labelconstraint",
 					ShortNames: []string{"lc"},
 				},
-				Validation: &v1beta1.Validation{
+				Validation: &constrainttemplatev1.Validation{
 					OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
 						Properties: map[string]apiextensionv1.JSONSchemaProps{
 							"labels": {
@@ -246,7 +246,7 @@ func genCTSpec() kubermaticv1.ConstraintTemplateSpec {
 				},
 			},
 		},
-		Targets: []v1beta1.Target{
+		Targets: []constrainttemplatev1.Target{
 			{
 				Target: "admission.k8s.gatekeeper.sh",
 				Rego: `

--- a/pkg/controller/user-cluster-controller-manager/rbac/resources.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/resources.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
-	gatekeeperv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/config/v1alpha1"
 
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
@@ -140,7 +140,7 @@ func CreateClusterRole(resourceName string, cr *rbacv1.ClusterRole) (*rbacv1.Clu
 			Verbs:     verbs,
 		},
 		{
-			APIGroups: []string{gatekeeperv1beta1.SchemeGroupVersion.Group},
+			APIGroups: []string{constrainttemplatesv1.SchemeGroupVersion.Group},
 			Resources: []string{"constrainttemplates"},
 			Verbs:     verbs,
 		},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
@@ -35,7 +35,7 @@ const (
 	controllerName = resources.GatekeeperControllerDeploymentName
 	auditName      = resources.GatekeeperAuditDeploymentName
 	imageName      = "openpolicyagent/gatekeeper"
-	tag            = "v3.5.2"
+	tag            = "v3.6.0"
 	// Namespace used by Dashboard to find required resources.
 	webhookServerPort  = 8443
 	metricsPort        = 8888

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
@@ -15,12 +15,13 @@ spec:
     listKind: AssignList
     plural: assign
     singular: assign
+  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: Assign is the Schema for the assign API
+          description: Assign is the Schema for the assign API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -31,7 +32,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: AssignSpec defines the desired state of Assign
+              description: AssignSpec defines the desired state of Assign.
               properties:
                 applyTo:
                   description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
@@ -155,7 +156,7 @@ spec:
                       type: object
                     pathTests:
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate"
+                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -170,17 +171,17 @@ spec:
                   type: object
               type: object
             status:
-              description: AssignStatus defines the observed state of Assign
+              description: AssignStatus defines the observed state of Assign.
               properties:
                 byPod:
                   items:
-                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
                       enforced:
                         type: boolean
                       errors:
                         items:
-                          description: MutatorError represents a single error caught while adding a mutator to a system
+                          description: MutatorError represents a single error caught while adding a mutator to a system.
                           properties:
                             message:
                               type: string

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assignmetadata-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assignmetadata-customresourcedefinition.yaml
@@ -15,12 +15,13 @@ spec:
     listKind: AssignMetadataList
     plural: assignmetadata
     singular: assignmetadata
+  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: AssignMetadata is the Schema for the assignmetadata API
+          description: AssignMetadata is the Schema for the assignmetadata API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -31,7 +32,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: AssignMetadataSpec defines the desired state of AssignMetadata
+              description: AssignMetadataSpec defines the desired state of AssignMetadata.
               properties:
                 location:
                   type: string
@@ -134,18 +135,18 @@ spec:
                   type: object
               type: object
             status:
-              description: AssignMetadataStatus defines the observed state of AssignMetadata
+              description: AssignMetadataStatus defines the observed state of AssignMetadata.
               properties:
                 byPod:
                   description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
                   items:
-                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
                       enforced:
                         type: boolean
                       errors:
                         items:
-                          description: MutatorError represents a single error caught while adding a mutator to a system
+                          description: MutatorError represents a single error caught while adding a mutator to a system.
                           properties:
                             message:
                               type: string

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
@@ -15,12 +15,13 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: Config is the Schema for the configs API
+          description: Config is the Schema for the configs API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -31,7 +32,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ConfigSpec defines the desired state of Config
+              description: ConfigSpec defines the desired state of Config.
               properties:
                 match:
                   description: Configuration for namespace exclusion
@@ -39,6 +40,8 @@ spec:
                     properties:
                       excludedNamespaces:
                         items:
+                          description: 'A string that supports globbing at its end.  Ex: "kube-*" will match "kube-system" or "kube-public".  The asterisk is required for wildcard matching.'
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
                           type: string
                         type: array
                       processes:
@@ -97,7 +100,7 @@ spec:
                   type: object
               type: object
             status:
-              description: ConfigStatus defines the observed state of Config
+              description: ConfigStatus defines the observed state of Config.
               type: object
           type: object
       served: true

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
@@ -15,12 +15,13 @@ spec:
     listKind: ConstraintPodStatusList
     plural: constraintpodstatuses
     singular: constraintpodstatus
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description: ConstraintPodStatus is the Schema for the constraintpodstatuses API
+          description: ConstraintPodStatus is the Schema for the constraintpodstatuses API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -31,7 +32,7 @@ spec:
             metadata:
               type: object
             status:
-              description: ConstraintPodStatusStatus defines the observed state of ConstraintPodStatus
+              description: ConstraintPodStatusStatus defines the observed state of ConstraintPodStatus.
               properties:
                 constraintUID:
                   description: Storing the constraint UID allows us to detect drift, such as when a constraint has been recreated after its CRD was deleted out from under it, interrupting the watch
@@ -40,7 +41,7 @@ spec:
                   type: boolean
                 errors:
                   items:
-                    description: Error represents a single error caught while adding a constraint to OPA
+                    description: Error represents a single error caught while adding a constraint to OPA.
                     properties:
                       code:
                         type: string

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
@@ -15,8 +15,102 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
+  preserveUnknownFields: false
   scope: Cluster
   versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ConstraintTemplate is the Schema for the constrainttemplates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+              properties:
+                crd:
+                  properties:
+                    spec:
+                      properties:
+                        names:
+                          properties:
+                            kind:
+                              type: string
+                            shortNames:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        validation:
+                          properties:
+                            legacySchema:
+                              default: false
+                              type: boolean
+                            openAPIV3Schema:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                  type: object
+                targets:
+                  items:
+                    properties:
+                      libs:
+                        items:
+                          type: string
+                        type: array
+                      rego:
+                        type: string
+                      target:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+              properties:
+                byPod:
+                  items:
+                    description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
+                    properties:
+                      errors:
+                        items:
+                          description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                          properties:
+                            code:
+                              type: string
+                            location:
+                              type: string
+                            message:
+                              type: string
+                          required:
+                            - code
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        description: a unique identifier for the pod that wrote the status
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                created:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
     - name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -48,6 +142,9 @@ spec:
                           type: object
                         validation:
                           properties:
+                            legacySchema:
+                              default: true
+                              type: boolean
                             openAPIV3Schema:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
@@ -138,6 +235,9 @@ spec:
                           type: object
                         validation:
                           properties:
+                            legacySchema:
+                              default: true
+                              type: boolean
                             openAPIV3Schema:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
@@ -194,6 +294,6 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -15,12 +15,13 @@ spec:
     listKind: ConstraintTemplatePodStatusList
     plural: constrainttemplatepodstatuses
     singular: constrainttemplatepodstatus
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API
+          description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -31,7 +32,7 @@ spec:
             metadata:
               type: object
             status:
-              description: ConstraintTemplatePodStatusStatus defines the observed state of ConstraintTemplatePodStatus
+              description: ConstraintTemplatePodStatusStatus defines the observed state of ConstraintTemplatePodStatus.
               properties:
                 errors:
                   items:
@@ -65,3 +66,4 @@ spec:
           type: object
       served: true
       storage: true
+

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
@@ -15,12 +15,13 @@ spec:
     listKind: MutatorPodStatusList
     plural: mutatorpodstatuses
     singular: mutatorpodstatus
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description: MutatorPodStatus is the Schema for the mutationpodstatuses API
+          description: MutatorPodStatus is the Schema for the mutationpodstatuses API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -31,13 +32,13 @@ spec:
             metadata:
               type: object
             status:
-              description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+              description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
               properties:
                 enforced:
                   type: boolean
                 errors:
                   items:
-                    description: MutatorError represents a single error caught while adding a mutator to a system
+                    description: MutatorError represents a single error caught while adding a mutator to a system.
                     properties:
                       message:
                         type: string

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -29,7 +29,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -147,12 +147,12 @@ func allowedRegistryCTCreatorGetter() reconciling.NamedKubermaticV1ConstraintTem
 		return AllowedRegistryCTName, func(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
 			ct.Name = AllowedRegistryCTName
 			ct.Spec = kubermaticv1.ConstraintTemplateSpec{
-				CRD: constrainttemplatev1beta1.CRD{
-					Spec: constrainttemplatev1beta1.CRDSpec{
-						Names: constrainttemplatev1beta1.Names{
+				CRD: constrainttemplatev1.CRD{
+					Spec: constrainttemplatev1.CRDSpec{
+						Names: constrainttemplatev1.Names{
 							Kind: AllowedRegistryCTName,
 						},
-						Validation: &constrainttemplatev1beta1.Validation{
+						Validation: &constrainttemplatev1.Validation{
 							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									AllowedRegistryField: {
@@ -168,7 +168,7 @@ func allowedRegistryCTCreatorGetter() reconciling.NamedKubermaticV1ConstraintTem
 						},
 					},
 				},
-				Targets: []constrainttemplatev1beta1.Target{
+				Targets: []constrainttemplatev1.Target{
 					{
 						Target: "admission.k8s.gatekeeper.sh",
 						Rego:   "package allowedregistry\n\nviolation[{\"msg\": msg}] {\n  container := input.review.object.spec.containers[_]\n  satisfied := [good | repo = input.parameters.allowed_registry[_] ; good = startswith(container.image, repo)]\n  not any(satisfied)\n  msg := sprintf(\"container <%v> has an invalid image registry <%v>, allowed image registries are %v\", [container.name, container.image, input.parameters.allowed_registry])\n}\nviolation[{\"msg\": msg}] {\n  container := input.review.object.spec.initContainers[_]\n  satisfied := [good | repo = input.parameters.allowed_registry[_] ; good = startswith(container.image, repo)]\n  not any(satisfied)\n  msg := sprintf(\"container <%v> has an invalid image registry <%v>, allowed image registries are %v\", [container.name, container.image, input.parameters.allowed_registry])\n}",

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -197,12 +197,12 @@ func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 
 	ct.Name = allowedregistrycontroller.AllowedRegistryCTName
 	ct.Spec = kubermaticv1.ConstraintTemplateSpec{
-		CRD: constrainttemplatev1beta1.CRD{
-			Spec: constrainttemplatev1beta1.CRDSpec{
-				Names: constrainttemplatev1beta1.Names{
+		CRD: constrainttemplatev1.CRD{
+			Spec: constrainttemplatev1.CRDSpec{
+				Names: constrainttemplatev1.Names{
 					Kind: allowedregistrycontroller.AllowedRegistryCTName,
 				},
-				Validation: &constrainttemplatev1beta1.Validation{
+				Validation: &constrainttemplatev1.Validation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							allowedregistrycontroller.AllowedRegistryField: {
@@ -218,7 +218,7 @@ func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 				},
 			},
 		},
-		Targets: []constrainttemplatev1beta1.Target{
+		Targets: []constrainttemplatev1.Target{
 			{
 				Target: "admission.k8s.gatekeeper.sh",
 				Rego:   "package allowedregistry\n\nviolation[{\"msg\": msg}] {\n  container := input.review.object.spec.containers[_]\n  satisfied := [good | repo = input.parameters.allowed_registry[_] ; good = startswith(container.image, repo)]\n  not any(satisfied)\n  msg := sprintf(\"container <%v> has an invalid image registry <%v>, allowed image registries are %v\", [container.name, container.image, input.parameters.allowed_registry])\n}\nviolation[{\"msg\": msg}] {\n  container := input.review.object.spec.initContainers[_]\n  satisfied := [good | repo = input.parameters.allowed_registry[_] ; good = startswith(container.image, repo)]\n  not any(satisfied)\n  msg := sprintf(\"container <%v> has an invalid image registry <%v>, allowed image registries are %v\", [container.name, container.image, input.parameters.allowed_registry])\n}",

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -37,7 +37,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -31,12 +31,13 @@ import (
 	"testing"
 	"time"
 
-	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	gatekeeperconfigv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/config/v1alpha1"
 	prometheusapi "github.com/prometheus/client_golang/api"
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -1474,13 +1475,13 @@ func GenDefaultConstraintTemplate(name string) apiv2.ConstraintTemplate {
 	return apiv2.ConstraintTemplate{
 		Name: name,
 		Spec: kubermaticv1.ConstraintTemplateSpec{
-			CRD: constrainttemplatev1beta1.CRD{
-				Spec: constrainttemplatev1beta1.CRDSpec{
-					Names: constrainttemplatev1beta1.Names{
+			CRD: constrainttemplatev1.CRD{
+				Spec: constrainttemplatev1.CRDSpec{
+					Names: constrainttemplatev1.Names{
 						Kind:       "labelconstraint",
 						ShortNames: []string{"lc"},
 					},
-					Validation: &constrainttemplatev1beta1.Validation{
+					Validation: &constrainttemplatev1.Validation{
 						OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
 							Properties: map[string]apiextensionv1.JSONSchemaProps{
 								"labels": {
@@ -1497,7 +1498,7 @@ func GenDefaultConstraintTemplate(name string) apiv2.ConstraintTemplate {
 					},
 				},
 			},
-			Targets: []constrainttemplatev1beta1.Target{
+			Targets: []constrainttemplatev1.Target{
 				{
 					Target: "admission.k8s.gatekeeper.sh",
 					Rego: `
@@ -1541,13 +1542,13 @@ func GenConstraintTemplate(name string) *kubermaticv1.ConstraintTemplate {
 	ct := &kubermaticv1.ConstraintTemplate{}
 	ct.Name = name
 	ct.Spec = kubermaticv1.ConstraintTemplateSpec{
-		CRD: constrainttemplatev1beta1.CRD{
-			Spec: constrainttemplatev1beta1.CRDSpec{
-				Names: constrainttemplatev1beta1.Names{
+		CRD: constrainttemplatev1.CRD{
+			Spec: constrainttemplatev1.CRDSpec{
+				Names: constrainttemplatev1.Names{
 					Kind:       "labelconstraint",
 					ShortNames: []string{"lc"},
 				},
-				Validation: &constrainttemplatev1beta1.Validation{
+				Validation: &constrainttemplatev1.Validation{
 					OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
 						Properties: map[string]apiextensionv1.JSONSchemaProps{
 							"labels": {
@@ -1564,7 +1565,7 @@ func GenConstraintTemplate(name string) *kubermaticv1.ConstraintTemplate {
 				},
 			},
 		},
-		Targets: []constrainttemplatev1beta1.Target{
+		Targets: []constrainttemplatev1.Target{
 			{
 				Target: "admission.k8s.gatekeeper.sh",
 				Rego: `

--- a/pkg/provider/kubernetes/util_test.go
+++ b/pkg/provider/kubernetes/util_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"gopkg.in/square/go-jose.v2/jwt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -269,15 +269,15 @@ func genConstraintTemplate(name string) *kubermaticv1.ConstraintTemplate {
 	ct.APIVersion = kubermaticv1.SchemeGroupVersion.String()
 	ct.Name = name
 	ct.Spec = kubermaticv1.ConstraintTemplateSpec{
-		CRD: v1beta1.CRD{
-			Spec: v1beta1.CRDSpec{
-				Names: v1beta1.Names{
+		CRD: constrainttemplatev1.CRD{
+			Spec: constrainttemplatev1.CRDSpec{
+				Names: constrainttemplatev1.Names{
 					Kind:       "labelconstraint",
 					ShortNames: []string{"lc"},
 				},
 			},
 		},
-		Targets: []v1beta1.Target{
+		Targets: []constrainttemplatev1.Target{
 			{
 				Target: "admission.k8s.gatekeeper.sh",
 				Rego: `

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -32,7 +32,7 @@ import (
 
 func init() {
 	// Kubernetes Objects can be deeper than the default 10 levels.
-	deep.MaxDepth = 25
+	deep.MaxDepth = 30
 	deep.LogErrors = true
 }
 

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	gatekeeperv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	gatekeeperv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -879,7 +879,7 @@ func ReconcileEtcdBackupConfigs(ctx context.Context, namedGetters []NamedEtcdBac
 }
 
 // ConstraintTemplateCreator defines an interface to create/update ConstraintTemplates
-type ConstraintTemplateCreator = func(existing *gatekeeperv1beta1.ConstraintTemplate) (*gatekeeperv1beta1.ConstraintTemplate, error)
+type ConstraintTemplateCreator = func(existing *gatekeeperv1.ConstraintTemplate) (*gatekeeperv1.ConstraintTemplate, error)
 
 // NamedConstraintTemplateCreatorGetter returns the name of the resource and the corresponding creator function
 type NamedConstraintTemplateCreatorGetter = func() (name string, create ConstraintTemplateCreator)
@@ -889,9 +889,9 @@ type NamedConstraintTemplateCreatorGetter = func() (name string, create Constrai
 func ConstraintTemplateObjectWrapper(create ConstraintTemplateCreator) ObjectCreator {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return create(existing.(*gatekeeperv1beta1.ConstraintTemplate))
+			return create(existing.(*gatekeeperv1.ConstraintTemplate))
 		}
-		return create(&gatekeeperv1beta1.ConstraintTemplate{})
+		return create(&gatekeeperv1.ConstraintTemplate{})
 	}
 }
 
@@ -907,7 +907,7 @@ func ReconcileConstraintTemplates(ctx context.Context, namedGetters []NamedConst
 			createObject = objectModifier(createObject)
 		}
 
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &gatekeeperv1beta1.ConstraintTemplate{}, false); err != nil {
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &gatekeeperv1.ConstraintTemplate{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ConstraintTemplate %s/%s: %w", namespace, name, err)
 		}
 	}

--- a/pkg/test/e2e/opa/constraint_template.yaml
+++ b/pkg/test/e2e/opa/constraint_template.yaml
@@ -1,0 +1,31 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: ConstraintTemplate
+metadata:
+  name: requiredlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            labels:
+              type: array
+              items:
+                type: string
+  selector:
+    labelSelector: {}
+  targets:
+    - rego: |
+        package k8srequiredlabels
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_]}
+          missing := required - provided
+          count(missing) > 0
+          msg := sprintf("you must provide labels: %v", [missing])
+        }
+      target: admission.k8s.gatekeeper.sh

--- a/pkg/test/e2e/opa/constraint_template.yaml
+++ b/pkg/test/e2e/opa/constraint_template.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kubermatic.k8c.io/v1
 kind: ConstraintTemplate
 metadata:

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
@@ -53,7 +53,7 @@ var (
 func TestOPAIntegration(t *testing.T) {
 	ctx := context.Background()
 
-	if err := constrainttemplatev1beta1.AddToScheme(scheme.Scheme); err != nil {
+	if err := constrainttemplatev1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("failed to register gatekeeper scheme: %v", err)
 	}
 
@@ -248,7 +248,7 @@ func testConstraintForConfigMap(ctx context.Context, userClient ctrlruntimeclien
 
 func waitForCTSync(ctx context.Context, userClient ctrlruntimeclient.Client, ctName string, deleted bool) error {
 	if !utils.WaitFor(1*time.Second, 1*time.Minute, func() bool {
-		gatekeeperCT := &constrainttemplatev1beta1.ConstraintTemplate{}
+		gatekeeperCT := &constrainttemplatev1.ConstraintTemplate{}
 		err := userClient.Get(ctx, types.NamespacedName{Name: ctName}, gatekeeperCT)
 
 		if deleted {

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -304,7 +304,7 @@ func createTestConstraintTemplate(ctx context.Context, client ctrlruntimeclient.
 	var ct *kubermaticv1.ConstraintTemplate
 	err := yaml.Unmarshal([]byte(testCT), &ct)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling Constraint Template: %v", err)
+		return nil, fmt.Errorf("error unmarshalling Constraint Template: %w", err)
 	}
 
 	return ct, client.Create(ctx, ct)

--- a/pkg/test/e2e/utils/apiclient/models/validation.go
+++ b/pkg/test/e2e/utils/apiclient/models/validation.go
@@ -18,7 +18,7 @@ import (
 // swagger:model Validation
 type Validation struct {
 
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	LegacySchema bool `json:"legacySchema,omitempty"`
 
 	// open API v3 schema

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -28,8 +28,8 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -30,6 +30,7 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -1653,6 +1654,7 @@ func (r *TestClient) CreateCT(name, ctKind string) (*kubermaticv1.ConstraintTemp
 				},
 				Validation: &models.Validation{
 					OpenAPIV3Schema: &models.JSONSchemaProps{
+						Type: "object",
 						Properties: map[string]models.JSONSchemaProps{
 							"labels": {
 								Type: "array",

--- a/pkg/test/e2e/utils/kubernetes.go
+++ b/pkg/test/e2e/utils/kubernetes.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"time"
 
-	constrainttemplatev1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -158,7 +158,7 @@ func GetClients() (ctrlruntimeclient.Client, rest.Interface, *rest.Config, error
 	if err := kubermaticv1.AddToScheme(scheme); err != nil {
 		return nil, nil, nil, err
 	}
-	if err := constrainttemplatev1beta1.AddToScheme(scheme); err != nil {
+	if err := constrainttemplatev1.AddToScheme(scheme); err != nil {
 		return nil, nil, nil, err
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Upgrades the OPA integration Gatekeeper from 3.5.2 to 3.6.0. 

Important change here is that ConstraintTemplates are now v1 from v1beta1

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8832 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgraded OPA integration Gatekeeper version from 3.5.2 to 3.6.0. Important change here is that the OPA ConstraintTemplates are upgraded from v1beta1 to v1. What this means for Kubermatic ConstraintTemplates is that when creating new ones, the `spec.crd.spec.validation.openAPIV3Schema` needs to be structurally correct. The old ConstraintTemplates will have a `legacySchema` flag in the `spec.crd.spec.validation` so they wont need to be migrated yet, although we suggest editing them and fixing the schema to be structurally correct.

More info about change from v1beta1 to v1 in gatekeeper docs:  https://open-policy-agent.github.io/gatekeeper/website/docs/constrainttemplates#v1-constraint-template
```
