### PR TITLE
do not reconcile MLA in clusters with no external name yet

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -118,6 +118,11 @@ func (r *datasourceGrafanaReconciler) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
+	if cluster.Address.ExternalName == "" {
+		log.Debug("Skipping cluster reconciling because it has no external name yet")
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	// Add a wrapping here so we can emit an event on error
 	result, err := kubermaticv1helper.ClusterReconcileWrapper(
 		ctx,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR fixes this:

![screenshot-2022-02-11-104810](https://user-images.githubusercontent.com/127499/153570168-9600b282-64e0-44d8-a68a-60d2fd8c8c55.png)

... which happens right after a cluster is created, but not yet healthy.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
