### PR TITLE
produce proper helm charts in canary releases

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -213,8 +213,14 @@ if ! $DRY_RUN; then
   releaseID=$(echo "$releasedata" | jq -r '.id')
 fi
 
-# prepare source for archiving
-set_helm_charts_version "$GIT_TAG"
+# prepare source for archiving (prepend "v9.9.9" if GIT_TAG is only
+# a hash, because Helm requires a semver version)
+CHART_TAG="$GIT_TAG"
+if [[ "$CHART_TAG" != v* ]]; then
+  CHART_TAG="v9.9.9-$CHART_TAG"
+fi
+
+set_helm_charts_version "$CHART_TAG" "$GIT_TAG"
 
 mkdir -p _dist
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Helm requires a semver version for charts.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
