### PR TITLE
Update RBAC and PodSecurityContext for VPA

### DIFF
--- a/pkg/controller/operator/common/vpa/admissionctrl.go
+++ b/pkg/controller/operator/common/vpa/admissionctrl.go
@@ -84,6 +84,13 @@ func AdmissionControllerDeploymentCreator(cfg *kubermaticv1.KubermaticConfigurat
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = AdmissionControllerName
+			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: pointer.Bool(true),
+				RunAsUser:    pointer.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "admission-controller",

--- a/pkg/controller/operator/common/vpa/recommender.go
+++ b/pkg/controller/operator/common/vpa/recommender.go
@@ -66,6 +66,13 @@ func RecommenderDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, ver
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = RecommenderName
+			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: pointer.Bool(true),
+				RunAsUser:    pointer.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "recommender",

--- a/pkg/controller/operator/common/vpa/updater.go
+++ b/pkg/controller/operator/common/vpa/updater.go
@@ -59,6 +59,13 @@ func UpdaterDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, version
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = UpdaterName
+			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: pointer.Bool(true),
+				RunAsUser:    pointer.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "updater",


### PR DESCRIPTION
Signed-off-by: Marvin Beckers <marvin@kubermatic.com>

**What does this PR do / Why do we need it**:

Looks like I did not test #8775 well enough; my bad. The pods were all running, but the RBAC for VPA changed. I've updated RBAC configuration and securityContexts to what is in https://github.com/kubernetes/autoscaler/tree/vertical-pod-autoscaler-0.9.2/vertical-pod-autoscaler/deploy.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
