### PR TITLE
Update nutanix-client-go to include category query fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cristim/ec2-instances-info v0.0.0-20201110114654-2dfcc09f67d4
 	github.com/digitalocean/godo v1.65.0
 	github.com/distribution/distribution/v3 v3.0.0-20220208183205-a4d9db5a884b
-	github.com/embik/nutanix-client-go v0.0.0-20220209085320-446760ae94b4
+	github.com/embik/nutanix-client-go v0.0.0-20220214103101-260fb79c8036
 	github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cristim/ec2-instances-info v0.0.0-20201110114654-2dfcc09f67d4
 	github.com/digitalocean/godo v1.65.0
 	github.com/distribution/distribution/v3 v3.0.0-20220208183205-a4d9db5a884b
-	github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60
+	github.com/embik/nutanix-client-go v0.0.0-20220209085320-446760ae94b4
 	github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -542,8 +542,8 @@ github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaB
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
-github.com/embik/nutanix-client-go v0.0.0-20220209085320-446760ae94b4 h1:7wT2rIh1TELK33ldh7ePJPo74mktXT1vlWYZkDpYoCQ=
-github.com/embik/nutanix-client-go v0.0.0-20220209085320-446760ae94b4/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
+github.com/embik/nutanix-client-go v0.0.0-20220214103101-260fb79c8036 h1:4N2mF5Li8RaeunKQdR9A9DC0YW9GohiPSBiDpNiiTCs=
+github.com/embik/nutanix-client-go v0.0.0-20220214103101-260fb79c8036/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.10.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,9 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60 h1:0FVKOkpksULFs6F7Kfd8ClBXVTvtiIKl07uV3HinOHk=
 github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
+github.com/embik/nutanix-client-go v0.0.0-20220209085320-446760ae94b4 h1:7wT2rIh1TELK33ldh7ePJPo74mktXT1vlWYZkDpYoCQ=
+github.com/embik/nutanix-client-go v0.0.0-20220209085320-446760ae94b4/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.10.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/pkg/provider/cloud/nutanix/api.go
+++ b/pkg/provider/cloud/nutanix/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nutanix
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -24,7 +25,7 @@ import (
 )
 
 func GetClusters(client *ClientSet) ([]nutanixv3.ClusterIntentResponse, error) {
-	resp, err := client.Prism.V3.ListAllCluster("")
+	resp, err := client.Prism.V3.ListAllCluster(context.TODO(), "")
 	if err != nil {
 		return nil, wrapNutanixError(err)
 	}
@@ -43,7 +44,7 @@ func GetClusters(client *ClientSet) ([]nutanixv3.ClusterIntentResponse, error) {
 }
 
 func GetProjects(client *ClientSet) ([]nutanixv3.Project, error) {
-	resp, err := client.Prism.V3.ListAllProject("")
+	resp, err := client.Prism.V3.ListAllProject(context.TODO(), "")
 	if err != nil {
 		return nil, wrapNutanixError(err)
 	}
@@ -62,7 +63,7 @@ func GetProjects(client *ClientSet) ([]nutanixv3.Project, error) {
 }
 
 func GetSubnets(client *ClientSet, clusterName, projectName string) ([]nutanixv3.SubnetIntentResponse, error) {
-	resp, err := client.Prism.V3.ListAllSubnet("")
+	resp, err := client.Prism.V3.ListAllSubnet(context.TODO(), "")
 	if err != nil {
 		return nil, wrapNutanixError(err)
 	}

--- a/pkg/provider/cloud/nutanix/client.go
+++ b/pkg/provider/cloud/nutanix/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nutanix
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -153,7 +154,7 @@ func getClientSet(credentials nutanixclient.Credentials) (*ClientSet, error) {
 
 func GetSubnetByName(client *ClientSet, name, clusterID string) (*nutanixv3.SubnetIntentResponse, error) {
 	filter := fmt.Sprintf("name==%s", name)
-	subnets, err := client.Prism.V3.ListAllSubnet(filter)
+	subnets, err := client.Prism.V3.ListAllSubnet(context.TODO(), filter)
 
 	if err != nil {
 		return nil, err
@@ -190,7 +191,7 @@ func GetSubnetByName(client *ClientSet, name, clusterID string) (*nutanixv3.Subn
 
 func GetProjectByName(client *ClientSet, name string) (*nutanixv3.Project, error) {
 	filter := fmt.Sprintf("name==%s", name)
-	projects, err := client.Prism.V3.ListAllProject(filter)
+	projects, err := client.Prism.V3.ListAllProject(context.TODO(), filter)
 
 	if err != nil {
 		return nil, err
@@ -219,7 +220,7 @@ func GetProjectByName(client *ClientSet, name string) (*nutanixv3.Project, error
 
 func GetClusterByName(client *ClientSet, name string) (*nutanixv3.ClusterIntentResponse, error) {
 	filter := fmt.Sprintf("name==%s", name)
-	clusters, err := client.Prism.V3.ListAllCluster(filter)
+	clusters, err := client.Prism.V3.ListAllCluster(context.TODO(), filter)
 
 	if err != nil {
 		return nil, err

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -155,7 +155,7 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 
 	projectID, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
 	if ok {
-		_, err := client.Prism.V3.GetCategoryValue(context.TODO(), ProjectCategoryName, projectID)
+		_, err := client.Prism.V3.GetCategoryValue(ctx, ProjectCategoryName, projectID)
 		if err != nil {
 			nutanixError, parseErr := ParseNutanixError(err)
 

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nutanix
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -150,9 +151,11 @@ func (n *Nutanix) reconcileCluster(cluster *kubermaticv1.Cluster, update provide
 }
 
 func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) error {
+	ctx := context.TODO()
+
 	projectID, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
 	if ok {
-		_, err := client.Prism.V3.GetCategoryValue(ProjectCategoryName, projectID)
+		_, err := client.Prism.V3.GetCategoryValue(context.TODO(), ProjectCategoryName, projectID)
 		if err != nil {
 			nutanixError, parseErr := ParseNutanixError(err)
 
@@ -167,7 +170,7 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 		} else {
 			// we need to make sure that no resources are attached
 			// to the project category before trying to delete it.
-			query, err := client.Prism.V3.GetCategoryQuery(&nutanixv3.CategoryQueryInput{
+			query, err := client.Prism.V3.GetCategoryQuery(ctx, &nutanixv3.CategoryQueryInput{
 				UsageType:        pointer.String("APPLIED_TO"),
 				GroupMemberCount: pointer.Int64(0),
 				CategoryFilter: &nutanixv3.CategoryFilter{
@@ -185,7 +188,7 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 
 			// no results mean it is safe to clean up this category value.
 			if len(query.Results) == 0 {
-				if err = client.Prism.V3.DeleteCategoryValue(ProjectCategoryName, projectID); err != nil {
+				if err = client.Prism.V3.DeleteCategoryValue(ctx, ProjectCategoryName, projectID); err != nil {
 					return err
 				}
 			} else {
@@ -207,7 +210,7 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 		}
 	}
 
-	_, err := client.Prism.V3.GetCategoryValue(ClusterCategoryName, CategoryValue(cluster.Name))
+	_, err := client.Prism.V3.GetCategoryValue(ctx, ClusterCategoryName, CategoryValue(cluster.Name))
 	if err != nil {
 		nutanixError, parseErr := ParseNutanixError(err)
 
@@ -219,7 +222,7 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 		if nutanixError.Code != http.StatusNotFound {
 			return err
 		}
-	} else if err = client.Prism.V3.DeleteCategoryValue(ClusterCategoryName, CategoryValue(cluster.Name)); err != nil {
+	} else if err = client.Prism.V3.DeleteCategoryValue(ctx, ClusterCategoryName, CategoryValue(cluster.Name)); err != nil {
 		return err
 	}
 
@@ -227,8 +230,10 @@ func deleteCategoryValues(client *ClientSet, cluster *kubermaticv1.Cluster) erro
 }
 
 func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster) error {
+	ctx := context.TODO()
+
 	// check if category (key) is present, create it if not
-	_, err := client.Prism.V3.GetCategoryKey(ClusterCategoryName)
+	_, err := client.Prism.V3.GetCategoryKey(ctx, ClusterCategoryName)
 	if err != nil {
 		nutanixError, err := ParseNutanixError(err)
 
@@ -238,7 +243,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 		}
 
 		if nutanixError.Code == http.StatusNotFound {
-			_, err := client.Prism.V3.CreateOrUpdateCategoryKey(&nutanixv3.CategoryKey{
+			_, err := client.Prism.V3.CreateOrUpdateCategoryKey(ctx, &nutanixv3.CategoryKey{
 				Name:        pointer.String(ClusterCategoryName),
 				Description: pointer.String(categoryDescription),
 			})
@@ -252,7 +257,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 	}
 
 	// check if category value is present, create it if not
-	_, err = client.Prism.V3.GetCategoryValue(ClusterCategoryName, CategoryValue(cluster.Name))
+	_, err = client.Prism.V3.GetCategoryValue(ctx, ClusterCategoryName, CategoryValue(cluster.Name))
 	if err != nil {
 		nutanixError, err := ParseNutanixError(err)
 
@@ -262,7 +267,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 		}
 
 		if nutanixError.Code == http.StatusNotFound {
-			_, err := client.Prism.V3.CreateOrUpdateCategoryValue(ClusterCategoryName, &nutanixv3.CategoryValue{
+			_, err := client.Prism.V3.CreateOrUpdateCategoryValue(ctx, ClusterCategoryName, &nutanixv3.CategoryValue{
 				Value:       pointer.String(CategoryValue(cluster.Name)),
 				Description: pointer.String(fmt.Sprintf("value for Kubernetes cluster %s", cluster.Name)),
 			})
@@ -276,7 +281,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 
 	projectID, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
 	if ok {
-		_, err = client.Prism.V3.GetCategoryKey(ProjectCategoryName)
+		_, err = client.Prism.V3.GetCategoryKey(ctx, ProjectCategoryName)
 		if err != nil {
 			nutanixError, err := ParseNutanixError(err)
 
@@ -286,7 +291,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 			}
 
 			if nutanixError.Code == http.StatusNotFound {
-				_, err := client.Prism.V3.CreateOrUpdateCategoryKey(&nutanixv3.CategoryKey{
+				_, err := client.Prism.V3.CreateOrUpdateCategoryKey(ctx, &nutanixv3.CategoryKey{
 					Name:        pointer.String(ProjectCategoryName),
 					Description: pointer.String(categoryDescription),
 				})
@@ -299,7 +304,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 			}
 		}
 
-		_, err = client.Prism.V3.GetCategoryValue(ProjectCategoryName, projectID)
+		_, err = client.Prism.V3.GetCategoryValue(ctx, ProjectCategoryName, projectID)
 		if err != nil {
 			nutanixError, err := ParseNutanixError(err)
 
@@ -309,7 +314,7 @@ func reconcileCategoryAndValue(client *ClientSet, cluster *kubermaticv1.Cluster)
 			}
 
 			if nutanixError.Code == http.StatusNotFound {
-				_, err := client.Prism.V3.CreateOrUpdateCategoryValue(ProjectCategoryName, &nutanixv3.CategoryValue{
+				_, err := client.Prism.V3.CreateOrUpdateCategoryValue(ctx, ProjectCategoryName, &nutanixv3.CategoryValue{
 					Value:       pointer.String(projectID),
 					Description: pointer.String(fmt.Sprintf("value for KKP project %s", projectID)),
 				})


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The Go client for Nutanix that we extracted some time ago from the Terraform provider has a bug for `GetCategoryQuery()`, which we are using in the Nutanix provider implementation. Fixed in https://github.com/embik/nutanix-client-go/commit/260fb79c80367eeefb3968e6b597adb5ed27a175.

In addition, I modified the client code some time ago to expose a `context.Context` argument, because I really do not like that it hardcoded `context.TODO()` for all HTTP requests.  The code changes in this PR don't change to a different context, but at least we can use it now. Might happen in a follow-up PR.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
