### PR TITLE
update usercluster Prometheus to 2.33.3, allow more CPU time

### DIFF
--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.29.1"
+	tag  = "v2.33.3"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"
@@ -42,11 +42,11 @@ var (
 		name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
-				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
-				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
 			},
 		},
 	}

--- a/pkg/resources/test/fixtures/statefulset-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.20.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-aws-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.21.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.20.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-azure-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.21.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.20.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.21.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.20.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.21.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.21.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.21.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.21.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.29.1
+        image: quay.io/prometheus/prometheus:v2.33.3
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -61,10 +61,10 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This simply bumps Prometheus to the latest stable version. There seem to be no breaking changes. I allowed Prometheus a bit more CPU, considering how large clusters can get.

**Does this PR introduce a user-facing change?**:
```release-note
Update usercluster Prometheus to 2.33.3
```
