### PR TITLE
Bring back vSphere cluster field and make it required

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -439,6 +439,10 @@ spec:
                               description: If set to true, disables the TLS certificate
                                 check against the endpoint.
                               type: boolean
+                            cluster:
+                              description: The name of the vSphere cluster to use.
+                                Used for out-of-tree CSI Driver.
+                              type: string
                             datacenter:
                               description: The name of the datacenter to use.
                               type: string
@@ -481,6 +485,7 @@ spec:
                                 See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation'
                               type: object
                           required:
+                          - cluster
                           - datacenter
                           - datastore
                           - endpoint

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -21440,6 +21440,11 @@
           "type": "boolean",
           "x-go-name": "AllowInsecure"
         },
+        "cluster": {
+          "description": "The name of the vSphere cluster to use. Used for out-of-tree CSI Driver.",
+          "type": "string",
+          "x-go-name": "Cluster"
+        },
         "datacenter": {
           "description": "The name of the datacenter to use.",
           "type": "string",

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -205,6 +205,8 @@ spec:
         vsphere:
           # If set to true, disables the TLS certificate check against the endpoint.
           allowInsecure: false
+          # The name of the vSphere cluster to use. Used for out-of-tree CSI Driver.
+          cluster: ""
           # The name of the datacenter to use.
           datacenter: ""
           # The default Datastore to be used for provisioning volumes using storage

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -68,6 +68,7 @@ spec:
           endpoint: "https://vcenter.loodse.io"
           datacenter: "dc-1"
           datastore: "exsi-nas"
+          cluster: "cl-1"
           rootPath: "/dc-1/vm/e2e-tests"
           templates:
             ubuntu: "machine-controller-e2e-ubuntu"

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -76,6 +76,7 @@ spec:
           endpoint: "https://vcenter.loodse.io"
           datacenter: "dc-1"
           datastore: "exsi-nas"
+          cluster: "cl-1"
           rootPath: "/dc-1/vm/e2e-tests"
           templates:
             ubuntu: "machine-controller-e2e-ubuntu"

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -368,6 +368,8 @@ type DatacenterSpecVSphere struct {
 	DefaultDatastore string `json:"datastore"`
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter"`
+	// The name of the vSphere cluster to use. Used for out-of-tree CSI Driver.
+	Cluster string `json:"cluster"`
 	// The name of the storage policy to use for the storage class created in the user cluster.
 	DefaultStoragePolicy string `json:"storagePolicy,omitempty"`
 	// Optional: The root path for cluster specific VM folders. Each cluster gets its own

--- a/pkg/handler/v1/provider/vsphere_test.go
+++ b/pkg/handler/v1/provider/vsphere_test.go
@@ -128,6 +128,7 @@ func (v *vSphereMock) buildVSphereDatacenter() provider.SeedsGetter {
 									AllowInsecure:    true,
 									DefaultDatastore: "LocalDS_0",
 									Datacenter:       "ha-datacenter",
+									Cluster:          "localhost.localdomain",
 									RootPath:         "/ha-datacenter/vm/",
 								},
 							},

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -309,6 +309,7 @@ func getVsphereCloudConfig(
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			DefaultDatastore: datastore,
 			WorkingDir:       cluster.Name,
+			ClusterID:        dc.Spec.VSphere.Cluster,
 		},
 		Workspace: vsphere.WorkspaceOpts{
 			// This is redundant with what the Vsphere cloud provider itself does:

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -200,6 +200,7 @@ func getVSphereProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc
 		Datacenter:       providerconfig.ConfigVarString{Value: dc.Spec.VSphere.Datacenter},
 		Datastore:        providerconfig.ConfigVarString{Value: datastore},
 		DatastoreCluster: providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.DatastoreCluster},
+		Cluster:          providerconfig.ConfigVarString{Value: dc.Spec.VSphere.Cluster},
 		Folder:           providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.Folder},
 		AllowInsecure:    providerconfig.ConfigVarBool{Value: pointer.Bool(dc.Spec.VSphere.AllowInsecure)},
 		ResourcePool:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.ResourcePool},

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = ""
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = ""
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = ""
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = ""
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = ""
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = ""
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -232,6 +232,7 @@ func TestLoadFiles(t *testing.T) {
 				AllowInsecure:    false,
 				DefaultDatastore: "vs-datastore",
 				Datacenter:       "vs-datacenter",
+				Cluster:          "vs-cluster",
 				RootPath:         "vs-cluster",
 			},
 			AWS: &kubermaticv1.DatacenterSpecAWS{

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_v_sphere.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_v_sphere.go
@@ -21,6 +21,9 @@ type DatacenterSpecVSphere struct {
 	// If set to true, disables the TLS certificate check against the endpoint.
 	AllowInsecure bool `json:"allowInsecure,omitempty"`
 
+	// The name of the vSphere cluster to use. Used for out-of-tree CSI Driver.
+	Cluster string `json:"cluster,omitempty"`
+
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter,omitempty"`
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Revert SOME changes from #8961.

As it turned out we actually need vSphere cluster field for CSI driver, vsphere cluster field is back and is made **REQUIRED**.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bring back vSphere cluster field and make it required
```
