### PR TITLE
Use retry for adding/removing finalizers

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -189,7 +189,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 
 		// load config files
 		if len(kubeconfig) == 0 {
-			return fmt.Errorf("no kubeconfig (--%s or $%s) given", deployKubeContextFlag.Name, deployKubeconfigFlag.EnvVar)
+			return fmt.Errorf("no kubeconfig (--%s or $%s) given", deployKubeconfigFlag.Name, deployKubeconfigFlag.EnvVar)
 		}
 
 		kubermaticConfig, rawKubermaticConfig, err := loadKubermaticConfiguration(ctx.String(deployConfigFlag.Name))

--- a/pkg/clusterdeletion/clusterrolebindings.go
+++ b/pkg/clusterdeletion/clusterrolebindings.go
@@ -22,18 +22,10 @@ import (
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // cleanupClusterRoleBindings is deprecated and should be removed in KKP 2.20+, because
 // nowadays we use owner references for cleanup and this manual step is not needed anymore.
 func (d *Deletion) cleanupClusterRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer) {
-		return nil
-	}
-
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer)
-	return d.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/constraints.go
+++ b/pkg/clusterdeletion/constraints.go
@@ -47,14 +47,11 @@ func (d *Deletion) cleanupConstraints(ctx context.Context, cluster *kubermaticv1
 	}
 
 	for _, constraint := range constraintList.Items {
-		oldConstraint := constraint.DeepCopy()
-		kuberneteshelper.RemoveFinalizer(&constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
-		if err := d.seedClient.Patch(ctx, &constraint, ctrlruntimeclient.MergeFrom(oldConstraint)); err != nil {
+		err := kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, &constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
+		if err != nil {
 			return fmt.Errorf("failed to remove constraint finalizer %s: %w", constraint.Name, err)
 		}
 	}
 
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.KubermaticConstraintCleanupFinalizer)
-	return d.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.KubermaticConstraintCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -151,7 +151,5 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, log *zap.Sugar
 		return nil
 	}
 
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.InClusterLBCleanupFinalizer, kubermaticapiv1.InClusterPVCleanupFinalizer)
-	return d.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.InClusterLBCleanupFinalizer, kubermaticapiv1.InClusterPVCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/etcdbackupconfig.go
+++ b/pkg/clusterdeletion/etcdbackupconfig.go
@@ -48,7 +48,5 @@ func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kuberm
 		}
 	}
 
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.EtcdBackupConfigCleanupFinalizer)
-	return d.seedClient.Patch(ctx, cluster, controllerruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.EtcdBackupConfigCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/node.go
+++ b/pkg/clusterdeletion/node.go
@@ -109,7 +109,5 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 		return nil
 	}
 
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer)
-	return d.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.NodeDeletionFinalizer)
 }

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -198,9 +198,7 @@ func (r *Reconciler) cleanUpKubeconfigSecret(ctx context.Context, cluster *kuber
 		return err
 	}
 
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.ExternalClusterKubeconfigCleanupFinalizer)
-	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, kubermaticapiv1.ExternalClusterKubeconfigCleanupFinalizer)
 }
 
 func (r *Reconciler) cleanUpCredentialsSecret(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
@@ -208,9 +206,7 @@ func (r *Reconciler) cleanUpCredentialsSecret(ctx context.Context, cluster *kube
 		return err
 	}
 
-	oldCluster := cluster.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
-	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
 }
 
 func (r *Reconciler) deleteSecret(ctx context.Context, secretName string) error {

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -146,20 +146,11 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 			return err
 		}
 
-		oldConstraintTemplate := constraintTemplate.DeepCopy()
-		kuberneteshelper.RemoveFinalizer(constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
-		if err := r.masterClient.Patch(ctx, constraintTemplate, ctrlruntimeclient.MergeFrom(oldConstraintTemplate)); err != nil {
-			return fmt.Errorf("failed to remove constraint template finalizer %s: %w", constraintTemplate.Name, err)
-		}
-		return nil
+		return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
 	}
 
-	if !kuberneteshelper.HasFinalizer(constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer) {
-		oldConstraintTemplate := constraintTemplate.DeepCopy()
-		kuberneteshelper.AddFinalizer(constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
-		if err := r.masterClient.Patch(ctx, constraintTemplate, ctrlruntimeclient.MergeFrom(oldConstraintTemplate)); err != nil {
-			return fmt.Errorf("failed to set constraint template finalizer %s: %w", constraintTemplate.Name, err)
-		}
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
 	ctCreatorGetters := []reconciling.NamedKubermaticV1ConstraintTemplateCreatorGetter{

--- a/pkg/controller/master-controller-manager/rbac/sync_project.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project.go
@@ -94,11 +94,7 @@ func (c *projectController) sync(ctx context.Context, key ctrlruntimeclient.Obje
 }
 
 func (c *projectController) ensureCleanupFinalizerExists(ctx context.Context, project *kubermaticv1.Project) error {
-	if !kuberneteshelper.HasFinalizer(project, CleanupFinalizerName) {
-		kuberneteshelper.AddFinalizer(project, CleanupFinalizerName)
-		return c.client.Update(ctx, project)
-	}
-	return nil
+	return kuberneteshelper.TryAddFinalizer(ctx, c.client, project, CleanupFinalizerName)
 }
 
 func (c *projectController) ensureProjectIsInActivePhase(ctx context.Context, project *kubermaticv1.Project) error {
@@ -574,9 +570,7 @@ func (c *projectController) ensureProjectCleanup(ctx context.Context, project *k
 		}
 	}
 
-	oldProject := project.DeepCopy()
-	kuberneteshelper.RemoveFinalizer(project, CleanupFinalizerName)
-	return c.client.Patch(ctx, project, ctrlruntimeclient.MergeFrom(oldProject))
+	return kuberneteshelper.TryRemoveFinalizer(ctx, c.client, project, CleanupFinalizerName)
 }
 
 func cleanUpClusterRBACRoleBindingFor(ctx context.Context, c ctrlruntimeclient.Client, groupName, resource string) error {

--- a/pkg/controller/master-controller-manager/user-project-binding/user_project_binding_controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/user_project_binding_controller.go
@@ -149,12 +149,7 @@ func (r *reconcileSyncProjectBinding) ensureNotProjectOwnerForBinding(ctx contex
 }
 
 func (r *reconcileSyncProjectBinding) removeFinalizerFromBinding(ctx context.Context, projectBinding *kubermaticv1.UserProjectBinding) error {
-	if kuberneteshelper.HasFinalizer(projectBinding, rbac.CleanupFinalizerName) {
-		oldBinding := projectBinding.DeepCopy()
-		kuberneteshelper.RemoveFinalizer(projectBinding, rbac.CleanupFinalizerName)
-		return r.Patch(ctx, projectBinding, ctrlruntimeclient.MergeFrom(oldBinding))
-	}
-	return nil
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, projectBinding, rbac.CleanupFinalizerName)
 }
 
 func (r *reconcileSyncProjectBinding) userForBinding(ctx context.Context, projectBinding *kubermaticv1.UserProjectBinding) (*kubermaticv1.User, error) {

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -276,15 +276,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 }
 
 func (r *Reconciler) removeCleanupFinalizer(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon) error {
-	if kuberneteshelper.HasFinalizer(addon, cleanupFinalizerName) {
-		oldAddon := addon.DeepCopy()
-		kuberneteshelper.RemoveFinalizer(addon, cleanupFinalizerName)
-		if err := r.Client.Patch(ctx, addon, ctrlruntimeclient.MergeFrom(oldAddon)); err != nil {
-			return err
-		}
-		log.Debugw("Removed the cleanup finalizer", "finalizer", cleanupFinalizerName)
-	}
-	return nil
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, addon, cleanupFinalizerName)
 }
 
 func (r *Reconciler) getAddonManifests(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) ([]runtime.RawExtension, error) {
@@ -522,13 +514,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 }
 
 func (r *Reconciler) ensureFinalizerIsSet(ctx context.Context, addon *kubermaticv1.Addon) error {
-	if kuberneteshelper.HasFinalizer(addon, cleanupFinalizerName) {
-		return nil
-	}
-
-	oldAddon := addon.DeepCopy()
-	kuberneteshelper.AddFinalizer(addon, cleanupFinalizerName)
-	return r.Client.Patch(ctx, addon, ctrlruntimeclient.MergeFrom(oldAddon))
+	return kuberneteshelper.TryAddFinalizer(ctx, r, addon, cleanupFinalizerName)
 }
 
 func (r *Reconciler) ensureResourcesCreatedConditionIsSet(ctx context.Context, addon *kubermaticv1.Addon) error {

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -173,9 +173,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 	log.Infof("performing etcd restore from backup %v", restore.Spec.BackupName)
 
 	if restore.DeletionTimestamp == nil {
-		if err := r.updateRestore(ctx, restore, func(restore *kubermaticv1.EtcdRestore) {
-			kuberneteshelper.AddFinalizer(restore, FinishRestoreFinalizer)
-		}); err != nil {
+		if err := kuberneteshelper.TryAddFinalizer(ctx, r, restore, FinishRestoreFinalizer); err != nil {
 			return nil, fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -328,18 +328,7 @@ func (r *Reconciler) updateCluster(ctx context.Context, cluster *kubermaticv1.Cl
 }
 
 func (r *Reconciler) AddFinalizers(ctx context.Context, cluster *kubermaticv1.Cluster, finalizers ...string) (*reconcile.Result, error) {
-	if err := r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-		kuberneteshelper.AddFinalizer(c, finalizers...)
-	}, ctrlruntimeclient.MergeFromWithOptimisticLock{}); err != nil {
-		if !kerrors.IsConflict(err) {
-			return nil, fmt.Errorf("failed to add finalizers %v: %w", finalizers, err)
-		}
-		// In case of conflict we just re-enqueue the item for later
-		// processing without returning an error.
-		r.log.Infow("failed to add finalizers", "error", err, "finalizers", finalizers)
-		return &reconcile.Result{Requeue: true}, nil
-	}
-	return &reconcile.Result{}, nil
+	return &reconcile.Result{}, kuberneteshelper.TryAddFinalizer(ctx, r, cluster, finalizers...)
 }
 
 func (r *Reconciler) updateClusterError(ctx context.Context, cluster *kubermaticv1.Cluster, reason kubermaticv1.ClusterStatusError, message string) error {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -331,6 +331,8 @@ func (r *Reconciler) ensureDeployments(ctx context.Context, cluster *kubermaticv
 
 // GetSecretCreators returns all SecretCreators that are currently in use.
 func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconciling.NamedSecretCreatorGetter {
+	namespace := data.Cluster().Status.NamespaceName
+
 	creators := []reconciling.NamedSecretCreatorGetter{
 		certificates.RootCACreator(data),
 		certificates.FrontProxyCACreator(),
@@ -344,14 +346,14 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 		machinecontroller.TLSServingCertificateCreator(data),
 
 		// Kubeconfigs
-		resources.GetInternalKubeconfigCreator(resources.SchedulerKubeconfigSecretName, resources.SchedulerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.MachineControllerKubeconfigSecretName, resources.MachineControllerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.OperatingSystemManagerKubeconfigSecretName, resources.OperatingSystemManagerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
-		resources.GetInternalKubeconfigCreator(resources.KubernetesDashboardKubeconfigSecretName, resources.KubernetesDashboardCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.SchedulerKubeconfigSecretName, resources.SchedulerCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.MachineControllerKubeconfigSecretName, resources.MachineControllerCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.OperatingSystemManagerKubeconfigSecretName, resources.OperatingSystemManagerCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.KubernetesDashboardKubeconfigSecretName, resources.KubernetesDashboardCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data),
 		resources.AdminKubeconfigCreator(data),
 		apiserver.TokenViewerCreator(),
 		apiserver.TokenUsersCreator(data),
@@ -369,14 +371,14 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 			openvpn.TLSServingCertificateCreator(data),
 			openvpn.InternalClientCertificateCreator(data),
 			metricsserver.TLSServingCertSecretCreator(data.GetRootCA),
-			resources.GetInternalKubeconfigCreator(resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data),
-			resources.GetInternalKubeconfigCreator(resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil, data),
+			resources.GetInternalKubeconfigCreator(namespace, resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data),
+			resources.GetInternalKubeconfigCreator(namespace, resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil, data),
 		)
 	}
 
 	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; flag {
 		creators = append(creators, resources.GetInternalKubeconfigCreator(
-			resources.CloudControllerManagerKubeconfigSecretName, resources.CloudControllerManagerCertUsername, nil, data,
+			namespace, resources.CloudControllerManagerKubeconfigSecretName, resources.CloudControllerManagerCertUsername, nil, data,
 		))
 	}
 

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
@@ -109,11 +109,8 @@ func (r *orgGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	if !kubernetes.HasFinalizer(project, mlaFinalizer) {
-		kubernetes.AddFinalizer(project, mlaFinalizer)
-		if err := r.Update(ctx, project); err != nil {
-			return reconcile.Result{}, fmt.Errorf("updating finalizers: %w", err)
-		}
+	if err := kubernetes.TryAddFinalizer(ctx, r, project, mlaFinalizer); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
 	org := grafanasdk.Org{

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -116,11 +116,8 @@ func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, nil
 	}
 
-	if !kubernetes.HasFinalizer(ruleGroup, ruleGroupFinalizer) {
-		kubernetes.AddFinalizer(ruleGroup, ruleGroupFinalizer)
-		if err := r.Update(ctx, ruleGroup); err != nil {
-			return reconcile.Result{}, fmt.Errorf("updating finalizers for ruleGroup object: %w", err)
-		}
+	if err := kubernetes.TryAddFinalizer(ctx, r, ruleGroup, ruleGroupFinalizer); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
 	if err := r.ruleGroupSyncController.syncClusterNS(ctx, log, ruleGroup, func(seedClient ctrlruntimeclient.Client, ruleGroup *kubermaticv1.RuleGroup, cluster *kubermaticv1.Cluster) error {
@@ -182,14 +179,7 @@ func (r *ruleGroupSyncController) handleDeletion(ctx context.Context, log *zap.S
 		return err
 	}
 
-	if kubernetes.HasFinalizer(ruleGroup, ruleGroupFinalizer) {
-		oldGroup := ruleGroup.DeepCopy()
-		kubernetes.RemoveFinalizer(ruleGroup, ruleGroupFinalizer)
-		if err := r.Patch(ctx, ruleGroup, ctrlruntimeclient.MergeFrom(oldGroup)); err != nil {
-			return fmt.Errorf("failed to remove ruleGroup finalizer: %w", err)
-		}
-	}
-	return nil
+	return kubernetes.TryRemoveFinalizer(ctx, r, ruleGroup, ruleGroupFinalizer)
 }
 
 func (r *ruleGroupSyncController) syncClusterNS(

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ce.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ce.go
@@ -27,36 +27,25 @@ import (
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
+	finalizer := kubermaticapiv1.GatekeeperConstraintCleanupFinalizer
+
 	// constraint deletion
 	if constraint.DeletionTimestamp != nil {
-		if !kuberneteshelper.HasFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer) {
-			return nil
+		if kuberneteshelper.HasFinalizer(constraint, finalizer) {
+			if err := r.cleanupConstraint(ctx, constraint, log); err != nil {
+				return err
+			}
 		}
 
-		if err := r.cleanupConstraint(ctx, constraint, log); err != nil {
-			return err
-		}
-
-		oldConstraint := constraint.DeepCopy()
-		kuberneteshelper.RemoveFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
-		if err := r.seedClient.Patch(ctx, constraint, ctrlruntimeclient.MergeFrom(oldConstraint)); err != nil {
-			return fmt.Errorf("failed to remove constraint finalizer %s: %w", constraint.Name, err)
-		}
-		return nil
+		return kuberneteshelper.TryRemoveFinalizer(ctx, r.seedClient, constraint, finalizer)
 	}
 
 	// add finalizer
-	if !kuberneteshelper.HasFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer) {
-		oldConstraint := constraint.DeepCopy()
-		kuberneteshelper.AddFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
-		if err := r.seedClient.Patch(ctx, constraint, ctrlruntimeclient.MergeFrom(oldConstraint)); err != nil {
-			return fmt.Errorf("failed to set constraint finalizer %s: %w", constraint.Name, err)
-		}
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.seedClient, constraint, finalizer); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
 	// constraint creation

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ee.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ee.go
@@ -27,11 +27,11 @@ import (
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
+	finalizer := kubermaticapiv1.GatekeeperConstraintCleanupFinalizer
+
 	// constraint deletion
 	if constraint.Spec.Disabled {
 		if err := r.cleanupConstraint(ctx, constraint, log); err != nil {
@@ -40,31 +40,21 @@ func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Con
 	}
 
 	if constraint.DeletionTimestamp != nil {
-		if !kuberneteshelper.HasFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer) {
-			return nil
+		if kuberneteshelper.HasFinalizer(constraint, finalizer) {
+			if err := r.cleanupConstraint(ctx, constraint, log); err != nil {
+				return err
+			}
 		}
 
-		if err := r.cleanupConstraint(ctx, constraint, log); err != nil {
-			return err
-		}
-
-		oldConstraint := constraint.DeepCopy()
-		kuberneteshelper.RemoveFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
-		if err := r.seedClient.Patch(ctx, constraint, ctrlruntimeclient.MergeFrom(oldConstraint)); err != nil {
-			return fmt.Errorf("failed to remove constraint finalizer %s: %w", constraint.Name, err)
-		}
-		return nil
+		return kuberneteshelper.TryRemoveFinalizer(ctx, r.seedClient, constraint, finalizer)
 	}
 
 	if !constraint.Spec.Disabled {
 		// add finalizer
-		if !kuberneteshelper.HasFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer) {
-			oldConstraint := constraint.DeepCopy()
-			kuberneteshelper.AddFinalizer(constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
-			if err := r.seedClient.Patch(ctx, constraint, ctrlruntimeclient.MergeFrom(oldConstraint)); err != nil {
-				return fmt.Errorf("failed to set constraint finalizer %s: %w", constraint.Name, err)
-			}
+		if err := kuberneteshelper.TryAddFinalizer(ctx, r.seedClient, constraint, finalizer); err != nil {
+			return fmt.Errorf("failed to add finalizer: %w", err)
 		}
+
 		// constraint creation
 		if err := r.createConstraint(ctx, constraint, log); err != nil {
 			return err

--- a/pkg/resources/kubeconfig.go
+++ b/pkg/resources/kubeconfig.go
@@ -111,7 +111,7 @@ type internalKubeconfigCreatorData interface {
 }
 
 // GetInternalKubeconfigCreator is a generic function to return a secret generator to create a kubeconfig which must only be used within the seed-cluster as it uses the ClusterIP of the apiserver.
-func GetInternalKubeconfigCreator(name, commonName string, organizations []string, data internalKubeconfigCreatorData) reconciling.NamedSecretCreatorGetter {
+func GetInternalKubeconfigCreator(namespace, name, commonName string, organizations []string, data internalKubeconfigCreatorData) reconciling.NamedSecretCreatorGetter {
 	return func() (string, reconciling.SecretCreator) {
 		return name, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
@@ -128,9 +128,9 @@ func GetInternalKubeconfigCreator(name, commonName string, organizations []strin
 			valid, err := IsValidKubeconfig(b, ca.Cert, apiserverURL, commonName, organizations, data.Cluster().Name)
 			if err != nil || !valid {
 				if err != nil {
-					klog.V(2).Infof("failed to validate existing kubeconfig from %s/%s %v. Regenerating it...", se.Namespace, se.Name, err)
+					klog.V(2).Infof("failed to validate existing kubeconfig from %s/%s, regenerating it: %v", namespace, name, err)
 				} else {
-					klog.V(2).Infof("invalid/outdated kubeconfig found in %s/%s. Regenerating it...", se.Namespace, se.Name)
+					klog.V(2).Infof("invalid/outdated kubeconfig found in %s/%s. Regenerating it...", namespace, name)
 				}
 
 				se.Data[KubeconfigSecretKey], err = BuildNewKubeconfigAsByte(ca, apiserverURL, commonName, organizations, data.Cluster().Name)

--- a/pkg/resources/kubeconfig_test.go
+++ b/pkg/resources/kubeconfig_test.go
@@ -118,7 +118,7 @@ func checkKubeConfigRegeneration(t *testing.T, orgs []string) {
 	data := &fakeDataProvider{caPair: ca}
 	assert.NotNil(t, data)
 
-	_, create := GetInternalKubeconfigCreator("some-name", "test-creator-cn", orgs, data)()
+	_, create := GetInternalKubeconfigCreator("some-namespace", "some-name", "test-creator-cn", orgs, data)()
 	secret, err := create(&corev1.Secret{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This introduces new helpers that use `retry` just like `UpdateClusterStatus()` does (since #8893). Since retrying seems very successful and hides a lot of transient, pointless errors from our logs, I think it's worth it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
