### PR TITLE
Improve rbac log messages in master-ctrl-mgr

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -547,7 +547,7 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	}
 
 	// unknown group passed
-	return nil, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
+	return nil, fmt.Errorf("unable to generate verbs, unknown group name %q passed in", groupName)
 }
 
 // generateVerbsForResource generates verbs for a resource for example "cluster"
@@ -597,7 +597,7 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 	}
 
 	// unknown group passed
-	return nil, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
+	return nil, fmt.Errorf("unable to generate verbs, unknown group name %q given", groupName)
 }
 
 func generateVerbsForNamespacedResource(groupName, resourceKind, namespace string) ([]string, error) {
@@ -615,7 +615,7 @@ func generateVerbsForNamespacedResource(groupName, resourceKind, namespace strin
 	}
 
 	// unknown group passed
-	return nil, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s, namespace = %s", groupName, namespace)
+	return nil, fmt.Errorf("unable to generate verbs, unknown group name %q, namespace %q given", groupName, namespace)
 }
 
 // generateVerbsForNamedResourceInNamespace generates a set of verbs for a named resource in a given namespace
@@ -635,7 +635,7 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 	}
 
 	// unknown group passed
-	return nil, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
+	return nil, fmt.Errorf("unable to generate verbs for group %q, kind %q and namespace %q", groupName, resourceKind, namespace)
 }
 
 func generateVerbsForClusterNamespaceResource(cluster *kubermaticv1.Cluster, groupName, kind string) ([]string, error) {
@@ -654,7 +654,7 @@ func generateVerbsForClusterNamespaceResource(cluster *kubermaticv1.Cluster, gro
 	}
 
 	// unknown group passed
-	return nil, fmt.Errorf("unable to generate verbs for cluster namespace resource cluster = %s, group = %s, kind = %s", cluster.Name, groupName, kind)
+	return nil, fmt.Errorf("unable to generate verbs for cluster namespace resource cluster %q, group %q and kind %q", cluster.Name, groupName, kind)
 }
 
 func generateVerbsForClusterNamespaceNamedResource(cluster *kubermaticv1.Cluster, groupName, kind, name string) ([]string, error) {
@@ -679,7 +679,7 @@ func generateVerbsForClusterNamespaceNamedResource(cluster *kubermaticv1.Cluster
 	}
 
 	// unknown group passed
-	return nil, fmt.Errorf("unable to generate verbs for cluster namespace resource cluster = %s, group = %s, kind = %s, name = %s", cluster.Name, groupName, kind, name)
+	return nil, fmt.Errorf("unable to generate verbs for cluster namespace resource cluster %q, group %q, kind %q and name %q", cluster.Name, groupName, kind, name)
 }
 
 func formatMapping(rmapping *meta.RESTMapping) string {

--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -23,6 +23,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -679,4 +680,8 @@ func generateVerbsForClusterNamespaceNamedResource(cluster *kubermaticv1.Cluster
 
 	// unknown group passed
 	return nil, fmt.Errorf("unable to generate verbs for cluster namespace resource cluster = %s, group = %s, kind = %s, name = %s", cluster.Name, groupName, kind, name)
+}
+
+func formatMapping(rmapping *meta.RESTMapping) string {
+	return rmapping.GroupVersionKind.Kind
 }

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -62,7 +62,7 @@ func (c *resourcesController) syncClusterScopedProjectResource(ctx context.Conte
 		return err
 	}
 
-	projectName, err := getProjectName(metaObject, rmapping)
+	projectName, err := getProjectName(obj)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (c *resourcesController) syncNamespaceScopedProjectResource(ctx context.Con
 		return err
 	}
 
-	projectName, err := getProjectName(metaObject, rmapping)
+	projectName, err := getProjectName(obj)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (c *resourcesController) syncClusterResource(ctx context.Context, obj ctrlr
 		return err
 	}
 
-	projectName, err := getProjectName(obj, rmapping)
+	projectName, err := getProjectName(obj)
 	if err != nil {
 		return err
 	}
@@ -221,9 +221,9 @@ func userClusterMLAEnabled(cluster *kubermaticv1.Cluster) (bool, error) {
 	return cluster.Spec.MLA != nil && (cluster.Spec.MLA.MonitoringEnabled || cluster.Spec.MLA.LoggingEnabled), nil
 }
 
-func getProjectName(metaObject metav1.Object, rmapping *meta.RESTMapping) (string, error) {
+func getProjectName(obj ctrlruntimeclient.Object) (string, error) {
 	projectName := ""
-	for _, owner := range metaObject.GetOwnerReferences() {
+	for _, owner := range obj.GetOwnerReferences() {
 		if owner.APIVersion == kubermaticv1.SchemeGroupVersion.String() && owner.Kind == kubermaticv1.ProjectKindName &&
 			len(owner.Name) > 0 && len(owner.UID) > 0 {
 			projectName = owner.Name
@@ -231,11 +231,11 @@ func getProjectName(metaObject metav1.Object, rmapping *meta.RESTMapping) (strin
 		}
 	}
 	if len(projectName) == 0 {
-		projectName = metaObject.GetLabels()[kubermaticv1.ProjectIDLabelKey]
+		projectName = obj.GetLabels()[kubermaticv1.ProjectIDLabelKey]
 	}
 
 	if len(projectName) == 0 {
-		return "", fmt.Errorf("unable to find owning project for %s %s", formatMapping(rmapping), metaObject.GetName())
+		return "", fmt.Errorf("unable to find owning project for %s %s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
 	}
 	return projectName, nil
 }

--- a/pkg/controller/master-controller-manager/service-account/service_account_binding_controller.go
+++ b/pkg/controller/master-controller-manager/service-account/service_account_binding_controller.go
@@ -100,7 +100,7 @@ func (r *reconcileServiceAccountProjectBinding) ensureServiceAccountProjectBindi
 	}
 
 	if len(projectName) == 0 {
-		return fmt.Errorf("unable to find owing project for the service account = %s", sa.Name)
+		return fmt.Errorf("unable to find owing project for the service account %q", sa.Name)
 	}
 
 	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", kubermaticv1.ProjectIDLabelKey, projectName))

--- a/pkg/controller/user-cluster-controller-manager/rbac/mapper.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/mapper.go
@@ -58,7 +58,7 @@ func generateVerbsForGroup(groupName string) ([]string, error) {
 	}
 
 	// unknown group passed
-	return []string{}, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
+	return []string{}, fmt.Errorf("unable to generate verbs, unknown group %q name given", groupName)
 }
 
 // GenerateRBACClusterRole creates role for specific group.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -94,7 +94,7 @@ func (f FeatureGate) Set(s string) error {
 
 		arr := strings.SplitN(s, "=", 2)
 		if len(arr) != 2 {
-			return fmt.Errorf("missing bool value for feature gate key = %s", s)
+			return fmt.Errorf("missing bool value for feature gate %s", s)
 		}
 
 		k := strings.TrimSpace(arr[0])
@@ -102,7 +102,7 @@ func (f FeatureGate) Set(s string) error {
 
 		boolValue, err := strconv.ParseBool(v)
 		if err != nil {
-			return fmt.Errorf("invalid value %v for feature gate key = %s, use true|false instead", v, k)
+			return fmt.Errorf("invalid value %v for feature gate %s, use true|false instead", v, k)
 		}
 		f[k] = boolValue
 	}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -45,7 +45,7 @@ func TestFeatureGates(t *testing.T) {
 			for feature, shouldBeEnabled := range tc.output {
 				isEnabled := target.Enabled(feature)
 				if isEnabled != shouldBeEnabled {
-					t.Fatalf("expected feature = %s to be set to %v but was set to %v", feature, shouldBeEnabled, isEnabled)
+					t.Fatalf("expected feature %s to be set to %v but was set to %v", feature, shouldBeEnabled, isEnabled)
 				}
 			}
 		})

--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -260,7 +260,7 @@ func CreateOIDCKubeconfigEndpoint(ctx context.Context, projectProvider provider.
 	// PHASE initial handles request from the end-user that wants to authenticate
 	// and kicksoff the process of kubeconfig generation
 	if req.phase != initialPhase {
-		return nil, kcerrors.NewBadRequest(fmt.Sprintf("bad request unexpected phase = %d, expected phase = %d, did you forget to set the phase while decoding the request ?", req.phase, initialPhase))
+		return nil, kcerrors.NewBadRequest(fmt.Sprintf("bad request unexpected phase %d, expected phase %d, did you forget to set the phase while decoding the request?", req.phase, initialPhase))
 	}
 
 	rsp := createOIDCKubeconfigRsp{}
@@ -366,7 +366,7 @@ func DecodeCreateOIDCKubeconfig(c context.Context, r *http.Request) (interface{}
 		errType := r.URL.Query().Get("error")
 		errMessage := r.URL.Query().Get("error_description")
 		if len(errMessage) != 0 {
-			return nil, fmt.Errorf("OIDC provider error type = %s, description = %s", errType, errMessage)
+			return nil, fmt.Errorf("OIDC provider error %s: %s", errType, errMessage)
 		}
 	}
 

--- a/pkg/handler/v1/admin/admission_plugin.go
+++ b/pkg/handler/v1/admin/admission_plugin.go
@@ -144,7 +144,7 @@ type updateAdmissionPluginReq struct {
 // Validate validates UpdateAdmissionPluginEndpoint request.
 func (r updateAdmissionPluginReq) Validate() error {
 	if r.Name != r.Body.Name {
-		return fmt.Errorf("admission plugin name mismatch, you requested to update AdmissionPlugin = %s but body contains AdmissionPlugin = %s", r.Name, r.Body.Name)
+		return fmt.Errorf("admission plugin name mismatch, you requested to update AdmissionPlugin %q but body contains AdmissionPlugin %q", r.Name, r.Body.Name)
 	}
 	return nil
 }

--- a/pkg/handler/v1/admin/seed.go
+++ b/pkg/handler/v1/admin/seed.go
@@ -220,7 +220,7 @@ func DecodeSeedReq(c context.Context, r *http.Request) (interface{}, error) {
 // Validate validates UpdateAdmissionPluginEndpoint request.
 func (r updateSeedReq) Validate() error {
 	if r.Name != r.Body.Name {
-		return fmt.Errorf("seed name mismatch, you requested to update Seed = %s but body contains Seed = %s", r.Name, r.Body.Name)
+		return fmt.Errorf("seed name mismatch, you requested to update Seed %q but body contains Seed %q", r.Name, r.Body.Name)
 	}
 	return nil
 }

--- a/pkg/handler/v1/admin/seed_test.go
+++ b/pkg/handler/v1/admin/seed_test.go
@@ -179,7 +179,7 @@ func TestUpdateSeedEndpoint(t *testing.T) {
 			name:                   "scenario 3: seed name mismatch",
 			body:                   `{"name":"central1","spec":{"country":"US","location":"us-central","kubeconfig":{},"datacenters":{"audited-dc":{"country":"Germany","location":"Finanzamt Castle","node":{},"spec":{"fake":{},"enforceAuditLogging":true}},"fake-dc":{"country":"Germany","location":"Henrik's basement","node":{},"spec":{"fake":{},"enforceAuditLogging":false}},"private-do1":{"country":"NL","location":"US ","node":{},"spec":{"digitalocean":{"region":"ams2"},"enforceAuditLogging":false}},"regular-do1":{"country":"NL","location":"Amsterdam","node":{},"spec":{"digitalocean":{"region":"ams2"},"enforceAuditLogging":false}},"restricted-fake-dc":{"country":"NL","location":"Amsterdam","node":{},"spec":{"fake":{},"requiredEmails":["example.com"],"enforceAuditLogging":false}},"restricted-fake-dc2":{"country":"NL","location":"Amsterdam","node":{},"spec":{"fake":{},"requiredEmails":["23f67weuc.com","example.com","12noifsdsd.org"],"enforceAuditLogging":false}}}}}`,
 			seedName:               "us-central1",
-			expectedResponse:       `{"error":{"code":400,"message":"seed name mismatch, you requested to update Seed = us-central1 but body contains Seed = central1"}}`,
+			expectedResponse:       `{"error":{"code":400,"message":"seed name mismatch, you requested to update Seed \"us-central1\" but body contains Seed \"central1\""}}`,
 			httpStatus:             http.StatusBadRequest,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true), test.GenTestSeed()},
 			existingAPIUser:        test.GenDefaultAPIUser(),

--- a/pkg/handler/v1/cluster/binding_test.go
+++ b/pkg/handler/v1/cluster/binding_test.go
@@ -236,7 +236,7 @@ func TestBindUserToRole(t *testing.T) {
 			roleName:         "role-1",
 			namespace:        "default",
 			body:             `{"userEmail":"test@example.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -353,7 +353,7 @@ func TestUnbindUserFromRoleBinding(t *testing.T) {
 			roleName:         "role-1",
 			namespace:        "default",
 			body:             `{"userEmail":"bob@acme.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -451,7 +451,7 @@ func TestListRoleBinding(t *testing.T) {
 		},
 		{
 			name:             "scenario 3: the user John can not list Bob's bindings",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -695,7 +695,7 @@ func TestBindUserToClusterRole(t *testing.T) {
 			name:             "scenario 11: user John can not update existing binding for the new user for Bob's cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"test@example.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -812,7 +812,7 @@ func TestUnbindUserFromClusterRoleBinding(t *testing.T) {
 			name:             "scenario 4: the user can not remove user from existing cluster role binding for Bob's cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"bob@acme.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -910,7 +910,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 		// scenario 3
 		{
 			name:             "scenario 3: the user John can not list Bob's cluster role bindings",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(

--- a/pkg/handler/v1/cluster/cluster_test.go
+++ b/pkg/handler/v1/cluster/cluster_test.go
@@ -327,10 +327,10 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 			Name:                            "scenario 3: the user John can not detach any key from the Bob cluster",
 			Body:                            ``,
 			KeyToDelete:                     "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedDeleteResponse:          `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedDeleteResponse:          `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ExpectedDeleteHTTPStatus:        http.StatusForbidden,
 			ExpectedGetHTTPStatus:           http.StatusForbidden,
-			ExpectedResponseOnGetAfterDelte: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponseOnGetAfterDelte: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ProjectToSync:                   test.GenDefaultProject().Name,
 			ExistingAPIUser:                 test.GenAPIUser("John", "john@acme.com"),
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -633,7 +633,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 4: the user John can not assign ssh key to the Bob's cluster",
 			SSHKeyID:         "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingAPIUser:  test.GenAPIUser("John", "john@acme.com"),
@@ -739,7 +739,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 3: unable to create a cluster when the user doesn't belong to the project",
 			Body:             `{"cluster":{"name":"keen-snyder","pause":false,"spec":{"version":"1.22.5","cloud":{"version":"1.22.5","fake":{"token":"dummy_token"},"dc":"fake-dc"}}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -1016,7 +1016,7 @@ func TestGetClusterHealth(t *testing.T) {
 		{
 			Name:             "scenario 3: the user Bob can not get John's cluster health status",
 			Body:             ``,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ClusterToGet:     "keen-snyder",
 			ProjectToSync:    test.GenDefaultProject().Name,
@@ -1336,7 +1336,7 @@ func TestPatchCluster(t *testing.T) {
 		{
 			Name:             "scenario 7: the regular user John can not update Bob's cluster version",
 			Body:             `{"spec":{"version":"1.2.3"}}`,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			cluster:          "keen-snyder",
 			HTTPStatus:       http.StatusForbidden,
 			project:          test.GenDefaultProject().Name,
@@ -1455,7 +1455,7 @@ func TestGetCluster(t *testing.T) {
 		{
 			Name:             "scenario 4: the regular user John can not get Bob's cluster",
 			Body:             ``,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -2027,7 +2027,7 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 		// scenario 3
 		{
 			name:             "scenario 3: the user John can not revoke Bob's cluster token",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster(),
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -2174,7 +2174,7 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine"),
 				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine"),
 			},
-			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},
 	}
 
@@ -2320,7 +2320,7 @@ func TestGetClusterMetrics(t *testing.T) {
 		{
 			Name:             "scenario 2: the user John can not get Bob's cluster metrics",
 			Body:             ``,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingNodes: []*corev1.Node{
@@ -2452,7 +2452,7 @@ func TestListNamespace(t *testing.T) {
 		// scenario 3
 		{
 			name:             "scenario 3: the user John can not get Bob's cluster namespaces",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(

--- a/pkg/handler/v1/cluster/kubeconfig_test.go
+++ b/pkg/handler/v1/cluster/kubeconfig_test.go
@@ -430,7 +430,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("bob", "bob@acme.com"),
-			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to the given project = foo-ID"}}`,
+			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to project foo-ID"}}`,
 		},
 	}
 

--- a/pkg/handler/v1/node/node_test.go
+++ b/pkg/handler/v1/node/node_test.go
@@ -138,7 +138,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 				genTestMachine("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExpectedHTTPStatusOnGet: http.StatusForbidden,
-			ExpectedResponseOnGet:   `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponseOnGet:   `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ExpectedNodeCount:       2,
 		},
 	}
@@ -1096,7 +1096,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine"),
 				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine"),
 			},
-			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},
 	}
 
@@ -1257,7 +1257,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 7: The user John can not update Bob's node deployment",
 			Body:                       fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
-			ExpectedResponse:           `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse:           `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusForbidden,
 			project:                    test.GenDefaultProject().Name,
@@ -1554,7 +1554,7 @@ func TestNodeDeploymentMetrics(t *testing.T) {
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},
 	}
 

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -179,7 +179,7 @@ func TestRenameProjectEndpoint(t *testing.T) {
 			Name:             "scenario 7: the user John can't update Bob's project",
 			Body:             `{"Name": "Super-Project"}`,
 			ProjectToRename:  "my-third-project-ID",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-third-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-third-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingKubermaticObjects: []ctrlruntimeclient.Object{
 				// add some projects
@@ -612,7 +612,7 @@ func TestGetProjectEndpoint(t *testing.T) {
 			Name:             "scenario 3: the user John can't get Bob's project",
 			Body:             ``,
 			ProjectToSync:    "my-third-project-ID",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-third-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-third-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingKubermaticObjects: []ctrlruntimeclient.Object{
 				// add some projects

--- a/pkg/handler/v1/provider/openstack.go
+++ b/pkg/handler/v1/provider/openstack.go
@@ -76,7 +76,7 @@ func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, presetProvider prov
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got %T", request)
 		}
 		userInfo, cred, err := getAuthInfo(ctx, req, userInfoGetter, presetProvider)
 		if err != nil {
@@ -110,7 +110,7 @@ func OpenstackTenantEndpoint(seedsGetter provider.SeedsGetter, presetProvider pr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		reqTenant, ok := request.(OpenstackTenantReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackTenantReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackTenantReq, got %T", request)
 		}
 		req := OpenstackReq{
 			Username:                    reqTenant.Username,
@@ -149,7 +149,7 @@ func OpenstackNetworkEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got %T", request)
 		}
 		userInfo, cred, err := getAuthInfo(ctx, req, userInfoGetter, presetProvider)
 		if err != nil {
@@ -174,7 +174,7 @@ func OpenstackSecurityGroupEndpoint(seedsGetter provider.SeedsGetter, presetProv
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got %T", request)
 		}
 		userInfo, cred, err := getAuthInfo(ctx, req, userInfoGetter, presetProvider)
 		if err != nil {
@@ -199,7 +199,7 @@ func OpenstackSubnetsEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackSubnetReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackSubnetReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackSubnetReq, got %T", request)
 		}
 		userInfo, cred, err := getAuthInfo(ctx, req.OpenstackReq, userInfoGetter, presetProvider)
 		if err != nil {
@@ -224,7 +224,7 @@ func OpenstackAvailabilityZoneEndpoint(seedsGetter provider.SeedsGetter, presetP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got %T", request)
 		}
 		userInfo, cred, err := getAuthInfo(ctx, req, userInfoGetter, presetProvider)
 		if err != nil {

--- a/pkg/handler/v1/provider/vsphere.go
+++ b/pkg/handler/v1/provider/vsphere.go
@@ -35,7 +35,7 @@ func VsphereNetworksEndpoint(seedsGetter provider.SeedsGetter, presetProvider pr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(VSphereNetworksReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = VSphereNetworksReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = VSphereNetworksReq, got %T", request)
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -74,7 +74,7 @@ func VsphereFoldersEndpoint(seedsGetter provider.SeedsGetter, presetProvider pro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(VSphereFoldersReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = VSphereFoldersReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = VSphereFoldersReq, got %T", request)
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {

--- a/pkg/handler/v1/serviceaccount/sa.go
+++ b/pkg/handler/v1/serviceaccount/sa.go
@@ -347,7 +347,7 @@ func (r updateReq) Validate() error {
 		return err
 	}
 	if r.ServiceAccountID != r.Body.ID {
-		return fmt.Errorf("service account ID mismatch, you requested to update ServiceAccount = %s but body contains ServiceAccount = %s", r.ServiceAccountID, r.Body.ID)
+		return fmt.Errorf("service account ID mismatch, you requested to update ServiceAccount %q but body contains ServiceAccount %q", r.ServiceAccountID, r.Body.ID)
 	}
 	return nil
 }

--- a/pkg/handler/v1/serviceaccount/sa_test.go
+++ b/pkg/handler/v1/serviceaccount/sa_test.go
@@ -162,7 +162,7 @@ func TestCreateServiceAccountProject(t *testing.T) {
 			},
 			existingAPIUser:  *test.GenAPIUser("bob", "bob@acme.com"),
 			projectToSync:    "plan9-ID",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to the given project = plan9-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to project plan9-ID"}}`,
 		},
 	}
 

--- a/pkg/handler/v1/serviceaccount/token.go
+++ b/pkg/handler/v1/serviceaccount/token.go
@@ -441,7 +441,7 @@ func (r updateTokenReq) Validate() error {
 		return fmt.Errorf("new name can not be empty")
 	}
 	if r.TokenID != r.Body.ID {
-		return fmt.Errorf("token ID mismatch, you requested to update token = %s but body contains token = %s", r.TokenID, r.Body.ID)
+		return fmt.Errorf("token ID mismatch, you requested to update token %q but body contains token %q", r.TokenID, r.Body.ID)
 	}
 
 	return nil

--- a/pkg/handler/v1/serviceaccount/token_test.go
+++ b/pkg/handler/v1/serviceaccount/token_test.go
@@ -640,7 +640,7 @@ func TestUpdateToken(t *testing.T) {
 			projectToSync:    "plan9-ID",
 			saToSync:         "1",
 			tokenToSync:      "1",
-			expectedErrorMsg: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to the given project = plan9-ID"}}`,
+			expectedErrorMsg: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to project plan9-ID"}}`,
 		},
 	}
 

--- a/pkg/handler/v1/ssh/ssh.go
+++ b/pkg/handler/v1/ssh/ssh.go
@@ -203,7 +203,7 @@ func DecodeCreateReq(c context.Context, r *http.Request) (interface{}, error) {
 
 	req.Key = apiv1.SSHKey{}
 	if err := json.NewDecoder(r.Body).Decode(&req.Key); err != nil {
-		return nil, errors.NewBadRequest("unable to parse the input, err = %v", err.Error())
+		return nil, errors.NewBadRequest("unable to parse the input: %v", err)
 	}
 
 	if len(req.Key.Name) == 0 {

--- a/pkg/handler/v1/user/user.go
+++ b/pkg/handler/v1/user/user.go
@@ -66,7 +66,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(memberList) == 0 {
-			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot delete the user = %s from the project %s because the user is not a member of the project", user.Spec.Email, req.ProjectID))
+			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot delete the user %s from the project %s because the user is not a member of the project", user.Spec.Email, req.ProjectID))
 		}
 		if len(memberList) != 1 {
 			return nil, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot delete the user user %s from the project, inconsistent state in database", user.Spec.Email))
@@ -163,7 +163,7 @@ func EditEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(memberList) == 0 {
-			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot change the membership of the user = %s for the project %s because the user is not a member of the project", currentMemberFromRequest.Email, req.ProjectID))
+			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot change the membership of the user %s for the project %s because the user is not a member of the project", currentMemberFromRequest.Email, req.ProjectID))
 		}
 		if len(memberList) != 1 {
 			return nil, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot change the membershp of the user %s, inconsistent state in database", currentMemberFromRequest.Email))
@@ -482,7 +482,7 @@ func (r EditReq) Validate(authenticatesUserInfo *provider.UserInfo) error {
 		return err
 	}
 	if r.UserID != r.Body.ID {
-		return k8cerrors.NewBadRequest(fmt.Sprintf("userID mismatch, you requested to update user = %s but body contains user = %s", r.UserID, r.Body.ID))
+		return k8cerrors.NewBadRequest(fmt.Sprintf("userID mismatch, you requested to update user %q but body contains user %q", r.UserID, r.Body.ID))
 	}
 	return nil
 }

--- a/pkg/handler/v1/user/user_test.go
+++ b/pkg/handler/v1/user/user_test.go
@@ -156,7 +156,7 @@ func TestGetUsersForProject(t *testing.T) {
 				genDefaultUser(), /*bob*/
 			},
 			ExistingAPIUser:        *genAPIUser("alice2", "alice2@acme.com"),
-			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"alice2@acme.com\" doesn't belong to the given project = foo2-ID"}}`,
+			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"alice2@acme.com\" doesn't belong to project foo2-ID"}}`,
 		},
 		{
 			Name:         "scenario 3: the admin can get a list of user for any project",
@@ -335,7 +335,7 @@ func TestDeleteUserFromProject(t *testing.T) {
 			},
 			UserIDToDelete:   genDefaultUser().Name,
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
-			ExpectedResponse: `{"error":{"code":400,"message":"cannot delete the user = bob@acme.com from the project plan9-ID because the user is not a member of the project"}}`,
+			ExpectedResponse: `{"error":{"code":400,"message":"cannot delete the user bob@acme.com from the project plan9-ID because the user is not a member of the project"}}`,
 		},
 
 		// scenario 3
@@ -485,7 +485,7 @@ func TestEditUserInProject(t *testing.T) {
 			},
 			UserIDToUpdate:   genDefaultUser().Name,
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
-			ExpectedResponse: `{"error":{"code":400,"message":"cannot change the membership of the user = bob@acme.com for the project plan9-ID because the user is not a member of the project"}}`,
+			ExpectedResponse: `{"error":{"code":400,"message":"cannot change the membership of the user bob@acme.com for the project plan9-ID because the user is not a member of the project"}}`,
 		},
 
 		// scenario 3

--- a/pkg/handler/v2/cluster/binding_test.go
+++ b/pkg/handler/v2/cluster/binding_test.go
@@ -236,7 +236,7 @@ func TestBindUserToRole(t *testing.T) {
 			roleName:         "role-1",
 			namespace:        "default",
 			body:             `{"userEmail":"test@example.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -353,7 +353,7 @@ func TestUnbindUserFromRoleBinding(t *testing.T) {
 			roleName:         "role-1",
 			namespace:        "default",
 			body:             `{"userEmail":"bob@acme.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -590,7 +590,7 @@ func TestBindUserToClusterRole(t *testing.T) {
 			name:             "scenario 11: user John can not update existing binding for the new user for Bob's cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"test@example.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -707,7 +707,7 @@ func TestUnbindUserFromClusterRoleBinding(t *testing.T) {
 			name:             "scenario 4: the user can not remove user from existing cluster role binding for Bob's cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"bob@acme.com"}`,
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -806,7 +806,7 @@ func TestListRoleBinding(t *testing.T) {
 		},
 		{
 			name:             "scenario 3: the user John can not list Bob's bindings",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -910,7 +910,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 		// scenario 3
 		{
 			name:             "scenario 3: the user John can not list Bob's cluster role bindings",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -108,7 +108,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 3: unable to create a cluster when the user doesn't belong to the project",
 			Body:             `{"cluster":{"name":"keen-snyder","pause":false,"spec":{"version":"1.22.5","cloud":{"version":"1.22.5","fake":{"token":"dummy_token"},"dc":"fake-dc","enableUserSSHKeyAgent":true,"containerRuntime":"containerd"}}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -681,7 +681,7 @@ func TestGetCluster(t *testing.T) {
 		{
 			Name:             "scenario 5: the regular user John can not get Bob's cluster",
 			Body:             ``,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -1001,7 +1001,7 @@ func TestPatchCluster(t *testing.T) {
 		{
 			Name:             "scenario 7: the regular user John can not update Bob's cluster version",
 			Body:             `{"spec":{"version":"1.2.3"}}`,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			cluster:          "keen-snyder",
 			HTTPStatus:       http.StatusForbidden,
 			project:          test.GenDefaultProject().Name,
@@ -1166,7 +1166,7 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine"),
 				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine"),
 			},
-			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},
 	}
 
@@ -1274,7 +1274,7 @@ func TestGetClusterHealth(t *testing.T) {
 		{
 			Name:             "scenario 3: the user Bob can not get John's cluster health status",
 			Body:             ``,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ClusterToGet:     "keen-snyder",
 			ProjectToSync:    test.GenDefaultProject().Name,
@@ -1561,7 +1561,7 @@ func TestGetClusterMetrics(t *testing.T) {
 		// scenario 3
 		{
 			Name:             "scenario 3: the user John can not get Bob's cluster metrics",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingNodes: []*corev1.Node{
@@ -1693,7 +1693,7 @@ func TestListNamespace(t *testing.T) {
 		// scenario 3
 		{
 			name:             "scenario 3: the user John can not get Bob's cluster namespaces",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -1864,10 +1864,10 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 			Name:                            "scenario 3: the user John can not detach any key from the Bob cluster",
 			Body:                            ``,
 			KeyToDelete:                     "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedDeleteResponse:          `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedDeleteResponse:          `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ExpectedDeleteHTTPStatus:        http.StatusForbidden,
 			ExpectedGetHTTPStatus:           http.StatusForbidden,
-			ExpectedResponseOnGetAfterDelte: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponseOnGetAfterDelte: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ProjectToSync:                   test.GenDefaultProject().Name,
 			ExistingAPIUser:                 test.GenAPIUser("John", "john@acme.com"),
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -2051,7 +2051,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 4: the user John can not assign ssh key to the Bob's cluster",
 			SSHKeyID:         "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingAPIUser:  test.GenAPIUser("John", "john@acme.com"),
@@ -2264,7 +2264,7 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 		// scenario 3
 		{
 			name:             "scenario 3: the user John can not revoke Bob's cluster token",
-			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			clusterToGet:     test.GenDefaultCluster(),
 			httpStatus:       http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(

--- a/pkg/handler/v2/cluster/kubeconfig_test.go
+++ b/pkg/handler/v2/cluster/kubeconfig_test.go
@@ -165,7 +165,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("bob", "bob@acme.com"),
-			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to the given project = foo-ID"}}`,
+			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to project foo-ID"}}`,
 		},
 	}
 

--- a/pkg/handler/v2/constraint/constraint_test.go
+++ b/pkg/handler/v2/constraint/constraint_test.go
@@ -213,7 +213,7 @@ func TestGetConstraints(t *testing.T) {
 			ConstraintName:   "ct1",
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingObjects: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
@@ -404,7 +404,7 @@ func TestDeleteConstraints(t *testing.T) {
 			ConstraintName:   "ct1",
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingObjects: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
@@ -488,7 +488,7 @@ func TestCreateConstraints(t *testing.T) {
 			},
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingObjects: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
@@ -646,7 +646,7 @@ func TestPatchConstraints(t *testing.T) {
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			Patch:            `{"spec":{"constraintType":"RequiredLabel","parameters":{"labels":["test"]},"match":{"kinds":[{"kinds":["pods"], "apiGroups":["v1"]}, {"kinds":["namespaces"]}]}}}`,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingObjects: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),

--- a/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -65,7 +65,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:                   "scenario 2: unable to create a cluster when the user doesn't belong to the project",
 			Body:                   `{"name":"test","kubeconfig":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBZWEJwVm1WeWMybHZiam9nZGpFS1kyeDFjM1JsY25NNkNpMGdZMngxYzNSbGNqb0tJQ0FnSUdObGNuUnBabWxqWVhSbExXRjFkR2h2Y21sMGVTMWtZWFJoT2lCaFltTUtJQ0FnSUhObGNuWmxjam9nYUhSMGNITTZMeTlzYzJoNmRtTm5PR3RrTG1WMWNtOXdaUzEzWlhOME15MWpMbVJsZGk1cmRXSmxjbTFoZEdsakxtbHZPak14TWpjMUNpQWdibUZ0WlRvZ2JITm9lblpqWnpoclpBcGpiMjUwWlhoMGN6b0tMU0JqYjI1MFpYaDBPZ29nSUNBZ1kyeDFjM1JsY2pvZ2JITm9lblpqWnpoclpBb2dJQ0FnZFhObGNqb2daR1ZtWVhWc2RBb2dJRzVoYldVNklHUmxabUYxYkhRS1kzVnljbVZ1ZEMxamIyNTBaWGgwT2lCa1pXWmhkV3gwQ210cGJtUTZJRU52Ym1acFp3cHdjbVZtWlhKbGJtTmxjem9nZTMwS2RYTmxjbk02Q2kwZ2JtRnRaVG9nWkdWbVlYVnNkQW9nSUhWelpYSTZDaUFnSUNCMGIydGxiam9nWVdGaExtSmlZZ289CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbG9jYWxob3N0OjMwODA4CiAgbmFtZTogaHZ3OWs0c2djbApjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogaHZ3OWs0c2djbAogICAgdXNlcjogZGVmYXVsdAogIG5hbWU6IGRlZmF1bHQKY3VycmVudC1jb250ZXh0OiBkZWZhdWx0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdAogIHVzZXI6CiAgICB0b2tlbjogejlzaDc2LjI0ZGNkaDU3czR6ZGt4OGwK"}`,
-			ExpectedResponse:       `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse:       `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:             http.StatusForbidden,
 			ProjectToSync:          test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenUser("", "John", "john@acme.com")),
@@ -249,7 +249,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: the user John can not delete Bob's cluster",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -413,7 +413,7 @@ func TestGetClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: the user John can not get Bob's cluster",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -487,7 +487,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 3: the user John can not update Bob's cluster",
 			Body:             `{"name":"test"}`,
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -628,7 +628,7 @@ func TestGetClusterMetrics(t *testing.T) {
 		// scenario 3
 		{
 			Name:             "scenario 3: the user John can not get Bob's cluster metrics",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     "clusterAbcID",
 			HTTPStatus:       http.StatusForbidden,
 			ExistingNodes: []*corev1.Node{
@@ -775,7 +775,7 @@ func TestGetClusterEvents(t *testing.T) {
 		// scenario 4
 		{
 			Name:             "scenario 4: the user John can not get Bob's cluster events",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     "clusterAbcID",
 			HTTPStatus:       http.StatusForbidden,
 			ExistingNodes: []*corev1.Node{

--- a/pkg/handler/v2/external_cluster/node_test.go
+++ b/pkg/handler/v2/external_cluster/node_test.go
@@ -77,7 +77,7 @@ func TestListNodesEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: the user John can not get Bob's cluster nodes",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -159,7 +159,7 @@ func TestGetNodeEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: the user John can not get Bob's cluster nodes",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -271,7 +271,7 @@ func TestGetClusterNodesMetrics(t *testing.T) {
 		// scenario 3
 		{
 			Name:             "scenario 3: the user John can not get Bob's cluster nodes metrics",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ClusterToGet:     "clusterAbcID",
 			HTTPStatus:       http.StatusForbidden,
 			ExistingNodes: []*corev1.Node{

--- a/pkg/handler/v2/gatekeeperconfig/gatekeeperconfig_test.go
+++ b/pkg/handler/v2/gatekeeperconfig/gatekeeperconfig_test.go
@@ -77,7 +77,7 @@ func TestGetConfigEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: user john can not get bobs gatekeeper config",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,
@@ -172,7 +172,7 @@ func TestDeleteConfigEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: user john can not delete bobs gatekeeper config",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,
@@ -269,7 +269,7 @@ func TestCreateConfigEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: user john can not create bob cluster gatekeeper config",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			ToCreateConfig:   genAPIGatekeeperConfig(),
@@ -372,7 +372,7 @@ func TestPatchConfigEndpoint(t *testing.T) {
 		},
 		{
 			Name:             "scenario 3: user john can not patch bobs gatekeeper config",
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusForbidden,

--- a/pkg/handler/v2/machine/machine_test.go
+++ b/pkg/handler/v2/machine/machine_test.go
@@ -303,7 +303,7 @@ func TestDeleteMachineDeploymentNode(t *testing.T) {
 				genTestMachine("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExpectedHTTPStatusOnGet: http.StatusForbidden,
-			ExpectedResponseOnGet:   `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponseOnGet:   `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			ExpectedNodeCount:       2,
 		},
 	}
@@ -1369,7 +1369,7 @@ func TestMachineDeploymentMetrics(t *testing.T) {
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},
 	}
 
@@ -1528,7 +1528,7 @@ func TestPatchMachineDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 7: The user John can not update Bob's machine deployment",
 			Body:                       fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
-			ExpectedResponse:           `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse:           `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusForbidden,
 			project:                    test.GenDefaultProject().Name,
@@ -1713,7 +1713,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine"),
 				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine"),
 			},
-			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},
 	}
 

--- a/pkg/handler/v2/provider/vsphere.go
+++ b/pkg/handler/v2/provider/vsphere.go
@@ -57,7 +57,7 @@ func VsphereDatastoreEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(vSphereDatastoresReq)
 		if !ok {
-			return nil, fmt.Errorf("incorrect type of request, expected = VSphereFoldersReq, got = %T", request)
+			return nil, fmt.Errorf("incorrect type of request, expected = VSphereFoldersReq, got %T", request)
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {

--- a/pkg/provider/kubernetes/member.go
+++ b/pkg/provider/kubernetes/member.go
@@ -172,7 +172,7 @@ func (p *ProjectMemberProvider) MapUserToGroup(userEmail string, projectID strin
 		}
 	}
 
-	return "", kerrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("%q doesn't belong to the given project = %s", userEmail, projectID))
+	return "", kerrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("%q doesn't belong to project %s", userEmail, projectID))
 }
 
 // MappingsFor returns the list of projects (bindings) for the given user


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This fixes ugly errors like

> failed to sync RBAC RoleBinding for &{kubermatic.k8c.io/v1, Resource=clusters kubermatic.k8c.io/v1, Kind=Cluster %!s(*meta.restScope=&{root})} resource for kubermatic cluster provider: rolebindings.rbac.authorization.k8s.io "kubermatic:etcdrestore:viewers" already exists

Now it will read:
> failed to sync RBAC RoleBinding for Cluster resource for kubermatic cluster provider: rolebindings.rbac.authorization.k8s.io "kubermatic:etcdrestore:viewers" already exists

To actually get rid of this error alltogether, we would need to finally refactor the RBAC controller to use our reconciling framework.

PS: Fun fact, "kubermatic cluster provider" means "the 'kubermatic' Seed cluster".

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
