### PR TITLE
Fix resource overrides and use resource values in naming for nodeport-proxy

### DIFF
--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -38,7 +38,7 @@ import (
 const (
 	name               = "nodeport-proxy"
 	imageName          = "kubermatic/nodeport-proxy"
-	envoyAppLabelValue = name + "-envoy"
+	envoyAppLabelValue = resources.NodePortProxyEnvoyDeploymentName
 
 	// NodePortProxyExposeNamespacedAnnotationKey is the annotation key used to indicate that
 	// a service should be exposed by the namespaced NodeportProxy instance.
@@ -123,7 +123,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("48Mi"),
 			},
 		},
-		"envoy": {
+		resources.NodePortProxyEnvoyContainerName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
@@ -244,9 +244,8 @@ func roleBinding(ns string) reconciling.NamedRoleBindingCreatorGetter {
 
 func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDeploymentCreatorGetter {
 	volumeMountNameEnvoyConfig := "envoy-config"
-	name := envoyAppLabelValue
 	return func() (string, reconciling.DeploymentCreator) {
-		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 			d.Labels = resources.BaseAppLabels(name, nil)
 			d.Spec.Replicas = resources.Int32(2)
 			d.Spec.Selector = &metav1.LabelSelector{
@@ -297,7 +296,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 					},
 				},
 			}, {
-				Name:  "envoy",
+				Name:  resources.NodePortProxyEnvoyContainerName,
 				Image: data.ImageRegistry("docker.io") + "/envoyproxy/envoy-alpine:v1.16.0",
 				Command: []string{
 					"/usr/local/bin/envoy",

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -102,6 +102,8 @@ const (
 	EtcdTLSEnabledAnnotation = "etcd.kubermatic.k8c.io/tls-peer-enabled"
 	// NodePortProxyEnvoyDeploymentName is the name of the nodeport-proxy deployment in the user cluster.
 	NodePortProxyEnvoyDeploymentName = "nodeport-proxy-envoy"
+	// NodePortProxyEnvoyContainerName is the name of the envoy container in the nodeport-proxy deployment.
+	NodePortProxyEnvoyContainerName = "envoy"
 
 	// ApiserverServiceName is the name for the apiserver service.
 	ApiserverServiceName = "apiserver-external"
@@ -1278,7 +1280,7 @@ func GetOverrides(componentSettings kubermaticv1.ComponentSettings) map[string]*
 	}
 	if componentSettings.NodePortProxyEnvoy.Resources.Requests != nil ||
 		componentSettings.NodePortProxyEnvoy.Resources.Limits != nil {
-		r[NodePortProxyEnvoyDeploymentName] = componentSettings.NodePortProxyEnvoy.Resources.DeepCopy()
+		r[NodePortProxyEnvoyContainerName] = componentSettings.NodePortProxyEnvoy.Resources.DeepCopy()
 	}
 
 	return r


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The nodeport-proxy resource overrides introduced in #8859 don't work because the resource override map populated by `GetOverrides()` holds the nodeport-proxy values under key `nodeport-proxy-envoy` (the Deployment name), but `SetResourceRequirements` uses the container names (which are `envoy-manager`, `envoy` and `lb-updater` for the `nodeport-proxy-envoy` Deployment). Because of that, the override was not applied correctly.

Since I don't want to rename the container (there is no point in causing a restart), I'm adding "global" `resources` values and use it on both sides for consistency. The map now uses the envoy container name instead of the Deployment name.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

No changelog because this just fixes the feature that was supposed to work with #8859.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
