### PR TITLE
bump Minio, fix deprecated env vars

### DIFF
--- a/charts/minio/.helmignore
+++ b/charts/minio/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+test/

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: minio
 version: v9.9.9-dev
-appVersion: RELEASE.2021-08-20T18-32-01Z
+appVersion: RELEASE.2022-02-16T00-35-27Z
 description: minio
 keywords:
   - kubermatic

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -51,12 +51,12 @@ spec:
         - server
         - /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           valueFrom:
             secretKeyRef:
               name: minio
               key: accessKey
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: minio

--- a/charts/minio/test/test.sh
+++ b/charts/minio/test/test.sh
@@ -1,0 +1,1 @@
+../../../hack/test-chart-rendering.sh

--- a/charts/minio/test/values.example.ce.yaml
+++ b/charts/minio/test/values.example.ce.yaml
@@ -1,0 +1,1 @@
+../../values.example.ce.yaml

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -1,0 +1,222 @@
+---
+# Source: minio/templates/secret-external.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "s3-credentials"
+  namespace: "kube-system"
+type: Opaque
+data:
+  ACCESS_KEY_ID: ""
+  SECRET_ACCESS_KEY: ""
+---
+# Source: minio/templates/secret.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+type: Opaque
+data:
+  accessKey: ""
+  secretKey: ""
+---
+# Source: minio/templates/pvc.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  labels:
+    app: minio
+spec:
+  storageClassName: "minio-hdd"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+---
+# Source: minio/templates/service.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio
+---
+# Source: minio/templates/deployment.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9000"
+        prometheus.io/metrics_path: /minio/prometheus/metrics
+        kubermatic.io/chart: minio
+        backup.velero.io/backup-volumes: minio-backup
+        pre.hook.backup.velero.io/container: backup
+        pre.hook.backup.velero.io/timeout: 60m
+        pre.hook.backup.velero.io/command: '["mc", "mirror", "--remove", "--quiet", "src", "/backup"]'
+    spec:
+      containers:
+      - name: minio
+        image: 'docker.io/minio/minio:RELEASE.2021-08-20T18-32-01Z'
+        args:
+        - server
+        - /storage
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: secretKey
+        # disable authentication for /metrics endpoints
+        - name: MINIO_PROMETHEUS_AUTH_TYPE
+          value: public
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+        resources:
+          limits:
+            cpu: 1
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+      - name: backup
+        image: 'quay.io/kubermatic/util:2.0.0'
+        args:
+        - /bin/sh
+        - -c
+        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: secretKey
+        volumeMounts:
+        - mountPath: /backup
+          name: minio-backup
+          readOnly: false
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        resources:
+          limits:
+            cpu: 1
+            memory: 1500Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: minio-data
+      - name: minio-backup
+        emptyDir: {}
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -147,17 +147,17 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2021-08-20T18-32-01Z'
+        image: 'docker.io/minio/minio:RELEASE.2022-02-16T00-35-27Z'
         args:
         - server
         - /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           valueFrom:
             secretKeyRef:
               name: minio
               key: accessKey
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: minio

--- a/charts/minio/test/values.example.ee.yaml
+++ b/charts/minio/test/values.example.ee.yaml
@@ -1,0 +1,1 @@
+../../values.example.ee.yaml

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -1,0 +1,222 @@
+---
+# Source: minio/templates/secret-external.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "s3-credentials"
+  namespace: "kube-system"
+type: Opaque
+data:
+  ACCESS_KEY_ID: ""
+  SECRET_ACCESS_KEY: ""
+---
+# Source: minio/templates/secret.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+type: Opaque
+data:
+  accessKey: ""
+  secretKey: ""
+---
+# Source: minio/templates/pvc.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  labels:
+    app: minio
+spec:
+  storageClassName: "minio-hdd"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+---
+# Source: minio/templates/service.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio
+---
+# Source: minio/templates/deployment.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9000"
+        prometheus.io/metrics_path: /minio/prometheus/metrics
+        kubermatic.io/chart: minio
+        backup.velero.io/backup-volumes: minio-backup
+        pre.hook.backup.velero.io/container: backup
+        pre.hook.backup.velero.io/timeout: 60m
+        pre.hook.backup.velero.io/command: '["mc", "mirror", "--remove", "--quiet", "src", "/backup"]'
+    spec:
+      containers:
+      - name: minio
+        image: 'docker.io/minio/minio:RELEASE.2021-08-20T18-32-01Z'
+        args:
+        - server
+        - /storage
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: secretKey
+        # disable authentication for /metrics endpoints
+        - name: MINIO_PROMETHEUS_AUTH_TYPE
+          value: public
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+        resources:
+          limits:
+            cpu: 1
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+      - name: backup
+        image: 'quay.io/kubermatic/util:2.0.0'
+        args:
+        - /bin/sh
+        - -c
+        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: secretKey
+        volumeMounts:
+        - mountPath: /backup
+          name: minio-backup
+          readOnly: false
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        resources:
+          limits:
+            cpu: 1
+            memory: 1500Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: minio-data
+      - name: minio-backup
+        emptyDir: {}
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -147,17 +147,17 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2021-08-20T18-32-01Z'
+        image: 'docker.io/minio/minio:RELEASE.2022-02-16T00-35-27Z'
         args:
         - server
         - /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           valueFrom:
             secretKeyRef:
               name: minio
               key: accessKey
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: minio

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -15,7 +15,7 @@
 minio:
   image:
     repository: docker.io/minio/minio
-    tag: RELEASE.2021-08-20T18-32-01Z
+    tag: RELEASE.2022-02-16T00-35-27Z
   storeSize: 100Gi
 
   # The is required to enable the BackupRestore controller so it can backup


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Minio keeps logging

```
WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated.
         Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
```

**Does this PR introduce a user-facing change?**:
```release-note
Update Minio to RELEASE.2022-02-16T00-35-27Z
```
