### PR TITLE
bugfix: check data dir state before starting etcd

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -119,6 +119,9 @@ func main() {
 		}
 	}
 
+	_, err = os.Stat(filepath.Join(e.dataDir, "member"))
+	dataDirectoryIsEmpty := os.IsNotExist(err)
+
 	// setup and start etcd command
 	etcdCmd, err := startEtcdCmd(e, log)
 	if err != nil {
@@ -138,7 +141,7 @@ func main() {
 	if thisMember != nil {
 		log.Infof("%v is a member", thisMember.GetPeerURLs())
 
-		if _, err := os.Stat(filepath.Join(e.dataDir, "member")); os.IsNotExist(err) {
+		if dataDirectoryIsEmpty {
 			client, err := e.getClusterClient()
 			if err != nil {
 				log.Panicw("can't find cluster client: %v", zap.Error(err))


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Fixes broken feature when for any reason data directory for one of the etcd instances was lost then the etcd instance re-adds itself to the cluster and starts as a new member.
There was a **race** in the code because **checking if data directory empty after starting etcd always false**. The data directory must be checked before starting etcd instance.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

**Special notes for your reviewer**:

You can test this by creating a cluster then deleting PVC/PV for one of the etcd members in the cluster. Without this fix the instance will always fail. With this fix the instance will rejoin the cluster as a new member.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
