### PR TITLE
[release/v2.18] Override resource requirements for nodeport-proxy for user clusters

### DIFF
--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -244,6 +244,19 @@ spec:
       resources: null
       storageClass: ""
       tolerations: null
+    nodePortProxyEnvoy:
+      # DockerRepository is the repository containing the component's image.
+      docker_repository: ""
+      # Resources describes the requested and maximum allowed CPU/memory usage.
+      resources:
+        # Limits describes the maximum amount of compute resources allowed.
+        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        limits: null
+        # Requests describes the minimum amount of compute resources required.
+        # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+        # otherwise to an implementation-defined value.
+        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        requests: null
     prometheus:
       resources: null
     scheduler:

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -408,11 +408,12 @@ type MLASettings struct {
 }
 
 type ComponentSettings struct {
-	Apiserver         APIServerSettings       `json:"apiserver"`
-	ControllerManager ControllerSettings      `json:"controllerManager"`
-	Scheduler         ControllerSettings      `json:"scheduler"`
-	Etcd              EtcdStatefulSetSettings `json:"etcd"`
-	Prometheus        StatefulSetSettings     `json:"prometheus"`
+	Apiserver          APIServerSettings       `json:"apiserver"`
+	ControllerManager  ControllerSettings      `json:"controllerManager"`
+	Scheduler          ControllerSettings      `json:"scheduler"`
+	Etcd               EtcdStatefulSetSettings `json:"etcd"`
+	Prometheus         StatefulSetSettings     `json:"prometheus"`
+	NodePortProxyEnvoy NodeportProxyComponent  `json:"nodePortProxyEnvoy"`
 }
 
 type APIServerSettings struct {

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -1300,6 +1300,7 @@ func (in *ComponentSettings) DeepCopyInto(out *ComponentSettings) {
 	in.Scheduler.DeepCopyInto(&out.Scheduler)
 	in.Etcd.DeepCopyInto(&out.Etcd)
 	in.Prometheus.DeepCopyInto(&out.Prometheus)
+	in.NodePortProxyEnvoy.DeepCopyInto(&out.NodePortProxyEnvoy)
 	return
 }
 

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -38,7 +38,7 @@ import (
 const (
 	name               = "nodeport-proxy"
 	imageName          = "kubermatic/nodeport-proxy"
-	envoyAppLabelValue = name + "-envoy"
+	envoyAppLabelValue = resources.NodePortProxyEnvoyDeploymentName
 
 	// NodePortProxyExposeNamespacedAnnotationKey is the annotation key used to indicate that
 	// a service should be exposed by the namespaced NodeportProxy instance.
@@ -123,7 +123,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("48Mi"),
 			},
 		},
-		"envoy": {
+		resources.NodePortProxyEnvoyContainerName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
@@ -244,9 +244,8 @@ func roleBinding(ns string) reconciling.NamedRoleBindingCreatorGetter {
 
 func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDeploymentCreatorGetter {
 	volumeMountNameEnvoyConfig := "envoy-config"
-	name := envoyAppLabelValue
 	return func() (string, reconciling.DeploymentCreator) {
-		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 			d.Labels = resources.BaseAppLabels(name, nil)
 			d.Spec.Replicas = resources.Int32(2)
 			d.Spec.Selector = &metav1.LabelSelector{
@@ -297,7 +296,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 					},
 				},
 			}, {
-				Name:  "envoy",
+				Name:  resources.NodePortProxyEnvoyContainerName,
 				Image: data.ImageRegistry("docker.io") + "/envoyproxy/envoy-alpine:v1.16.0",
 				Command: []string{
 					"/usr/local/bin/envoy",
@@ -345,7 +344,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 					MountPath: "/etc/envoy",
 				}},
 			}}
-			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, d.Annotations)
+			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, defaultResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), d.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -105,6 +105,10 @@ const (
 	EtcdStatefulSetName = "etcd"
 	// EtcdDefaultBackupConfigName is the name for the default (preinstalled) EtcdBackupConfig of a cluster
 	EtcdDefaultBackupConfigName = "default-backups"
+	// NodePortProxyEnvoyDeploymentName is the name of the nodeport-proxy deployment in the user cluster.
+	NodePortProxyEnvoyDeploymentName = "nodeport-proxy-envoy"
+	// NodePortProxyEnvoyContainerName is the name of the envoy container in the nodeport-proxy deployment.
+	NodePortProxyEnvoyContainerName = "envoy"
 
 	// ApiserverServiceName is the name for the apiserver service
 	ApiserverServiceName = "apiserver-external"
@@ -1165,6 +1169,13 @@ func SetResourceRequirements(containers []corev1.Container, defaultRequirements,
 		}
 	}
 	for k, v := range overrides {
+		if v.Requests == nil {
+			v.Requests = defaultRequirements[k].Requests
+		}
+		if v.Limits == nil {
+			v.Limits = defaultRequirements[k].Limits
+		}
+
 		requirements[k] = v.DeepCopy()
 	}
 
@@ -1193,6 +1204,10 @@ func GetOverrides(componentSettings kubermaticv1.ComponentSettings) map[string]*
 	}
 	if componentSettings.Prometheus.Resources != nil {
 		r[PrometheusStatefulSetName] = componentSettings.Prometheus.Resources.DeepCopy()
+	}
+	if componentSettings.NodePortProxyEnvoy.Resources.Requests != nil ||
+		componentSettings.NodePortProxyEnvoy.Resources.Limits != nil {
+		r[NodePortProxyEnvoyContainerName] = componentSettings.NodePortProxyEnvoy.Resources.DeepCopy()
 	}
 
 	return r


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Backports #8859 and #9016 to `release/v2.18`.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8826

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support custom pod resources for NodePort-Proxy pod for the user cluster.
```
