### PR TITLE
Make container names canonical in loki and promtail

### DIFF
--- a/charts/logging/loki/test/default.yaml.out
+++ b/charts/logging/loki/test/default.yaml.out
@@ -150,7 +150,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.4.2"
+          image: "docker.io/grafana/loki:2.4.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/charts/logging/loki/test/values.example.ce.yaml.out
+++ b/charts/logging/loki/test/values.example.ce.yaml.out
@@ -150,7 +150,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.4.2"
+          image: "docker.io/grafana/loki:2.4.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/charts/logging/loki/test/values.example.ee.yaml.out
+++ b/charts/logging/loki/test/values.example.ee.yaml.out
@@ -150,7 +150,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.4.2"
+          image: "docker.io/grafana/loki:2.4.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 loki:
-
+  image:
+    repository: docker.io/grafana/loki
   fullnameOverride: loki
 
   affinity: {}

--- a/charts/logging/promtail/test/default.yaml.out
+++ b/charts/logging/promtail/test/default.yaml.out
@@ -392,7 +392,7 @@ spec:
       serviceAccountName: promtail
       initContainers:
         - name: init
-          image: "docker.io/busybox:1.33"
+          image: "docker.io/library/busybox:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
@@ -392,7 +392,7 @@ spec:
       serviceAccountName: promtail
       initContainers:
         - name: init
-          image: "docker.io/busybox:1.33"
+          image: "docker.io/library/busybox:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
@@ -392,7 +392,7 @@ spec:
       serviceAccountName: promtail
       initContainers:
         - name: init
-          image: "docker.io/busybox:1.33"
+          image: "docker.io/library/busybox:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -20,6 +20,8 @@ promtail:
   initContainer:
     enabled: true
     fsInotifyMaxUserInstances: 256
+    image:
+      repository: library/busybox
 
   podAnnotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
image-loader (used for offline installations) requires all container names to be canonicalized to work properly, some upstream charts require tuning.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9011

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
