### PR TITLE
Update helm Chart.yaml apiVersions to v2

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
+apiVersion: v2
 name: cert-manager
 version: v9.9.9-dev
 appVersion: v1.6.1

--- a/charts/cert-manager/test/test-certmanager.sh
+++ b/charts/cert-manager/test/test-certmanager.sh
@@ -33,7 +33,7 @@ helm upgrade \
   --atomic \
   cert-manager charts/cert-manager/
 
-if ! which cmctl; then 
+if ! which cmctl; then
   echodate "Downloading cmctl..."
   OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sLo cmctl.tar.gz https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-$OS-$ARCH.tar.gz
   tar xzf cmctl.tar.gz
@@ -41,9 +41,8 @@ if ! which cmctl; then
   function cmctl_cleanup {
     echodate "Cleaning up..."
     rm cmctl cmctl.tar.gz
-    exit $exitcode
   }
-  trap cmctl_cleanup EXIT
+  appendTrap cmctl_cleanup EXIT
 fi
 echodate "Testing cert-manager..."
 ./cmctl check api --wait=2m

--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: "v1"
+apiVersion: v2
 name: loki
 version: v9.9.9-dev
 appVersion: v2.4.2

--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
+apiVersion: v2
 name: promtail
 version: v9.9.9-dev
 appVersion: v2.4.2

--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
+apiVersion: v2
 name: nginx-ingress-controller
 version: v9.9.9-dev
 appVersion: 1.0.2


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
`dependencies` field in Chart.yaml is only supported in apiVersion: v2

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8962 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
