### PR TITLE
disable konnectivity e2e test

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1082,42 +1082,42 @@ presubmits:
   # Konnectivity e2e tests
   #########################################################
 
-  - name: pre-kubermatic-konnectivity-e2e
-    run_if_changed: "(.*[kK]onnectivity.*|pkg/resources/apiserver|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
-          imagePullPolicy: Always
-          command:
-            - "./hack/ci/run-konnectivity-e2e-test.sh"
-          env:
-            - name: VERSION_TO_TEST
-              value: v1.22.5
-            - name: KUBERMATIC_EDITION
-              value: ee
-            - name: SERVICE_ACCOUNT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: e2e-ci
-                  key: serviceAccountSigningKey
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-            limits:
-              memory: 6Gi
+#  - name: pre-kubermatic-konnectivity-e2e
+#    run_if_changed: "(.*[kK]onnectivity.*|pkg/resources/apiserver|.prow.yaml)"
+#    decorate: true
+#    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+#    labels:
+#      preset-aws: "true"
+#      preset-kubeconfig-ci: "true"
+#      preset-docker-pull: "true"
+#      preset-docker-push: "true"
+#      preset-kind-volume-mounts: "true"
+#      preset-vault: "true"
+#      preset-goproxy: "true"
+#    spec:
+#      containers:
+#        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+#          imagePullPolicy: Always
+#          command:
+#            - "./hack/ci/run-konnectivity-e2e-test.sh"
+#          env:
+#            - name: VERSION_TO_TEST
+#              value: v1.22.5
+#            - name: KUBERMATIC_EDITION
+#              value: ee
+#            - name: SERVICE_ACCOUNT_KEY
+#              valueFrom:
+#                secretKeyRef:
+#                  name: e2e-ci
+#                  key: serviceAccountSigningKey
+#          securityContext:
+#            privileged: true
+#          resources:
+#            requests:
+#              memory: 4Gi
+#              cpu: 2
+#            limits:
+#              memory: 6Gi
 
 
   #########################################################


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This will unblock tests failing due to a Konnectivity issue described here https://github.com/kubermatic/kubermatic/issues/9035 

**Does this PR introduce a user-facing change?**:
No. 

```release-note
NONE
```
