### PR TITLE
use yaml.UnmarshalStrict

### DIFF
--- a/cmd/image-loader/operator.go
+++ b/cmd/image-loader/operator.go
@@ -38,7 +38,7 @@ func loadKubermaticConfiguration(log *zap.SugaredLogger, filename string) (*kube
 	}
 
 	config := &kubermaticv1.KubermaticConfiguration{}
-	if err := yaml.Unmarshal(content, &config); err != nil {
+	if err := yaml.UnmarshalStrict(content, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse file as YAML: %w", err)
 	}
 

--- a/cmd/kubermatic-api/options.go
+++ b/cmd/kubermatic-api/options.go
@@ -195,7 +195,7 @@ func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfi
 	}
 
 	config := &kubermaticv1.KubermaticConfiguration{}
-	if err := yaml.Unmarshal(content, &config); err != nil {
+	if err := yaml.UnmarshalStrict(content, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse file as YAML: %w", err)
 	}
 

--- a/cmd/kubermatic-webhook/options.go
+++ b/cmd/kubermatic-webhook/options.go
@@ -102,7 +102,7 @@ func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfi
 	}
 
 	config := &kubermaticv1.KubermaticConfiguration{}
-	if err := yaml.Unmarshal(content, &config); err != nil {
+	if err := yaml.UnmarshalStrict(content, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse file as YAML: %w", err)
 	}
 

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -207,7 +207,7 @@ func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfi
 	}
 
 	config := &kubermaticv1.KubermaticConfiguration{}
-	if err := yaml.Unmarshal(content, &config); err != nil {
+	if err := yaml.UnmarshalStrict(content, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse file as YAML: %w", err)
 	}
 

--- a/cmd/node-resource-documenter/documenter.go
+++ b/cmd/node-resource-documenter/documenter.go
@@ -59,25 +59,25 @@ func (d *documenter) scanAll() error {
 
 func (d *documenter) scanManifest(manifest []byte) error {
 	var u unstructured.Unstructured
-	if err := yaml.Unmarshal(manifest, &u); err != nil {
+	if err := yaml.UnmarshalStrict(manifest, &u); err != nil {
 		return err
 	}
 	switch u.GetKind() {
 	case "Deployment":
 		var ad appsv1.Deployment
-		if err := yaml.Unmarshal(manifest, &ad); err != nil {
+		if err := yaml.UnmarshalStrict(manifest, &ad); err != nil {
 			return err
 		}
 		d.addSpec(ad.Spec.Template.Spec)
 	case "DaemonSet":
 		var ad appsv1.DaemonSet
-		if err := yaml.Unmarshal(manifest, &ad); err != nil {
+		if err := yaml.UnmarshalStrict(manifest, &ad); err != nil {
 			return err
 		}
 		d.addSpec(ad.Spec.Template.Spec)
 	case "StatefulSet":
 		var as appsv1.StatefulSet
-		if err := yaml.Unmarshal(manifest, &as); err != nil {
+		if err := yaml.UnmarshalStrict(manifest, &as); err != nil {
 			return err
 		}
 		d.addSpec(as.Spec.Template.Spec)

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -237,7 +237,7 @@ func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfi
 	}
 
 	config := &kubermaticv1.KubermaticConfiguration{}
-	if err := yaml.Unmarshal(content, &config); err != nil {
+	if err := yaml.UnmarshalStrict(content, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse file as YAML: %w", err)
 	}
 

--- a/pkg/addon/template_test.go
+++ b/pkg/addon/template_test.go
@@ -52,7 +52,7 @@ func testRenderAddonsForOrchestrator(t *testing.T, orchestrator string) {
 		}
 
 		cluster := kubermaticv1.Cluster{}
-		err = yaml.Unmarshal(content, &cluster)
+		err = yaml.UnmarshalStrict(content, &cluster)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/addon/testdata/cluster-kubernetes-aws.yaml
+++ b/pkg/addon/testdata/cluster-kubernetes-aws.yaml
@@ -130,16 +130,15 @@ status:
       lastHeartbeatTime: "2020-04-01T23:19:14Z"
       lastTransitionTime: "2020-04-01T23:19:14Z"
       status: "True"
-    extendedHealth:
-      apiserver: HealthStatusDown
-      cloudProviderInfrastructure: HealthStatusDown
-      controller: HealthStatusDown
-      etcd: HealthStatusUp
-      machineController: HealthStatusDown
-      openvpn: HealthStatusDown
-      scheduler: HealthStatusDown
-      userClusterControllerManager: HealthStatusDown
-  kubermaticVersion: 1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+  extendedHealth:
+    apiserver: HealthStatusDown
+    cloudProviderInfrastructure: HealthStatusDown
+    controller: HealthStatusDown
+    etcd: HealthStatusUp
+    machineController: HealthStatusDown
+    openvpn: HealthStatusDown
+    scheduler: HealthStatusDown
+    userClusterControllerManager: HealthStatusDown
   lastUpdated: null
   namespaceName: cluster-bbc8sc24wb
   userEmail: user@example.com

--- a/pkg/addon/testdata/cluster-kubernetes-do.yaml
+++ b/pkg/addon/testdata/cluster-kubernetes-do.yaml
@@ -126,7 +126,6 @@ status:
     openvpn: HealthStatusDown
     scheduler: HealthStatusDown
     userClusterControllerManager: HealthStatusDown
-  kubermaticVersion: 1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
   lastUpdated: null
   namespaceName: cluster-nmxjm7ngzw
   userEmail: user@example.com

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -219,7 +219,7 @@ func (r *Reconciler) getAddons(ctx context.Context) (*kubermaticv1.AddonList, er
 	}
 
 	if c.DefaultManifests != "" {
-		if err := yaml.Unmarshal([]byte(c.DefaultManifests), result); err != nil {
+		if err := yaml.UnmarshalStrict([]byte(c.DefaultManifests), result); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal default addon list: %w", err)
 		}
 	}
@@ -240,7 +240,7 @@ func (r *Reconciler) getAddons(ctx context.Context) (*kubermaticv1.AddonList, er
 // mechanism where instead of an AddonList, only a []string is given.
 func getDefaultAddonManifests() (*kubermaticv1.AddonList, error) {
 	defaultAddonList := kubermaticv1.AddonList{}
-	if err := yaml.Unmarshal([]byte(defaults.DefaultKubernetesAddons), &defaultAddonList); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(defaults.DefaultKubernetesAddons), &defaultAddonList); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal default addon list: %w", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -349,7 +349,7 @@ func (r *alertmanagerController) ensureAlertmanagerConfiguration(ctx context.Con
 		return err
 	}
 	expectedConfig := map[string]interface{}{}
-	if err := yaml.Unmarshal(config, &expectedConfig); err != nil {
+	if err := yaml.UnmarshalStrict(config, &expectedConfig); err != nil {
 		return fmt.Errorf("unable to unmarshal expected config: %w", err)
 	}
 	if reflect.DeepEqual(currentConfig, expectedConfig) {

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -393,10 +393,10 @@ func jsonEqual(expectedBody, body []byte) bool {
 func yamlEqual(expectedBody, body []byte) bool {
 	expectedBodyMap := map[string]interface{}{}
 	bodyMap := map[string]interface{}{}
-	if err := yaml.Unmarshal(expectedBody, &expectedBodyMap); err != nil {
+	if err := yaml.UnmarshalStrict(expectedBody, &expectedBodyMap); err != nil {
 		return false
 	}
-	if err := yaml.Unmarshal(body, &bodyMap); err != nil {
+	if err := yaml.UnmarshalStrict(body, &bodyMap); err != nil {
 		return false
 	}
 	return reflect.DeepEqual(expectedBodyMap, bodyMap)

--- a/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go
@@ -165,7 +165,7 @@ func (r *ratelimitCortexController) ensureLimits(ctx context.Context, mlaAdminSe
 		return errors.New("unable to find runtime config file in configmap")
 	}
 	or := &Overrides{}
-	if err := yaml.Unmarshal([]byte(config), or); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(config), or); err != nil {
 		return fmt.Errorf("unable to unmarshal runtime config[%s]: %w", config, err)
 	}
 
@@ -226,7 +226,7 @@ func (r *ratelimitCortexController) handleDeletion(ctx context.Context, log *zap
 		return errors.New("unable to find runtime config file in configmap")
 	}
 	or := &Overrides{}
-	if err := yaml.Unmarshal([]byte(config), or); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(config), or); err != nil {
 		return fmt.Errorf("unable to unmarshal runtime config[%s]: %w", config, err)
 	}
 	if _, ok := or.Overrides[mlaAdminSetting.Spec.ClusterName]; ok {

--- a/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller_test.go
@@ -291,7 +291,7 @@ func TestRatelimitCortexReconcile(t *testing.T) {
 				t.Fatalf("unable to get configMap: %v", err)
 			}
 			actualOverrides := &Overrides{}
-			err = yaml.Unmarshal([]byte(configMap.Data[RuntimeConfigFileName]), actualOverrides)
+			err = yaml.UnmarshalStrict([]byte(configMap.Data[RuntimeConfigFileName]), actualOverrides)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expectedOverrides, *actualOverrides)
 			mlaAdminSetting := &kubermaticv1.MLAAdminSetting{}

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -319,7 +319,7 @@ func (r *ruleGroupController) ensureRuleGroup(ctx context.Context, ruleGroup *ku
 		return err
 	}
 	expectedRuleGroup := map[string]interface{}{}
-	if err := yaml.Unmarshal(ruleGroup.Spec.Data, &expectedRuleGroup); err != nil {
+	if err := yaml.UnmarshalStrict(ruleGroup.Spec.Data, &expectedRuleGroup); err != nil {
 		return fmt.Errorf("unable to unmarshal expected rule group: %w", err)
 	}
 	if reflect.DeepEqual(currentRuleGroup, expectedRuleGroup) {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
@@ -54,7 +54,7 @@ func ConfigCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConfigCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(configYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(configYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}
@@ -76,7 +76,7 @@ func ConstraintTemplateCRDCreator() reconciling.NamedCustomResourceDefinitionCre
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConstraintTemplateCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(constraintTemplateYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(constraintTemplateYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}
@@ -98,7 +98,7 @@ func ConstraintPodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCr
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConstraintPodStatusCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(constraintPodStatusYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(constraintPodStatusYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}
@@ -120,7 +120,7 @@ func ConstraintTemplatePodStatusCRDCreator() reconciling.NamedCustomResourceDefi
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperConstraintTemplatePodStatusCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(constraintTemplatePodStatusYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(constraintTemplatePodStatusYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}
@@ -141,7 +141,7 @@ func MutatorPodStatusCRDCreator() reconciling.NamedCustomResourceDefinitionCreat
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperMutatorPodStatusCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(mutatorPodStatusYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(mutatorPodStatusYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}
@@ -162,7 +162,7 @@ func AssignCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperAssignCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(assignYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(assignYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}
@@ -183,7 +183,7 @@ func AssignMetadataCRDCreator() reconciling.NamedCustomResourceDefinitionCreator
 	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.GatekeeperAssignMetadataCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
-			err := yaml.Unmarshal([]byte(assignMetadataYAML), &fileCRD)
+			err := yaml.UnmarshalStrict([]byte(assignMetadataYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/handler/v2/alertmanager/alertmanager.go
+++ b/pkg/handler/v2/alertmanager/alertmanager.go
@@ -110,7 +110,7 @@ type updateAlertmanagerReq struct {
 
 func (req *updateAlertmanagerReq) validateUpdateAlertmanagerReq() error {
 	bodyMap := map[string]interface{}{}
-	if err := yaml.Unmarshal(req.Body.Spec.Config, &bodyMap); err != nil {
+	if err := yaml.UnmarshalStrict(req.Body.Spec.Config, &bodyMap); err != nil {
 		return fmt.Errorf("can not unmarshal yaml configuration: %w", err)
 	}
 	return nil

--- a/pkg/handler/v2/rulegroup/request.go
+++ b/pkg/handler/v2/rulegroup/request.go
@@ -193,7 +193,7 @@ func DecodeRuleGroupID(r *http.Request) (string, error) {
 
 func GetRuleGroupNameInData(data []byte) (string, error) {
 	bodyMap := map[string]interface{}{}
-	if err := yaml.Unmarshal(data, &bodyMap); err != nil {
+	if err := yaml.UnmarshalStrict(data, &bodyMap); err != nil {
 		return "", fmt.Errorf("cannot unmarshal rule group data in yaml: %w", err)
 	}
 	ruleGroupName, ok := bodyMap["name"].(string)

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -242,7 +242,7 @@ rules:
     description: "log stream is a bit high"
 `
 	expectedLogRuleGroup := map[string]interface{}{}
-	if err := yaml.Unmarshal([]byte(lokiRule), &expectedLogRuleGroup); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(lokiRule), &expectedLogRuleGroup); err != nil {
 		t.Fatalf("unable to unmarshal expected rule group: %v", err)
 	}
 
@@ -282,7 +282,7 @@ rules:
 	// Metric RuleGroup
 	testRuleGroup := test.GenerateTestRuleGroupData("test-metric-rule")
 	expectedRuleGroup := map[string]interface{}{}
-	if err := yaml.Unmarshal(testRuleGroup, &expectedRuleGroup); err != nil {
+	if err := yaml.UnmarshalStrict(testRuleGroup, &expectedRuleGroup); err != nil {
 		t.Fatalf("unable to unmarshal expected rule group: %v", err)
 	}
 
@@ -337,7 +337,7 @@ rules:
 
 	alertmanagerURL := "http://localhost:3001" + mla.AlertmanagerConfigEndpoint
 	expectedConfig := map[string]interface{}{}
-	if err := yaml.Unmarshal([]byte(testAlertmanagerConfig), &expectedConfig); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(testAlertmanagerConfig), &expectedConfig); err != nil {
 		t.Fatalf("unable to unmarshal expected config: %v", err)
 	}
 	if !utils.WaitFor(1*time.Second, timeout, func() bool {
@@ -398,7 +398,7 @@ rules:
 			t.Fatalf("unable to get configMap: %v", err)
 		}
 		actualOverrides := &mla.Overrides{}
-		if err := yaml.Unmarshal([]byte(configMap.Data[mla.RuntimeConfigFileName]), actualOverrides); err != nil {
+		if err := yaml.UnmarshalStrict([]byte(configMap.Data[mla.RuntimeConfigFileName]), actualOverrides); err != nil {
 			t.Fatalf("unable to unmarshal rate limit config map")
 		}
 		actualRateLimits, ok := actualOverrides.Overrides[cluster.Name]

--- a/pkg/util/yamled/document.go
+++ b/pkg/util/yamled/document.go
@@ -347,7 +347,7 @@ func (d *Document) normalize() interface{} {
 	encoded, _ := yaml.Marshal(d.root)
 
 	var normal interface{}
-	_ = yaml.Unmarshal(encoded, &normal)
+	_ = yaml.UnmarshalStrict(encoded, &normal)
 
 	return normal
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
I noticed old `KuberamaticConfiguration` was parsed happily by `loadKubermaticConfiguration`. Strict parsing would have saved me some debugging. This PR changes all the  `use yaml.Unmarshal` to `use yaml.UnmarshalStrict`. 


**Does this PR introduce a user-facing change?**:
NO 

```release-note
NONE
```
