### PR TITLE
Update preset for OpenStack

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -315,10 +315,6 @@ spec:
                     type: string
                 required:
                 - domain
-                - password
-                - project
-                - projectID
-                - username
                 type: object
               packet:
                 properties:

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13095,13 +13095,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13113,6 +13106,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -190,10 +190,10 @@ type Openstack struct {
 	ApplicationCredentialID     string `json:"applicationCredentialID,omitempty"`
 	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
 
-	Username  string `json:"username"`
-	Password  string `json:"password"`
-	Project   string `json:"project"`
-	ProjectID string `json:"projectID"`
+	Username  string `json:"username,omitempty"`
+	Password  string `json:"password,omitempty"`
+	Project   string `json:"project,omitempty"`
+	ProjectID string `json:"projectID,omitempty"`
 	Domain    string `json:"domain"`
 
 	Network        string `json:"network,omitempty"`


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
Update preset for OpenStack and make default credentials optional. The validation to ensure that one of default or user credentials is provided is already in-place at https://github.com/kubermatic/kubermatic/blob/master/pkg/apis/kubermatic/v1/preset.go#L206

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
xref https://github.com/kubermatic/dashboard/issues/4187

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
