### PR TITLE
Reconcile kubernetes service endpoints in KKP user-cluster-controller

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -61,6 +61,17 @@ func main() {
 				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
 			},
 			{
+				ResourceName:       "Endpoints",
+				ResourceNamePlural: "Endpoints",
+				ImportAlias:        "corev1",
+				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
+			},
+			{
+				ResourceName:       "EndpointSlice",
+				ImportAlias:        "discovery",
+				ResourceImportPath: "k8s.io/api/discovery/v1",
+			},
+			{
 				ResourceName:       "StatefulSet",
 				ImportAlias:        "appsv1",
 				ResourceImportPath: "k8s.io/api/apps/v1",

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -666,19 +666,20 @@ func (r *reconciler) reconcileServices(ctx context.Context) error {
 }
 
 func (r *reconciler) reconcileEndpoints(ctx context.Context, data reconcileData) error {
-	if data.reconcileK8sSvcEndpoints {
-		epCreators := []reconciling.NamedEndpointsCreatorGetter{
-			kubernetesresources.EndpointsCreator(data.clusterAddress),
-		}
-		if err := reconciling.ReconcileEndpoints(ctx, epCreators, metav1.NamespaceDefault, r.Client); err != nil {
-			return fmt.Errorf("failed to reconcile Endpoints: %w", err)
-		}
-		epSliceCreators := []reconciling.NamedEndpointSliceCreatorGetter{
-			kubernetesresources.EndpointSliceCreator(data.clusterAddress),
-		}
-		if err := reconciling.ReconcileEndpointSlices(ctx, epSliceCreators, metav1.NamespaceDefault, r.Client); err != nil {
-			return fmt.Errorf("failed to reconcile EndpointSlices: %w", err)
-		}
+	if !data.reconcileK8sSvcEndpoints {
+		return nil
+	}
+	epCreators := []reconciling.NamedEndpointsCreatorGetter{
+		kubernetesresources.EndpointsCreator(data.clusterAddress),
+	}
+	if err := reconciling.ReconcileEndpoints(ctx, epCreators, metav1.NamespaceDefault, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Endpoints: %w", err)
+	}
+	epSliceCreators := []reconciling.NamedEndpointSliceCreatorGetter{
+		kubernetesresources.EndpointSliceCreator(data.clusterAddress),
+	}
+	if err := reconciling.ReconcileEndpointSlices(ctx, epSliceCreators, metav1.NamespaceDefault, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile EndpointSlices: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes/endpoints.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes/endpoints.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// ServiceName is the name of the kubernetes service in the default namespace.
+	ServiceName = "kubernetes"
+)
+
+// EndpointsCreator returns the func to create/update the endpoints of the kubernetes service.
+func EndpointsCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.NamedEndpointsCreatorGetter {
+	return func() (string, reconciling.EndpointsCreator) {
+		return ServiceName, func(ep *corev1.Endpoints) (*corev1.Endpoints, error) {
+			// our controller is reconciling the endpoint slice, do not mirror with EndpointSliceMirroring controller
+			ep.Labels = map[string]string{
+				discovery.LabelSkipMirror: "true",
+			}
+			ep.Subsets = []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{
+							IP: clusterAddress.IP,
+						},
+					},
+					Ports: []corev1.EndpointPort{
+						{
+							Name:     "https",
+							Port:     clusterAddress.Port,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+			return ep, nil
+		}
+	}
+}
+
+// EndpointSliceCreator returns the func to create/update the endpoint slice of the kubernetes service.
+func EndpointSliceCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.NamedEndpointSliceCreatorGetter {
+	return func() (string, reconciling.EndpointSliceCreator) {
+		return ServiceName, func(es *discovery.EndpointSlice) (*discovery.EndpointSlice, error) {
+			es.AddressType = discovery.AddressTypeIPv4
+			es.Labels = map[string]string{
+				discovery.LabelServiceName: ServiceName,
+			}
+			es.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{
+						clusterAddress.IP,
+					},
+					Conditions: discovery.EndpointConditions{
+						Ready: pointer.BoolPtr(true),
+					},
+				},
+			}
+			protoTCP := corev1.ProtocolTCP
+			es.Ports = []discovery.EndpointPort{
+				{
+					Name:     pointer.String("https"),
+					Port:     pointer.Int32Ptr(clusterAddress.Port),
+					Protocol: &protoTCP,
+				},
+			}
+			return es, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes/endpoints.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes/endpoints.go
@@ -26,14 +26,18 @@ import (
 )
 
 const (
-	// ServiceName is the name of the kubernetes service in the default namespace.
-	ServiceName = "kubernetes"
+	// serviceName is the name of the kubernetes service in the default namespace.
+	serviceName = "kubernetes"
+
+	// endpointSliceName is the name of the endpoint slice for the kubernetes service in the default namespace.
+	// To be aligned with upstream endpoint reconcilers we name it as the service itself.
+	endpointSliceName = serviceName
 )
 
 // EndpointsCreator returns the func to create/update the endpoints of the kubernetes service.
 func EndpointsCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.NamedEndpointsCreatorGetter {
 	return func() (string, reconciling.EndpointsCreator) {
-		return ServiceName, func(ep *corev1.Endpoints) (*corev1.Endpoints, error) {
+		return serviceName, func(ep *corev1.Endpoints) (*corev1.Endpoints, error) {
 			// our controller is reconciling the endpoint slice, do not mirror with EndpointSliceMirroring controller
 			ep.Labels = map[string]string{
 				discovery.LabelSkipMirror: "true",
@@ -62,10 +66,10 @@ func EndpointsCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.N
 // EndpointSliceCreator returns the func to create/update the endpoint slice of the kubernetes service.
 func EndpointSliceCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.NamedEndpointSliceCreatorGetter {
 	return func() (string, reconciling.EndpointSliceCreator) {
-		return ServiceName, func(es *discovery.EndpointSlice) (*discovery.EndpointSlice, error) {
+		return endpointSliceName, func(es *discovery.EndpointSlice) (*discovery.EndpointSlice, error) {
 			es.AddressType = discovery.AddressTypeIPv4
 			es.Labels = map[string]string{
-				discovery.LabelServiceName: ServiceName,
+				discovery.LabelServiceName: serviceName,
 			}
 			es.Endpoints = []discovery.Endpoint{
 				{

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -315,36 +315,26 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--profiling=false",
 	}
 
-	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
-		flags = append(flags,
-			// The advertise address is used as endpoint address for the kubernetes
-			// service in the default namespace of the user cluster.
-			"--advertise-address", cluster.Address.IP,
-			// The secure port is used as target port for the kubernetes service in
-			// the default namespace of the user cluster, we use the NodePort value
-			// for being able to access the apiserver from the usercluster side.
-			"--secure-port", fmt.Sprint(cluster.Address.Port))
-	} else {
-		// pre-pend to have advertise-address as first argument and avoid
-		// triggering unneeded redeployments.
-		flags = append([]string{
-			// The advertise address is used as endpoint address for the kubernetes
-			// service in the default namespace of the user cluster.
-			"--advertise-address", cluster.Address.IP,
-			// The secure port is used as target port for the kubernetes service in
-			// the default namespace of the user cluster, we use the NodePort value
-			// for being able to access the apiserver from the usercluster side.
-			"--secure-port", fmt.Sprint(cluster.Address.Port),
-			"--kubernetes-service-node-port", fmt.Sprint(cluster.Address.Port),
-		}, flags...)
-	}
+	// pre-pend to have advertise-address as first argument and avoid
+	// triggering unneeded redeployments.
+	flags = append([]string{
+		// advertise-address is the external IP under which the apiserver is available.
+		// The same address is used for all apiserver replicas.
+		"--advertise-address", cluster.Address.IP,
+		// The port on which apiserver is serving.
+		// For Nodeport / LoadBalancer expose strategies we use the apiserver-external service NodePort value.
+		// For Tunneling expose strategy we use a fixed port.
+		"--secure-port", fmt.Sprint(cluster.Address.Port),
+	}, flags...)
 
 	if auditLogEnabled {
 		flags = append(flags, "--audit-policy-file", "/etc/kubernetes/audit/policy.yaml")
 	}
 
-	if *overrideFlags.EndpointReconcilingDisabled {
-		flags = append(flags, "--endpoint-reconciler-type=none")
+	// kubernetes service endpoints are reconciled by KKP user-cluster-controller for kubernetes versions v1.21+
+	// TODO: This condition can be removed after KKP support for k8s versions below 1.21 is removed.
+	if (cluster.Spec.Version.Semver().Major() >= 1 && cluster.Spec.Version.Semver().Minor() > 20) || *overrideFlags.EndpointReconcilingDisabled {
+		flags = append(flags, "--endpoint-reconciler-type", "none")
 	}
 
 	// enable service account signing key and issuer in Kubernetes 1.20 or when

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -201,6 +202,80 @@ func ReconcileServiceAccounts(ctx context.Context, namedGetters []NamedServiceAc
 
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.ServiceAccount{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ServiceAccount %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// EndpointsCreator defines an interface to create/update Endpointss
+type EndpointsCreator = func(existing *corev1.Endpoints) (*corev1.Endpoints, error)
+
+// NamedEndpointsCreatorGetter returns the name of the resource and the corresponding creator function
+type NamedEndpointsCreatorGetter = func() (name string, create EndpointsCreator)
+
+// EndpointsObjectWrapper adds a wrapper so the EndpointsCreator matches ObjectCreator.
+// This is needed as Go does not support function interface matching.
+func EndpointsObjectWrapper(create EndpointsCreator) ObjectCreator {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return create(existing.(*corev1.Endpoints))
+		}
+		return create(&corev1.Endpoints{})
+	}
+}
+
+// ReconcileEndpoints will create and update the Endpoints coming from the passed EndpointsCreator slice
+func ReconcileEndpoints(ctx context.Context, namedGetters []NamedEndpointsCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
+	for _, get := range namedGetters {
+		name, create := get()
+		createObject := EndpointsObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			createObject = objectModifier(createObject)
+		}
+
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Endpoints{}, false); err != nil {
+			return fmt.Errorf("failed to ensure Endpoints %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// EndpointSliceCreator defines an interface to create/update EndpointSlices
+type EndpointSliceCreator = func(existing *discovery.EndpointSlice) (*discovery.EndpointSlice, error)
+
+// NamedEndpointSliceCreatorGetter returns the name of the resource and the corresponding creator function
+type NamedEndpointSliceCreatorGetter = func() (name string, create EndpointSliceCreator)
+
+// EndpointSliceObjectWrapper adds a wrapper so the EndpointSliceCreator matches ObjectCreator.
+// This is needed as Go does not support function interface matching.
+func EndpointSliceObjectWrapper(create EndpointSliceCreator) ObjectCreator {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return create(existing.(*discovery.EndpointSlice))
+		}
+		return create(&discovery.EndpointSlice{})
+	}
+}
+
+// ReconcileEndpointSlices will create and update the EndpointSlices coming from the passed EndpointSliceCreator slice
+func ReconcileEndpointSlices(ctx context.Context, namedGetters []NamedEndpointSliceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
+	for _, get := range namedGetters {
+		name, create := get()
+		createObject := EndpointSliceObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			createObject = objectModifier(createObject)
+		}
+
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &discovery.EndpointSlice{}, false); err != nil {
+			return fmt.Errorf("failed to ensure EndpointSlice %s/%s: %w", namespace, name, err)
 		}
 	}
 

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -140,8 +140,6 @@ spec:
         - 35.198.93.90
         - --secure-port
         - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -207,6 +205,8 @@ spec:
         - --requestheader-username-headers
         - X-Remote-User
         - --profiling=false
+        - --endpoint-reconciler-type
+        - none
         - --service-account-issuer
         - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Kubernetes by default uses kubernetes service endpoint reconcilers that are designed to work with multiple different apiserver IP addresses. In case of KKP, all apiserver instances share the same advertise-address, which causes issues in some edge scenarios (e.g. hitting issues like https://github.com/kubernetes/kubernetes/issues/76146 & https://github.com/kubernetes/kubernetes/issues/104252 occasionally in our e2e tests) and breaks the user cluster is the apiserver-external service is removed (https://github.com/kubermatic/kubermatic/issues/9039).

As KKP has special needs for configuring the kubernetes service endpoints given its expose strategies, it makes more sense to reconcile them by KKP itself. With this PR, the KKP user-cluster-controller-manager becomes the owner of the endpoints of the kubernetes service (by setting the apiserver flag `--endpoint-reconciler-type=none`) and reconciles them according to the used KKP expose strategy needs.

This also allows for future enhancements (not part of this PR), such as:
- Having multiple endpoints for kubernetes service if apiserver/nodeport-proxy is exposed on a LB address that resolves to multiple IP addresses (e.g. in case of AWS), thus aching better HA,
- By the Tunneling expose strategy, the tunneling agents can run as standard pods, without the need to bind on arbitrary IP address in the host network namespace. That would mean simplification and better stability.
- Ability to expose the apiserver via dual-stack for in-cluster pods, even if not supported in the given kubernetes version.

Further notes: 
- To be aligned with the upstream endpoint reconcilers, we reconcile EndpointSlices as well. This also makes sure that in existing clusters we do not end up having multiple EndpointSlices for the same service after this switch.
- This change is effective only on clusters with k8s version 1.21 and higher, as EndpointSlices became stable in v1.21. Making this change compatible with older versions is not worth the effort given that v1.20 end of life is coming soon.
- This change also unifies the flags passed to the apiserver across expose strategies. There is no need for passing `kubernetes-service-node-port` and making the kubernetes service a NodePort service in the user cluster - ClusterIP actually makes much more sense and aligns with other similar platforms.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9039 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
