### PR TITLE
Add seccomp profiles to all pod specs created via reconciling

### DIFF
--- a/cmd/conformance-tests/custom_tests.go
+++ b/cmd/conformance-tests/custom_tests.go
@@ -426,3 +426,69 @@ func (r *testRunner) testUserClusterPodAndNodeMetrics(ctx context.Context, log *
 	log.Info("Successfully validated user cluster pod and node metrics.")
 	return nil
 }
+
+func (r *testRunner) testUserClusterControlPlaneSecurityContext(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client) error {
+	log.Infof("Testing security context of control plane components in Seed cluster...")
+
+	pods := &corev1.PodList{}
+
+	if err := seedClient.List(ctx, pods, &ctrlruntimeclient.ListOptions{Namespace: cluster.Status.NamespaceName}); err != nil {
+		return fmt.Errorf("failed to list control plane pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no control plane pods found")
+	}
+
+	errors := []string{}
+
+	for _, pod := range pods.Items {
+		var privilegedContainers int
+		for _, container := range pod.Spec.Containers {
+			if container.SecurityContext != nil && container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged {
+				privilegedContainers++
+			}
+		}
+
+		// all containers in the Pod are running as privileged, we can skip the Pod; privileged mode disables any seccomp profile
+		if len(pod.Spec.Containers) == privilegedContainers {
+			continue
+		}
+
+		// no security context means no seccomp profile
+		if pod.Spec.SecurityContext == nil {
+			errors = append(
+				errors,
+				fmt.Sprintf("expected security context on Pod %s/%s, got none", pod.Namespace, pod.Name),
+			)
+			continue
+		}
+
+		// no seccomp profile means no profile is applied to the containers
+		if pod.Spec.SecurityContext.SeccompProfile == nil {
+			errors = append(
+				errors,
+				fmt.Sprintf("expected seccomp profile on Pod %s/%s, got none", pod.Namespace, pod.Name),
+			)
+			continue
+		}
+
+		// the 'unconfined' profile disables any seccomp filtering
+		if pod.Spec.SecurityContext.SeccompProfile.Type == corev1.SeccompProfileTypeUnconfined {
+			errors = append(
+				errors,
+				fmt.Sprintf(
+					"seccomp profile of Pod %s/%s is '%s', should be '%s' or '%s'", pod.Namespace, pod.Name,
+					corev1.SeccompProfileTypeUnconfined, corev1.SeccompProfileTypeRuntimeDefault, corev1.SeccompProfileTypeLocalhost,
+				),
+			)
+			continue
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errors, "\n"))
+}

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -763,6 +763,16 @@ func (r *testRunner) testCluster(
 		log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
 	}
 
+	// Check security context (seccomp profiles) for control plane pods running on seed cluster - with retries
+	if err := junitReporterWrapper(
+		"[Kubermatic] Test pod security context on seed cluster", report, func() error {
+			return retryNAttempts(maxTestAttempts, func(attempt int) error {
+				return r.testUserClusterControlPlaneSecurityContext(ctx, log, cluster, r.seedClusterClient)
+			})
+		}); err != nil {
+		log.Errorf("failed to verify security context for control plane pods: %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/resources/reconciling/wrapper.go
+++ b/pkg/resources/reconciling/wrapper.go
@@ -146,14 +146,10 @@ func DefaultPodSpec(oldPodSpec, newPodSpec corev1.PodSpec) (corev1.PodSpec, erro
 	// set KKP specific defaults for every Pod created by it
 
 	if newPodSpec.SecurityContext == nil {
-		newPodSpec.SecurityContext = &corev1.PodSecurityContext{
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
-		}
+		newPodSpec.SecurityContext = &corev1.PodSecurityContext{}
 	}
 
-	if newPodSpec.SecurityContext != nil && newPodSpec.SecurityContext.SeccompProfile == nil {
+	if newPodSpec.SecurityContext.SeccompProfile == nil {
 		newPodSpec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		}

--- a/pkg/resources/reconciling/wrapper.go
+++ b/pkg/resources/reconciling/wrapper.go
@@ -111,6 +111,8 @@ func DefaultContainer(c *corev1.Container, procMountType *corev1.ProcMountType) 
 
 // DefaultPodSpec defaults all Container attributes to the same values as they would get from the Kubernetes API.
 // In addition, it sets default PodSpec values that KKP requires in all workloads, for example appropriate security settings.
+// The following KKP-specific defaults are applied:
+// - SecurityContext.SeccompProfile is set to be of type `RuntimeDefault` to enable seccomp isolation if not set.
 func DefaultPodSpec(oldPodSpec, newPodSpec corev1.PodSpec) (corev1.PodSpec, error) {
 	// make sure to keep the old procmount types in case a creator overrides the entire PodSpec
 	initContainerProcMountType := map[string]*corev1.ProcMountType{}
@@ -159,6 +161,7 @@ func DefaultPodSpec(oldPodSpec, newPodSpec corev1.PodSpec) (corev1.PodSpec, erro
 }
 
 // DefaultDeployment defaults all Deployment attributes to the same values as they would get from the Kubernetes API.
+// In addition, the Deployment's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
 func DefaultDeployment(creator DeploymentCreator) DeploymentCreator {
 	return func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 		old := d.DeepCopy()
@@ -195,6 +198,7 @@ func DefaultDeployment(creator DeploymentCreator) DeploymentCreator {
 }
 
 // DefaultStatefulSet defaults all StatefulSet attributes to the same values as they would get from the Kubernetes API.
+// In addition, the StatefulSet's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
 func DefaultStatefulSet(creator StatefulSetCreator) StatefulSetCreator {
 	return func(ss *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 		old := ss.DeepCopy()
@@ -214,6 +218,7 @@ func DefaultStatefulSet(creator StatefulSetCreator) StatefulSetCreator {
 }
 
 // DefaultDaemonSet defaults all DaemonSet attributes to the same values as they would get from the Kubernetes API.
+// In addition, the DaemonSet's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
 func DefaultDaemonSet(creator DaemonSetCreator) DaemonSetCreator {
 	return func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 		old := ds.DeepCopy()
@@ -233,6 +238,7 @@ func DefaultDaemonSet(creator DaemonSetCreator) DaemonSetCreator {
 }
 
 // DefaultCronJob defaults all CronJob attributes to the same values as they would get from the Kubernetes API.
+// In addition, the CronJob's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
 func DefaultCronJob(creator CronJobCreator) CronJobCreator {
 	return func(cj *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
 		old := cj.DeepCopy()

--- a/pkg/resources/reconciling/wrapper_test.go
+++ b/pkg/resources/reconciling/wrapper_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	utilpointer "k8s.io/utils/pointer"
 	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	controllerruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -47,13 +48,18 @@ func TestDefaultPodSpec(t *testing.T) {
 		expectedObject corev1.PodSpec
 	}{
 		{
-			name: "Default values for termination message and pull policies are added",
+			name: "Default values for security context, termination message and pull policies are added",
 			newObject: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{},
 				},
 			},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -84,6 +90,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 			},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						ImagePullPolicy:          corev1.PullNever,
@@ -114,6 +125,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 			},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						SecurityContext: &corev1.SecurityContext{
@@ -153,6 +169,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 			},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						Name:                     "b",
@@ -193,6 +214,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 			},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				InitContainers: []corev1.Container{
 					{
 						Name:                     "b",
@@ -239,6 +265,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 			},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				InitContainers: []corev1.Container{
 					{
 						Name:                     "a",
@@ -271,6 +302,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 				}},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Volumes: []corev1.Volume{{
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
@@ -292,6 +328,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 				}},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Volumes: []corev1.Volume{{
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
@@ -311,6 +352,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 				}},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Volumes: []corev1.Volume{{
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -332,6 +378,11 @@ func TestDefaultPodSpec(t *testing.T) {
 				},
 				}},
 			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Volumes: []corev1.Volume{{
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -339,6 +390,36 @@ func TestDefaultPodSpec(t *testing.T) {
 						},
 					},
 				}},
+			},
+		},
+		{
+			name: "Partial security context gets seccomp profile added",
+			newObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:    pointer.Int64(1000),
+					RunAsGroup:   pointer.Int64(1000),
+					RunAsNonRoot: pointer.Bool(true),
+				},
+				Containers: []corev1.Container{
+					{},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:    pointer.Int64(1000),
+					RunAsGroup:   pointer.Int64(1000),
+					RunAsNonRoot: pointer.Bool(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					},
+				},
 			},
 		},
 	}

--- a/pkg/resources/reconciling/wrapper_test.go
+++ b/pkg/resources/reconciling/wrapper_test.go
@@ -486,6 +486,11 @@ func TestDefaultDeployment(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -554,6 +559,11 @@ func TestDefaultStatefulSet(t *testing.T) {
 		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -622,6 +632,11 @@ func TestDefaultDaemonSet(t *testing.T) {
 		Spec: appsv1.DaemonSetSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -696,6 +711,11 @@ func TestDefaultCronJob(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
+							SecurityContext: &corev1.PodSecurityContext{
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							Containers: []corev1.Container{
 								{
 									ImagePullPolicy:          corev1.PullIfNotPresent,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Adds seccomp profiles to every PodSpec that gets defaulted during a reconcile. Also adds a test to check that all control plane components are using the seccomp profile.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9052

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
All pods created by KKP are assigned the `RuntimeDefault` seccomp profile
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>