### PR TITLE
Implement Provider Reconciling for KubeVirt

### DIFF
--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -118,9 +118,6 @@ func (k *kubevirt) GetClientWithRestConfigForCluster(cluster *kubermaticv1.Clust
 	if err != nil {
 		return nil, nil, err
 	}
-	if err != nil {
-		return nil, nil, err
-	}
 
 	return client, restConfig, nil
 }

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -27,7 +27,9 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type kubevirt struct {
@@ -72,8 +74,26 @@ func (k *kubevirt) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (k *kubevirt) InitializeCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return c, nil
+func (k *kubevirt) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return k.reconcileCluster(cluster, update)
+}
+
+func (k *kubevirt) ReconcileCluster(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return k.reconcileCluster(cluster, update)
+}
+
+func (k *kubevirt) reconcileCluster(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	// Reconcile CSI access: Role and Rolebinding
+	client, restConfig, err := k.GetClientWithRestConfigForCluster(cluster)
+	if err != nil {
+		return cluster, err
+	}
+	err = ReconcileCSIRoleRoleBinding(client, restConfig)
+	if err != nil {
+		return cluster, err
+	}
+
+	return cluster, nil
 }
 
 func (k *kubevirt) CleanUpCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
@@ -82,6 +102,27 @@ func (k *kubevirt) CleanUpCloudProvider(c *kubermaticv1.Cluster, p provider.Clus
 
 func (k *kubevirt) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
 	return nil
+}
+
+// GetClientWithRestConfigForCluster returns the kubernetes client and the rest config for the KubeVirt underlying cluster.
+func (k *kubevirt) GetClientWithRestConfigForCluster(cluster *kubermaticv1.Cluster) (ctrlruntimeclient.Client, *restclient.Config, error) {
+	if cluster.Spec.Cloud.Kubevirt == nil {
+		return nil, nil, errors.New("No KubeVirt provider spec")
+	}
+	kubeconfig, err := GetCredentialsForCluster(cluster.Spec.Cloud, k.secretKeySelector)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, restConfig, err := NewClientWithRestConfig(kubeconfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, restConfig, nil
 }
 
 // GetCredentialsForCluster returns the credentials for the passed in cloud spec or an error.


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
Implement the Provider Reconciling for Kubevirt for the CSI Access (Role and Rolebinding). As discussed, the needed ServiceAccount is not reconciled in this process, only created at cluster creation time.
This prepares also for the namespace creation in #8489 that will be reconciled too.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8144

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
