### PR TITLE
Restore correct labels on nodeport-proxy-envoy Deployment

### DIFF
--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -246,11 +246,11 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 	volumeMountNameEnvoyConfig := "envoy-config"
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Labels = resources.BaseAppLabels(name, nil)
+			d.Labels = resources.BaseAppLabels(envoyAppLabelValue, nil)
 			d.Spec.Replicas = resources.Int32(2)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(name, nil)}
-			d.Spec.Template.Labels = resources.BaseAppLabels(name, nil)
+				MatchLabels: resources.BaseAppLabels(envoyAppLabelValue, nil)}
+			d.Spec.Template.Labels = resources.BaseAppLabels(envoyAppLabelValue, nil)
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fixes my fuckup introduced in #9016 and all backports of that feature down to 2.19.1 and 2.18.6. Labels on the `nodeport-proxy-envoy` Deployment changed because the `name` variable overshadowed the constant, so I did not realise it was used further down in the code: https://github.com/kubermatic/kubermatic/pull/9060/files#diff-a8c7447895f60d1db0d6a70b86f819b1329b41ffa19a26a71c5c124902f6f535R458. This makes the Deployment add the labels via the constant that is used by the service matching.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9059

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: Restore correct labels on nodeport-proxy-envoy Deployment. Deleting the existing Deployment for each cluster with the `LoadBalancer` expose strategy if upgrading from affected version is necessary
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
