### PR TITLE
Use cluster name as cluster-id in cloud-config for vSphere

### DIFF
--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -301,12 +301,12 @@ func getVsphereCloudConfig(
 	dc *kubermaticv1.Datacenter,
 	credentials resources.Credentials,
 ) (*vsphere.CloudConfig, error) {
-	vspherURL, err := url.Parse(dc.Spec.VSphere.Endpoint)
+	vsphereURL, err := url.Parse(dc.Spec.VSphere.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse vsphere endpoint: %w", err)
 	}
 	port := "443"
-	if urlPort := vspherURL.Port(); urlPort != "" {
+	if urlPort := vsphereURL.Port(); urlPort != "" {
 		port = urlPort
 	}
 	datastore := dc.Spec.VSphere.DefaultDatastore
@@ -321,13 +321,13 @@ func getVsphereCloudConfig(
 		Global: vsphere.GlobalOpts{
 			User:             credentials.VSphere.Username,
 			Password:         credentials.VSphere.Password,
-			VCenterIP:        vspherURL.Hostname(),
+			VCenterIP:        vsphereURL.Hostname(),
 			VCenterPort:      port,
 			InsecureFlag:     dc.Spec.VSphere.AllowInsecure,
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			DefaultDatastore: datastore,
 			WorkingDir:       cluster.Name,
-			ClusterID:        dc.Spec.VSphere.Cluster,
+			ClusterID:        cluster.Name,
 		},
 		Workspace: vsphere.WorkspaceOpts{
 			// This is redundant with what the Vsphere cloud provider itself does:
@@ -336,7 +336,7 @@ func getVsphereCloudConfig(
 			// are marked as deprecated even thought the code checks
 			// if they are set and will make the controller-manager crash
 			// if they are not - But maybe that will change at some point
-			VCenterIP:        vspherURL.Hostname(),
+			VCenterIP:        vsphereURL.Hostname(),
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			Folder:           cluster.Spec.Cloud.VSphere.Folder,
 			DefaultDatastore: datastore,
@@ -345,7 +345,7 @@ func getVsphereCloudConfig(
 			SCSIControllerType: "pvscsi",
 		},
 		VirtualCenter: map[string]*vsphere.VirtualCenterConfig{
-			vspherURL.Hostname(): {
+			vsphereURL.Hostname(): {
 				User:        credentials.VSphere.Username,
 				Password:    credentials.VSphere.Password,
 				VCenterPort: port,

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "vs-cluster"
+    cluster-id        = "de-test-01"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "vs-cluster"
+    cluster-id        = "de-test-01"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "vs-cluster"
+    cluster-id        = "de-test-01"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "vs-cluster"
+    cluster-id        = "de-test-01"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "vs-cluster"
+    cluster-id        = "de-test-01"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "vs-cluster"
+    cluster-id        = "de-test-01"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -26,6 +26,8 @@ import (
 // BinaryForClusterVersion returns the full path to a kubectl binary
 // that shall be used to communicate with a usercluster. An error is
 // returned if no suitable kubectl can be determined.
+// We take advantage of version skew policy for kubectl, v1.1.1 would support v1.2.x and v1.0.x, to ship
+// only mandatory variants for kubectl.
 func BinaryForClusterVersion(version *semver.Version) (string, error) {
 	var binary string
 
@@ -33,7 +35,7 @@ func BinaryForClusterVersion(version *semver.Version) (string, error) {
 	case 20:
 		binary = "kubectl-1.20"
 	case 21:
-		binary = "kubectl-1.21"
+		binary = "kubectl-1.22"
 	case 22:
 		binary = "kubectl-1.22"
 	default:

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -33,7 +33,7 @@ func BinaryForClusterVersion(version *semver.Version) (string, error) {
 	case 20:
 		binary = "kubectl-1.20"
 	case 21:
-		binary = "kubectl-1.22"
+		binary = "kubectl-1.21"
 	case 22:
 		binary = "kubectl-1.22"
 	default:


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
Use cluster name as cluster-id in cloud-config for vSphere. `cluster-id` is only consumed by CSI driver and it MUST be unique across each Kubernetes cluster.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8705 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
