### PR TITLE
[release/v2.18] Fix LB expose strategy for LBs with external DNS names instead of IPs (#7933)

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -53,8 +53,12 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 	}
 
 	// Deploy & Update master components for Kubernetes
-	if err := r.ensureResourcesAreDeployed(ctx, cluster); err != nil {
+	res, err := r.ensureResourcesAreDeployed(ctx, cluster)
+	if err != nil {
 		return nil, err
+	}
+	if !res.IsZero() {
+		return res, nil
 	}
 
 	var finalizers []string

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -19,6 +19,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"time"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -47,71 +48,79 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+const (
+	clusterIPUnknownRetryTimeout = 5 * time.Second
+)
+
+func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	seed, err := r.seedGetter()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	data, err := r.getClusterTemplateData(ctx, cluster, seed)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all services are available
 	if err := r.ensureServices(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Set the hostname & url
 	if err := r.syncAddress(ctx, r.log.With("cluster", cluster.Name), cluster, seed); err != nil {
-		return fmt.Errorf("failed to sync address: %v", err)
+		return nil, fmt.Errorf("failed to sync address: %v", err)
 	}
 
 	// We should not proceed without having an IP address unless tunneling
 	// strategy is used. Its required for all Kubeconfigs & triggers errors
 	// otherwise.
 	if cluster.Address.IP == "" && cluster.Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
-		return nil
+		// This can happen e.g. if a LB external IP address has not yet been allocated by a CCM.
+		// Try to reconcile after some time and do not return an error.
+		r.log.Debugf("Cluster IP address not known, retry after %.0f s", clusterIPUnknownRetryTimeout.Seconds())
+		return &reconcile.Result{RequeueAfter: clusterIPUnknownRetryTimeout}, nil
 	}
 
 	// check that all secrets are available // New way of handling secrets
 	if err := r.ensureSecrets(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureServiceAccounts(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureRoles(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureRoleBindings(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureClusterRoles(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureClusterRoleBindings(ctx, cluster); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureNetworkPolicies(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all StatefulSets are created
 	if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureEtcdBackupConfigs(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Wait until the cloud provider infra is ready before attempting
@@ -121,59 +130,59 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	// isn't working correctly"
 	// https://github.com/kubermatic/kubermatic/issues/2948
 	if kubermaticv1.HealthStatusUp != cluster.Status.ExtendedHealth.CloudProviderInfrastructure {
-		return nil
+		return nil, nil
 	}
 
 	// check that all ConfigMaps are available
 	if err := r.ensureConfigMaps(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all Deployments are available
 	if err := r.ensureDeployments(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// This needs to happen after other secrets are created
 	// because it uses some secrets created in previous steps.
 	if data.IsKonnectivityEnabled() {
 		if err := r.ensureKonnectivitySecrets(ctx, cluster, data); err != nil {
-			return err
+			return nil, err
 		}
 
 		// check that all Deployments are available
 		if err := r.ensureKonnectivityDeployments(ctx, cluster, data); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	// check that all CronJobs are created
 	if err := r.ensureCronJobs(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all PodDisruptionBudgets are created
 	if err := r.ensurePodDisruptionBudgets(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	// check that all VerticalPodAutoscalers are created
 	if err := r.ensureVerticalPodAutoscalers(ctx, cluster, data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
 		if err := nodeportproxy.EnsureResources(ctx, r.Client, data); err != nil {
-			return fmt.Errorf("failed to ensure NodePortProxy resources: %v", err)
+			return nil, fmt.Errorf("failed to ensure NodePortProxy resources: %v", err)
 		}
 	}
 
 	// Remove possible leftovers of older version of Gatekeeper, remove this in 1.19
 	if err := r.ensureOldOPAIntegrationIsRemoved(ctx, data); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &reconcile.Result{}, nil
 }
 
 func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) (*resources.TemplateData, error) {
@@ -263,7 +272,7 @@ func GetServiceCreators(data *resources.TemplateData) []reconciling.NamedService
 	}
 
 	if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
-		creators = append(creators, nodeportproxy.FrontLoadBalancerServiceCreator())
+		creators = append(creators, nodeportproxy.FrontLoadBalancerServiceCreator(data))
 	}
 
 	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureRancherIntegration]; flag {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -209,11 +209,11 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		userClusterConnProvider: new(testUserClusterConnectionProvider),
 	}
 
-	if err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
+	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
 		t.Fatalf("Initial resource deployment failed, this indicates that some resources are invalid. Error: %v", err)
 	}
 
-	if err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
+	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster); err != nil {
 		t.Fatalf("The second resource reconciliation failed, indicating we don't properly default some fields. Check the `Object differs from generated one` error for the object for which we timed out. Original error: %v", err)
 	}
 

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -101,27 +101,36 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 		subdomain = m.seed.Spec.SeedDNSOverwrite
 	}
 
-	frontProxyLoadBalancerServiceIP := ""
+	frontProxyLBServiceIP := ""
+	frontProxyLBServiceHostname := ""
 	if m.cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
 		frontProxyLoadBalancerService := &corev1.Service{}
 		nn := types.NamespacedName{Namespace: m.cluster.Status.NamespaceName, Name: resources.FrontLoadBalancerServiceName}
 		if err := m.client.Get(ctx, nn, frontProxyLoadBalancerService); err != nil {
 			return nil, fmt.Errorf("failed to get the front-loadbalancer service: %v", err)
 		}
-		// Use this as default in case the implementation doesn't populate the status
-		frontProxyLoadBalancerServiceIP = frontProxyLoadBalancerService.Spec.LoadBalancerIP
-		// Supposively there is only one if not..Good luck
+		frontProxyLBServiceIP = frontProxyLoadBalancerService.Spec.LoadBalancerIP // default in case the implementation doesn't populate the status
 		for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
 			if ingress.IP != "" {
-				frontProxyLoadBalancerServiceIP = ingress.IP
+				frontProxyLBServiceIP = ingress.IP
 			}
+			if ingress.Hostname != "" {
+				frontProxyLBServiceHostname = ingress.Hostname
+			}
+		}
+		if len(frontProxyLoadBalancerService.Status.LoadBalancer.Ingress) > 1 {
+			m.log.Debugw("Multiple ingress values in LB status, the following values will be used", "ip", frontProxyLBServiceIP, "hostname", frontProxyLBServiceHostname)
 		}
 	}
 
 	// External Name
 	externalName := ""
 	if m.cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
-		externalName = frontProxyLoadBalancerServiceIP
+		if frontProxyLBServiceIP != "" {
+			externalName = frontProxyLBServiceIP
+		} else {
+			externalName = frontProxyLBServiceHostname
+		}
 	} else {
 		externalName = fmt.Sprintf("%s.%s.%s", m.cluster.Name, subdomain, m.externalURL)
 	}
@@ -149,7 +158,16 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 	// controller manager.
 	switch m.cluster.Spec.ExposeStrategy {
 	case kubermaticv1.ExposeStrategyLoadBalancer:
-		ip = frontProxyLoadBalancerServiceIP
+		if frontProxyLBServiceIP != "" {
+			ip = frontProxyLBServiceIP
+		} else if frontProxyLBServiceHostname != "" {
+			var err error
+			// Always lookup IP address, in case it changes
+			ip, err = m.getExternalIPv4(frontProxyLBServiceHostname)
+			if err != nil {
+				return nil, err
+			}
+		}
 	case kubermaticv1.ExposeStrategyNodePort:
 		var err error
 		// Always lookup IP address, in case it changes (IP's on AWS LB's change)

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -424,7 +424,7 @@ func podDisruptionBudget() reconciling.NamedPodDisruptionBudgetCreatorGetter {
 
 // FrontLoadBalancerServiceCreator returns the creator for the LoadBalancer that fronts apiserver
 // and openVPN when using exposeStrategy=LoadBalancer
-func FrontLoadBalancerServiceCreator() reconciling.NamedServiceCreatorGetter {
+func FrontLoadBalancerServiceCreator(data *resources.TemplateData) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.FrontLoadBalancerServiceName, func(s *corev1.Service) (*corev1.Service, error) {
 			// We don't actually manage this service, that is done by the nodeport proxy, we just
@@ -441,7 +441,20 @@ func FrontLoadBalancerServiceCreator() reconciling.NamedServiceCreatorGetter {
 					},
 				}
 			}
+			if data.Cluster().Spec.Cloud.AWS != nil {
+				if s.Annotations == nil {
+					s.Annotations = make(map[string]string)
+				}
+				// NOTE: While KKP uses in-tree CCM for AWS, we use annotations defined in
+				// https://github.com/kubernetes/kubernetes/blob/v1.22.2/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
 
+				// Make sure to use Network Load Balancer with fixed IPs instead of Classic Load Balancer
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+				// Extend the default idle timeout (60s), e.g. to not timeout "kubectl logs -f"
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"] = "3600"
+				// Load-balance across nodes in all zones to ensure HA if nodes in a DNS-selected zone are not available
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+			}
 			s.Spec.Selector = resources.BaseAppLabels(envoyAppLabelValue, nil)
 			return s, nil
 		}

--- a/pkg/resources/test/fixtures/service-aws-1.19.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.19.0-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.21.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.21.0-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-front-loadbalancer.yaml
@@ -1,6 +1,10 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
 spec:
   ports:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This just tripped us up when testing 2.18 and I think it's worth it to backport this, just so we support AWS LB's in case we ever do another 2.18.x release.

**Does this PR introduce a user-facing change?**:
```release-note
Fix LoadBalancer expose strategy for LBs with external DNS names instead of IPs
```
