### PR TITLE
[release/v2.18] re-enable vsphere integration tests (#9084)

### DIFF
--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -132,8 +132,9 @@ type secrets struct {
 		Password string
 	}
 	VSphere struct {
-		Username string
-		Password string
+		Username  string
+		Password  string
+		Datastore string
 	}
 	Packet struct {
 		APIKey    string
@@ -231,6 +232,7 @@ func main() {
 	flag.StringVar(&opts.secrets.OpenStack.Password, "openstack-password", "", "OpenStack: Password")
 	flag.StringVar(&opts.secrets.VSphere.Username, "vsphere-username", "", "vSphere: Username")
 	flag.StringVar(&opts.secrets.VSphere.Password, "vsphere-password", "", "vSphere: Password")
+	flag.StringVar(&opts.secrets.VSphere.Datastore, "vsphere-datastore", "", "vSphere: Datastore")
 	flag.StringVar(&opts.secrets.Azure.ClientID, "azure-client-id", "", "Azure: ClientID")
 	flag.StringVar(&opts.secrets.Azure.ClientSecret, "azure-client-secret", "", "Azure: ClientSecret")
 	flag.StringVar(&opts.secrets.Azure.TenantID, "azure-tenant-id", "", "Azure: TenantID")

--- a/cmd/conformance-tests/scenarios_vsphere.go
+++ b/cmd/conformance-tests/scenarios_vsphere.go
@@ -87,7 +87,7 @@ func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 					Vsphere: &apimodels.VSphereCloudSpec{
 						Username:  secrets.VSphere.Username,
 						Password:  secrets.VSphere.Password,
-						Datastore: "exsi-nas",
+						Datastore: secrets.VSphere.Datastore,
 					},
 				},
 				Version: s.version.String(),

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -61,7 +61,8 @@ elif [[ $provider == "openstack" ]]; then
     -openstack-password=${OS_PASSWORD}"
 elif [[ $provider == "vsphere" ]]; then
   EXTRA_ARGS="-vsphere-username=${VSPHERE_E2E_USERNAME}
-    -vsphere-password=${VSPHERE_E2E_PASSWORD}"
+    -vsphere-password=${VSPHERE_E2E_PASSWORD}
+    -vsphere-datastore=HS-FreeNAS"
 elif [[ $provider == "kubevirt" ]]; then
   tmpFile="$(mktemp)"
   echo "$KUBEVIRT_E2E_TESTS_KUBECONFIG" > "$tmpFile"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -65,9 +65,9 @@ spec:
       country: DE
       spec:
         vsphere:
-          endpoint: "https://vcenter.loodse.io"
+          endpoint: "https://vcenter.qa.lab.kubermatic.io"
           datacenter: "dc-1"
-          datastore: "exsi-nas"
+          datastore: "HS-FreeNAS"
           cluster: "cl-1"
           root_path: "/dc-1/vm/e2e-tests"
           templates:

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -121,7 +121,8 @@ vsphere)
   VSPHERE_USERNAME="${VSPHERE_USERNAME:-$(vault kv get -field=username dev/vsphere)}"
   VSPHERE_PASSWORD="${VSPHERE_PASSWORD:-$(vault kv get -field=password dev/vsphere)}"
   extraArgs="-vsphere-username=$VSPHERE_USERNAME
-      -vsphere-password=$VSPHERE_PASSWORD"
+      -vsphere-password=$VSPHERE_PASSWORD
+      -vsphere-datastore=HS-FreeNAS"
   ;;
 
 *)

--- a/pkg/provider/cloud/vsphere/folder_test.go
+++ b/pkg/provider/cloud/vsphere/folder_test.go
@@ -64,18 +64,14 @@ func TestProvider_GetVMFolders(t *testing.T) {
 		name            string
 		dc              *kubermaticv1.DatacenterSpecVSphere
 		expectedFolders sets.String
-		// If we check for folders on the root we might have other tests creating folders, so we have to skip that check
-		skipAdditionalFoldersCheck bool
 	}{
 		{
-			name:                       "successfully-list-default-folders",
-			skipAdditionalFoldersCheck: true,
-			dc:                         getTestDC(),
+			name: "successfully-list-default-folders",
+			dc:   getTestDC(),
 			expectedFolders: sets.NewString(
 				path.Join("/", vSphereDatacenter, "vm"),
-				path.Join("/", vSphereDatacenter, "vm", "kubermatic-e2e-tests"),
-				path.Join("/", vSphereDatacenter, "vm", "kubermatic-e2e-tests", "test-1"),
-				path.Join("/", vSphereDatacenter, "vm", "kubermatic-e2e-tests-2"),
+				path.Join("/", vSphereDatacenter, "vm", "e2e-tests"),
+				path.Join("/", vSphereDatacenter, "vm", "kubermatic"),
 			),
 		},
 		{
@@ -83,11 +79,11 @@ func TestProvider_GetVMFolders(t *testing.T) {
 			dc: &kubermaticv1.DatacenterSpecVSphere{
 				Datacenter: vSphereDatacenter,
 				Endpoint:   vSphereEndpoint,
-				RootPath:   path.Join("/", vSphereDatacenter, "vm", "kubermatic-e2e-tests"),
+				RootPath:   path.Join("/", vSphereDatacenter, "vm"),
 			},
 			expectedFolders: sets.NewString(
-				path.Join("/", vSphereDatacenter, "vm", "kubermatic-e2e-tests"),
-				path.Join("/", vSphereDatacenter, "vm", "kubermatic-e2e-tests", "test-1"),
+				path.Join("/", vSphereDatacenter, "vm", "e2e-tests"),
+				path.Join("/", vSphereDatacenter, "vm", "kubermatic"),
 			),
 		},
 	}
@@ -107,11 +103,6 @@ func TestProvider_GetVMFolders(t *testing.T) {
 
 			if diff := test.expectedFolders.Difference(gotFolders); diff.Len() > 0 {
 				t.Errorf("Response is missing expected folders: %v", diff.List())
-			}
-			if !test.skipAdditionalFoldersCheck {
-				if diff := gotFolders.Difference(test.expectedFolders); diff.Len() > 0 {
-					t.Errorf("Response contains unexpected folders: %v", diff.List())
-				}
 			}
 		})
 	}

--- a/pkg/provider/cloud/vsphere/network_test.go
+++ b/pkg/provider/cloud/vsphere/network_test.go
@@ -33,16 +33,10 @@ func TestGetPossibleVMNetworks(t *testing.T) {
 			name: "get all networks",
 			expectedNetworkInfos: []NetworkInfo{
 				{
-					AbsolutePath: "/kubermatic-e2e/network/e2e-networks/subfolder/e2e-distributed-port-group",
-					RelativePath: "e2e-networks/subfolder/e2e-distributed-port-group",
-					Type:         "DistributedVirtualPortgroup",
-					Name:         "e2e-distributed-port-group",
-				},
-				{
-					AbsolutePath: "/kubermatic-e2e/network/e2e-networks/subfolder/e2e-distributed-switch-uplinks",
-					RelativePath: "e2e-networks/subfolder/e2e-distributed-switch-uplinks",
-					Type:         "DistributedVirtualPortgroup",
-					Name:         "e2e-distributed-switch-uplinks",
+					AbsolutePath: "/dc-1/network/VM Network",
+					RelativePath: "VM Network",
+					Type:         "Network",
+					Name:         "VM Network",
 				},
 			},
 		},


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This backports #9084 manually because of merge conflicts.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
