### PR TITLE
Remove experimental notice for Nutanix

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -585,7 +585,6 @@ spec:
                     type: object
                   nutanix:
                     description: NutanixCloudSpec specifies the access data to Nutanix.
-                      NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.
                     properties:
                       clusterName:
                         description: ClusterName is the Nutanix cluster that this

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -550,7 +550,6 @@ spec:
                     type: object
                   nutanix:
                     description: NutanixCloudSpec specifies the access data to Nutanix.
-                      NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.
                     properties:
                       clusterName:
                         description: ClusterName is the Nutanix cluster that this

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -3633,11 +3633,6 @@
         "parameters": [
           {
             "type": "string",
-            "name": "Region",
-            "in": "header"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -3656,6 +3651,11 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "Region",
+            "in": "header"
           }
         ],
         "responses": {
@@ -13095,6 +13095,13 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13106,13 +13113,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
           }
         ],
         "responses": {
@@ -21479,7 +21479,6 @@
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
     },
     "DatacenterSpecNutanix": {
-      "description": "NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.",
       "type": "object",
       "title": "DatacenterSpecNutanix describes a Nutanix datacenter.",
       "properties": {
@@ -24874,7 +24873,6 @@
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
     },
     "NutanixCloudSpec": {
-      "description": "NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.",
       "type": "object",
       "title": "NutanixCloudSpec specifies the access data to Nutanix.",
       "properties": {

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -856,7 +856,6 @@ type NutanixCSIConfig struct {
 }
 
 // NutanixCloudSpec specifies the access data to Nutanix.
-// NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.
 type NutanixCloudSpec struct {
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -434,7 +434,6 @@ type DatacenterSpecKubevirt struct {
 }
 
 // DatacenterSpecNutanix describes a Nutanix datacenter.
-// NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.
 type DatacenterSpecNutanix struct {
 	// Endpoint to use for accessing Nutanix Prism Central. No protocol or port should be passed,
 	// for example "nutanix.example.com" or "10.0.0.1"

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_nutanix.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_nutanix.go
@@ -15,8 +15,6 @@ import (
 
 // DatacenterSpecNutanix DatacenterSpecNutanix describes a Nutanix datacenter.
 //
-// NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.
-//
 // swagger:model DatacenterSpecNutanix
 type DatacenterSpecNutanix struct {
 

--- a/pkg/test/e2e/utils/apiclient/models/nutanix_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/nutanix_cloud_spec.go
@@ -15,8 +15,6 @@ import (
 
 // NutanixCloudSpec NutanixCloudSpec specifies the access data to Nutanix.
 //
-// NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.
-//
 // swagger:model NutanixCloudSpec
 type NutanixCloudSpec struct {
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**
The Nutanix cloud provider implementation is now feature-complete for the initial support, and we shouldn't mark it as "do not use" anymore.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
Signed-off-by: Marvin Beckers <marvin@kubermatic.com>