### PR TITLE
ensure new Cluster objects from templates appear in the cache before proceeding

### DIFF
--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -30,12 +30,14 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -126,6 +128,8 @@ func (r *reconciler) reconcile(ctx context.Context, instance *kubermaticv1.Clust
 		return err
 	}
 
+	log.Info("all clusters created successfully, deleting temporary ClusterTemplateInstance")
+
 	// now that all clusters are created, delete this temporary object
 	return r.seedClient.Delete(ctx, instance)
 }
@@ -146,37 +150,15 @@ func (r *reconciler) patchInstance(ctx context.Context, instance *kubermaticv1.C
 
 func (r *reconciler) createClusters(ctx context.Context, instance *kubermaticv1.ClusterTemplateInstance, log *zap.SugaredLogger) error {
 	if instance.Spec.Replicas > 0 {
-		log.Debugf("create clusters from template %s, number of clusters: %d", instance.Spec.ClusterTemplateID, instance.Spec.Replicas)
+		log.Infof("creating %d clusters", instance.Spec.Replicas)
 
 		template := &kubermaticv1.ClusterTemplate{}
 		if err := r.seedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: instance.Spec.ClusterTemplateID}, template); err != nil {
 			return fmt.Errorf("failed to get template %s: %w", instance.Spec.ClusterTemplateID, err)
 		}
 
-		// This is temporary cluster with cloud spec from the template.
-		// It holds credential for the new cluster
-		partialCluster := &kubermaticv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: template.Name,
-			},
-		}
-		partialCluster.Spec = template.Spec
-
 		for i := 0; i < int(instance.Spec.Replicas); i++ {
-			newCluster := genNewCluster(template, instance, r.workerName)
-			newStatus := newCluster.Status.DeepCopy()
-
-			// Here partialCluster is used to copy credentials to the new cluster
-			err := resources.CopyCredentials(resources.NewCredentialsData(context.Background(), partialCluster, r.seedClient), newCluster)
-			if err != nil {
-				return fmt.Errorf("failed to get credentials: %w", err)
-			}
-			if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster, false); err != nil {
-				return err
-			}
-			kuberneteshelper.AddFinalizer(newCluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
-
-			if err := r.seedClient.Create(ctx, newCluster); err != nil {
+			if err := r.createCluster(ctx, log, template, instance); err != nil {
 				created := int64(i + 1)
 				totalReplicas := instance.Spec.Replicas
 
@@ -188,17 +170,57 @@ func (r *reconciler) createClusters(ctx context.Context, instance *kubermaticv1.
 
 				return fmt.Errorf("failed to create desired number of clusters. Created %d of %d", created, totalReplicas)
 			}
-
-			if err := helper.UpdateClusterStatus(ctx, r.seedClient, newCluster, func(c *kubermaticv1.Cluster) {
-				c.Status = *newStatus
-			}); err != nil {
-				return fmt.Errorf("failed to set cluster status: %w", err)
-			}
-
-			if err := r.assignSSHKeyToCluster(ctx, newCluster.Name, template.UserSSHKeys); err != nil {
-				log.Errorf("failed to assign SSH key to the cluster %v", err)
-			}
 		}
+	}
+
+	return nil
+}
+
+func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, template *kubermaticv1.ClusterTemplate, instance *kubermaticv1.ClusterTemplateInstance) error {
+	// This is temporary cluster with cloud spec from the template.
+	// It holds credential for the new cluster
+	partialCluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: template.Name,
+		},
+	}
+	partialCluster.Spec = template.Spec
+
+	newCluster := genNewCluster(template, instance, r.workerName)
+	newStatus := newCluster.Status.DeepCopy()
+
+	// Here partialCluster is used to copy credentials to the new cluster
+	err := resources.CopyCredentials(resources.NewCredentialsData(context.Background(), partialCluster, r.seedClient), newCluster)
+	if err != nil {
+		return fmt.Errorf("failed to get credentials: %w", err)
+	}
+	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster, false); err != nil {
+		return err
+	}
+	kuberneteshelper.AddFinalizer(newCluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
+
+	// re-use our reconciling framework, because this is a special place where right after the Cluster
+	// creation, we must set some status fields and this requires us to wait for the Cluster object
+	// to appear in our caches.
+	name := types.NamespacedName{Name: newCluster.Name}
+	dummyCreator := func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		return newCluster, nil
+	}
+
+	log.Infof("creating cluster %s", newCluster.Name)
+
+	if err := reconciling.EnsureNamedObject(ctx, name, dummyCreator, r.seedClient, &kubermaticv1.Cluster{}, false); err != nil {
+		return fmt.Errorf("failed to create cluster: %w", err)
+	}
+
+	if err := helper.UpdateClusterStatus(ctx, r.seedClient, newCluster, func(c *kubermaticv1.Cluster) {
+		c.Status = *newStatus
+	}); err != nil {
+		return fmt.Errorf("failed to set cluster status: %w", err)
+	}
+
+	if err := r.assignSSHKeyToCluster(ctx, newCluster.Name, template.UserSSHKeys); err != nil {
+		log.Errorf("failed to assign SSH key to the cluster %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
During the CRD refactoring, we changed all code places in KKP to work based on controllers, so that we never have to do

```
client.Create(ctx, cluster)
// and then immediately
client.Status().Patch(ctx, cluster) // this will fail most of the time
```

This is because of the caches. However, the cluster template controller is the only place that needs to do this sequence of operations. But for this to work, it first needs to wait for each of the new Cluster objects to appear in the cache. That's why this PR re-uses parts of our reconciling framework (lines 202-214), which already contains a "wait for cache" loop. I also added a bit more logging to see what's going on.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
