### PR TITLE
update kubevirt cloud controller manager version

### DIFF
--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	KubeVirtCCMDeploymentName = "kubevirt-cloud-controller-manager"
-	KubeVirtCCMTag            = "v0.0.8"
+	KubeVirtCCMTag            = "v0.0.9"
 )
 
 var (


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

- This PR updates the version of kubevirt-cloud-controller-manager from v0.0.8 to v.0.09.
-  kubevirt-cloud-controller-manager has been updated as part of #9107



**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


Signed-off-by: Sankalp Rangare <sankalprangare786@gmail.com>
