### PR TITLE
Create dedicated namespace in KubeVirt infra cluster

### DIFF
--- a/pkg/provider/cloud/kubevirt/namespace.go
+++ b/pkg/provider/cloud/kubevirt/namespace.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NamespaceCreator(name string) reconciling.NamedNamespaceCreatorGetter {
+	return func() (string, reconciling.NamespaceCreator) {
+		return name, func(n *corev1.Namespace) (*corev1.Namespace, error) {
+			return n, nil
+		}
+	}
+}
+
+// reconcileNamespace reconciles a dedicated namespace in the underlying KubeVirt cluster.
+func reconcileNamespace(name string, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, client ctrlruntimeclient.Client) (*kubermaticv1.Cluster, error) {
+	ctx := context.Background()
+
+	creators := []reconciling.NamedNamespaceCreatorGetter{
+		NamespaceCreator(name),
+	}
+
+	if err := reconciling.ReconcileNamespaces(ctx, creators, "", client); err != nil {
+		return cluster, fmt.Errorf("failed to reconcile Namespace: %w", err)
+	}
+
+	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerNamespace)
+	})
+}
+
+// deleteNamespace deletes the dedicated namespace.
+func deleteNamespace(name string, client ctrlruntimeclient.Client) error {
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+		return fmt.Errorf("failed to reconcile Namespace: %w", err)
+	}
+
+	if err := client.Delete(ctx, ns); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/provider/cloud/kubevirt/namespace.go
+++ b/pkg/provider/cloud/kubevirt/namespace.go
@@ -64,9 +64,5 @@ func deleteNamespace(name string, client ctrlruntimeclient.Client) error {
 		return fmt.Errorf("failed to reconcile Namespace: %w", err)
 	}
 
-	if err := client.Delete(ctx, ns); err != nil {
-		return err
-	}
-
-	return nil
+	return client.Delete(ctx, ns)
 }

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -19,14 +19,22 @@ package kubevirt
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// FinalizerNamespace will ensure the deletion of the dedicated namespace.
+	FinalizerNamespace = "kubermatic.k8c.io/cleanup-kubevirt-namespace"
 )
 
 type kubevirt struct {
@@ -82,6 +90,12 @@ func (k *kubevirt) reconcileCluster(cluster *kubermaticv1.Cluster, update provid
 	if err != nil {
 		return cluster, err
 	}
+
+	cluster, err = reconcileNamespace(cluster.Status.NamespaceName, cluster, update, client)
+	if err != nil {
+		return cluster, err
+	}
+
 	err = ReconcileCSIRoleRoleBinding(client, restConfig)
 	if err != nil {
 		return cluster, err
@@ -90,8 +104,25 @@ func (k *kubevirt) reconcileCluster(cluster *kubermaticv1.Cluster, update provid
 	return cluster, nil
 }
 
-func (k *kubevirt) CleanUpCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return c, nil
+func (k *kubevirt) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	client, _, err := k.GetClientWithRestConfigForCluster(cluster)
+	if err != nil {
+		return cluster, err
+	}
+
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerNamespace) {
+		if err := deleteNamespace(cluster.Status.NamespaceName, client); err != nil && !kerrors.IsNotFound(err) {
+			return cluster, fmt.Errorf("failed to delete namespace %s: %w", cluster.Status.NamespaceName, err)
+		}
+		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerNamespace)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return cluster, nil
 }
 
 func (k *kubevirt) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -114,12 +114,10 @@ func (k *kubevirt) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update pr
 		if err := deleteNamespace(cluster.Status.NamespaceName, client); err != nil && !kerrors.IsNotFound(err) {
 			return cluster, fmt.Errorf("failed to delete namespace %s: %w", cluster.Status.NamespaceName, err)
 		}
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerNamespace)
 		})
-		if err != nil {
-			return nil, err
-		}
+
 	}
 
 	return cluster, nil

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -117,7 +117,6 @@ func (k *kubevirt) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update pr
 		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerNamespace)
 		})
-
 	}
 
 	return cluster, nil


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
This PR handles the creation/cleanup of a dedicated namespace in the KubeVirt underlying cluster when we create/delete a cluster. It's a pre-requisite for the following user stories where we will reconcile the CSI access and create the VM in this namespace. This PR contains only the creation/cleanup of the namespace.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9094

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
