### PR TITLE
Support Nutanix subnet types without a cluster reference

### DIFF
--- a/pkg/provider/cloud/nutanix/api.go
+++ b/pkg/provider/cloud/nutanix/api.go
@@ -89,10 +89,20 @@ func GetSubnets(ctx context.Context, client *ClientSet, clusterName, projectName
 		}
 	}
 
+	cluster, err := GetClusterByName(client, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if cluster.Metadata == nil || cluster.Metadata.UUID == nil {
+		return nil, fmt.Errorf("Cluster '%s' has no valid metadata", clusterName)
+	}
+
 	if resp != nil {
 		for _, entity := range resp.Entities {
 			if entity != nil {
-				if entity.Status != nil && entity.Status.ClusterReference != nil && *entity.Status.ClusterReference.Name == clusterName &&
+				if entity.Status != nil &&
+					(entity.Status.ClusterReference == nil || (entity.Status.ClusterReference.UUID != nil && *entity.Status.ClusterReference.UUID == *cluster.Metadata.UUID)) &&
 					(projectName == "" || contains(projectAllowedUUIDs, *entity.Metadata.UUID)) {
 					subnets = append(subnets, *entity)
 				}

--- a/pkg/provider/cloud/nutanix/api.go
+++ b/pkg/provider/cloud/nutanix/api.go
@@ -89,7 +89,7 @@ func GetSubnets(ctx context.Context, client *ClientSet, clusterName, projectName
 		}
 	}
 
-	cluster, err := GetClusterByName(client, clusterName)
+	cluster, err := GetClusterByName(ctx, client, clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/cloud/nutanix/client.go
+++ b/pkg/provider/cloud/nutanix/client.go
@@ -177,11 +177,7 @@ func GetSubnetByName(ctx context.Context, client *ClientSet, name, clusterID str
 			return nil, errors.New("subnet name is nil")
 		}
 
-		if subnet.Status.ClusterReference == nil || subnet.Status.ClusterReference.UUID == nil {
-			return nil, errors.New("subnet status does not contain valid cluster reference")
-		}
-
-		if *subnet.Status.Name == name && *subnet.Status.ClusterReference.UUID == clusterID {
+		if *subnet.Status.Name == name && (subnet.Status.ClusterReference == nil || (subnet.Status.ClusterReference.UUID != nil && *subnet.Status.ClusterReference.UUID == clusterID)) {
 			return subnet, nil
 		}
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Implements the realisation that some Nutanix subnet types do not have a cluster reference, as per https://github.com/kubermatic/machine-controller/pull/1193.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>