### PR TITLE
Fix CRD migration oversights

### DIFF
--- a/cmd/kubermatic-installer/cmd_shutdown.go
+++ b/cmd/kubermatic-installer/cmd_shutdown.go
@@ -118,8 +118,8 @@ func ShutdownAction(logger *logrus.Logger) cli.ActionFunc {
 			return fmt.Errorf("operation failed: %w", err)
 		}
 
-		logger.Info("All controllers have been scaled down to 0 replicas now. It can take up to 3 minutes for all pods to be terminated.")
-		logger.Info("Please run the `migrate-crds` command now to migrate your resources. The migration will first ensure that all controller pods have been removed.")
+		logger.Info("All controllers have been scaled down to 0 replicas and webhooks have been removed now.")
+		logger.Info("Please run the `migrate-crds` command now to migrate your resources.")
 
 		return nil
 	}))

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -2120,6 +2120,10 @@ func convertDatacenter(oldDC kubermaticv1.Datacenter) newv1.Datacenter {
 		}
 	}
 
+	if oldSpec.BringYourOwn != nil {
+		newDC.Spec.BringYourOwn = &newv1.DatacenterSpecBringYourOwn{}
+	}
+
 	if oldSpec.Fake != nil {
 		newDC.Spec.Fake = &newv1.DatacenterSpecFake{
 			FakeProperty: oldSpec.Fake.FakeProperty,

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -153,9 +153,49 @@ func cloneResourcesInCluster(ctx context.Context, logger logrus.FieldLogger, cli
 		oldAPIVersion: "v1",
 		newAPIVersion: "v1",
 	}, ownerRefTask{
+		kind:          "Service",
+		oldAPIVersion: "v1",
+		newAPIVersion: "v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
 		kind:          "Secret",
 		oldAPIVersion: "v1",
 		newAPIVersion: "v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "ConfigMap",
+		oldAPIVersion: "v1",
+		newAPIVersion: "v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "Deployment",
+		oldAPIVersion: "apps/v1",
+		newAPIVersion: "apps/v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "ServiceAccount",
+		oldAPIVersion: "v1",
+		newAPIVersion: "v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "Role",
+		oldAPIVersion: "rbac.authorization.k8s.io/v1",
+		newAPIVersion: "rbac.authorization.k8s.io/v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "RoleBinding",
+		oldAPIVersion: "rbac.authorization.k8s.io/v1",
+		newAPIVersion: "rbac.authorization.k8s.io/v1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "PodDisruptionBudget",
+		oldAPIVersion: "policy/v1beta1",
+		newAPIVersion: "policy/v1beta1",
+		namespaces:    []string{kubermaticNamespace},
+	}, ownerRefTask{
+		kind:          "Ingress",
+		oldAPIVersion: "networking.k8s.io/v1",
+		newAPIVersion: "networking.k8s.io/v1",
 		namespaces:    []string{kubermaticNamespace},
 	}, ownerRefTask{
 		kind:          "CronJob",
@@ -679,7 +719,7 @@ func cloneKubermaticConfigurationResourcesInCluster(ctx context.Context, logger 
 
 		logger.WithField("resource", ctrlruntimeclient.ObjectKeyFromObject(&oldObject)).Debug("Duplicating KubermaticConfiguration…")
 
-		if err := ensureObject(ctx, client, &newObject, false); err != nil {
+		if err := ensureObject(ctx, client, &newObject, true); err != nil {
 			return 0, fmt.Errorf("failed to clone %s: %w", oldObject.Name, err)
 		}
 	}

--- a/pkg/install/crdmigration/preflight.go
+++ b/pkg/install/crdmigration/preflight.go
@@ -317,7 +317,12 @@ func validateNoStuckResourcesInCluster(ctx context.Context, logger logrus.FieldL
 		}
 
 		for _, object := range objectList.Items {
-			objectLogger := logger.WithField(strings.ToLower(object.GetKind()), object.GetName())
+			key := object.GetName()
+			if ns := object.GetNamespace(); ns != "" {
+				key = fmt.Sprintf("%s/%s", ns, key)
+			}
+
+			objectLogger := logger.WithField(strings.ToLower(object.GetKind()), key)
 			objectLogger.Debug("Validating…")
 
 			if object.GetDeletionTimestamp() != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
During testing, we found a couple more minor issues. This PR fixes them, one per commit.

* Stale ownerRefs on Deployments nuked the nodeport-proxy, making all userclusters temporarily unavailable.
* Not super help messages about blocked objects, because no namespace was logged.
* Mutating webhooks were not removed, leading to trouble during the `--remove-old-resources` phase.
* BYO datacenters were not correctly migrated.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
