### PR TITLE
Add dual-stack support for AWS security groups

### DIFF
--- a/pkg/provider/cloud/aws/security_group_test.go
+++ b/pkg/provider/cloud/aws/security_group_test.go
@@ -77,8 +77,10 @@ func assertSecurityGroup(t *testing.T, cluster *kubermaticv1.Cluster, group *ec2
 		}
 	}
 
+	permissions := getCommonSecurityGroupPermissions(*group.GroupId, true, false)
+
 	lowPort, highPort := getNodePortRange(cluster)
-	permissions := getSecurityGroupPermissions(*group.GroupId, lowPort, highPort, "0.0.0.0/0")
+	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "0.0.0.0/0")...)
 
 	stringPermissions := sets.NewString()
 	for _, perm := range permissions {

--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -60,6 +60,11 @@ func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {
 			Cloud: kubermaticv1.CloudSpec{
 				AWS: cloudSpec,
 			},
+			ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+				Pods: kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+			},
 		},
 	}
 }

--- a/pkg/util/network/network.go
+++ b/pkg/util/network/network.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	"k8s.io/utils/net"
+)
+
+// IsIPv4OnlyCluster returns true if the cluster networking is IPv4-only.
+func IsIPv4OnlyCluster(cluster *kubermaticv1.Cluster) bool {
+	return len(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks) == 1 && net.IsIPv4CIDRString(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+}
+
+// IsIPv6OnlyCluster returns true if the cluster networking is IPv6-only.
+func IsIPv6OnlyCluster(cluster *kubermaticv1.Cluster) bool {
+	return len(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks) == 1 && net.IsIPv6CIDRString(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+}
+
+// IsDualStackCluster returns true if the cluster networking is dual-stack (IPv4 + IPv6).
+func IsDualStackCluster(cluster *kubermaticv1.Cluster) bool {
+	res, err := net.IsDualStackCIDRStrings(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks)
+	if err != nil {
+		return false
+	}
+	return res
+}

--- a/pkg/util/network/network_test.go
+++ b/pkg/util/network/network_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+)
+
+func TestClusterIPFamily(t *testing.T) {
+	tests := []struct {
+		name                string
+		cluster             *kubermaticv1.Cluster
+		wantIPv4OnlyResult  bool
+		wantIPv6OnlyResult  bool
+		wantDualStackResult bool
+	}{
+		{
+			name: "ipv4-only",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{
+							CIDRBlocks: []string{"172.25.0.0/16"},
+						},
+					},
+				},
+			},
+			wantIPv4OnlyResult:  true,
+			wantIPv6OnlyResult:  false,
+			wantDualStackResult: false,
+		},
+		{
+			name: "ipv6-only",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{
+							CIDRBlocks: []string{"fd00::/104"},
+						},
+					},
+				},
+			},
+			wantIPv4OnlyResult:  false,
+			wantIPv6OnlyResult:  true,
+			wantDualStackResult: false,
+		},
+		{
+			name: "dual-stack",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{
+							CIDRBlocks: []string{"172.25.0.0/16", "fd00::/104"},
+						},
+					},
+				},
+			},
+			wantIPv4OnlyResult:  false,
+			wantIPv6OnlyResult:  false,
+			wantDualStackResult: true,
+		},
+		{
+			name:                "invalid-empty-network-config",
+			cluster:             &kubermaticv1.Cluster{},
+			wantIPv4OnlyResult:  false,
+			wantIPv6OnlyResult:  false,
+			wantDualStackResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if res := IsIPv4OnlyCluster(tt.cluster); res != tt.wantIPv4OnlyResult {
+				t.Errorf("IsIPv4OnlyCluster result = %v, wantResult %v", res, tt.wantIPv4OnlyResult)
+			}
+			if res := IsIPv6OnlyCluster(tt.cluster); res != tt.wantIPv6OnlyResult {
+				t.Errorf("IsIPv6OnlyCluster result = %v, wantResult %v", res, tt.wantIPv6OnlyResult)
+			}
+			if res := IsDualStackCluster(tt.cluster); res != tt.wantDualStackResult {
+				t.Errorf("IsDualStackCluster result = %v, wantResult %v", res, tt.wantDualStackResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
 Adds dual-stack support for AWS security groups managed by KKP.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9142 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add dual-stack support for AWS security groups
```
