### PR TITLE
Use klog in fewer places

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -346,14 +346,14 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 		machinecontroller.TLSServingCertificateCreator(data),
 
 		// Kubeconfigs
-		resources.GetInternalKubeconfigCreator(namespace, resources.SchedulerKubeconfigSecretName, resources.SchedulerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.MachineControllerKubeconfigSecretName, resources.MachineControllerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.OperatingSystemManagerKubeconfigSecretName, resources.OperatingSystemManagerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.KubernetesDashboardKubeconfigSecretName, resources.KubernetesDashboardCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(namespace, resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data),
+		resources.GetInternalKubeconfigCreator(namespace, resources.SchedulerKubeconfigSecretName, resources.SchedulerCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.MachineControllerKubeconfigSecretName, resources.MachineControllerCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.OperatingSystemManagerKubeconfigSecretName, resources.OperatingSystemManagerCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.KubernetesDashboardKubeconfigSecretName, resources.KubernetesDashboardCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigCreator(namespace, resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data, r.log),
 		resources.AdminKubeconfigCreator(data),
 		apiserver.TokenViewerCreator(),
 		apiserver.TokenUsersCreator(data),
@@ -371,14 +371,14 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 			openvpn.TLSServingCertificateCreator(data),
 			openvpn.InternalClientCertificateCreator(data),
 			metricsserver.TLSServingCertSecretCreator(data.GetRootCA),
-			resources.GetInternalKubeconfigCreator(namespace, resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data),
-			resources.GetInternalKubeconfigCreator(namespace, resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil, data),
+			resources.GetInternalKubeconfigCreator(namespace, resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data, r.log),
+			resources.GetInternalKubeconfigCreator(namespace, resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil, data, r.log),
 		)
 	}
 
 	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; flag {
 		creators = append(creators, resources.GetInternalKubeconfigCreator(
-			namespace, resources.CloudControllerManagerKubeconfigSecretName, resources.CloudControllerManagerCertUsername, nil, data,
+			namespace, resources.CloudControllerManagerKubeconfigSecretName, resources.CloudControllerManagerCertUsername, nil, data, r.log,
 		))
 	}
 

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
+	"go.uber.org/zap"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -34,13 +35,12 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
-
-	"k8s.io/klog"
 )
 
 func CreateEndpoint(
@@ -123,7 +123,7 @@ func ListAllEndpoint(
 			// if a Seed is bad, do not forward that error to the user, but only log
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
-				klog.Errorf("failed to create cluster provider for seed %s: %v", seed.Name, err)
+				kubermaticlog.Logger.Errorw("failed to create cluster provider", "seed", seed.Name, zap.Error(err))
 				continue
 			}
 			apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, configGetter)

--- a/pkg/handler/v2/cluster/cluster.go
+++ b/pkg/handler/v2/cluster/cluster.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 
 	"github.com/go-kit/kit/endpoint"
+	"go.uber.org/zap"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -33,13 +34,12 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
-
-	"k8s.io/klog"
 )
 
 func CreateEndpoint(
@@ -94,7 +94,7 @@ func ListEndpoint(
 			// if a Seed is bad, do not forward that error to the user, but only log
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
-				klog.Errorf("failed to create cluster provider for seed %s: %v", seed.Name, err)
+				kubermaticlog.Logger.Errorw("failed to create cluster provider", "seed", seed.Name, zap.Error(err))
 				continue
 			}
 			apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, configGetter)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -39,10 +39,9 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-
-	"k8s.io/klog"
 )
 
 const (
@@ -631,7 +630,7 @@ func addICMPRulesToSecurityGroupIfNecesary(cluster *kubermaticv1.Cluster, secGro
 			SecGroupID: secGroup.ID,
 			Protocol:   osecuritygrouprules.ProtocolICMP,
 		})
-		klog.Infof("Adding ICMP allow rule to cluster %q", cluster.Name)
+		kubermaticlog.Logger.Infow("Adding Openstack ICMP allow rule to cluster", "cluster", cluster.Name)
 	}
 	if !hasIPV6Rule {
 		rulesToCreate = append(rulesToCreate, osecuritygrouprules.CreateOpts{
@@ -640,7 +639,7 @@ func addICMPRulesToSecurityGroupIfNecesary(cluster *kubermaticv1.Cluster, secGro
 			SecGroupID: secGroup.ID,
 			Protocol:   osecuritygrouprules.ProtocolIPv6ICMP,
 		})
-		klog.Infof("Adding ICMP6 allow rule to cluster %q", cluster.Name)
+		kubermaticlog.Logger.Infow("Adding Openstack ICMP6 allow rule to cluster", "cluster", cluster.Name)
 	}
 
 	for _, rule := range rulesToCreate {

--- a/pkg/resources/kubeconfig_test.go
+++ b/pkg/resources/kubeconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
@@ -118,7 +119,7 @@ func checkKubeConfigRegeneration(t *testing.T, orgs []string) {
 	data := &fakeDataProvider{caPair: ca}
 	assert.NotNil(t, data)
 
-	_, create := GetInternalKubeconfigCreator("some-namespace", "some-name", "test-creator-cn", orgs, data)()
+	_, create := GetInternalKubeconfigCreator("some-namespace", "some-name", "test-creator-cn", orgs, data, zap.NewNop().Sugar())()
 	secret, err := create(&corev1.Secret{})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -19,14 +19,18 @@ package reconciling
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
+
+	"go.uber.org/zap"
+
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	appsv1 "k8s.io/api/apps/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,6 +64,17 @@ func createWithName(rawcreate ObjectCreator, name string) ObjectCreator {
 	}
 }
 
+func objectLogger(obj ctrlruntimeclient.Object) *zap.SugaredLogger {
+	// make sure we handle objects with broken typeMeta and still create a nice-looking kind name
+	logger := kubermaticlog.Logger.With("kind", reflect.TypeOf(obj).Elem())
+	if ns := obj.GetNamespace(); ns != "" {
+		logger = logger.With("namespace", ns)
+	}
+
+	// ensure name comes after namespace
+	return logger.With("name", obj.GetName())
+}
+
 // EnsureNamedObject will generate the Object with the passed create function & create or update it in Kubernetes if necessary.
 func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName, rawcreate ObjectCreator, client ctrlruntimeclient.Client, emptyObject ctrlruntimeclient.Object, requiresRecreate bool) error {
 	// A wrapper to ensure we always set the Namespace and Name. This is useful as we call create twice
@@ -85,13 +100,13 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 			return fmt.Errorf("failed to create %T '%s': %w", obj, namespacedName.String(), err)
 		}
 		// Wait until the object exists in the cache
-		createdObjectIsInCache := waitUntilObjectExistsInCacheConditionFunc(ctx, client, namespacedName, obj)
+		createdObjectIsInCache := waitUntilObjectExistsInCacheConditionFunc(ctx, client, objectLogger(obj), namespacedName, obj)
 		err = wait.PollImmediate(10*time.Millisecond, 10*time.Second, createdObjectIsInCache)
 		if err != nil {
 			return fmt.Errorf("failed waiting for the cache to contain our newly created object: %w", err)
 		}
 
-		klog.V(2).Infof("Created %T %s in Namespace %q", obj, obj.(metav1.Object).GetName(), obj.(metav1.Object).GetNamespace())
+		objectLogger(obj).Info("created new resource")
 		return nil
 	}
 
@@ -117,7 +132,7 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 		}
 
 		if err := client.Update(ctx, obj); err != nil {
-			return fmt.Errorf("failed to update object %T '%s': %w", obj, namespacedName.String(), err)
+			return fmt.Errorf("failed to update object %T %q: %w", obj, namespacedName.String(), err)
 		}
 	} else {
 		if err := client.Delete(ctx, obj.DeepCopyObject().(ctrlruntimeclient.Object)); err != nil {
@@ -134,13 +149,13 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 	}
 
 	// Wait until the object we retrieve via "client.Get" has a different ResourceVersion than the old object
-	updatedObjectIsInCache := waitUntilUpdateIsInCacheConditionFunc(ctx, client, namespacedName, existingObject)
+	updatedObjectIsInCache := waitUntilUpdateIsInCacheConditionFunc(ctx, client, objectLogger(obj), namespacedName, existingObject)
 	err = wait.PollImmediate(10*time.Millisecond, 10*time.Second, updatedObjectIsInCache)
 	if err != nil {
 		return fmt.Errorf("failed waiting for the cache to contain our latest changes: %w", err)
 	}
 
-	klog.V(2).Infof("Updated %T %s in Namespace %q", obj, obj.(metav1.Object).GetName(), obj.(metav1.Object).GetNamespace())
+	objectLogger(obj).Info("updated resource")
 
 	return nil
 }
@@ -148,6 +163,7 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 func waitUntilUpdateIsInCacheConditionFunc(
 	ctx context.Context,
 	client ctrlruntimeclient.Client,
+	log *zap.SugaredLogger,
 	namespacedName types.NamespacedName,
 	oldObj ctrlruntimeclient.Object,
 ) wait.ConditionFunc {
@@ -156,7 +172,7 @@ func waitUntilUpdateIsInCacheConditionFunc(
 		currentObj := oldObj.DeepCopyObject().(ctrlruntimeclient.Object)
 
 		if err := client.Get(ctx, namespacedName, currentObj); err != nil {
-			klog.Errorf("failed retrieving object %T %s while waiting for the cache to contain our latest changes: %v", currentObj, namespacedName, err)
+			log.Errorw("failed retrieving object while waiting for the cache to contain our latest changes", zap.Error(err))
 			return false, nil
 		}
 
@@ -166,6 +182,7 @@ func waitUntilUpdateIsInCacheConditionFunc(
 		if !DeepEqual(currentObj.(metav1.Object), oldObj.(metav1.Object)) {
 			return true, nil
 		}
+
 		return false, nil
 	}
 }
@@ -173,6 +190,7 @@ func waitUntilUpdateIsInCacheConditionFunc(
 func waitUntilObjectExistsInCacheConditionFunc(
 	ctx context.Context,
 	client ctrlruntimeclient.Client,
+	log *zap.SugaredLogger,
 	namespacedName types.NamespacedName,
 	obj ctrlruntimeclient.Object,
 ) wait.ConditionFunc {
@@ -182,9 +200,11 @@ func waitUntilObjectExistsInCacheConditionFunc(
 			if kubeerrors.IsNotFound(err) {
 				return false, nil
 			}
-			klog.Errorf("failed retrieving object %T %s while waiting for the cache to contain our newly created object: %v", newObj, namespacedName, err)
+
+			log.Errorw("failed retrieving object while waiting for the cache to contain our newly created object", zap.Error(err))
 			return false, nil
 		}
+
 		return true, nil
 	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -32,8 +32,10 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -45,7 +47,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/klog"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -972,7 +973,7 @@ func IsServerCertificateValidForAllOf(cert *x509.Certificate, commonName string,
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 	if _, err := cert.Verify(verifyOptions); err != nil {
-		klog.Errorf("Certificate verification for CN %s failed: %v", commonName, err)
+		kubermaticlog.Logger.Errorw("certificate verification failed", "cn", commonName, zap.Error(err))
 		return false
 	}
 
@@ -1004,7 +1005,7 @@ func IsClientCertificateValidForAllOf(cert *x509.Certificate, commonName string,
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 	if _, err := cert.Verify(verifyOptions); err != nil {
-		klog.Errorf("Certificate verification for CN %s failed: %v", commonName, err)
+		kubermaticlog.Logger.Errorw("certificate verification failed", "cn", commonName, zap.Error(err))
 		return false
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This gets rid of more places where we used klog, while still relying on the global `kubermaticlog.Logger` variable. It would be a major undertaking to properly inject a logger everywhere and I'm not even sure it would be worth it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
