### PR TITLE
Add Go contexts to cloud providers, cleanup misplaced TODO() contexts

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
@@ -200,7 +200,7 @@ func TestReconcilingSeed(t *testing.T) {
 			existingSeeds: existingSeeds,
 			validate: func(_, _ *kubermaticv1.Seed, masterClient, seedClient ctrlruntimeclient.Client) error {
 				cfg := &kubermaticv1.KubermaticConfiguration{}
-				err := seedClient.Get(context.TODO(), types.NamespacedName{
+				err := seedClient.Get(context.Background(), types.NamespacedName{
 					Namespace: "kubermatic",
 					Name:      "kubermatic",
 				}, cfg)

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -80,7 +80,7 @@ func Add(
 		return fmt.Errorf("failed to create watcher for secrets: %w", err)
 	}
 
-	if err := reconciler.watchAuthorizedKeys(context.TODO(), authorizedKeysPaths); err != nil {
+	if err := reconciler.watchAuthorizedKeys(authorizedKeysPaths); err != nil {
 		return fmt.Errorf("failed to watch authorized_keys files: %w", err)
 	}
 
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) watchAuthorizedKeys(ctx context.Context, paths []string) error {
+func (r *Reconciler) watchAuthorizedKeys(paths []string) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed creating a new file watcher: %w", err)

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -44,7 +44,7 @@ import (
 // This function assumes that the KubermaticConfiguration has already been defaulted
 // (as the KubermaticConfigurationGetter does that automatically), but the Seed
 // does not yet need to be defaulted (to the values of the KubermaticConfiguration).
-func DefaultClusterSpec(spec *kubermaticv1.ClusterSpec, template *kubermaticv1.ClusterTemplate, seed *kubermaticv1.Seed, config *kubermaticv1.KubermaticConfiguration, cloudProvider provider.CloudProvider) error {
+func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, template *kubermaticv1.ClusterTemplate, seed *kubermaticv1.Seed, config *kubermaticv1.KubermaticConfiguration, cloudProvider provider.CloudProvider) error {
 	var err error
 
 	// Apply default values to the Seed, just in case.
@@ -74,7 +74,7 @@ func DefaultClusterSpec(spec *kubermaticv1.ClusterSpec, template *kubermaticv1.C
 
 	// Give cloud providers a chance to default their spec.
 	if cloudProvider != nil {
-		if err := cloudProvider.DefaultCloudSpec(&spec.Cloud); err != nil {
+		if err := cloudProvider.DefaultCloudSpec(ctx, &spec.Cloud); err != nil {
 			return fmt.Errorf("failed to default cloud spec: %w", err)
 		}
 	}

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -198,7 +198,7 @@ func GenerateCluster(
 
 	// Create the Cluster object.
 	secretKeyGetter := provider.SecretKeySelectorValueFuncFactory(ctx, seedClient)
-	spec, err := cluster.Spec(body.Cluster, defaultingTemplate, seed, dc, config, secretKeyGetter, caBundle, features)
+	spec, err := cluster.Spec(ctx, body.Cluster, defaultingTemplate, seed, dc, config, secretKeyGetter, caBundle, features)
 	if err != nil {
 		return nil, kubermaticerrors.NewBadRequest("invalid cluster: %v", err)
 	}
@@ -500,7 +500,7 @@ func PatchEndpoint(
 	}
 
 	// apply default values to the new cluster
-	if err := defaulting.DefaultClusterSpec(&newInternalCluster.Spec, defaultingTemplate, seed, config, cloudProvider); err != nil {
+	if err := defaulting.DefaultClusterSpec(ctx, &newInternalCluster.Spec, defaultingTemplate, seed, config, cloudProvider); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -77,7 +77,7 @@ func AWSSubnetNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider
 		return nil, err
 	}
 
-	subnetList, err := ListAWSSubnets(accessKeyID, secretAccessKey, assumeRoleID, assumeRoleExternalID, cluster.Spec.Cloud.AWS.VPCID, dc)
+	subnetList, err := ListAWSSubnets(ctx, accessKeyID, secretAccessKey, assumeRoleID, assumeRoleExternalID, cluster.Spec.Cloud.AWS.VPCID, dc)
 	if err != nil {
 		return nil, err
 	}
@@ -125,12 +125,12 @@ func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.U
 	return AWSSizes(dc.Spec.AWS.Region, architecture, settings.Spec.MachineDeploymentVMResourceQuota)
 }
 
-func ListAWSSubnets(accessKeyID, secretAccessKey, assumeRoleID string, assumeRoleExternalID string, vpcID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSSubnetList, error) {
+func ListAWSSubnets(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleID string, assumeRoleExternalID string, vpcID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSSubnetList, error) {
 	if datacenter.Spec.AWS == nil {
 		return nil, errors.NewBadRequest("datacenter is not an AWS datacenter")
 	}
 
-	subnetResults, err := awsprovider.GetSubnets(accessKeyID, secretAccessKey, assumeRoleID, assumeRoleExternalID, datacenter.Spec.AWS.Region, vpcID)
+	subnetResults, err := awsprovider.GetSubnets(ctx, accessKeyID, secretAccessKey, assumeRoleID, assumeRoleExternalID, datacenter.Spec.AWS.Region, vpcID)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get subnets: %w", err)
 	}

--- a/pkg/handler/common/provider/eks.go
+++ b/pkg/handler/common/provider/eks.go
@@ -118,7 +118,7 @@ func ValidateEKSCredentials(ctx context.Context, credential EKSCredential) error
 func ListEKSSubnetIDs(ctx context.Context, cred EKSCredential, vpcID string) (apiv2.EKSSubnetIDList, error) {
 	subnetIDs := apiv2.EKSSubnetIDList{}
 
-	subnetResults, err := awsprovider.GetSubnets(cred.AccessKeyID, cred.SecretAccessKey, "", "", cred.Region, vpcID)
+	subnetResults, err := awsprovider.GetSubnets(ctx, cred.AccessKeyID, cred.SecretAccessKey, "", "", cred.Region, vpcID)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func ListEKSSubnetIDs(ctx context.Context, cred EKSCredential, vpcID string) (ap
 func ListEKSVPC(ctx context.Context, cred EKSCredential) (apiv2.EKSVPCList, error) {
 	vpcs := apiv2.EKSVPCList{}
 
-	vpcResults, err := awsprovider.GetVPCS(cred.AccessKeyID, cred.SecretAccessKey, "", "", cred.Region)
+	vpcResults, err := awsprovider.GetVPCS(ctx, cred.AccessKeyID, cred.SecretAccessKey, "", "", cred.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func ListEKSRegions(ctx context.Context, cred EKSCredential) (apiv2.EKSRegions, 
 func ListEKSSecurityGroupIDs(ctx context.Context, cred EKSCredential, vpcID string) (apiv2.EKSSecurityGroupIDList, error) {
 	securityGroupID := apiv2.EKSSecurityGroupIDList{}
 
-	securityGroups, err := awsprovider.GetSecurityGroupsByVPC(cred.AccessKeyID, cred.SecretAccessKey, "", "", cred.Region, vpcID)
+	securityGroups, err := awsprovider.GetSecurityGroupsByVPC(ctx, cred.AccessKeyID, cred.SecretAccessKey, "", "", cred.Region, vpcID)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get security groups: %w", err)
 	}

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -173,7 +173,7 @@ func ListGCPDiskTypes(ctx context.Context, sa string, zone string) (apiv1.GCPDis
 	diskTypes := apiv1.GCPDiskTypeList{}
 	// TODO: There are some issues at the moment with local-ssd and pd-balanced, that's why it is disabled at the moment.
 	excludedDiskTypes := sets.NewString("local-ssd", "pd-balanced")
-	computeService, project, err := gcp.ConnectToComputeService(sa)
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
 	if err != nil {
 		return diskTypes, err
 	}
@@ -207,7 +207,7 @@ func ListGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datace
 
 	subnetworks := apiv1.GCPSubnetworkList{}
 
-	computeService, project, err := gcp.ConnectToComputeService(sa)
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
 	if err != nil {
 		return subnetworks, err
 	}
@@ -246,7 +246,7 @@ func ListGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datace
 func ListGCPNetworks(ctx context.Context, sa string) (apiv1.GCPNetworkList, error) {
 	networks := apiv1.GCPNetworkList{}
 
-	computeService, project, err := gcp.ConnectToComputeService(sa)
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
 	if err != nil {
 		return networks, err
 	}
@@ -284,7 +284,7 @@ func ListGCPZones(ctx context.Context, userInfo *provider.UserInfo, sa, datacent
 		return nil, errors.NewBadRequest("the %s is not GCP datacenter", datacenterName)
 	}
 
-	computeService, project, err := gcp.ConnectToComputeService(sa)
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func ListGCPZones(ctx context.Context, userInfo *provider.UserInfo, sa, datacent
 func ListGCPSizes(ctx context.Context, quota kubermaticv1.MachineDeploymentVMResourceQuota, sa, zone string) (apiv1.GCPMachineSizeList, error) {
 	sizes := apiv1.GCPMachineSizeList{}
 
-	computeService, project, err := gcp.ConnectToComputeService(sa)
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
 	if err != nil {
 		return sizes, err
 	}

--- a/pkg/handler/common/provider/nutanix.go
+++ b/pkg/handler/common/provider/nutanix.go
@@ -39,9 +39,9 @@ type NutanixCredentials struct {
 }
 
 type NutanixClientSet interface {
-	ListNutanixClusters() (apiv1.NutanixClusterList, error)
-	ListNutanixProjects() (apiv1.NutanixProjectList, error)
-	ListNutanixSubnets(clusterName, projectName string) (apiv1.NutanixSubnetList, error)
+	ListNutanixClusters(ctx context.Context) (apiv1.NutanixClusterList, error)
+	ListNutanixProjects(ctx context.Context) (apiv1.NutanixProjectList, error)
+	ListNutanixSubnets(ctx context.Context, clusterName, projectName string) (apiv1.NutanixSubnetList, error)
 }
 
 type nutanixClientImpl struct {
@@ -56,13 +56,13 @@ var NewNutanixClient = func(dc *kubermaticv1.DatacenterSpecNutanix, creds *Nutan
 	}
 }
 
-func (n *nutanixClientImpl) ListNutanixClusters() (apiv1.NutanixClusterList, error) {
+func (n *nutanixClientImpl) ListNutanixClusters(ctx context.Context) (apiv1.NutanixClusterList, error) {
 	clientSet, err := nutanixprovider.GetClientSetWithCreds(n.dc.Endpoint, n.dc.Port, &n.dc.AllowInsecure, n.creds.ProxyURL, n.creds.Username, n.creds.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterResp, err := nutanixprovider.GetClusters(clientSet)
+	clusterResp, err := nutanixprovider.GetClusters(ctx, clientSet)
 	if err != nil {
 		return nil, err
 	}
@@ -79,13 +79,13 @@ func (n *nutanixClientImpl) ListNutanixClusters() (apiv1.NutanixClusterList, err
 	return clusters, nil
 }
 
-func (n *nutanixClientImpl) ListNutanixProjects() (apiv1.NutanixProjectList, error) {
+func (n *nutanixClientImpl) ListNutanixProjects(ctx context.Context) (apiv1.NutanixProjectList, error) {
 	clientSet, err := nutanixprovider.GetClientSetWithCreds(n.dc.Endpoint, n.dc.Port, &n.dc.AllowInsecure, n.creds.ProxyURL, n.creds.Username, n.creds.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	projectsResp, err := nutanixprovider.GetProjects(clientSet)
+	projectsResp, err := nutanixprovider.GetProjects(ctx, clientSet)
 	if err != nil {
 		return nil, err
 	}
@@ -100,17 +100,17 @@ func (n *nutanixClientImpl) ListNutanixProjects() (apiv1.NutanixProjectList, err
 	return projects, nil
 }
 
-func (n *nutanixClientImpl) ListNutanixSubnets(clusterName, projectName string) (apiv1.NutanixSubnetList, error) {
+func (n *nutanixClientImpl) ListNutanixSubnets(ctx context.Context, clusterName, projectName string) (apiv1.NutanixSubnetList, error) {
 	clientSet, err := nutanixprovider.GetClientSetWithCreds(n.dc.Endpoint, n.dc.Port, &n.dc.AllowInsecure, n.creds.ProxyURL, n.creds.Username, n.creds.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	return listNutanixSubnets(clientSet, clusterName, projectName)
+	return listNutanixSubnets(ctx, clientSet, clusterName, projectName)
 }
 
-func listNutanixSubnets(client *nutanixprovider.ClientSet, clusterName, projectName string) (apiv1.NutanixSubnetList, error) {
-	subnetResp, err := nutanixprovider.GetSubnets(client, clusterName, projectName)
+func listNutanixSubnets(ctx context.Context, client *nutanixprovider.ClientSet, clusterName, projectName string) (apiv1.NutanixSubnetList, error) {
+	subnetResp, err := nutanixprovider.GetSubnets(ctx, client, clusterName, projectName)
 	if err != nil {
 		return nil, err
 	}
@@ -163,5 +163,5 @@ func NutanixSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfoG
 		return nil, fmt.Errorf("failed to get client set: %w", err)
 	}
 
-	return listNutanixSubnets(client, clusterName, projectName)
+	return listNutanixSubnets(ctx, client, clusterName, projectName)
 }

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -108,7 +108,7 @@ func OpenstackNetworkWithClusterCredentialsEndpoint(ctx context.Context, userInf
 	if err != nil {
 		return nil, err
 	}
-	return GetOpenstackNetworks(userInfo, seedsGetter, creds, datacenterName, caBundle)
+	return GetOpenstackNetworks(ctx, userInfo, seedsGetter, creds, datacenterName, caBundle)
 }
 
 func OpenstackSecurityGroupWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
@@ -131,7 +131,7 @@ func OpenstackSecurityGroupWithClusterCredentialsEndpoint(ctx context.Context, u
 		return nil, err
 	}
 
-	return GetOpenstackSecurityGroups(userInfo, seedsGetter, creds, datacenterName, caBundle)
+	return GetOpenstackSecurityGroups(ctx, userInfo, seedsGetter, creds, datacenterName, caBundle)
 }
 
 func OpenstackSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
@@ -154,7 +154,7 @@ func OpenstackSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInf
 		return nil, err
 	}
 
-	return GetOpenstackSubnets(userInfo, seedsGetter, creds, networkID, datacenterName, caBundle)
+	return GetOpenstackSubnets(ctx, userInfo, seedsGetter, creds, networkID, datacenterName, caBundle)
 }
 
 func OpenstackAvailabilityZoneWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
@@ -201,13 +201,13 @@ func GetOpenstackAvailabilityZones(datacenter *kubermaticv1.Datacenter, credenti
 	return apiAvailabilityZones, nil
 }
 
-func GetOpenstackSubnets(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, credentials *resources.OpenstackCredentials, networkID, datacenterName string, caBundle *x509.CertPool) ([]apiv1.OpenstackSubnet, error) {
+func GetOpenstackSubnets(ctx context.Context, userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, credentials *resources.OpenstackCredentials, networkID, datacenterName string, caBundle *x509.CertPool) ([]apiv1.OpenstackSubnet, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	subnets, err := openstack.GetSubnets(authURL, region, networkID, credentials, caBundle)
+	subnets, err := openstack.GetSubnets(ctx, authURL, region, networkID, credentials, caBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -223,13 +223,13 @@ func GetOpenstackSubnets(userInfo *provider.UserInfo, seedsGetter provider.Seeds
 	return apiSubnetIDs, nil
 }
 
-func GetOpenstackNetworks(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, credentials *resources.OpenstackCredentials, datacenterName string, caBundle *x509.CertPool) ([]apiv1.OpenstackNetwork, error) {
+func GetOpenstackNetworks(ctx context.Context, userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, credentials *resources.OpenstackCredentials, datacenterName string, caBundle *x509.CertPool) ([]apiv1.OpenstackNetwork, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	networks, err := openstack.GetNetworks(authURL, region, credentials, caBundle)
+	networks, err := openstack.GetNetworks(ctx, authURL, region, credentials, caBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -346,13 +346,13 @@ func IsFlavorEnabled(apiSize apiv1.OpenstackSize, enabledFlavors []string) bool 
 	return false
 }
 
-func GetOpenstackSecurityGroups(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, credentials *resources.OpenstackCredentials, datacenterName string, caBundle *x509.CertPool) ([]apiv1.OpenstackSecurityGroup, error) {
+func GetOpenstackSecurityGroups(ctx context.Context, userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, credentials *resources.OpenstackCredentials, datacenterName string, caBundle *x509.CertPool) ([]apiv1.OpenstackSecurityGroup, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	securityGroups, err := openstack.GetSecurityGroups(authURL, region, credentials, caBundle)
+	securityGroups, err := openstack.GetSecurityGroups(ctx, authURL, region, credentials, caBundle)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/common/provider/vsphere.go
+++ b/pkg/handler/common/provider/vsphere.go
@@ -67,16 +67,16 @@ func VsphereNetworksWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 	if err != nil {
 		return nil, err
 	}
-	return GetVsphereNetworks(userInfo, seedsGetter, username, password, datacenterName, caBundle)
+	return GetVsphereNetworks(ctx, userInfo, seedsGetter, username, password, datacenterName, caBundle)
 }
 
-func GetVsphereNetworks(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, datacenterName string, caBundle *x509.CertPool) ([]apiv1.VSphereNetwork, error) {
+func GetVsphereNetworks(ctx context.Context, userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, datacenterName string, caBundle *x509.CertPool) ([]apiv1.VSphereNetwork, error) {
 	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %w", datacenterName, err)
 	}
 
-	networks, err := vsphere.GetNetworks(datacenter.Spec.VSphere, username, password, caBundle)
+	networks, err := vsphere.GetNetworks(ctx, datacenter.Spec.VSphere, username, password, caBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -128,16 +128,16 @@ func VsphereFoldersWithClusterCredentialsEndpoint(ctx context.Context, userInfoG
 	if err != nil {
 		return nil, err
 	}
-	return GetVsphereFolders(userInfo, seedsGetter, username, password, datacenterName, caBundle)
+	return GetVsphereFolders(ctx, userInfo, seedsGetter, username, password, datacenterName, caBundle)
 }
 
-func GetVsphereFolders(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, datacenterName string, caBundle *x509.CertPool) ([]apiv1.VSphereFolder, error) {
+func GetVsphereFolders(ctx context.Context, userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, datacenterName string, caBundle *x509.CertPool) ([]apiv1.VSphereFolder, error) {
 	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %w", datacenterName, err)
 	}
 
-	folders, err := vsphere.GetVMFolders(datacenter.Spec.VSphere, username, password, caBundle)
+	folders, err := vsphere.GetVMFolders(ctx, datacenter.Spec.VSphere, username, password, caBundle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get folders: %w", err)
 	}
@@ -150,14 +150,14 @@ func GetVsphereFolders(userInfo *provider.UserInfo, seedsGetter provider.SeedsGe
 	return apiFolders, nil
 }
 
-func GetVsphereDatastoreList(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password,
+func GetVsphereDatastoreList(ctx context.Context, userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password,
 	datacenterName string, caBundle *x509.CertPool) (*apiv1.VSphereDatastoreList, error) {
 	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %w", datacenterName, err)
 	}
 
-	datastores, err := vsphere.GetDatastoreList(datacenter.Spec.VSphere, username, password, caBundle)
+	datastores, err := vsphere.GetDatastoreList(ctx, datacenter.Spec.VSphere, username, password, caBundle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get datastore list: %w", err)
 	}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -38,7 +38,7 @@ func TestEncodeJSON(t *testing.T) {
 		{12, `12`},
 	}
 
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	for _, testcase := range testcases {
 		writer := httptest.NewRecorder()

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handler
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"net/url"
@@ -129,7 +128,7 @@ func verifyAuthorizationToken(req *http.Request, tokenVerifier auth.TokenVerifie
 		return nil, err
 	}
 
-	claims, err := tokenVerifier.Verify(context.TODO(), token)
+	claims, err := tokenVerifier.Verify(req.Context(), token)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v1/cluster/upgrade_test.go
+++ b/pkg/handler/v1/cluster/upgrade_test.go
@@ -402,7 +402,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 			}
 
 			mds := &clusterv1alpha1.MachineDeploymentList{}
-			if err := cs.FakeClient.List(context.TODO(), mds); err != nil {
+			if err := cs.FakeClient.List(context.Background(), mds); err != nil {
 				t.Fatalf("failed to list machine deployments: %v", err)
 			}
 

--- a/pkg/handler/v1/node/node_test.go
+++ b/pkg/handler/v1/node/node_test.go
@@ -169,7 +169,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 			}
 
 			machines := &clusterv1alpha1.MachineList{}
-			if err := clientsSets.FakeClient.List(context.TODO(), machines); err != nil {
+			if err := clientsSets.FakeClient.List(context.Background(), machines); err != nil {
 				t.Fatalf("failed to list machines from fake client: %v", err)
 			}
 
@@ -1421,7 +1421,7 @@ func TestDeleteNodeDeployment(t *testing.T) {
 			}
 
 			machineDeployments := &clusterv1alpha1.MachineDeploymentList{}
-			if err := clientsSets.FakeClient.List(context.TODO(), machineDeployments); err != nil {
+			if err := clientsSets.FakeClient.List(context.Background(), machineDeployments); err != nil {
 				t.Fatalf("failed to list MachineDeployments: %v", err)
 			}
 

--- a/pkg/handler/v1/provider/aws.go
+++ b/pkg/handler/v1/provider/aws.go
@@ -237,7 +237,7 @@ func AWSSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter provi
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		subnetList, err := providercommon.ListAWSSubnets(accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, vpcID, dc)
+		subnetList, err := providercommon.ListAWSSubnets(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, vpcID, dc)
 		if err != nil {
 			return nil, err
 		}
@@ -277,7 +277,7 @@ func AWSVPCEndpoint(presetProvider provider.PresetProvider, seedsGetter provider
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		return listAWSVPCS(credentials.accessKeyID, credentials.secretAccessKey, credentials.assumeRoleARN, credentials.assumeRoleExternalID, datacenter)
+		return listAWSVPCS(ctx, credentials.accessKeyID, credentials.secretAccessKey, credentials.assumeRoleARN, credentials.assumeRoleExternalID, datacenter)
 	}
 }
 
@@ -301,14 +301,14 @@ func AWSSecurityGroupsEndpoint(presetProvider provider.PresetProvider, seedsGett
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		return listSecurityGroup(credentials.accessKeyID, credentials.secretAccessKey, credentials.assumeRoleARN, credentials.assumeRoleExternalID, datacenter.Spec.AWS.Region, credentials.vpcID)
+		return listSecurityGroup(ctx, credentials.accessKeyID, credentials.secretAccessKey, credentials.assumeRoleARN, credentials.assumeRoleExternalID, datacenter.Spec.AWS.Region, credentials.vpcID)
 	}
 }
 
-func listSecurityGroup(accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, vpc string) (*apiv1.AWSSecurityGroupList, error) {
+func listSecurityGroup(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, vpc string) (*apiv1.AWSSecurityGroupList, error) {
 	securityGroupList := &apiv1.AWSSecurityGroupList{}
 
-	securityGroups, err := awsprovider.GetSecurityGroups(accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, vpc)
+	securityGroups, err := awsprovider.GetSecurityGroups(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, vpc)
 	if err != nil {
 		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get Security Groups: %v", err))
 	}
@@ -363,12 +363,12 @@ func getAWSCredentialsFromRequest(ctx context.Context, req AWSCommonReq, userInf
 	}, nil
 }
 
-func listAWSVPCS(accessKeyID, secretAccessKey string, assumeRoleARN string, assumeRoleExternalID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSVPCList, error) {
+func listAWSVPCS(ctx context.Context, accessKeyID, secretAccessKey string, assumeRoleARN string, assumeRoleExternalID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSVPCList, error) {
 	if datacenter.Spec.AWS == nil {
 		return nil, errors.NewBadRequest("datacenter is not an AWS datacenter")
 	}
 
-	vpcsResults, err := awsprovider.GetVPCS(accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, datacenter.Spec.AWS.Region)
+	vpcsResults, err := awsprovider.GetVPCS(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, datacenter.Spec.AWS.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v1/provider/openstack.go
+++ b/pkg/handler/v1/provider/openstack.go
@@ -155,7 +155,7 @@ func OpenstackNetworkEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 		if err != nil {
 			return nil, err
 		}
-		return providercommon.GetOpenstackNetworks(userInfo, seedsGetter, cred, req.DatacenterName, caBundle)
+		return providercommon.GetOpenstackNetworks(ctx, userInfo, seedsGetter, cred, req.DatacenterName, caBundle)
 	}
 }
 
@@ -180,7 +180,7 @@ func OpenstackSecurityGroupEndpoint(seedsGetter provider.SeedsGetter, presetProv
 		if err != nil {
 			return nil, err
 		}
-		return providercommon.GetOpenstackSecurityGroups(userInfo, seedsGetter, cred, req.DatacenterName, caBundle)
+		return providercommon.GetOpenstackSecurityGroups(ctx, userInfo, seedsGetter, cred, req.DatacenterName, caBundle)
 	}
 }
 
@@ -205,7 +205,7 @@ func OpenstackSubnetsEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 		if err != nil {
 			return nil, err
 		}
-		return providercommon.GetOpenstackSubnets(userInfo, seedsGetter, cred, req.NetworkID, req.DatacenterName, caBundle)
+		return providercommon.GetOpenstackSubnets(ctx, userInfo, seedsGetter, cred, req.NetworkID, req.DatacenterName, caBundle)
 	}
 }
 

--- a/pkg/handler/v1/provider/vsphere.go
+++ b/pkg/handler/v1/provider/vsphere.go
@@ -55,7 +55,7 @@ func VsphereNetworksEndpoint(seedsGetter provider.SeedsGetter, presetProvider pr
 			}
 		}
 
-		return providercommon.GetVsphereNetworks(userInfo, seedsGetter, username, password, req.DatacenterName, caBundle)
+		return providercommon.GetVsphereNetworks(ctx, userInfo, seedsGetter, username, password, req.DatacenterName, caBundle)
 	}
 }
 
@@ -94,7 +94,7 @@ func VsphereFoldersEndpoint(seedsGetter provider.SeedsGetter, presetProvider pro
 			}
 		}
 
-		return providercommon.GetVsphereFolders(userInfo, seedsGetter, username, password, req.DatacenterName, caBundle)
+		return providercommon.GetVsphereFolders(ctx, userInfo, seedsGetter, username, password, req.DatacenterName, caBundle)
 	}
 }
 

--- a/pkg/handler/v2/cluster/upgrade_test.go
+++ b/pkg/handler/v2/cluster/upgrade_test.go
@@ -391,7 +391,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 			}
 
 			mds := &clusterv1alpha1.MachineDeploymentList{}
-			if err := cs.FakeClient.List(context.TODO(), mds); err != nil {
+			if err := cs.FakeClient.List(context.Background(), mds); err != nil {
 				t.Fatalf("failed to list machine deployments: %v", err)
 			}
 

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -119,7 +119,7 @@ func GKEZonesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 		if err != nil {
 			return nil, err
 		}
-		computeService, gcpProject, err := gcp.ConnectToComputeService(sa)
+		computeService, gcpProject, err := gcp.ConnectToComputeService(ctx, sa)
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func listGKEDiskTypes(ctx context.Context, sa string, zone string) (apiv1.GCPDis
 	diskTypes := apiv1.GCPDiskTypeList{}
 	// TODO: There are some issues at the moment with local-ssd and pd-extreme, that's why it is disabled at the moment.
 	excludedDiskTypes := sets.NewString("local-ssd", "pd-extreme")
-	computeService, project, err := gcp.ConnectToComputeService(sa)
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
 	if err != nil {
 		return diskTypes, err
 	}

--- a/pkg/handler/v2/machine/machine_test.go
+++ b/pkg/handler/v2/machine/machine_test.go
@@ -334,7 +334,7 @@ func TestDeleteMachineDeploymentNode(t *testing.T) {
 			}
 
 			machines := &clusterv1alpha1.MachineList{}
-			if err := clientsSets.FakeClient.List(context.TODO(), machines); err != nil {
+			if err := clientsSets.FakeClient.List(context.Background(), machines); err != nil {
 				t.Fatalf("failed to list machines from fake client: %v", err)
 			}
 
@@ -1875,7 +1875,7 @@ func TestDeleteMachineDeployment(t *testing.T) {
 			}
 
 			machineDeployments := &clusterv1alpha1.MachineDeploymentList{}
-			if err := clientsSets.FakeClient.List(context.TODO(), machineDeployments); err != nil {
+			if err := clientsSets.FakeClient.List(context.Background(), machineDeployments); err != nil {
 				t.Fatalf("failed to list MachineDeployments: %v", err)
 			}
 

--- a/pkg/handler/v2/preset/preset_test.go
+++ b/pkg/handler/v2/preset/preset_test.go
@@ -573,7 +573,7 @@ func TestUpdatePresetStatus(t *testing.T) {
 			}
 
 			preset := &kubermaticv1.Preset{}
-			if err := clientSets.FakeClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
+			if err := clientSets.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
 				t.Fatalf("failed to get preset: %+v", err)
 			}
 
@@ -817,7 +817,7 @@ func TestCreatePreset(t *testing.T) {
 			}
 
 			preset := &kubermaticv1.Preset{}
-			if err := clientSets.FakeClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
+			if err := clientSets.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
 				t.Fatalf("failed to get preset: %+v", err)
 			}
 
@@ -1176,7 +1176,7 @@ func TestUpdatePreset(t *testing.T) {
 			}
 
 			preset := &kubermaticv1.Preset{}
-			if err := clientSets.FakeClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
+			if err := clientSets.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
 				t.Fatalf("failed to get preset: %+v", err)
 			}
 
@@ -1276,7 +1276,7 @@ func TestDeleteProviderPreset(t *testing.T) {
 			assert.Equal(t, tc.HTTPStatus, res.Code)
 
 			preset := &kubermaticv1.Preset{}
-			if err := clientSets.FakeClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
+			if err := clientSets.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
 				if !tc.IsDeleted {
 					t.Fatalf("failed to get preset: %+v", err)
 				} else {
@@ -1383,7 +1383,7 @@ func TestDeletePresetProvider(t *testing.T) {
 			}
 
 			preset := &kubermaticv1.Preset{}
-			if err := clientSets.FakeClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
+			if err := clientSets.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
 				t.Fatalf("failed to get preset: %+v", err)
 			}
 
@@ -1457,7 +1457,7 @@ func TestDeletePreset(t *testing.T) {
 			}
 
 			preset := &kubermaticv1.Preset{}
-			if err := clientSets.FakeClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
+			if err := clientSets.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "", Name: tc.PresetName}, preset); err != nil {
 				if !tc.IsDeleted {
 					t.Fatalf("failed to get preset: %+v", err)
 				} else {

--- a/pkg/handler/v2/provider/nutanix.go
+++ b/pkg/handler/v2/provider/nutanix.go
@@ -177,7 +177,7 @@ func NutanixClusterEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 			return nil, errors.NewBadRequest("datacenter '%s' is not a Nutanix datacenter", req.DC)
 		}
 
-		clusters, err := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds).ListNutanixClusters()
+		clusters, err := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds).ListNutanixClusters(ctx)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list clusters: %s", err.Error()))
 		}
@@ -226,7 +226,7 @@ func NutanixProjectEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 			return nil, errors.NewBadRequest("datacenter '%s' is not a Nutanix datacenter", req.DC)
 		}
 
-		projects, err := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds).ListNutanixProjects()
+		projects, err := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds).ListNutanixProjects(ctx)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list projects: %s", err.Error()))
 		}
@@ -280,7 +280,7 @@ func NutanixSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 			return nil, errors.NewBadRequest("datacenter '%s' is not a Nutanix datacenter", req.DC)
 		}
 
-		subnets, err := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds).ListNutanixSubnets(cluster, project)
+		subnets, err := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds).ListNutanixSubnets(ctx, cluster, project)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list subnets: %s", err.Error()))
 		}

--- a/pkg/handler/v2/provider/nutanix_test.go
+++ b/pkg/handler/v2/provider/nutanix_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -275,15 +276,15 @@ func mockNutanixClient(dc *kubermaticv1.DatacenterSpecNutanix, creds *providerco
 	}
 }
 
-func (m *mockClientImpl) ListNutanixClusters() (apiv1.NutanixClusterList, error) {
+func (m *mockClientImpl) ListNutanixClusters(ctx context.Context) (apiv1.NutanixClusterList, error) {
 	return m.clusterList, nil
 }
 
-func (m *mockClientImpl) ListNutanixProjects() (apiv1.NutanixProjectList, error) {
+func (m *mockClientImpl) ListNutanixProjects(ctx context.Context) (apiv1.NutanixProjectList, error) {
 	return m.projectList, nil
 }
 
-func (m *mockClientImpl) ListNutanixSubnets(clusterName, projectName string) (apiv1.NutanixSubnetList, error) {
+func (m *mockClientImpl) ListNutanixSubnets(ctx context.Context, clusterName, projectName string) (apiv1.NutanixSubnetList, error) {
 	return nil, nil
 }
 

--- a/pkg/handler/v2/provider/vsphere.go
+++ b/pkg/handler/v2/provider/vsphere.go
@@ -77,7 +77,7 @@ func VsphereDatastoreEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 			}
 		}
 
-		return providercommon.GetVsphereDatastoreList(userInfo, seedsGetter, username, password, req.DatacenterName, caBundle)
+		return providercommon.GetVsphereDatastoreList(ctx, userInfo, seedsGetter, username, password, req.DatacenterName, caBundle)
 	}
 }
 

--- a/pkg/provider/cloud/alibaba/provider.go
+++ b/pkg/provider/cloud/alibaba/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package alibaba
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -32,6 +33,8 @@ type Alibaba struct {
 	secretKeySelector provider.SecretKeySelectorValueFunc
 }
 
+var _ provider.CloudProvider = &Alibaba{}
+
 func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (*Alibaba, error) {
 	if dc.Spec.Alibaba == nil {
 		return nil, errors.New("datacenter is not an Alibaba datacenter")
@@ -42,11 +45,11 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 	}, nil
 }
 
-func (a *Alibaba) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (a *Alibaba) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (a *Alibaba) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (a *Alibaba) ValidateCloudSpec(_ context.Context, spec kubermaticv1.CloudSpec) error {
 	accessKeyID, accessKeySecret, err := GetCredentialsForCluster(spec, a.secretKeySelector, a.dc)
 	if err != nil {
 		return err
@@ -59,15 +62,15 @@ func (a *Alibaba) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (a *Alibaba) InitializeCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return c, nil
+func (a *Alibaba) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return cluster, nil
 }
 
-func (a *Alibaba) CleanUpCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return c, nil
+func (a *Alibaba) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return cluster, nil
 }
 
-func (a *Alibaba) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (a *Alibaba) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/anexia/provider.go
+++ b/pkg/provider/cloud/anexia/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package anexia
 
 import (
+	"context"
 	"errors"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -29,6 +30,8 @@ type Anexia struct {
 	secretKeySelector provider.SecretKeySelectorValueFunc
 }
 
+var _ provider.CloudProvider = &Anexia{}
+
 func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (*Anexia, error) {
 	if dc.Spec.Anexia == nil {
 		return nil, errors.New("datacenter is not an Anexia datacenter")
@@ -39,11 +42,11 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 	}, nil
 }
 
-func (a *Anexia) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (a *Anexia) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (a *Anexia) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (a *Anexia) ValidateCloudSpec(_ context.Context, spec kubermaticv1.CloudSpec) error {
 	_, err := GetCredentialsForCluster(spec, a.secretKeySelector)
 	if err != nil {
 		return err
@@ -51,15 +54,15 @@ func (a *Anexia) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (a *Anexia) InitializeCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return c, nil
+func (a *Anexia) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return cluster, nil
 }
 
-func (a *Anexia) CleanUpCloudProvider(c *kubermaticv1.Cluster, p provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return c, nil
+func (a *Anexia) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return cluster, nil
 }
 
-func (a *Anexia) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (a *Anexia) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/aws/route_table_test.go
+++ b/pkg/provider/cloud/aws/route_table_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -26,14 +27,15 @@ import (
 
 func TestGetDefaultRouteTable(t *testing.T) {
 	cs := getTestClientSet(t)
+	ctx := context.Background()
 
-	defaultVPC, err := getDefaultVPC(cs.EC2)
+	defaultVPC, err := getDefaultVPC(ctx, cs.EC2)
 	if err != nil {
 		t.Fatalf("getDefaultVPC should not have errored, but returned %v", err)
 	}
 
 	t.Run("valid-vpc", func(t *testing.T) {
-		rt, err := getDefaultRouteTable(cs.EC2, *defaultVPC.VpcId)
+		rt, err := getDefaultRouteTable(ctx, cs.EC2, *defaultVPC.VpcId)
 		if err != nil {
 			t.Fatalf("getDefaultRouteTable should not have errored, but returned %v", err)
 		}
@@ -44,7 +46,7 @@ func TestGetDefaultRouteTable(t *testing.T) {
 	})
 
 	t.Run("invalid-vpc", func(t *testing.T) {
-		_, err := getDefaultRouteTable(cs.EC2, "does-not-exist")
+		_, err := getDefaultRouteTable(ctx, cs.EC2, "does-not-exist")
 		if err == nil {
 			t.Fatalf("getDefaultRouteTable should have errored, but returned %v", err)
 		}
@@ -53,13 +55,14 @@ func TestGetDefaultRouteTable(t *testing.T) {
 
 func TestReconcileRouteTable(t *testing.T) {
 	cs := getTestClientSet(t)
+	ctx := context.Background()
 
-	defaultVPC, err := getDefaultVPC(cs.EC2)
+	defaultVPC, err := getDefaultVPC(ctx, cs.EC2)
 	if err != nil {
 		t.Fatalf("getDefaultVPC should not have errored, but returned %v", err)
 	}
 
-	defaultRT, err := getDefaultRouteTable(cs.EC2, *defaultVPC.VpcId)
+	defaultRT, err := getDefaultRouteTable(ctx, cs.EC2, *defaultVPC.VpcId)
 	if err != nil {
 		t.Fatalf("getDefaultRouteTable should not have errored, but returned %v", err)
 	}
@@ -73,7 +76,7 @@ func TestReconcileRouteTable(t *testing.T) {
 			RouteTableID: defaultRouteTableID,
 		})
 
-		cluster, err = reconcileRouteTable(cs.EC2, cluster, testClusterUpdater(cluster))
+		cluster, err = reconcileRouteTable(ctx, cs.EC2, cluster, testClusterUpdater(cluster))
 		if err != nil {
 			t.Fatalf("reconcileRouteTable should not have errored, but returned %v", err)
 		}
@@ -92,7 +95,7 @@ func TestReconcileRouteTable(t *testing.T) {
 			VPCID: defaultVPCID,
 		})
 
-		cluster, err = reconcileRouteTable(cs.EC2, cluster, testClusterUpdater(cluster))
+		cluster, err = reconcileRouteTable(ctx, cs.EC2, cluster, testClusterUpdater(cluster))
 		if err != nil {
 			t.Fatalf("reconcileRouteTable should not have errored, but returned %v", err)
 		}
@@ -112,7 +115,7 @@ func TestReconcileRouteTable(t *testing.T) {
 			RouteTableID: "does-not-exist",
 		})
 
-		cluster, err = reconcileRouteTable(cs.EC2, cluster, testClusterUpdater(cluster))
+		cluster, err = reconcileRouteTable(ctx, cs.EC2, cluster, testClusterUpdater(cluster))
 		if err != nil {
 			t.Fatalf("reconcileRouteTable should not have errored, but returned %v", err)
 		}

--- a/pkg/provider/cloud/bringyourown/provider.go
+++ b/pkg/provider/cloud/bringyourown/provider.go
@@ -17,6 +17,8 @@ limitations under the License.
 package bringyourown
 
 import (
+	"context"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 )
@@ -30,23 +32,23 @@ func NewCloudProvider() provider.CloudProvider {
 
 var _ provider.CloudProvider = &bringyourown{}
 
-func (b *bringyourown) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (b *bringyourown) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (b *bringyourown) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (b *bringyourown) ValidateCloudSpec(_ context.Context, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (b *bringyourown) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (b *bringyourown) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
-func (b *bringyourown) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (b *bringyourown) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (b *bringyourown) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (b *bringyourown) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }

--- a/pkg/provider/cloud/digitalocean/provider.go
+++ b/pkg/provider/cloud/digitalocean/provider.go
@@ -41,7 +41,7 @@ func NewCloudProvider(secretKeyGetter provider.SecretKeySelectorValueFunc) provi
 
 var _ provider.CloudProvider = &digitalocean{}
 
-func (do *digitalocean) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (do *digitalocean) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
@@ -53,25 +53,25 @@ func ValidateCredentials(ctx context.Context, token string) error {
 	return err
 }
 
-func (do *digitalocean) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (do *digitalocean) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.CloudSpec) error {
 	token, err := GetCredentialsForCluster(spec, do.secretKeySelector)
 	if err != nil {
 		return err
 	}
 
-	return ValidateCredentials(context.Background(), token)
+	return ValidateCredentials(ctx, token)
 }
 
-func (do *digitalocean) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (do *digitalocean) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
-func (do *digitalocean) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (do *digitalocean) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (do *digitalocean) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (do *digitalocean) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/fake/provider.go
+++ b/pkg/provider/cloud/fake/provider.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -35,23 +37,23 @@ func NewCloudProvider() provider.CloudProvider {
 
 var _ provider.CloudProvider = &fakeCloudProvider{}
 
-func (p *fakeCloudProvider) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (p *fakeCloudProvider) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (p *fakeCloudProvider) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (p *fakeCloudProvider) ValidateCloudSpec(_ context.Context, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (p *fakeCloudProvider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (p *fakeCloudProvider) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
-func (p *fakeCloudProvider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (p *fakeCloudProvider) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (p *fakeCloudProvider) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (p *fakeCloudProvider) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }

--- a/pkg/provider/cloud/hetzner/provider.go
+++ b/pkg/provider/cloud/hetzner/provider.go
@@ -42,12 +42,12 @@ func NewCloudProvider(secretKeyGetter provider.SecretKeySelectorValueFunc) provi
 var _ provider.CloudProvider = &hetzner{}
 
 // DefaultCloudSpec.
-func (h *hetzner) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (h *hetzner) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
 // ValidateCloudSpec.
-func (h *hetzner) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (h *hetzner) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.CloudSpec) error {
 	hetznerToken, err := GetCredentialsForCluster(spec, h.secretKeySelector)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (h *hetzner) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 
 	client := hcloud.NewClient(hcloud.WithToken(hetznerToken))
 
-	timeout, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	timeout, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	if spec.Hetzner.Network == "" {
@@ -70,17 +70,17 @@ func (h *hetzner) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 }
 
 // InitializeCloudProvider.
-func (h *hetzner) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (h *hetzner) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // CleanUpCloudProvider.
-func (h *hetzner) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (h *hetzner) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (h *hetzner) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (h *hetzner) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/kubevirt/namespace.go
+++ b/pkg/provider/cloud/kubevirt/namespace.go
@@ -26,7 +26,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -58,12 +57,7 @@ func reconcileNamespace(ctx context.Context, name string, cluster *kubermaticv1.
 func deleteNamespace(ctx context.Context, name string, client ctrlruntimeclient.Client) error {
 	ns := &corev1.Namespace{}
 	if err := client.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
-		// namespace is already gone
-		if kerrors.IsNotFound(err) {
-			return nil
-		}
-
-		return fmt.Errorf("failed to reconcile Namespace: %w", err)
+		return ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
 	return client.Delete(ctx, ns)

--- a/pkg/provider/cloud/kubevirt/storage.go
+++ b/pkg/provider/cloud/kubevirt/storage.go
@@ -90,9 +90,7 @@ func csiRoleBindingCreator(name, namespace string) reconciling.NamedRoleBindingC
 }
 
 // reconcileCSIRoleRoleBinding reconciles the Role and Rolebindings needed by CSI driver.
-func ReconcileCSIRoleRoleBinding(client ctrlruntimeclient.Client, restConfig *restclient.Config) error {
-	ctx := context.Background()
-
+func ReconcileCSIRoleRoleBinding(ctx context.Context, client ctrlruntimeclient.Client, restConfig *restclient.Config) error {
 	roleCreators := []reconciling.NamedRoleCreatorGetter{
 		csiRoleCreator(csiResourceName),
 	}

--- a/pkg/provider/cloud/nutanix/api.go
+++ b/pkg/provider/cloud/nutanix/api.go
@@ -24,8 +24,8 @@ import (
 	nutanixv3 "github.com/embik/nutanix-client-go/pkg/client/v3"
 )
 
-func GetClusters(client *ClientSet) ([]nutanixv3.ClusterIntentResponse, error) {
-	resp, err := client.Prism.V3.ListAllCluster(context.TODO(), "")
+func GetClusters(ctx context.Context, client *ClientSet) ([]nutanixv3.ClusterIntentResponse, error) {
+	resp, err := client.Prism.V3.ListAllCluster(ctx, "")
 	if err != nil {
 		return nil, wrapNutanixError(err)
 	}
@@ -43,8 +43,8 @@ func GetClusters(client *ClientSet) ([]nutanixv3.ClusterIntentResponse, error) {
 	return clusters, nil
 }
 
-func GetProjects(client *ClientSet) ([]nutanixv3.Project, error) {
-	resp, err := client.Prism.V3.ListAllProject(context.TODO(), "")
+func GetProjects(ctx context.Context, client *ClientSet) ([]nutanixv3.Project, error) {
+	resp, err := client.Prism.V3.ListAllProject(ctx, "")
 	if err != nil {
 		return nil, wrapNutanixError(err)
 	}
@@ -62,8 +62,8 @@ func GetProjects(client *ClientSet) ([]nutanixv3.Project, error) {
 	return projects, nil
 }
 
-func GetSubnets(client *ClientSet, clusterName, projectName string) ([]nutanixv3.SubnetIntentResponse, error) {
-	resp, err := client.Prism.V3.ListAllSubnet(context.TODO(), "")
+func GetSubnets(ctx context.Context, client *ClientSet, clusterName, projectName string) ([]nutanixv3.SubnetIntentResponse, error) {
+	resp, err := client.Prism.V3.ListAllSubnet(ctx, "")
 	if err != nil {
 		return nil, wrapNutanixError(err)
 	}
@@ -77,7 +77,7 @@ func GetSubnets(client *ClientSet, clusterName, projectName string) ([]nutanixv3
 	// want to return the full information of subnets, so we only use this list of names as
 	// constraints for our loop later on.
 	if projectName != "" {
-		project, err := GetProjectByName(client, projectName)
+		project, err := GetProjectByName(ctx, client, projectName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/cloud/nutanix/client.go
+++ b/pkg/provider/cloud/nutanix/client.go
@@ -152,9 +152,9 @@ func getClientSet(credentials nutanixclient.Credentials) (*ClientSet, error) {
 	}, nil
 }
 
-func GetSubnetByName(client *ClientSet, name, clusterID string) (*nutanixv3.SubnetIntentResponse, error) {
+func GetSubnetByName(ctx context.Context, client *ClientSet, name, clusterID string) (*nutanixv3.SubnetIntentResponse, error) {
 	filter := fmt.Sprintf("name==%s", name)
-	subnets, err := client.Prism.V3.ListAllSubnet(context.TODO(), filter)
+	subnets, err := client.Prism.V3.ListAllSubnet(ctx, filter)
 
 	if err != nil {
 		return nil, err
@@ -189,9 +189,9 @@ func GetSubnetByName(client *ClientSet, name, clusterID string) (*nutanixv3.Subn
 	return nil, fmt.Errorf("no subnet found for '%s' on cluster '%s'", filter, clusterID)
 }
 
-func GetProjectByName(client *ClientSet, name string) (*nutanixv3.Project, error) {
+func GetProjectByName(ctx context.Context, client *ClientSet, name string) (*nutanixv3.Project, error) {
 	filter := fmt.Sprintf("name==%s", name)
-	projects, err := client.Prism.V3.ListAllProject(context.TODO(), filter)
+	projects, err := client.Prism.V3.ListAllProject(ctx, filter)
 
 	if err != nil {
 		return nil, err
@@ -218,9 +218,9 @@ func GetProjectByName(client *ClientSet, name string) (*nutanixv3.Project, error
 	return nil, fmt.Errorf("no project found for '%s'", filter)
 }
 
-func GetClusterByName(client *ClientSet, name string) (*nutanixv3.ClusterIntentResponse, error) {
+func GetClusterByName(ctx context.Context, client *ClientSet, name string) (*nutanixv3.ClusterIntentResponse, error) {
 	filter := fmt.Sprintf("name==%s", name)
-	clusters, err := client.Prism.V3.ListAllCluster(context.TODO(), filter)
+	clusters, err := client.Prism.V3.ListAllCluster(ctx, filter)
 
 	if err != nil {
 		return nil, err

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"context"
 	"crypto/x509"
 	"net/http"
 	"reflect"
@@ -341,12 +342,12 @@ func TestInitializeCloudProvider(t *testing.T) {
 
 			os := &Provider{
 				dc: tt.dc,
-				getClientFunc: func(cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error) {
+				getClientFunc: func(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error) {
 					sc := s.GetClient()
 					return sc, nil
 				},
 			}
-			c, err := os.InitializeCloudProvider(tt.cluster, (&fakeClusterUpdater{c: tt.cluster}).update)
+			c, err := os.InitializeCloudProvider(context.TODO(), tt.cluster, (&fakeClusterUpdater{c: tt.cluster}).update)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.InitializeCloudProvider() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -347,7 +347,7 @@ func TestInitializeCloudProvider(t *testing.T) {
 					return sc, nil
 				},
 			}
-			c, err := os.InitializeCloudProvider(context.TODO(), tt.cluster, (&fakeClusterUpdater{c: tt.cluster}).update)
+			c, err := os.InitializeCloudProvider(context.Background(), tt.cluster, (&fakeClusterUpdater{c: tt.cluster}).update)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.InitializeCloudProvider() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/cloud/packet/provider.go
+++ b/pkg/provider/cloud/packet/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package packet
 
 import (
+	"context"
 	"errors"
 
 	"github.com/packethost/packngo"
@@ -44,19 +45,19 @@ func NewCloudProvider(secretKeyGetter provider.SecretKeySelectorValueFunc) provi
 var _ provider.CloudProvider = &packet{}
 
 // DefaultCloudSpec adds defaults to the CloudSpec.
-func (p *packet) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
+func (p *packet) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
 	return nil
 }
 
 // ValidateCloudSpec validates the given CloudSpec.
-func (p *packet) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (p *packet) ValidateCloudSpec(_ context.Context, spec kubermaticv1.CloudSpec) error {
 	_, _, err := GetCredentialsForCluster(spec, p.secretKeySelector)
 	return err
 }
 
 // InitializeCloudProvider initializes a cluster, in particular
 // updates BillingCycle to the defaultBillingCycle, if it is not set.
-func (p *packet) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (p *packet) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	var err error
 	if cluster.Spec.Cloud.Packet.BillingCycle == "" {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
@@ -76,12 +77,12 @@ func (p *packet) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update p
 // }
 
 // CleanUpCloudProvider.
-func (p *packet) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (p *packet) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (p *packet) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (p *packet) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/vsphere/ca_test.go
+++ b/pkg/provider/cloud/vsphere/ca_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package vsphere
 
 import (
+	"context"
 	"crypto/x509"
 	"strings"
 	"testing"
@@ -48,7 +49,7 @@ func TestVSphereCA(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := GetNetworks(getTestDC(), vSphereUsername, vSpherePassword, test.caBundle)
+			_, err := GetNetworks(context.Background(), getTestDC(), vSphereUsername, vSpherePassword, test.caBundle)
 			if test.expectedError {
 				if err == nil {
 					t.Fatal("expected err, got nil")

--- a/pkg/provider/cloud/vsphere/folder_test.go
+++ b/pkg/provider/cloud/vsphere/folder_test.go
@@ -90,7 +90,7 @@ func TestProvider_GetVMFolders(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			folders, err := GetVMFolders(test.dc, vSphereUsername, vSpherePassword, nil)
+			folders, err := GetVMFolders(context.Background(), test.dc, vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/cloud/vsphere/network_test.go
+++ b/pkg/provider/cloud/vsphere/network_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package vsphere
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -44,7 +45,7 @@ func TestGetPossibleVMNetworks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			networkInfos, err := GetNetworks(getTestDC(), vSphereUsername, vSpherePassword, nil)
+			networkInfos, err := GetNetworks(context.Background(), getTestDC(), vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/cloud/vsphere/provider_test.go
+++ b/pkg/provider/cloud/vsphere/provider_test.go
@@ -294,7 +294,7 @@ func TestProviderValidateCloudSpec(t *testing.T) {
 			v := &Provider{
 				dc: tt.dc,
 			}
-			if err := v.ValidateCloudSpec(context.TODO(), tt.spec); (err != nil) != tt.wantErr {
+			if err := v.ValidateCloudSpec(context.Background(), tt.spec); (err != nil) != tt.wantErr {
 				t.Errorf("Provider.ValidateCloudSpec() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/cloud/vsphere/provider_test.go
+++ b/pkg/provider/cloud/vsphere/provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vsphere
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -293,7 +294,7 @@ func TestProviderValidateCloudSpec(t *testing.T) {
 			v := &Provider{
 				dc: tt.dc,
 			}
-			if err := v.ValidateCloudSpec(tt.spec); (err != nil) != tt.wantErr {
+			if err := v.ValidateCloudSpec(context.TODO(), tt.spec); (err != nil) != tt.wantErr {
 				t.Errorf("Provider.ValidateCloudSpec() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -433,7 +433,7 @@ func createOrUpdateKubevirtSecret(ctx context.Context, seedClient ctrlruntimecli
 		return err
 	}
 
-	err = kubevirt.ReconcileCSIRoleRoleBinding(client, restConfig)
+	err = kubevirt.ReconcileCSIRoleRoleBinding(ctx, client, restConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -53,11 +53,11 @@ const (
 
 // CloudProvider declares a set of methods for interacting with a cloud provider.
 type CloudProvider interface {
-	InitializeCloudProvider(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
-	CleanUpCloudProvider(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
-	DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error
-	ValidateCloudSpec(spec kubermaticv1.CloudSpec) error
-	ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error
+	InitializeCloudProvider(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
+	CleanUpCloudProvider(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
+	DefaultCloudSpec(context.Context, *kubermaticv1.CloudSpec) error
+	ValidateCloudSpec(context.Context, kubermaticv1.CloudSpec) error
+	ValidateCloudSpecUpdate(ctx context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error
 }
 
 // ReconcilingCloudProvider is a cloud provider that can not just created resources
@@ -65,7 +65,7 @@ type CloudProvider interface {
 type ReconcilingCloudProvider interface {
 	CloudProvider
 
-	ReconcileCluster(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
+	ReconcileCluster(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
 }
 
 // UpdaterOption represent an option for the updater function.

--- a/pkg/resources/cluster/cluster.go
+++ b/pkg/resources/cluster/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -34,7 +35,7 @@ import (
 
 // Spec builds ClusterSpec kubermatic Custom Resource from API Cluster.
 // The ClusterTemplate can be nil.
-func Spec(apiCluster apiv1.Cluster, template *kubermaticv1.ClusterTemplate, seed *kubermaticv1.Seed, dc *kubermaticv1.Datacenter, config *kubermaticv1.KubermaticConfiguration, secretKeyGetter provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool, features features.FeatureGate) (*kubermaticv1.ClusterSpec, error) {
+func Spec(ctx context.Context, apiCluster apiv1.Cluster, template *kubermaticv1.ClusterTemplate, seed *kubermaticv1.Seed, dc *kubermaticv1.Datacenter, config *kubermaticv1.KubermaticConfiguration, secretKeyGetter provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool, features features.FeatureGate) (*kubermaticv1.ClusterSpec, error) {
 	var userSSHKeysAgentEnabled = pointer.BoolPtr(true)
 
 	if apiCluster.Spec.EnableUserSSHKeyAgent != nil {
@@ -73,11 +74,11 @@ func Spec(apiCluster apiv1.Cluster, template *kubermaticv1.ClusterTemplate, seed
 		return nil, err
 	}
 
-	if err := defaulting.DefaultClusterSpec(spec, template, seed, config, cloudProvider); err != nil {
+	if err := defaulting.DefaultClusterSpec(ctx, spec, template, seed, config, cloudProvider); err != nil {
 		return nil, err
 	}
 
-	if errs := validation.ValidateNewClusterSpec(spec, dc, cloudProvider, features, nil).ToAggregate(); errs != nil {
+	if errs := validation.ValidateNewClusterSpec(ctx, spec, dc, cloudProvider, features, nil).ToAggregate(); errs != nil {
 		return spec, errs
 	}
 

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -55,22 +55,22 @@ type AgentConfig struct {
 }
 
 // DeployAgentPod deploys the pod to be used to verify tunneling expose strategy.
-func (a *AgentConfig) DeployAgentPod() error {
+func (a *AgentConfig) DeployAgentPod(ctx context.Context) error {
 	agentCm := a.newAgentConfigMap(a.Namespace)
-	if err := a.Client.Create(context.TODO(), agentCm); err != nil {
+	if err := a.Client.Create(ctx, agentCm); err != nil {
 		return errors.Wrap(err, "failed to create agent config map")
 	}
 	a.AgentConfigMap = agentCm
 	agentPod := a.newAgentPod(a.Namespace)
-	if err := a.Client.Create(context.TODO(), agentPod); err != nil {
+	if err := a.Client.Create(ctx, agentPod); err != nil {
 		return errors.Wrap(err, "failed to create agent pod")
 	}
 
-	if !e2eutils.CheckPodsRunningReady(a.Client, a.Namespace, []string{agentPod.Name}, agentDeployTimeout) {
+	if !e2eutils.CheckPodsRunningReady(ctx, a.Client, a.Namespace, []string{agentPod.Name}, agentDeployTimeout) {
 		return errors.New("timeout occurred while waiting for agent pod readiness")
 	}
 
-	if err := a.Client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{
+	if err := a.Client.Get(ctx, ctrlruntimeclient.ObjectKey{
 		Namespace: agentPod.Namespace,
 		Name:      agentPod.Name,
 	}, agentPod); err != nil {
@@ -81,12 +81,12 @@ func (a *AgentConfig) DeployAgentPod() error {
 }
 
 // CleanUp deletes the resources.
-func (a *AgentConfig) CleanUp() error {
+func (a *AgentConfig) CleanUp(ctx context.Context) error {
 	if a.AgentPod != nil {
-		return a.Client.Delete(context.TODO(), a.AgentPod)
+		return a.Client.Delete(ctx, a.AgentPod)
 	}
 	if a.AgentConfigMap != nil {
-		return a.Client.Delete(context.TODO(), a.AgentConfigMap)
+		return a.Client.Delete(ctx, a.AgentConfigMap)
 	}
 	return nil
 }

--- a/pkg/test/e2e/expose-strategy/cluster.go
+++ b/pkg/test/e2e/expose-strategy/cluster.go
@@ -50,7 +50,7 @@ type ClusterJig struct {
 	Cluster *kubermaticv1.Cluster
 }
 
-func (c *ClusterJig) SetUp() error {
+func (c *ClusterJig) SetUp(ctx context.Context) error {
 	c.Log.Debugw("Creating cluster", "name", c.Name)
 	c.Cluster = &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,11 +97,11 @@ func (c *ClusterJig) SetUp() error {
 			Version:               c.Version,
 		},
 	}
-	if err := c.Client.Create(context.TODO(), c.Cluster); err != nil {
+	if err := c.Client.Create(ctx, c.Cluster); err != nil {
 		return errors.Wrap(err, "failed to create cluster")
 	}
 
-	if err := kubermaticv1helper.UpdateClusterStatus(context.TODO(), c.Client, c.Cluster, func(c *kubermaticv1.Cluster) {
+	if err := kubermaticv1helper.UpdateClusterStatus(ctx, c.Client, c.Cluster, func(c *kubermaticv1.Cluster) {
 		c.Status.UserEmail = "e2e@test.com"
 	}); err != nil {
 		return errors.Wrap(err, "failed to update cluster status")
@@ -111,8 +111,8 @@ func (c *ClusterJig) SetUp() error {
 }
 
 // CleanUp deletes the cluster.
-func (c *ClusterJig) CleanUp() error {
-	return c.Client.Delete(context.TODO(), c.Cluster)
+func (c *ClusterJig) CleanUp(ctx context.Context) error {
+	return c.Client.Delete(ctx, c.Cluster)
 }
 
 func (c *ClusterJig) waitForClusterControlPlaneReady(cl *kubermaticv1.Cluster) error {

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package exposestrategy
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
@@ -29,6 +31,8 @@ import (
 )
 
 var _ = ginkgo.Describe("The Tunneling strategy", func() {
+	ctx := context.Background()
+
 	var (
 		clusterJig  *ClusterJig
 		agentConfig *AgentConfig
@@ -43,7 +47,7 @@ var _ = ginkgo.Describe("The Tunneling strategy", func() {
 			DatacenterName: options.datacenter,
 			Version:        options.kubernetesVersion,
 		}
-		gomega.Expect(clusterJig.SetUp()).NotTo(gomega.HaveOccurred(), "user cluster should deploy successfully")
+		gomega.Expect(clusterJig.SetUp(ctx)).NotTo(gomega.HaveOccurred(), "user cluster should deploy successfully")
 		agentConfig = &AgentConfig{
 			Log:       e2eutils.DefaultLogger,
 			Client:    k8scli,
@@ -58,17 +62,17 @@ var _ = ginkgo.Describe("The Tunneling strategy", func() {
 			Config:        restConf,
 			CreatePodFunc: newClientPod,
 		}}
-		gomega.Expect(agentConfig.DeployAgentPod()).NotTo(gomega.HaveOccurred(), "agent should deploy successfully")
-		gomega.Expect(client.DeployTestPod()).NotTo(gomega.HaveOccurred(), "client pod should deploy successfully")
+		gomega.Expect(agentConfig.DeployAgentPod(ctx)).NotTo(gomega.HaveOccurred(), "agent should deploy successfully")
+		gomega.Expect(client.DeployTestPod(ctx)).NotTo(gomega.HaveOccurred(), "client pod should deploy successfully")
 	})
 	ginkgo.AfterEach(func() {
 		if !options.skipCleanup {
-			gomega.Expect(clusterJig.CleanUp()).NotTo(gomega.HaveOccurred())
+			gomega.Expect(clusterJig.CleanUp(ctx)).NotTo(gomega.HaveOccurred())
 			if agentConfig != nil {
-				gomega.Expect(agentConfig.CleanUp()).NotTo(gomega.HaveOccurred())
+				gomega.Expect(agentConfig.CleanUp(ctx)).NotTo(gomega.HaveOccurred())
 			}
 			if client != nil {
-				gomega.Expect(client.CleanUp()).NotTo(gomega.HaveOccurred())
+				gomega.Expect(client.CleanUp(ctx)).NotTo(gomega.HaveOccurred())
 			}
 		}
 	})

--- a/pkg/test/e2e/nodeport-proxy/nodeport_proxy_suite_test.go
+++ b/pkg/test/e2e/nodeport-proxy/nodeport_proxy_suite_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package nodeportproxy
 
 import (
+	"context"
 	"flag"
 	"testing"
 
@@ -63,15 +64,15 @@ var _ = ginkgo.BeforeSuite(func() {
 			CreatePodFunc: newAgnhostPod,
 		},
 	}
-	gomega.Expect(deployer.SetUp()).NotTo(gomega.HaveOccurred(), "nodeport-proxy should deploy successfully")
+	gomega.Expect(deployer.SetUp(context.Background())).NotTo(gomega.HaveOccurred(), "nodeport-proxy should deploy successfully")
 	// We put the test pod in same namespace as the nodeport proxy
 	networkingTest.Namespace = deployer.Namespace
-	gomega.Expect(networkingTest.DeployTestPod()).NotTo(gomega.HaveOccurred(), "test pod should deploy successfully")
+	gomega.Expect(networkingTest.DeployTestPod(context.Background())).NotTo(gomega.HaveOccurred(), "test pod should deploy successfully")
 })
 
 var _ = ginkgo.AfterSuite(func() {
 	if !skipCleanup {
-		gomega.Expect(networkingTest.CleanUp()).NotTo(gomega.HaveOccurred(), "failed to clean-up networkingTest")
-		gomega.Expect(deployer.CleanUp()).NotTo(gomega.HaveOccurred(), "failed to clean-up deployer")
+		gomega.Expect(networkingTest.CleanUp(context.Background())).NotTo(gomega.HaveOccurred(), "failed to clean-up networkingTest")
+		gomega.Expect(deployer.CleanUp(context.Background())).NotTo(gomega.HaveOccurred(), "failed to clean-up deployer")
 	}
 })

--- a/pkg/test/e2e/nodeport-proxy/services.go
+++ b/pkg/test/e2e/nodeport-proxy/services.go
@@ -47,7 +47,7 @@ type ServiceJig struct {
 }
 
 // CreateServiceWithPods deploys a service and the associated pods.
-func (n *ServiceJig) CreateServiceWithPods(svc *corev1.Service, numPods int32, https bool) (*corev1.Service, error) {
+func (n *ServiceJig) CreateServiceWithPods(ctx context.Context, svc *corev1.Service, numPods int32, https bool) (*corev1.Service, error) {
 	if len(svc.Spec.Ports) == 0 {
 		return nil, errors.New("failed to create service: at least one port is required")
 	}
@@ -58,7 +58,7 @@ func (n *ServiceJig) CreateServiceWithPods(svc *corev1.Service, numPods int32, h
 	// Create the namespace to host the service
 	ns := n.newNamespaceTemplate()
 	n.Log.Debugw("Creating namespace", "service", ns)
-	if err := n.Client.Create(context.TODO(), ns); err != nil {
+	if err := n.Client.Create(ctx, ns); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, err
 		}
@@ -70,7 +70,7 @@ func (n *ServiceJig) CreateServiceWithPods(svc *corev1.Service, numPods int32, h
 
 	svc.Namespace = n.Namespace
 	n.Log.Debugw("Creating nodeport service", "service", svc)
-	if err := n.Client.Create(context.TODO(), svc); err != nil {
+	if err := n.Client.Create(ctx, svc); err != nil {
 		return nil, errors.Wrap(err, "failed to create service of type nodeport")
 	}
 	gomega.Expect(svc).NotTo(gomega.BeNil())
@@ -78,16 +78,16 @@ func (n *ServiceJig) CreateServiceWithPods(svc *corev1.Service, numPods int32, h
 	// Create service pods
 	rc := n.newRCFromService(svc, https, numPods)
 	n.Log.Debugw("Creating replication controller", "rc", rc)
-	if err := n.Client.Create(context.TODO(), rc); err != nil {
+	if err := n.Client.Create(ctx, rc); err != nil {
 		return nil, err
 	}
 
 	// Wait for the pod to be ready
-	pods, err := e2eutils.WaitForPodsCreated(n.Client, int(*rc.Spec.Replicas), rc.Namespace, svc.Spec.Selector)
+	pods, err := e2eutils.WaitForPodsCreated(ctx, n.Client, int(*rc.Spec.Replicas), rc.Namespace, svc.Spec.Selector)
 	if err != nil {
 		return svc, errors.Wrap(err, "error occurred while waiting for pods to be ready")
 	}
-	if !e2eutils.CheckPodsRunningReady(n.Client, n.Namespace, pods, podReadinessTimeout) {
+	if !e2eutils.CheckPodsRunningReady(ctx, n.Client, n.Namespace, pods, podReadinessTimeout) {
 		return svc, fmt.Errorf("timeout waiting for %d pods to be ready", len(pods))
 	}
 	if n.ServicePods == nil {
@@ -165,11 +165,11 @@ func (n *ServiceJig) newRCFromService(svc *corev1.Service, https bool, replicas 
 }
 
 // CleanUp removes the resources.
-func (n *ServiceJig) CleanUp() error {
+func (n *ServiceJig) CleanUp(ctx context.Context) error {
 	ns := corev1.Namespace{}
-	if err := n.Client.Get(context.TODO(), types.NamespacedName{Name: n.Namespace}, &ns); err != nil {
+	if err := n.Client.Get(ctx, types.NamespacedName{Name: n.Namespace}, &ns); err != nil {
 		return err
 	}
 	n.Log.Infow("deleting test namespace", "namespace", ns)
-	return n.Client.Delete(context.TODO(), &ns)
+	return n.Client.Delete(ctx, &ns)
 }

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -103,11 +103,11 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 	return allErrs
 }
 
-func ValidateNewClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datacenter, cloudProvider provider.CloudProvider, enabledFeatures features.FeatureGate, parentFieldPath *field.Path) field.ErrorList {
+func ValidateNewClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datacenter, cloudProvider provider.CloudProvider, enabledFeatures features.FeatureGate, parentFieldPath *field.Path) field.ErrorList {
 	allErrs := ValidateClusterSpec(spec, dc, enabledFeatures, parentFieldPath)
 
 	if cloudProvider != nil {
-		if err := cloudProvider.ValidateCloudSpec(spec.Cloud); err != nil {
+		if err := cloudProvider.ValidateCloudSpec(ctx, spec.Cloud); err != nil {
 			// Just using spec.Cloud for the error leads to a Go-representation of the struct being printed in
 			// the error message, which looks awful an is not helpful. However any other encoding (e.g. JSON)
 			// could lead to us leaking credentials that were given in the CloudSpec, so to be safe, we never
@@ -130,7 +130,7 @@ func ValidateClusterUpdate(ctx context.Context, newCluster, oldCluster *kubermat
 	}
 
 	if cloudProvider != nil {
-		if err := cloudProvider.ValidateCloudSpecUpdate(oldCluster.Spec.Cloud, newCluster.Spec.Cloud); err != nil {
+		if err := cloudProvider.ValidateCloudSpecUpdate(ctx, oldCluster.Spec.Cloud, newCluster.Spec.Cloud); err != nil {
 			allErrs = append(allErrs, field.Forbidden(specPath.Child("cloud"), err.Error()))
 		}
 	}

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -153,7 +153,7 @@ func (h *AdmissionHandler) applyDefaults(ctx context.Context, c *kubermaticv1.Cl
 		return err
 	}
 
-	return defaulting.DefaultClusterSpec(&c.Spec, defaultTemplate, seed, config, provider)
+	return defaulting.DefaultClusterSpec(ctx, &c.Spec, defaultTemplate, seed, config, provider)
 }
 
 // mutateCreate is an addition to regular defaulting for new clusters.

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -69,7 +69,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) erro
 		return err
 	}
 
-	return validation.ValidateNewClusterSpec(&cluster.Spec, datacenter, cloudProvider, v.features, nil).ToAggregate()
+	return validation.ValidateNewClusterSpec(ctx, &cluster.Spec, datacenter, cloudProvider, v.features, nil).ToAggregate()
 }
 
 func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {

--- a/pkg/webhook/operatingsystemmanager/operatingsystemconfig/validation/validation_test.go
+++ b/pkg/webhook/operatingsystemmanager/operatingsystemconfig/validation/validation_test.go
@@ -137,7 +137,7 @@ func TestHandle(t *testing.T) {
 				decoder: d,
 			}
 
-			if res := handler.Handle(context.TODO(), tt.req); res.Allowed != tt.wantAllowed {
+			if res := handler.Handle(context.Background(), tt.req); res.Allowed != tt.wantAllowed {
 				t.Errorf("Allowed %t, but wanted %t", res.Allowed, tt.wantAllowed)
 				t.Logf("Response: %v", res)
 			}

--- a/pkg/webhook/operatingsystemmanager/operatingsystemprofile/validation/validation_test.go
+++ b/pkg/webhook/operatingsystemmanager/operatingsystemprofile/validation/validation_test.go
@@ -137,7 +137,7 @@ func TestHandle(t *testing.T) {
 				decoder: d,
 			}
 
-			if res := handler.Handle(context.TODO(), tt.req); res.Allowed != tt.wantAllowed {
+			if res := handler.Handle(context.Background(), tt.req); res.Allowed != tt.wantAllowed {
 				t.Errorf("Allowed %t, but wanted %t", res.Allowed, tt.wantAllowed)
 				t.Logf("Response: %v", res)
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds context parameters to the cloud providers and then all the call chain up. It also replaces TODO contexts in unit tests with Background contexts, which are more appropriate.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
