### PR TITLE
make operator actually respect the worker-name label

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -26,8 +26,6 @@ apiVersion: kubermatic.k8c.io/v1
 metadata:
   name: "__SEED_NAME__"
   namespace: kubermatic
-  labels:
-    worker-name: "__BUILD_ID__"
 spec:
   country: Germany
   location: Hamburg

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -26,8 +26,6 @@ apiVersion: kubermatic.k8c.io/v1
 metadata:
   name: "__SEED_NAME__"
   namespace: kubermatic
-  labels:
-    worker-name: "__BUILD_ID__"
 spec:
   etcdBackupRestore:
     defaultDestination: minio

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -197,8 +197,6 @@ apiVersion: kubermatic.k8c.io/v1
 metadata:
   name: "${SEED_NAME}"
   namespace: kubermatic
-  labels:
-    worker-name: ""
 spec:
   country: Germany
   location: Hamburg

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -194,8 +194,6 @@ apiVersion: kubermatic.k8c.io/v1
 metadata:
   name: "${SEED_NAME}"
   namespace: kubermatic
-  labels:
-    worker-name: ""
 spec:
   country: Germany
   location: Hamburg

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -94,6 +94,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 		return nil
 	}
 
+	if seed.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		log.Debugf("seed does not have matching %s label", kubermaticv1.WorkerNameLabelKey)
+		return nil
+	}
+
 	// to allow a step-by-step migration of seed clusters, it's possible to
 	// disable the operator's reconciling logic for seeds
 	if _, ok := seed.Annotations[common.SkipReconcilingAnnotation]; ok {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
So far the KKP operator ignored the workerName when reconciling, which makes it impossible to test on a shared system (like our dev cluster). This PR makes it so that the operator only considers KubermaticConfigurations and Seeds with a matching worker-name label.

**Does this PR introduce a user-facing change?**:
```release-note
The KKP Operator now respects worker-name labels, making development on shared clusters much easier.
```
