### PR TITLE
Etcd backups api - make destinations required

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -3633,11 +3633,6 @@
         "parameters": [
           {
             "type": "string",
-            "name": "Region",
-            "in": "header"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -3656,6 +3651,11 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "Region",
+            "in": "header"
           }
         ],
         "responses": {
@@ -22086,7 +22086,7 @@
           "x-go-name": "ClusterID"
         },
         "destination": {
-          "description": "Destination indicates where the backup will be stored. The destination name should correspond to a destination in\nthe cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination in Seed.Spec.BackupRestore",
+          "description": "Destination indicates where the backup will be stored. The destination name should correspond to a destination in\nthe cluster's Seed.Spec.EtcdBackupRestore.",
           "type": "string",
           "x-go-name": "Destination"
         },
@@ -22219,7 +22219,7 @@
           "x-go-name": "ClusterID"
         },
         "destination": {
-          "description": "Destination indicates where the backup was stored. The destination name should correspond to a destination in\nthe cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore",
+          "description": "Destination indicates where the backup was stored. The destination name should correspond to a destination in\nthe cluster's Seed.Spec.EtcdBackupRestore.",
           "type": "string",
           "x-go-name": "Destination"
         }

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -302,7 +302,7 @@ type EtcdBackupConfigSpec struct {
 	// If not set, defaults to DefaultKeptBackupsCount. Only used if Schedule is set.
 	Keep *int `json:"keep,omitempty"`
 	// Destination indicates where the backup will be stored. The destination name should correspond to a destination in
-	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination in Seed.Spec.BackupRestore
+	// the cluster's Seed.Spec.EtcdBackupRestore.
 	Destination string `json:"destination,omitempty"`
 }
 
@@ -333,7 +333,7 @@ type EtcdRestoreSpec struct {
 	// credentials needed to download the backup
 	BackupDownloadCredentialsSecret string `json:"backupDownloadCredentialsSecret,omitempty"`
 	// Destination indicates where the backup was stored. The destination name should correspond to a destination in
-	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+	// the cluster's Seed.Spec.EtcdBackupRestore.
 	Destination string `json:"destination,omitempty"`
 }
 

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -2030,6 +2031,7 @@ func GenDefaultAPIBackupCredentials() *apiv2.BackupCredentials {
 			AccessKeyID:     "accessKeyId",
 			SecretAccessKey: "secretAccessKey",
 		},
+		Destination: "s3",
 	}
 }
 

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -37,7 +37,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1964,9 +1964,10 @@ func GenAPIEtcdBackupConfig(name, clusterID string) *apiv2.EtcdBackupConfig {
 			CreationTimestamp: apiv1.Date(0001, 01, 01, 00, 00, 0, 0, time.UTC),
 		},
 		Spec: apiv2.EtcdBackupConfigSpec{
-			ClusterID: clusterID,
-			Schedule:  "5 * * * * *",
-			Keep:      &keep,
+			ClusterID:   clusterID,
+			Schedule:    "5 * * * * *",
+			Keep:        &keep,
+			Destination: "s3",
 		},
 	}
 }
@@ -1984,10 +1985,11 @@ func GenEtcdBackupConfig(name string, cluster *kubermaticv1.Cluster, projectID s
 			},
 		},
 		Spec: kubermaticv1.EtcdBackupConfigSpec{
-			Name:     name,
-			Cluster:  *clusterObjectRef,
-			Schedule: "5 * * * * *",
-			Keep:     &keep,
+			Name:        name,
+			Cluster:     *clusterObjectRef,
+			Schedule:    "5 * * * * *",
+			Keep:        &keep,
+			Destination: "s3",
 		},
 	}
 }

--- a/pkg/test/e2e/utils/apiclient/models/etcd_backup_config_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/etcd_backup_config_spec.go
@@ -21,7 +21,7 @@ type EtcdBackupConfigSpec struct {
 	ClusterID string `json:"clusterId,omitempty"`
 
 	// Destination indicates where the backup will be stored. The destination name should correspond to a destination in
-	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination in Seed.Spec.BackupRestore
+	// the cluster's Seed.Spec.EtcdBackupRestore.
 	Destination string `json:"destination,omitempty"`
 
 	// Keep is the number of backups to keep around before deleting the oldest one

--- a/pkg/test/e2e/utils/apiclient/models/etcd_restore_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/etcd_restore_spec.go
@@ -28,7 +28,7 @@ type EtcdRestoreSpec struct {
 	ClusterID string `json:"clusterId,omitempty"`
 
 	// Destination indicates where the backup was stored. The destination name should correspond to a destination in
-	// the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+	// the cluster's Seed.Spec.EtcdBackupRestore.
 	Destination string `json:"destination,omitempty"`
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adjust KKP API to the latest cleanup of etcd backups, in which backup destination became required in https://github.com/kubermatic/kubermatic/pull/9003

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9121 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ETCD backup API now requires destination to be set for etcdbackupconfig, etcdrestore and backupcredentials endpoints.
```
