### PR TITLE
sync ApplicationDefinition from master to seed clusters

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -202,6 +202,12 @@ func main() {
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",
 			},
+			{
+				ResourceName:       "ApplicationDefinition",
+				ImportAlias:        "appkubermaticv1",
+				ResourceImportPath: "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1",
+				APIVersionPrefix:   "AppKubermaticV1",
+			},
 		},
 	}
 

--- a/pkg/apis/apps.kubermatic/v1/types.go
+++ b/pkg/apis/apps.kubermatic/v1/types.go
@@ -18,6 +18,11 @@ package v1
 
 import corev1 "k8s.io/api/core/v1"
 
+const (
+	// ApplicationDefinitionSeedCleanupFinalizer indicates that synced application definition on seed clusters need cleanup.
+	ApplicationDefinitionSeedCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-application-definition"
+)
+
 // GlobalSecretKeySelector is needed as we can not use v1.SecretKeySelector
 // because it is not cross namespace.
 type GlobalSecretKeySelector struct {

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig-app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -164,7 +164,6 @@ func (r *reconciler) syncAllSeeds(log *zap.SugaredLogger, applicationDef *appkub
 func applicationDefCreatorGetter(applicationDef *appkubermaticv1.ApplicationDefinition) reconciling.NamedAppKubermaticV1ApplicationDefinitionCreatorGetter {
 	return func() (string, reconciling.AppKubermaticV1ApplicationDefinitionCreator) {
 		return applicationDef.Name, func(a *appkubermaticv1.ApplicationDefinition) (*appkubermaticv1.ApplicationDefinition, error) {
-			a.Name = applicationDef.Name
 			a.Labels = applicationDef.Labels
 			a.Annotations = applicationDef.Annotations
 			a.Spec = applicationDef.Spec

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -1,0 +1,89 @@
+/*
+ Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package applicationdefinitionsynchronizer
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "application_definition_syncing_controller"
+)
+
+type reconciler struct {
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	masterClient ctrlruntimeclient.Client
+	seedClients  map[string]ctrlruntimeclient.Client
+}
+
+func Add(
+	masterManager manager.Manager,
+	seedManagers map[string]manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+) error {
+
+	r := &reconciler{
+		log:          log.Named(ControllerName),
+		recorder:     masterManager.GetEventRecorderFor(ControllerName),
+		masterClient: masterManager.GetClient(),
+		seedClients:  map[string]ctrlruntimeclient.Client{},
+	}
+
+	for seedName, seedManager := range seedManagers {
+		r.seedClients[seedName] = seedManager.GetClient()
+	}
+
+	c, err := controller.New(ControllerName, masterManager, controller.Options{Reconciler: r, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %v", err)
+	}
+
+	// Watch for changes to ApplicationDefinition
+	if err := c.Watch(&source.Kind{Type: &appkubermaticv1.ApplicationDefinition{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch for applicationDefinitions: %v", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles Kubermatic Project objects on the master cluster to all seed clusters
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("resource", request.Name)
+	log.Infof("start reconciling")
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, applicationDefiniton *appkubermaticv1.ApplicationDefinition) error {
+	log.Infof("remove")
+	return nil
+}

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+ Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@ package applicationdefinitionsynchronizer
 import (
 	"context"
 	"fmt"
-
 	"go.uber.org/zap"
 
 	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -50,7 +53,6 @@ func Add(
 	log *zap.SugaredLogger,
 	numWorkers int,
 ) error {
-
 	r := &reconciler{
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
@@ -64,26 +66,108 @@ func Add(
 
 	c, err := controller.New(ControllerName, masterManager, controller.Options{Reconciler: r, MaxConcurrentReconciles: numWorkers})
 	if err != nil {
-		return fmt.Errorf("failed to construct controller: %v", err)
+		return fmt.Errorf("failed to construct controller: %w", err)
 	}
 
 	// Watch for changes to ApplicationDefinition
 	if err := c.Watch(&source.Kind{Type: &appkubermaticv1.ApplicationDefinition{}}, &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("failed to create watch for applicationDefinitions: %v", err)
+		return fmt.Errorf("failed to create watch for applicationDefinitions: %w", err)
 	}
 
 	return nil
 }
 
-// Reconcile reconciles Kubermatic Project objects on the master cluster to all seed clusters
+// Reconcile reconciles ApplicationDefinition objects from master cluster to all seed clusters
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := r.log.With("resource", request.Name)
-	log.Infof("start reconciling")
+	log.Debug("Processing")
 
-	return reconcile.Result{}, nil
+	err := r.reconcile(ctx, log, request)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+	}
+
+	return reconcile.Result{}, err
 }
 
-func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, applicationDefiniton *appkubermaticv1.ApplicationDefinition) error {
-	log.Infof("remove")
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
+	applicationDef := &appkubermaticv1.ApplicationDefinition{}
+
+	if err := r.masterClient.Get(ctx, request.NamespacedName, applicationDef); err != nil {
+		return ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	// handling deletion
+	if !applicationDef.DeletionTimestamp.IsZero() {
+		if err := r.handleDeletion(ctx, log, applicationDef); err != nil {
+			return fmt.Errorf("handling deletion of application definition: %w", err)
+		}
+		return nil
+	}
+
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, applicationDef, appkubermaticv1.ApplicationDefinitionSeedCleanupFinalizer); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
+	}
+
+	applicationDefCreatorGetters := []reconciling.NamedAppKubermaticV1ApplicationDefinitionCreatorGetter{
+		applicationDefCreatorGetter(applicationDef),
+	}
+
+	err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, appDef *appkubermaticv1.ApplicationDefinition) error {
+		return reconciling.ReconcileAppKubermaticV1ApplicationDefinitions(ctx, applicationDefCreatorGetters, "", seedClient)
+	})
+	if err != nil {
+		r.recorder.Eventf(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		return fmt.Errorf("reconciled application definition: %s: %w", applicationDef.Name, err)
+	}
+
 	return nil
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, applicationDef *appkubermaticv1.ApplicationDefinition) error {
+	if kuberneteshelper.HasFinalizer(applicationDef, appkubermaticv1.ApplicationDefinitionSeedCleanupFinalizer) {
+		if err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, applicationDef *appkubermaticv1.ApplicationDefinition) error {
+			err := seedClient.Delete(ctx, &appkubermaticv1.ApplicationDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: applicationDef.Name,
+				},
+			})
+
+			return ctrlruntimeclient.IgnoreNotFound(err)
+		}); err != nil {
+			return err
+		}
+
+		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, applicationDef, appkubermaticv1.ApplicationDefinitionSeedCleanupFinalizer); err != nil {
+			return fmt.Errorf("failed to remove application definition finalizer %s: %w", applicationDef.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) syncAllSeeds(log *zap.SugaredLogger, applicationDef *appkubermaticv1.ApplicationDefinition, action func(seedClient ctrlruntimeclient.Client, applicationDef *appkubermaticv1.ApplicationDefinition) error) error {
+	for seedName, seedClient := range r.seedClients {
+		log := log.With("seed", seedName)
+
+		log.Debug("Reconciling application definition with seed")
+
+		err := action(seedClient, applicationDef)
+		if err != nil {
+			return fmt.Errorf("failed syncing application definition %s for seed %s: %w", applicationDef.Name, seedName, err)
+		}
+		log.Debug("Reconciled application definition with seed")
+	}
+	return nil
+}
+
+func applicationDefCreatorGetter(applicationDef *appkubermaticv1.ApplicationDefinition) reconciling.NamedAppKubermaticV1ApplicationDefinitionCreatorGetter {
+	return func() (string, reconciling.AppKubermaticV1ApplicationDefinitionCreator) {
+		return applicationDef.Name, func(a *appkubermaticv1.ApplicationDefinition) (*appkubermaticv1.ApplicationDefinition, error) {
+			a.Name = applicationDef.Name
+			a.Labels = applicationDef.Labels
+			a.Annotations = applicationDef.Annotations
+			a.Spec = applicationDef.Spec
+			return a, nil
+		}
+	}
 }

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -1,17 +1,17 @@
 /*
- Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package applicationdefinitionsynchronizer

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -19,6 +19,7 @@ package applicationdefinitionsynchronizer
 import (
 	"context"
 	"fmt"
+
 	"go.uber.org/zap"
 
 	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
@@ -77,7 +78,7 @@ func Add(
 	return nil
 }
 
-// Reconcile reconciles ApplicationDefinition objects from master cluster to all seed clusters
+// Reconcile reconciles ApplicationDefinition objects from master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := r.log.With("resource", request.Name)
 	log.Debug("Processing")

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
@@ -1,17 +1,17 @@
 /*
- Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package applicationdefinitionsynchronizer

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
@@ -1,0 +1,170 @@
+/*
+ Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package applicationdefinitionsynchronizer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func init() {
+	utilruntime.Must(kubermaticv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(appkubermaticv1.AddToScheme(scheme.Scheme))
+}
+
+const applicationDefinitionName = "app-def-1"
+
+func TestReconcile(t *testing.T) {
+	testCases := []struct {
+		name                          string
+		requestName                   string
+		expectedApplicationDefinition *appkubermaticv1.ApplicationDefinition
+		masterClient                  ctrlruntimeclient.Client
+		seedClient                    ctrlruntimeclient.Client
+	}{
+		{
+			name:                          "scenario 1: sync application definition from master cluster to seed cluster",
+			requestName:                   applicationDefinitionName,
+			expectedApplicationDefinition: generateApplicationDef(applicationDefinitionName, false),
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithObjects(generateApplicationDef(applicationDefinitionName, false), test.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				Build(),
+		},
+		{
+			name:                          "scenario 2: cleanup application definition on the seed cluster when master application definition is being terminated\"",
+			requestName:                   applicationDefinitionName,
+			expectedApplicationDefinition: nil,
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithObjects(generateApplicationDef(applicationDefinitionName, true), test.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithObjects(generateApplicationDef(applicationDefinitionName, false), test.GenTestSeed()).
+				Build(),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			r := &reconciler{
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: tc.masterClient,
+				seedClients:  map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			seedApplicationDef := &appkubermaticv1.ApplicationDefinition{}
+			err := tc.seedClient.Get(ctx, request.NamespacedName, seedApplicationDef)
+
+			if tc.expectedApplicationDefinition == nil {
+				if err == nil {
+					t.Fatal("failed clean up application definition on the seed cluster")
+				} else if !errors.IsNotFound(err) {
+					t.Fatalf("failed to get application definition: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("failed to get application definition: %v", err)
+				}
+				if !reflect.DeepEqual(seedApplicationDef.Name, tc.expectedApplicationDefinition.Name) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedApplicationDef, tc.expectedApplicationDefinition))
+				}
+				if !reflect.DeepEqual(seedApplicationDef.Labels, tc.expectedApplicationDefinition.Labels) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedApplicationDef, tc.expectedApplicationDefinition))
+				}
+				if !reflect.DeepEqual(seedApplicationDef.Annotations, tc.expectedApplicationDefinition.Annotations) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedApplicationDef, tc.expectedApplicationDefinition))
+				}
+				if !reflect.DeepEqual(seedApplicationDef.Spec, tc.expectedApplicationDefinition.Spec) {
+					t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(seedApplicationDef, tc.expectedApplicationDefinition))
+				}
+				// todo label and annotation
+			}
+		})
+	}
+}
+
+func generateApplicationDef(name string, deleted bool) *appkubermaticv1.ApplicationDefinition {
+	applicationDef := &appkubermaticv1.ApplicationDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"someLabelKey": "someLabelValue",
+			},
+			Annotations: map[string]string{
+				"someAnnotationKey": "someAnnotationValue",
+			},
+		},
+		Spec: appkubermaticv1.ApplicationDefinitionSpec{
+			Description: "sample app",
+			Versions: []appkubermaticv1.ApplicationVersion{
+				{
+					Version: "version 1",
+					Constraints: appkubermaticv1.ApplicationConstraints{
+						K8sVersion: "> 1.0.0",
+						KKPVersion: "> 1.1.1",
+					},
+					Template: appkubermaticv1.ApplicationTemplate{
+						Source: appkubermaticv1.ApplicationSource{
+							Helm: &appkubermaticv1.HelmSource{
+								URL:          "https://my-chart-repo.local",
+								ChartName:    "sample-app",
+								ChartVersion: "1.0",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if deleted {
+		deleteTime := metav1.NewTime(time.Now())
+		applicationDef.DeletionTimestamp = &deleteTime
+		applicationDef.Finalizers = append(applicationDef.Finalizers, appkubermaticv1.ApplicationDefinitionSeedCleanupFinalizer)
+	}
+
+	return applicationDef
+}

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/doc.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/doc.go
@@ -1,0 +1,21 @@
+/*
+ Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+Package applicationdefinitionsynchronizer contains a controller that is responsible for ensuring that
+ApplicationDefinition are synced from master to the seed clusters.
+*/
+package applicationdefinitionsynchronizer

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/doc.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/doc.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+ Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/doc.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/doc.go
@@ -1,17 +1,17 @@
 /*
- Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 /*


### PR DESCRIPTION
This pr sync the ApplicationDefinition from master cluster to seed clusters

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8369

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
