### PR TITLE
Use sigs.k8s.io/yaml for KubermaticConfiguration unmarshalling in cmd/image-loader

### DIFF
--- a/cmd/image-loader/operator.go
+++ b/cmd/image-loader/operator.go
@@ -21,12 +21,13 @@ import (
 	"io/ioutil"
 
 	"go.uber.org/zap"
-	"gopkg.in/yaml.v2"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version"
+
+	"sigs.k8s.io/yaml"
 )
 
 func loadKubermaticConfiguration(log *zap.SugaredLogger, filename string) (*kubermaticv1.KubermaticConfiguration, error) {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

`sigs.k8s.io/yaml` is better than `gokpk.in/yaml/v3` when it comes to parsing Kubernetes YAML, including the `KubermaticConfiguration` file. While this already works on `master`, this is a problem on earlier release branches like `release/v2.19`, where a configured `versions` struct fails with this error:

```
{"error": "failed to parse file as YAML: yaml: unmarshal errors:\n  line 67: cannot unmarshal !!str `v1.21.8` into semver.Version"}
````

That's because `semver.Version` does not implement `UnmarshalYAML`. It's not a problem on `master` or `release/v2.20`, as the new CRDs uses `semver.Semver` (a `string` type) instead, but it's broken for `release/v2.19` and below. To make `image-loader` work in those branches, I'm starting this change top-down to have all release branches aligned, but the goal is to have this backported to older release branches.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>