### PR TITLE
do not log the same message in the initial-md-controller ad infinitum

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -73,9 +73,10 @@ func main() {
 		os.Exit(1)
 	}
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
-	log := rawLog.Sugar().With(
-		"worker-name", options.workerName,
-	)
+	log := rawLog.Sugar()
+	if options.workerName != "" {
+		log = log.With("worker-name", options.workerName)
+	}
 	defer func() {
 		if err := log.Sync(); err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The controller continued to log "cluster is not healthy" even if it already processsed its annotation and should not log anything anymore. I also adjusted the seed ctrl mgr to not include the worker-name if the name is empty, which gets rid of the `"worker-name":""` noise in every single log message.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
