### PR TITLE
Reconcile CSI access in a dedicated namespace

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -660,6 +660,49 @@ presubmits:
           limits:
             memory: 4Gi
 
+  - name: pre-kubermatic-e2e-kubevirt-ubuntu-1.22
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubevirt: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.22.5"
+        - name: PROVIDER
+          value: "kubevirt"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
+
   - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"

--- a/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/cmd/conformance-tests/scenarios_kubevirt.go
@@ -105,7 +105,7 @@ func (s *kubevirtScenario) NodeDeployments(_ context.Context, num int, _ secrets
 							SourceURL:        utilpointer.StringPtr(sourceURL),
 							StorageClassName: utilpointer.StringPtr("local-path"),
 							PVCSize:          utilpointer.StringPtr("25Gi"),
-							CPUs:             utilpointer.StringPtr("2"),
+							CPUs:             utilpointer.StringPtr("1"),
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -97,7 +97,7 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		return cluster, err
 	}
 
-	err = ReconcileCSIRoleRoleBinding(ctx, client, restConfig)
+	err = reconcileCSIRoleRoleBinding(ctx, cluster.Status.NamespaceName, client, restConfig)
 	if err != nil {
 		return cluster, err
 	}

--- a/pkg/provider/cloud/kubevirt/reconciler.go
+++ b/pkg/provider/cloud/kubevirt/reconciler.go
@@ -51,11 +51,11 @@ func (r *reconciler) ReconcileCSIServiceAccount(ctx context.Context) ([]byte, er
 	saCreators := []reconciling.NamedServiceAccountCreatorGetter{
 		csiServiceAccountCreator(csiResourceName),
 	}
-	if err := reconciling.ReconcileServiceAccounts(ctx, saCreators, csiResourceNamespace, r.Client); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(ctx, saCreators, csiServiceAccountNamespace, r.Client); err != nil {
 		return nil, err
 	}
 
-	return r.GenerateKubeConfigForSA(ctx, csiResourceName, csiResourceNamespace)
+	return r.GenerateKubeConfigForSA(ctx, csiResourceName, csiServiceAccountNamespace)
 }
 
 func (r *reconciler) GenerateKubeConfigForSA(ctx context.Context, name string, namespace string) ([]byte, error) {

--- a/pkg/provider/cloud/kubevirt/storage.go
+++ b/pkg/provider/cloud/kubevirt/storage.go
@@ -23,14 +23,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	// soon we are going to change the default namespace to cluster namespace.
-	csiResourceNamespace = "default"
-	csiResourceName      = "kubevirt-csi"
+	csiServiceAccountNamespace = metav1.NamespaceDefault
+	csiResourceName            = "kubevirt-csi"
 )
 
 func csiServiceAccountCreator(name string) reconciling.NamedServiceAccountCreatorGetter {
@@ -90,18 +90,18 @@ func csiRoleBindingCreator(name, namespace string) reconciling.NamedRoleBindingC
 }
 
 // reconcileCSIRoleRoleBinding reconciles the Role and Rolebindings needed by CSI driver.
-func ReconcileCSIRoleRoleBinding(ctx context.Context, client ctrlruntimeclient.Client, restConfig *restclient.Config) error {
+func reconcileCSIRoleRoleBinding(ctx context.Context, namespace string, client ctrlruntimeclient.Client, restConfig *restclient.Config) error {
 	roleCreators := []reconciling.NamedRoleCreatorGetter{
 		csiRoleCreator(csiResourceName),
 	}
-	if err := reconciling.ReconcileRoles(ctx, roleCreators, csiResourceNamespace, client); err != nil {
+	if err := reconciling.ReconcileRoles(ctx, roleCreators, namespace, client); err != nil {
 		return err
 	}
 
 	roleBindingCreators := []reconciling.NamedRoleBindingCreatorGetter{
-		csiRoleBindingCreator(csiResourceName, csiResourceNamespace),
+		csiRoleBindingCreator(csiResourceName, csiServiceAccountNamespace),
 	}
-	if err := reconciling.ReconcileRoleBindings(ctx, roleBindingCreators, csiResourceNamespace, client); err != nil {
+	if err := reconciling.ReconcileRoleBindings(ctx, roleBindingCreators, namespace, client); err != nil {
 		return err
 	}
 

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -415,25 +415,14 @@ func createOrUpdateKubevirtSecret(ctx context.Context, seedClient ctrlruntimecli
 	}
 
 	// ensure that CSI driver on user cluster will have an access to KubeVirt cluster
-	// 1- Service Account
+	// Service Account
+	// Needed Role/Rolebinding are reconciled in pkg/provider/cloud/kubevirt/provider.go in ReconcileCluster(),
+	//   in a dedicated namespace <cluster-id>, after this namespace is reconciled.
 	r, err := kubevirt.NewReconciler(spec.Kubeconfig, cluster.Name)
 	if err != nil {
 		return err
 	}
 	csiKubeconfig, err := r.ReconcileCSIServiceAccount(ctx)
-	if err != nil {
-		return err
-	}
-
-	// 2- Role and RoleBinding,
-	// separated from the ReconcileCSIServiceAccount as Role and Rolebinding reconciliation
-	// is also called in `ReconcileCluster`, whereas the SA is only created here and not reconciled after.
-	client, restConfig, err := kubevirt.NewClientWithRestConfig(spec.Kubeconfig)
-	if err != nil {
-		return err
-	}
-
-	err = kubevirt.ReconcileCSIRoleRoleBinding(ctx, client, restConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
Reconciliation of CSI access (role/rolebinding) is done in the dedicated `<cluster-id>` namespace instead of the hard-coded `default`. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9155

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
