### PR TITLE
Use GOCACHE for building images with buildah

### DIFF
--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -17,9 +17,11 @@ FROM docker.io/golang:1.17.5 as builder
 # import the GOPROXY variable from Buildah via an arg and then use
 # that arg to define the environment variable later on
 ARG GOPROXY=
+ARG GOCACHE=
 ARG KUBERMATIC_EDITION=ce
 
 ENV GOPROXY=$GOPROXY
+ENV GOCACHE=$GOCACHE
 ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
 
 WORKDIR /go/src/k8c.io/kubermatic

--- a/cmd/kubeletdnat-controller/Makefile
+++ b/cmd/kubeletdnat-controller/Makefile
@@ -17,7 +17,7 @@ GOOS ?= $(shell go env GOOS)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/kubeletdnat-controller .
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/kubeletdnat-controller .
 
 .PHONY: docker
 docker: build

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -17,9 +17,11 @@ FROM docker.io/golang:1.17.5 as builder
 # import the GOPROXY variable from Buildah via an arg and then use
 # that arg to define the environment variable later on
 ARG GOPROXY=
+ARG GOCACHE=
 ARG KUBERMATIC_EDITION=ce
 
 ENV GOPROXY=$GOPROXY
+ENV GOCACHE=$GOCACHE
 ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
 
 WORKDIR /go/src/k8c.io/kubermatic

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+KUBERMATIC_EDITION ?= ce
 DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
+LDFLAGS ?= -w -extldflags '-static'
+GOTOOLFLAGS ?= -ldflags '$(LDFLAGS)' -v
+
+export CGO_ENABLED=0
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/user-ssh-keys-agent
+	go env
+	go build $(GOTOOLFLAGS) -tags "$(KUBERMATIC_EDITION)" -o ./_build/user-ssh-keys-agent
 
 .PHONY: docker
 docker: build

--- a/hack/ci/download-gocache.sh
+++ b/hack/ci/download-gocache.sh
@@ -46,13 +46,15 @@ trap exit_gracefully EXIT
 source $(dirname $0)/../lib.sh
 
 if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
-  echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
+  echodate "env var GOCACHE_MINIO_ADDRESS unset, cannot download gocache"
   exit 0
 fi
 
 GOCACHE="$(go env GOCACHE)"
+TARGET_DIRECTORY="${TARGET_DIRECTORY:-$GOCACHE}"
+
 # Make sure it actually exists
-mkdir -p "${GOCACHE}"
+mkdir -p "${TARGET_DIRECTORY}"
 
 # PULL_BASE_REF is the name of the current branch in case of a post-submit
 # or the name of the base branch in case of a PR.
@@ -100,6 +102,6 @@ TEST_NAME="Download and extract gocache"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 5 curl --fail -H @/tmp/headers "${URL}" | tar -C $GOCACHE -xf -
+retry 5 curl --fail -H @/tmp/headers "${URL}" | tar -C $TARGET_DIRECTORY -xf -
 
-echodate "Successfully fetched gocache into $GOCACHE"
+echodate "Successfully fetched gocache into $TARGET_DIRECTORY"

--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -59,27 +59,40 @@ fi
 PRIMARY_TAG="${1}"
 make docker-build TAGS="${PRIMARY_TAG}"
 make -C cmd/nodeport-proxy docker TAG="${PRIMARY_TAG}"
-make -C cmd/kubeletdnat-controller docker TAG="${PRIMARY_TAG}"
 docker build -t "${DOCKER_REPO}/addons:${PRIMARY_TAG}" addons
 docker build -t "${DOCKER_REPO}/etcd-launcher:${PRIMARY_TAG}" -f cmd/etcd-launcher/Dockerfile .
+
+# prepare gocaches for each arch
+gocaches="$(mktemp -d)"
+for ARCH in ${ARCHITECTURES}; do
+  cacheDir="$gocaches/$ARCH"
+  mkdir -p "$cacheDir"
+
+  # amd64 has been downloaded into $GOCACHE already, do not download it again
+  if [ "$ARCH" == "amd64" ]; then
+    cp -ar "$(go env GOCACHE)/*" "$cacheDir"
+    continue
+  fi
+
+  # try to get a gocache for this arch; this can "fail" but still exit with 0
+  TARGET_DIRECTORY="$cacheDir" GOARCH="$ARCH" ./hack/ci/download-gocache.sh
+done
 
 # build multi-arch images
 buildah manifest create "${DOCKER_REPO}/user-ssh-keys-agent:${PRIMARY_TAG}"
 for ARCH in ${ARCHITECTURES}; do
   echodate "Building user-ssh-keys-agent image for $ARCH..."
 
-  # Building via buildah does not use the gocache, but that's okay, because we
-  # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
-  # cache size and force every e2e test to download gigabytes worth of unneeded
-  # arm64 stuff. We might need to change this once we run e2e tests on arm64.
   buildah bud \
     --tag "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${PRIMARY_TAG}" \
     --build-arg "GOPROXY=${GOPROXY:-}" \
     --build-arg "KUBERMATIC_EDITION=${KUBERMATIC_EDITION}" \
+    --build-arg "GOCACHE=/gocache" \
     --arch "$ARCH" \
     --override-arch "$ARCH" \
     --format=docker \
     --file cmd/user-ssh-keys-agent/Dockerfile.multiarch \
+    --volume "$gocaches/$ARCH:/gocache" \
     .
   buildah manifest add "${DOCKER_REPO}/user-ssh-keys-agent:${PRIMARY_TAG}" "${DOCKER_REPO}/user-ssh-keys-agent-${ARCH}:${PRIMARY_TAG}"
 done
@@ -88,21 +101,21 @@ buildah manifest create "${DOCKER_REPO}/kubeletdnat-controller:${PRIMARY_TAG}"
 for ARCH in ${ARCHITECTURES}; do
   echodate "Building kubeletdnat-controller image for $ARCH..."
 
-  # Building via buildah does not use the gocache, but that's okay, because we
-  # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
-  # cache size and force every e2e test to download gigabytes worth of unneeded
-  # arm64 stuff. We might need to change this once we run e2e tests on arm64.
   buildah bud \
     --tag "${DOCKER_REPO}/kubeletdnat-controller-${ARCH}:${PRIMARY_TAG}" \
     --build-arg "GOPROXY=${GOPROXY:-}" \
     --build-arg "KUBERMATIC_EDITION=${KUBERMATIC_EDITION}" \
+    --build-arg "GOCACHE=/gocache" \
     --arch "$ARCH" \
     --override-arch "$ARCH" \
     --format=docker \
     --file cmd/kubeletdnat-controller/Dockerfile.multiarch \
+    --volume "$gocaches/$ARCH:/gocache" \
     .
   buildah manifest add "${DOCKER_REPO}/kubeletdnat-controller:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeletdnat-controller-${ARCH}:${PRIMARY_TAG}"
 done
+
+rm -rf -- "$gocaches"
 
 # for each given tag, tag and push the image
 for TAG in "$@"; do


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Use GOCACHE for building images with buildah. This should speed up the image building, hopefully, by a few minutes.

Currently, this doesn't work out of the box. If you check the `pre-kubermatic-test-user-ssh-key-agent-multiarch` job, you'll see that GOCACHE is not used. However, I believe there might be a problem because we're changing the `cmd/user-ssh-keys-agent` package, which is for some reason invalidating the cache. I would propose that we merge this PR and continue debugging in a follow-up PR.

h/t to @xrstf for initially implementing this in #9027

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
