### PR TITLE
Consider additional device owner for Openstack router discovery

### DIFF
--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -493,7 +493,7 @@ func getRouterIDForSubnet(netClient *gophercloud.ServiceClient, subnetID string)
 	}
 
 	for _, port := range ports {
-		if port.DeviceOwner == "network:router_interface" || port.DeviceOwner == "network:router_interface_distributed" {
+		if port.DeviceOwner == "network:router_interface" || port.DeviceOwner == "network:router_interface_distributed" || port.DeviceOwner == "network:ha_router_replicated_interface" {
 			// Check IP for the interface & check if the IP belongs to the subnet
 			return port.DeviceID, nil
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

In some Openstack setups, ports created on subnets when attaching a router come with a `device_owner` value that is not considered by our discovery mechanism yet. This PR adds it.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9163

**Special notes for your reviewer**:

- https://opendev.org/openstack/trove/commit/d5497179d4789ef1c22ad8f9a39c719459241a62 is a reference change upstream that includes three device_owner types, with `network:ha_router_replicated_interface` being the missing value from our code.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for `network:ha_router_replicated_interface` ports when discovering existing subnet router in Openstack
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
