### PR TITLE
Remove optional=true setting from prow jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -110,7 +110,6 @@ presubmits:
           value: ee
 
   - name: pre-kubermatic-shellcheck
-    optional: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -397,7 +396,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-azure-ubuntu-1.22
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-azure: "true"
@@ -444,7 +442,6 @@ presubmits:
   - name: pre-kubermatic-e2e-gcp-ubuntu-1.22
     decorate: true
     always_run: false
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-gce: "true"
@@ -488,7 +485,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-gcp-ubuntu-1.22-psp
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-gce: "true"
@@ -537,7 +533,6 @@ presubmits:
   - name: pre-kubermatic-e2e-do-centos-1.22
     decorate: true
     always_run: false
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-digitalocean: "true"
@@ -581,7 +576,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-packet-ubuntu-1.22
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-packet: "true"
@@ -625,7 +619,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-kubevirt-centos-1.22
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-kubevirt: "true"
@@ -669,7 +662,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-hetzner: "true"
@@ -715,7 +707,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-openstack-ubuntu-1.22
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-openstack: "true"
@@ -761,7 +752,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-openstack-centos-1.22
     decorate: true
-    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-openstack: "true"
@@ -851,7 +841,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-customfolder
     decorate: true
-    optional: true
     run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -898,7 +887,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.21-datastore-cluster
     decorate: true
-    optional: true
     run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -945,7 +933,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-nutanix-ubuntu-1.22
     decorate: true
-    optional: true
     run_if_changed: "(addons/csi/nutanix|pkg/provider/cloud/nutanix)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -990,7 +977,6 @@ presubmits:
 
   - name: pre-kubermatic-e2e-nutanix-centos-1.22
     decorate: true
-    optional: true
     run_if_changed: "(addons/csi/nutanix|pkg/provider/cloud/nutanix)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

This is a PR to start a discussion, not necessarily to be merged as a whole.

IMO, no prow jobs should be configured with `optional: true`. The reason for that is that it skips [checks for auto merging](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#requiring-jobs-for-auto-merge-through-tide). Usually, all of our jobs should succeed. In particular, cloud provider jobs are configured with this, but they only trigger when provider-specific code is changed - If the provider implementation is changed, our e2e tests should be a prerequisite for merging it! If they fail, our e2e setup might not be working, but then we cannot trust the PR anyway. Otherwise we might break a provider and don't realise we did.

There's just very few exceptions where these jobs can be disregarded, in particular if a provider is known to be flaky due to provider-side issues or long-term infra issues. I'm not aware we have that at the moment, but we can introduce it for jobs later on.

WDYT @xmudrii @xrstf @moadqassem?

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>