### PR TITLE
Cleanup: remove unnecessary check controllerutil.IsCacheNotStarted in controllers

### DIFF
--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -19,13 +19,11 @@ package clustertemplatesynchronizer
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -90,9 +88,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)
-	if controllerutil.IsCacheNotStarted(err) {
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-	}
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
 	}

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -19,13 +19,11 @@ package masterconstraintsynchronizer
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -104,9 +102,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)
-	if controllerutil.IsCacheNotStarted(err) {
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-	}
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
 	}
@@ -132,10 +127,6 @@ func (r *reconciler) syncAllSeeds(ctx context.Context, log *zap.SugaredLogger, c
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
 	constraint := &kubermaticv1.Constraint{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, constraint); err != nil {
-		if controllerutil.IsCacheNotStarted(err) {
-			return err
-		}
-
 		return ctrlruntimeclient.IgnoreNotFound(err)
 	}
 

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -19,13 +19,11 @@ package masterconstrainttemplatecontroller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -107,10 +105,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			log.Debug("constraint template not found, returning")
 			return reconcile.Result{}, nil
 		}
-		if controllerutil.IsCacheNotStarted(err) {
-			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-
 		return reconcile.Result{}, fmt.Errorf("failed to get constraint template %s: %w", constraintTemplate.Name, err)
 	}
 

--- a/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
@@ -19,7 +19,6 @@ package usersshkeyssynchronizer
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -129,9 +128,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)
-	if controllerutil.IsCacheNotStarted(err) {
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-	}
 	if err != nil {
 		log.Errorw("Reconciliation failed", zap.Error(err))
 	}
@@ -149,10 +145,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	// find all clusters in this seed
 	cluster := &kubermaticv1.Cluster{}
 	if err := seedClient.Get(ctx, types.NamespacedName{Name: request.Name}, cluster); err != nil {
-		if controllerutil.IsCacheNotStarted(err) {
-			return err
-		}
-
 		if kubeapierrors.IsNotFound(err) {
 			log.Debug("Could not find cluster")
 			return nil

--- a/pkg/controller/util/util.go
+++ b/pkg/controller/util/util.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -28,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -185,10 +183,4 @@ func ConcurrencyLimitReached(ctx context.Context, client ctrlruntimeclient.Clien
 	clustersUpdatingInProgressCount := len(clusters.Items) - finishedUpdatingClustersCount
 
 	return clustersUpdatingInProgressCount >= limit, nil
-}
-
-// IsCacheNotStarted returns true if the given error is not nil and an instance of
-// cache.ErrCacheNotStarted.
-func IsCacheNotStarted(err error) bool {
-	return errors.Is(err, &cache.ErrCacheNotStarted{})
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

In some controllers we check if error is due to cache not started. 
```go
err := r.reconcile(ctx, log, request)
if controllerutil.IsCacheNotStarted(err) {
   return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
}
```
However since controller-runtime [v0.8.1](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.8.1), the manager starts all caches before other Runnables  kubernetes-sigs/controller-runtime#1327.  Consequently, this check is not needed anymore.

This pr cleanup the controllers.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
