### PR TITLE
cleanup codespell.exclude

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -5,5 +5,3 @@ nd
 od
 uptodate
 aks
-imediate
-repesents


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Since #9014 we do not need to have these two in our exclusion list anymore :)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
