### PR TITLE
cleanup kubeletdnat controller naming

### DIFF
--- a/cmd/kubeletdnat-controller/main.go
+++ b/cmd/kubeletdnat-controller/main.go
@@ -24,7 +24,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/controller/kubeletdnat"
+	kubeletdnatcontroller "k8c.io/kubermatic/v2/pkg/controller/kubeletdnat-controller"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
@@ -90,15 +90,15 @@ func main() {
 	// 8080 is already in use by the insecure port of the apiserver
 	mgr, err := manager.New(config, manager.Options{MetricsBindAddress: ":8090"})
 	if err != nil {
-		log.Fatalw("failed to create mgr", zap.Error(err))
+		log.Fatalw("Failed to create manager", zap.Error(err))
 	}
 
-	if err := kubeletdnat.Add(mgr, *chainNameFlag, nodeAccessNetwork, log, *vpnInterfaceFlag); err != nil {
-		log.Fatalw("failed to add the kubelet dnat controller", zap.Error(err))
+	if err := kubeletdnatcontroller.Add(mgr, *chainNameFlag, nodeAccessNetwork, log, *vpnInterfaceFlag); err != nil {
+		log.Fatalw("Failed to add the kubelet dnat controller", zap.Error(err))
 	}
 
 	if err := mgr.Add(pprofOpts); err != nil {
-		log.Fatalw("failed to add pprof endpoint", zap.Error(err))
+		log.Fatalw("Failed to add pprof endpoint", zap.Error(err))
 	}
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/pkg/controller/kubeletdnat-controller/controller.go
+++ b/pkg/controller/kubeletdnat-controller/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeletdnat
+package kubeletdnatcontroller
 
 import (
 	"context"
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	ControllerName = "kubermatic_kubelet_dnat_controller"
+	ControllerName = "kkp-kubeletdnat-controller"
 )
 
 // Reconciler updates iptable rules to match node addresses.

--- a/pkg/controller/kubeletdnat-controller/controller_test.go
+++ b/pkg/controller/kubeletdnat-controller/controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeletdnat
+package kubeletdnatcontroller
 
 import (
 	"net"

--- a/pkg/controller/kubeletdnat-controller/doc.go
+++ b/pkg/controller/kubeletdnat-controller/doc.go
@@ -15,13 +15,12 @@ limitations under the License.
 */
 
 /*
-Package kubeletdnat contains the kubeletdnat controller which:
+Package kubeletdnatcontroller contains the kubeletdnat controller which:
 
 	* Is needed for all controlplane components running in the seed that need to reach nodes
 	* Is not needed if reaching the pods is sufficient
 	* Must be used in conjunction with the openvpn client
 	* Creates NAT rules for both the public and private node IP that tunnels access to them via the VPN
 	* Its counterpart runs within the openvpn client pod in the usercluster, is part of the openvpn addon and written in bash
-
 */
-package kubeletdnat
+package kubeletdnatcontroller


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
After #9148 (the attempt to rename all controllers in one go) was doomed to fail, this PR is part 1 of doing it step by step.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
