### PR TITLE
Fix copying GOCACHE in release-docker-images script

### DIFF
--- a/hack/release-docker-images.sh
+++ b/hack/release-docker-images.sh
@@ -70,7 +70,7 @@ for ARCH in ${ARCHITECTURES}; do
 
   # amd64 has been downloaded into $GOCACHE already, do not download it again
   if [ "$ARCH" == "amd64" ]; then
-    cp -ar "$(go env GOCACHE)/*" "$cacheDir"
+    cp -ar "$(go env GOCACHE)"/* "$cacheDir"
     continue
   fi
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Fix copying GOCACHE in release-docker-images script. This is a regression from #9158.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf 