### PR TITLE
fix more CRD migration oversights

### DIFF
--- a/hack/ci/testdata/crdmigration/seed/06-cluster-contents.yaml
+++ b/hack/ci/testdata/crdmigration/seed/06-cluster-contents.yaml
@@ -59,6 +59,7 @@ spec:
   keep: 20
   name: default-backups
   schedule: '@every 20m'
+  destination: s3
 status:
   conditions:
     - lastHeartbeatTime: null

--- a/pkg/install/crdmigration/clones.go
+++ b/pkg/install/crdmigration/clones.go
@@ -1448,10 +1448,15 @@ func cloneEtcdBackupConfigResourcesInCluster(ctx context.Context, logger logrus.
 				newObject.Status.Conditions = map[newv1.EtcdBackupConfigConditionType]newv1.EtcdBackupConfigCondition{}
 			}
 
+			heartbeat := condition.LastHeartbeatTime
+			if heartbeat.IsZero() {
+				heartbeat = metav1.Now()
+			}
+
 			conditionType := newv1.EtcdBackupConfigConditionType(condition.Type)
 			newObject.Status.Conditions[conditionType] = newv1.EtcdBackupConfigCondition{
 				Status:             condition.Status,
-				LastHeartbeatTime:  condition.LastHeartbeatTime,
+				LastHeartbeatTime:  heartbeat,
 				LastTransitionTime: condition.LastTransitionTime,
 				Reason:             condition.Reason,
 				Message:            condition.Message,

--- a/pkg/install/crdmigration/preflight.go
+++ b/pkg/install/crdmigration/preflight.go
@@ -402,7 +402,7 @@ func validateEtcdBackupConfiguration(ctx context.Context, logger logrus.FieldLog
 			return fmt.Errorf("Seed %s uses the deprecated `backupRestore` configuration; please migrate to the `etcdBackupRestore` configuration before proceeding, as the deprecated options have been removed in KKP 2.20", name)
 		}
 
-		if seed.Spec.EtcdBackupRestore.DefaultDestination == nil {
+		if seed.Spec.EtcdBackupRestore != nil && seed.Spec.EtcdBackupRestore.DefaultDestination == nil {
 			return fmt.Errorf("Seed %s does not set a default backup destination in `etcdBackupRestore`; please configure a default destination", name)
 		}
 	}

--- a/pkg/install/crdmigration/util.go
+++ b/pkg/install/crdmigration/util.go
@@ -117,6 +117,13 @@ func reverseKinds(kinds []Kind) []Kind {
 }
 
 func isNamespacedKind(name string) bool {
+	// KubermaticConfiguration is special, as is its own API group and the only one
+	// that is moved to a totally different API group during the migration, which is
+	// why it's not part of the big kind list.
+	if name == "KubermaticConfiguration" {
+		return true
+	}
+
 	return getKind(name).Namespaced
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This fixes a few asserted panics and errors during the CRD migration.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
