### PR TITLE
Fix cluster-external-addr-allow apiserver nw policy to allow access to nodeport-proxy

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -497,7 +497,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 				return fmt.Errorf("failed to resolve cluster external name %q: %w", c.Address.ExternalName, err)
 			}
 
-			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, apiserver.ClusterExternalAddrAllowCreator(ipList))
+			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters, apiserver.ClusterExternalAddrAllowCreator(ipList, c.Spec.ExposeStrategy))
 		} else {
 			namedNetworkPolicyCreatorGetters = append(namedNetworkPolicyCreatorGetters,
 				apiserver.OpenVPNServerAllowCreator(c),

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -227,7 +227,7 @@ func MetricsServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 // ClusterExternalAddrAllowCreator returns a func to create/update the apiserver cluster-external-addr-allow egress policy.
 // This policy is necessary in Konnectivity setup, so that konnectivity-server can connect to the apiserver via
 // the external URL (used as service-account-issuer) to validate konnectivity-agent authentication token.
-func ClusterExternalAddrAllowCreator(egressIPs []net.IP) reconciling.NamedNetworkPolicyCreatorGetter {
+func ClusterExternalAddrAllowCreator(egressIPs []net.IP, exposeStrategy kubermaticv1.ExposeStrategy) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return resources.NetworkPolicyClusterExternalAddrAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -241,17 +241,30 @@ func ClusterExternalAddrAllowCreator(egressIPs []net.IP) reconciling.NamedNetwor
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
-						To: append(ipListToPeers(egressIPs), networkingv1.NetworkPolicyPeer{
-							// allow egress traffic to the nodeport-proxy as for some CNI + kube-proxy mode
-							// combinations a local path to it may be used to reach the external apiserver address
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									common.NameLabel: nodeportproxy.EnvoyDeploymentName,
-								},
-							},
-						}),
+						To: ipListToPeers(egressIPs),
 					},
 				},
+			}
+
+			// allow egress traffic to the nodeport-proxy as for some CNI + kube-proxy mode
+			// combinations a local path to it may be used to reach the external apiserver address
+			if exposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
+				// allows traffic to the nodeport-proxy running in the user cluster namespace
+				// (deployed only in case of the LoadBalancer expose strategy)
+				np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: resources.BaseAppLabels(resources.NodePortProxyEnvoyDeploymentName, nil),
+					},
+				})
+			} else {
+				// allows traffic to the seed-level nodeport-proxy used for other expose strategies
+				np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							common.NameLabel: nodeportproxy.EnvoyDeploymentName,
+						},
+					},
+				})
 			}
 
 			return np, nil


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fixes konnectivity authentication issue in some scenarios where apiserver egress access to the nodeport-proxy is needed:
 - for LoadBalancer expose strategy, in which case the apiserver needs egress access to the usercluster-level nodeport-proxy,
 - for other expose strategies, in which case the apiserver needs egress access to the seed-level nodeport-proxy.

Note that the issue did not manifest in all setups - e.g. in case of seed in AWS it worked thanks to allowing apiserver external IPs.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9173 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed Konnectivity authentication issue in some scenarios by fixing cluster-external-addr-allow apiserver network policy.
```
