### PR TITLE
allow not having any user-accessible addons

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -206,9 +206,7 @@ func createExampleKubermaticConfiguration() *kubermaticv1.KubermaticConfiguratio
 				Domain: "example.com",
 			},
 			FeatureGates: map[string]bool{},
-			API: kubermaticv1.KubermaticAPIConfiguration{
-				AccessibleAddons: []string{},
-			},
+			API:          kubermaticv1.KubermaticAPIConfiguration{},
 			SeedController: kubermaticv1.KubermaticSeedControllerConfiguration{
 				BackupStoreContainer:   defaults.DefaultBackupStoreContainer,
 				BackupCleanupContainer: defaults.DefaultBackupCleanupContainer,

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -383,7 +383,8 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 		logger.Debugw("Defaulting field", "field", "userCluster.apiserverReplicas", "value", *configCopy.Spec.UserCluster.APIServerReplicas)
 	}
 
-	if len(configCopy.Spec.API.AccessibleAddons) == 0 {
+	// only default the accessible addons if they are not configured at all (nil)
+	if configCopy.Spec.API.AccessibleAddons == nil {
 		configCopy.Spec.API.AccessibleAddons = DefaultAccessibleAddons
 		logger.Debugw("Defaulting field", "field", "api.accessibleAddons", "value", configCopy.Spec.API.AccessibleAddons)
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This allows admins to configure `accessibleAddons: []` without having the operator overwrite this with the default addons.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9111

**Does this PR introduce a user-facing change?**:
```release-note
It is now possible to disable all user accessible addons in the operator by setting `spec.api.accessibleAddons=[]`.
```
