### PR TITLE
Implement vsphereCSIClusterID feature flag

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -239,6 +239,15 @@ const (
 	// The cluster-name flag is often used for naming cloud resources, such as load balancers.
 	ClusterFeatureCCMClusterName = "ccmClusterName"
 
+	// ClusterFeatureVsphereCSIClusterID sets the cluster-id in the vSphere CSI config to
+	// the name of the user cluster. Originally, we have been setting cluster-id to the
+	// vSphere Compute Cluster name (provided via the Datacenter object), however,
+	// this is supposed to identify the Kubernetes cluster, therefore it must be unique.
+	// This feature flag is enabled by default for new vSphere clusters, while existing
+	// vSphere clusters must be migrated manually (preferably by following advice here:
+	// https://kb.vmware.com/s/article/84446).
+	ClusterFeatureVsphereCSIClusterID = "vsphereCSIClusterID"
+
 	// ClusterFeatureEtcdLauncher enables features related to the experimental etcd-launcher. This includes user-cluster
 	// etcd scaling, automatic volume recovery and new backup/restore contorllers.
 	ClusterFeatureEtcdLauncher = "etcdLauncher"

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -265,6 +265,9 @@ func GenerateCluster(
 		if cloudcontroller.ExternalCloudControllerClusterName(partialCluster) {
 			partialCluster.Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] = true
 		}
+		if partialCluster.Spec.Cloud.VSphere != nil {
+			partialCluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID] = true
+		}
 	}
 
 	return partialCluster, nil

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -321,6 +321,19 @@ func getVsphereCloudConfig(
 	if cluster.Spec.Cloud.VSphere.Datastore != "" {
 		datastore = cluster.Spec.Cloud.VSphere.Datastore
 	}
+
+	// Originally, we have been setting cluster-id to the vSphere Compute Cluster name
+	// (provided via the Datacenter object), however, this is supposed to identify the
+	// Kubernetes cluster, therefore it must be unique. This feature flag is enabled by
+	// default for new vSphere clusters, while existing vSphere clusters must be
+	// migrated manually (preferably by following advice here:
+	// https://kb.vmware.com/s/article/84446).
+	clusterID := dc.Spec.VSphere.Cluster
+	clusterIDFlag, ok := cluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID]
+	if ok && clusterIDFlag {
+		clusterID = cluster.Name
+	}
+
 	return &vsphere.CloudConfig{
 		Global: vsphere.GlobalOpts{
 			User:             credentials.VSphere.Username,
@@ -331,7 +344,7 @@ func getVsphereCloudConfig(
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			DefaultDatastore: datastore,
 			WorkingDir:       cluster.Name,
-			ClusterID:        cluster.Name,
+			ClusterID:        clusterID,
 		},
 		Workspace: vsphere.WorkspaceOpts{
 			// This is redundant with what the Vsphere cloud provider itself does:

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -329,8 +329,7 @@ func getVsphereCloudConfig(
 	// migrated manually (preferably by following advice here:
 	// https://kb.vmware.com/s/article/84446).
 	clusterID := dc.Spec.VSphere.Cluster
-	clusterIDFlag, ok := cluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID]
-	if ok && clusterIDFlag {
+	if cluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID] {
 		clusterID = cluster.Name
 	}
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The vSphere CSI docs state that the `cluster-id` in the CSI config should be a unique identifier. Originally, we used vSphere Compute Cluster as a value for `cluster-id` for all user clusters, but this was changed recently by #9061.

However, the following [vSphere KB article](https://kb.vmware.com/s/article/84446) recommends a special procedure for changing the `cluster-id`. This means that we can't just change the value, instead, users will have to migrate manually. A document describing how to migrate will be added in a follow-up to the docs website.

To make this possible, we're introducing a feature flag on the cluster object (`vsphereCSIClusterID`). Enabling this feature gate will modify the `cluster-id` to the name of the user cluster (instead of the name of the vSphere Compute Cluster provided via Datacenter config).

**Documentation**:

Will be added in a follow-up.

**Does this PR introduce a user-facing change?**:
```release-note
Add `vsphereCSIClusterID` feature flag for the cluster object. This feature flag changes the cluster-id in the vSphere CSI config to the cluster name instead of the vSphere Compute Cluster name provided via Datacenter config. Migrating the cluster-id requires manual steps (docs link to be added).
```
