### PR TITLE
Docker is supported until Kubernetes 1.24.0

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -734,7 +734,7 @@ func ValidateContainerRuntime(spec *kubermaticv1.ClusterSpec) error {
 	}
 
 	// Docker is supported until 1.24.0, excluding 1.24.0
-	gteKube124Condition, _ := semver.NewConstraint(">= 1.24.0")
+	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
 	if spec.ContainerRuntime == "docker" && gteKube124Condition.Check(spec.Version.Semver()) {
 		return fmt.Errorf("docker not supported from version 1.24: %s", spec.ContainerRuntime)
 	}

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -733,9 +733,10 @@ func ValidateContainerRuntime(spec *kubermaticv1.ClusterSpec) error {
 		return fmt.Errorf("container runtime not supported: %s", spec.ContainerRuntime)
 	}
 
-	dockerSupportLimit := semver.MustParse("1.22.1")
-	if spec.ContainerRuntime == "docker" && !spec.Version.Semver().LessThan(dockerSupportLimit) {
-		return fmt.Errorf("docker not supported from version 1.22: %s", spec.ContainerRuntime)
+	// Docker is supported until 1.24.0, excluding 1.24.0
+	gteKube124Condition, _ := semver.NewConstraint(">= 1.24.0")
+	if spec.ContainerRuntime == "docker" && gteKube124Condition.Check(spec.Version.Semver()) {
+		return fmt.Errorf("docker not supported from version 1.24: %s", spec.ContainerRuntime)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
Update validation for container runtime in cluster spec. Docker should be supported in KKP until `1.24.0`. Following the official timeline for dockershim deprecation https://kubernetes.io/blog/2022/01/07/kubernetes-is-moving-on-from-dockershim/

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
