### PR TITLE
add mutating webhook for Addons

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -30,6 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+	addonmutation "k8c.io/kubermatic/v2/pkg/webhook/addon/mutation"
 	clustermutation "k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation"
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
 	oscvalidation "k8c.io/kubermatic/v2/pkg/webhook/operatingsystemmanager/operatingsystemconfig/validation"
@@ -140,6 +141,11 @@ func main() {
 
 	// mutation cannot, because we require separate defaulting for CREATE and UPDATE operations
 	clustermutation.NewAdmissionHandler(mgr.GetClient(), configGetter, seedGetter, caPool).SetupWebhookWithManager(mgr)
+
+	// /////////////////////////////////////////
+	// setup Addon webhook
+
+	addonmutation.NewAdmissionHandler(mgr.GetClient()).SetupWebhookWithManager(mgr)
 
 	// /////////////////////////////////////////
 	// setup UserSSHKey webhooks

--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -145,7 +145,7 @@ func main() {
 	// /////////////////////////////////////////
 	// setup Addon webhook
 
-	addonmutation.NewAdmissionHandler(mgr.GetClient()).SetupWebhookWithManager(mgr)
+	addonmutation.NewAdmissionHandler(seedGetter, seedClientGetter).SetupWebhookWithManager(mgr)
 
 	// /////////////////////////////////////////
 	// setup UserSSHKey webhooks

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -604,6 +604,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 
 	mutatingWebhookCreators := []reconciling.NamedMutatingWebhookConfigurationCreatorGetter{
 		kubermaticseed.ClusterMutatingWebhookConfigurationCreator(cfg, client),
+		kubermaticseed.AddonMutatingWebhookConfigurationCreator(cfg, client),
 	}
 
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, mutatingWebhookCreators, "", client); err != nil {

--- a/pkg/controller/operator/seed/resources/kubermatic/webhook.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/webhook.go
@@ -170,7 +170,7 @@ func AddonMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfig
 					FailurePolicy:           &failurePolicy,
 					ReinvocationPolicy:      &reinvocationPolicy,
 					SideEffects:             &sideEffects,
-					TimeoutSeconds:          pointer.Int32Ptr(30),
+					TimeoutSeconds:          pointer.Int32Ptr(10),
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						CABundle: ca,
 						Service: &admissionregistrationv1.ServiceReference{

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1142,6 +1142,7 @@ func GenTestAddon(name string, variables *runtime.RawExtension, cluster *kuberma
 		Spec: kubermaticv1.AddonSpec{
 			Name:      name,
 			Variables: variables,
+			// in reality, the addon webhook would ensure this objectRef
 			Cluster: corev1.ObjectReference{
 				APIVersion: kubermaticv1.SchemeGroupVersion.String(),
 				Kind:       kubermaticv1.ClusterKindName,

--- a/pkg/provider/kubernetes/addon.go
+++ b/pkg/provider/kubernetes/addon.go
@@ -24,7 +24,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,14 +141,7 @@ func genAddon(cluster *kubermaticv1.Cluster, addonName string, variables *runtim
 			Labels:    labels,
 		},
 		Spec: kubermaticv1.AddonSpec{
-			Name: addonName,
-			Cluster: corev1.ObjectReference{
-				Name:       cluster.Name,
-				Namespace:  "",
-				UID:        cluster.UID,
-				APIVersion: cluster.APIVersion,
-				Kind:       "Cluster",
-			},
+			Name:      addonName,
 			Variables: variables,
 		},
 	}, nil

--- a/pkg/provider/kubernetes/addon.go
+++ b/pkg/provider/kubernetes/addon.go
@@ -239,7 +239,6 @@ func (p *AddonProvider) Update(ctx context.Context, userInfo *provider.UserInfo,
 		return nil, err
 	}
 
-	addon.Namespace = cluster.Status.NamespaceName
 	if err := seedImpersonatedClient.Update(ctx, addon); err != nil {
 		return nil, err
 	}
@@ -270,7 +269,6 @@ func (p *AddonProvider) UpdateUnsecured(ctx context.Context, cluster *kubermatic
 		return nil, err
 	}
 
-	addon.Namespace = cluster.Status.NamespaceName
 	if err := p.clientPrivileged.Update(ctx, addon); err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating Kubermatic Addon2 CRD.
+type AdmissionHandler struct {
+	log     logr.Logger
+	decoder *admission.Decoder
+	client  ctrlruntimeclient.Client
+}
+
+// NewAdmissionHandler returns a new Addon AdmissionHandler.
+func NewAdmissionHandler(client ctrlruntimeclient.Client) *AdmissionHandler {
+	return &AdmissionHandler{
+		client: client,
+	}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-kubermatic-k8c-io-v1-addon", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
+	h.log = l.WithName("addon-mutation-handler")
+	return nil
+}
+
+func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	addon := &kubermaticv1.Addon{}
+	oldAddon := &kubermaticv1.Addon{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		if err := h.decoder.Decode(req, addon); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err := h.applyDefaults(ctx, addon)
+		if err != nil {
+			h.log.Info("addon mutation failed", "error", err)
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("addon mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Update:
+		if err := h.decoder.Decode(req, addon); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := h.decoder.DecodeRaw(req.OldObject, oldAddon); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// apply defaults to the existing addon
+		err := h.applyDefaults(ctx, addon)
+		if err != nil {
+			h.log.Info("addon mutation failed", "error", err)
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("addon mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Delete:
+		return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on addon resources", req.Operation))
+	}
+
+	mutatedKey, err := json.Marshal(addon)
+	if err != nil {
+		return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling addon object failed: %w", err))
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedKey)
+}
+
+func (h *AdmissionHandler) applyDefaults(ctx context.Context, addon *kubermaticv1.Addon) error {
+	clusters := kubermaticv1.ClusterList{}
+	if err := h.client.List(ctx, &clusters); err != nil {
+		return fmt.Errorf("failed to list Cluster objects: %w", err)
+	}
+
+	var cluster *kubermaticv1.Cluster
+	for i, c := range clusters.Items {
+		if c.Status.NamespaceName == addon.Namespace {
+			cluster = &clusters.Items[i]
+			break
+		}
+	}
+
+	if cluster == nil {
+		return errors.New("Addons can only be created in cluster namespaces, but no matching Cluster was found")
+	}
+
+	addon.Spec.Cluster = v1.ObjectReference{
+		Name:       cluster.Name,
+		Namespace:  "",
+		UID:        cluster.UID,
+		APIVersion: cluster.APIVersion,
+		Kind:       "Cluster",
+	}
+
+	return nil
+}

--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// AdmissionHandler for mutating Kubermatic Addon2 CRD.
+// AdmissionHandler for mutating Kubermatic Addon CRD.
 type AdmissionHandler struct {
 	log              logr.Logger
 	decoder          *admission.Decoder

--- a/pkg/webhook/addon/mutation/mutation_test.go
+++ b/pkg/webhook/addon/mutation/mutation_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-test/deep"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = kubermaticv1.AddToScheme(testScheme)
+}
+
+func TestHandle(t *testing.T) {
+	cluster := &kubermaticv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubermatic.k8c.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "xyz",
+			UID:  "12345",
+		},
+		Status: kubermaticv1.ClusterStatus{
+			NamespaceName: "cluster-xyz",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		req         webhook.AdmissionRequest
+		clusters    []ctrlruntimeclient.Object
+		wantError   bool
+		wantPatches []jsonpatch.JsonPatchOperation
+	}{
+		{
+			name:     "Add missing cluster ref to new addon",
+			clusters: []ctrlruntimeclient.Object{cluster},
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Addon",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAddonGen{
+							Name:      "my-addon",
+							Namespace: "cluster-xyz",
+						}.Do(),
+					},
+				},
+			},
+			wantError: false,
+			wantPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("add", "/spec/cluster/apiVersion", "kubermatic.k8c.io/v1"),
+				jsonpatch.NewOperation("add", "/spec/cluster/kind", "Cluster"),
+				jsonpatch.NewOperation("add", "/spec/cluster/name", "xyz"),
+				jsonpatch.NewOperation("add", "/spec/cluster/uid", "12345"),
+			},
+		},
+		{
+			name:     "Fix broken cluster ref in Addon",
+			clusters: []ctrlruntimeclient.Object{cluster},
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Addon",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAddonGen{
+							Name:      "my-addon",
+							Namespace: "cluster-xyz",
+							Cluster: &corev1.ObjectReference{
+								Kind:       "wrong",
+								Name:       "also wrong",
+								UID:        "totally wrong",
+								APIVersion: "not even close",
+							},
+						}.Do(),
+					},
+				},
+			},
+			wantError: false,
+			wantPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("replace", "/spec/cluster/apiVersion", "kubermatic.k8c.io/v1"),
+				jsonpatch.NewOperation("replace", "/spec/cluster/kind", "Cluster"),
+				jsonpatch.NewOperation("replace", "/spec/cluster/name", "xyz"),
+				jsonpatch.NewOperation("replace", "/spec/cluster/uid", "12345"),
+			},
+		},
+		{
+			name:     "Reject addons outside of cluster namespaces",
+			clusters: []ctrlruntimeclient.Object{cluster},
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Addon",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAddonGen{
+							Name:      "my-addon",
+							Namespace: "this-does-not-exist",
+						}.Do(),
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		d, err := admission.NewDecoder(testScheme)
+		if err != nil {
+			t.Fatalf("error occurred while creating decoder: %v", err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			handler := AdmissionHandler{
+				log:     logr.Discard(),
+				decoder: d,
+				client:  fake.NewClientBuilder().WithObjects(tt.clusters...).Build(),
+			}
+			res := handler.Handle(context.Background(), tt.req)
+			if res.AdmissionResponse.Result != nil && res.AdmissionResponse.Result.Code == http.StatusInternalServerError {
+				if tt.wantError {
+					return
+				}
+
+				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+			}
+
+			a := map[string]jsonpatch.JsonPatchOperation{}
+			for _, p := range res.Patches {
+				a[p.Path] = p
+			}
+			w := map[string]jsonpatch.JsonPatchOperation{}
+			for _, p := range tt.wantPatches {
+				w[p.Path] = p
+			}
+			if diff := deep.Equal(a, w); len(diff) > 0 {
+				t.Errorf("Diff found between wanted and actual patches: %+v", diff)
+			}
+		})
+	}
+}
+
+type rawAddonGen struct {
+	Name      string
+	Namespace string
+	Cluster   *corev1.ObjectReference
+}
+
+func (r rawAddonGen) Do() []byte {
+	addon := kubermaticv1.Addon{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubermatic.k8c.io/v1",
+			Kind:       "Addon",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name,
+			Namespace: r.Namespace,
+		},
+		Spec: kubermaticv1.AddonSpec{
+			Name: r.Name,
+		},
+	}
+
+	if r.Cluster != nil {
+		addon.Spec.Cluster = *r.Cluster
+	}
+
+	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, testScheme, testScheme, json.SerializerOptions{Pretty: true})
+	buff := bytes.NewBuffer([]byte{})
+	_ = s.Encode(&addon, buff)
+
+	return buff.Bytes()
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This does for Addons what #9200 does for UserSSHKeys.

**Does this PR introduce a user-facing change?**:
```release-note
The KKP webhook now ensures that Addons are only created in cluster namespaces and assigns a proper Cluster reference.
```
