### PR TITLE
wait longer for node readiness; run serially

### DIFF
--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -125,7 +125,7 @@ func TestCiliumClusters(t *testing.T) {
 	for _, test := range tests {
 		proxyMode := test.proxyMode
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			mu.Lock()
 			config, _, cleanup, err := createUsercluster(t, proxyMode)
 			mu.Unlock()
@@ -430,7 +430,7 @@ func runCiliumConnectivityTests(t *testing.T, userClient *kubernetes.Clientset, 
 
 func checkNodeReadiness(t *testing.T, userClient *kubernetes.Clientset, nodeIP string) string {
 	expectedNodes := 2
-	err := wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
+	err := wait.Poll(30*time.Second, 15*time.Minute, func() (bool, error) {
 		nodes, err := userClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			t.Logf("failed to get nodes list: %s", err)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Cilium e2e test is failing because nodes don't get ready in 5m. This PR increases timeout and runs the tests serially 
to require fewer machines simultaneously. 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
