### PR TITLE
try different method of suppressing deprecation warnings

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -47,9 +47,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
-	ctrlruntimecache "sigs.k8s.io/controller-runtime/pkg/cache"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlruntimecluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -105,6 +102,10 @@ func main() {
 		log.Fatalw("Failed to get kubeconfig", zap.Error(err))
 	}
 
+	// get rid of warnings related to
+	// policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
+	suppressWarnings()
+
 	// Create a manager, disable metrics as we have our own handler that exposes
 	// the metrics of both the ctrltuntime registry and the default registry
 	mgr, err := manager.New(cfg, manager.Options{
@@ -112,13 +113,6 @@ func main() {
 		LeaderElection:          options.enableLeaderElection,
 		LeaderElectionNamespace: options.leaderElectionNamespace,
 		LeaderElectionID:        electionName,
-		NewClient: func(c ctrlruntimecache.Cache, config *rest.Config, options ctrlruntimeclient.Options, uncachedObjects ...ctrlruntimeclient.Object) (ctrlruntimeclient.Client, error) {
-			// get rid of warnings related to
-			// policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
-			options.Opts.SuppressWarnings = true
-
-			return ctrlruntimecluster.DefaultNewClient(c, config, options, uncachedObjects...)
-		},
 	})
 	if err != nil {
 		log.Fatalw("Failed to create the manager", zap.Error(err))
@@ -235,4 +229,19 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 func isInternalConfig(cfg *rest.Config) bool {
 	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
 	return cfg.Host == "https://"+net.JoinHostPort(host, port)
+}
+
+func suppressWarnings() {
+	// Set a WarningHandler, the default WarningHandler
+	// is log.KubeAPIWarningLogger with deduplication enabled.
+	// See log.KubeAPIWarningLoggerOptions for considerations
+	// regarding deduplication.
+	rest.SetDefaultWarningHandler(
+		ctrlruntimelog.NewKubeAPIWarningLogger(
+			ctrlruntimelog.Log.WithName("KubeAPIWarningLogger"),
+			ctrlruntimelog.KubeAPIWarningLoggerOptions{
+				Deduplicate: true,
+			},
+		),
+	)
 }

--- a/pkg/cluster/client/client.go
+++ b/pkg/cluster/client/client.go
@@ -33,7 +33,7 @@ import (
 
 // NewInternal returns a new instance of the client connection provider that
 // only works from within the seed cluster but has the advantage that it doesn't leave
-// the seed clusters network.
+// the seed cluster's network.
 func NewInternal(seedClient ctrlruntimeclient.Client) (*Provider, error) {
 	return &Provider{
 		seedClient:         seedClient,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
#9172 didn't have any effect, so let's try it this way. Sadly this is not really testable on CI, we have to deploy it to dev to see if it works.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
