### PR TITLE
[release/v2.19] Fix OpenVPNServerDown alerting rule to work as expected and not fire if Konnectivity is enabled

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.4.11
+version: 2.4.12
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -73,7 +73,7 @@ groups:
         annotations:
           message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-openvpnserverdown
-        expr: absent(kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"} > 0) and count(kubermatic_cluster_info) > 0
+        expr: (kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"} != kube_deployment_spec_replicas{cluster!="",deployment="openvpn-server"}) and count(kubermatic_cluster_info) > 0
         for: 15m
         labels:
           severity: critical

--- a/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -99,7 +99,7 @@ groups:
     annotations:
       message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-openvpnserverdown
-    expr: absent(kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"} > 0) and count(kubermatic_cluster_info) > 0
+    expr: (kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"} != kube_deployment_spec_replicas{cluster!="",deployment="openvpn-server"}) and count(kubermatic_cluster_info) > 0
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a manual cherry-pick of #9216

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9102 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix OpenVPNServerDown alerting rule to work as expected and not fire if Konnectivity is enabled.
```
