### PR TITLE
make addon.spec.variables a pointer and truly optional

### DIFF
--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -61,7 +61,7 @@ type AddonSpec struct {
 	// Cluster is the reference to the cluster the addon should be installed in
 	Cluster corev1.ObjectReference `json:"cluster"`
 	// Variables is free form data to use for parsing the manifest templates
-	Variables runtime.RawExtension `json:"variables,omitempty"`
+	Variables *runtime.RawExtension `json:"variables,omitempty"`
 	// RequiredResourceTypes allows to indicate that this addon needs some resource type before it
 	// can be installed. This can be used to indicate that a specific CRD and/or extension
 	// apiserver must be installed before this addon can be installed. The addon will not

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -277,7 +277,11 @@ func (in *AddonList) DeepCopyObject() runtime.Object {
 func (in *AddonSpec) DeepCopyInto(out *AddonSpec) {
 	*out = *in
 	out.Cluster = in.Cluster
-	in.Variables.DeepCopyInto(&out.Variables)
+	if in.Variables != nil {
+		in, out := &in.Variables, &out.Variables
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RequiredResourceTypes != nil {
 		in, out := &in.RequiredResourceTypes, &out.RequiredResourceTypes
 		*out = make([]GroupVersionKind, len(*in))

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -308,7 +308,7 @@ func (r *Reconciler) getAddonManifests(ctx context.Context, log *zap.SugaredLogg
 		variables = sub.(map[string]interface{})
 	}
 
-	if len(addon.Spec.Variables.Raw) > 0 {
+	if addon.Spec.Variables != nil && len(addon.Spec.Variables.Raw) > 0 {
 		if err = json.Unmarshal(addon.Spec.Variables.Raw, &variables); err != nil {
 			return nil, err
 		}

--- a/pkg/handler/common/addon.go
+++ b/pkg/handler/common/addon.go
@@ -49,7 +49,7 @@ func PatchAddonEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGet
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	apiAddon.Spec.Variables = *rawVars
+	apiAddon.Spec.Variables = rawVars
 
 	if apiAddon.Labels == nil {
 		apiAddon.Labels = map[string]string{}
@@ -287,7 +287,7 @@ func convertInternalAddonToExternal(internalAddon *kubermaticv1.Addon) (*apiv1.A
 			IsDefault: internalAddon.Spec.IsDefault,
 		},
 	}
-	if len(internalAddon.Spec.Variables.Raw) > 0 {
+	if internalAddon.Spec.Variables != nil && len(internalAddon.Spec.Variables.Raw) > 0 {
 		if err := k8sjson.Unmarshal(internalAddon.Spec.Variables.Raw, &result.Spec.Variables); err != nil {
 			return nil, err
 		}

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1141,7 +1141,7 @@ func GenTestAddon(name string, variables *runtime.RawExtension, cluster *kuberma
 		},
 		Spec: kubermaticv1.AddonSpec{
 			Name:      name,
-			Variables: *variables,
+			Variables: variables,
 			Cluster: corev1.ObjectReference{
 				APIVersion: kubermaticv1.SchemeGroupVersion.String(),
 				Kind:       kubermaticv1.ClusterKindName,

--- a/pkg/provider/kubernetes/addon.go
+++ b/pkg/provider/kubernetes/addon.go
@@ -147,7 +147,7 @@ func genAddon(cluster *kubermaticv1.Cluster, addonName string, variables *runtim
 				APIVersion: cluster.APIVersion,
 				Kind:       "Cluster",
 			},
-			Variables: *variables,
+			Variables: variables,
 		},
 	}, nil
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
While working in #9205 it turns out that having a RawExtension being optional and _not_ a pointer is impossible. When the webhook would unmarshal and later re-marshal the response, a missing `"variables": ...` in the JSON will be replaced with `"variables":null`, which is not allowed:

 > {"level":"error","time":"2022-03-03T13:36:58.180Z","logger":"kubermatic_addoninstaller_controller","caller":"addoninstaller/addoninstaller_controller.go:156","msg":"Reconciling failed","request":"/htx58b2qnp","error":"failed to create addon \"canal\": failed to create addon: [Addon.kubermatic.k8c.io](http://addon.kubermatic.k8c.io/) \"canal\" is invalid: spec.variables: Invalid value: \"null\": spec.variables in body must be of type object: \"null\"","errorCauses":[{"error":"failed to create addon \"canal\": failed to create addon: [Addon.kubermatic.k8c.io](http://addon.kubermatic.k8c.io/) \"canal\" is invalid: spec.variables: Invalid value: \"null\": spec.variables in body must be of type object: \"null\""}]}

This PR changes the type of the field to be truly optional.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
