### PR TITLE
add OpenStack credential validation

### DIFF
--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -194,7 +194,7 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	if err != nil {
 		return fmt.Errorf("failed to get credentials: %w", err)
 	}
-	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster, false); err != nil {
+	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster); err != nil {
 		return err
 	}
 	kuberneteshelper.AddFinalizer(newCluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -117,7 +117,7 @@ func CreateEndpoint(
 		return nil, kubermaticerrors.NewAlreadyExists("cluster", partialCluster.Spec.HumanReadableName)
 	}
 
-	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster, false); err != nil {
+	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {
 		return nil, err
 	}
 	kuberneteshelper.AddFinalizer(partialCluster, apiv1.CredentialsSecretsCleanupFinalizer)
@@ -504,7 +504,12 @@ func PatchEndpoint(
 		return nil, err
 	}
 
-	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, seedClient, newInternalCluster, true); err != nil {
+	validate := &kubernetesprovider.ValidateCredentials{
+		Datacenter: dc,
+		CABundle:   caBundle,
+	}
+
+	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForClusterWithValidation(ctx, seedClient, newInternalCluster, validate); err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -357,7 +357,7 @@ func createClusterTemplate(ctx context.Context, userInfoGetter provider.UserInfo
 		Spec:                   partialCluster.Spec,
 	}
 
-	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster, false); err != nil {
+	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -810,3 +810,15 @@ func ignoreRouterAlreadyHasPortInSubnetError(err error, subnetID string) error {
 
 	return nil
 }
+
+func ValidateCredentials(authURL, region string, credentials *resources.OpenstackCredentials, caBundle *x509.CertPool) error {
+	computeClient, err := getComputeClient(authURL, region, credentials, caBundle)
+	if err != nil {
+		return err
+	}
+	_, err = getAvailabilityZones(computeClient)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/provider/kubernetes/external_cluster.go
+++ b/pkg/provider/kubernetes/external_cluster.go
@@ -425,7 +425,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateCredentialSecretForCluster(ctx c
 		cluster.Spec.Cloud.GCP = &kubermaticv1.GCPCloudSpec{
 			ServiceAccount: cloud.GKE.ServiceAccount,
 		}
-		err := CreateOrUpdateCredentialSecretForCluster(ctx, p.clientPrivileged, cluster, false)
+		err := CreateOrUpdateCredentialSecretForCluster(ctx, p.clientPrivileged, cluster)
 		if err != nil {
 			return nil, err
 		}
@@ -436,7 +436,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateCredentialSecretForCluster(ctx c
 			AccessKeyID:     cloud.EKS.AccessKeyID,
 			SecretAccessKey: cloud.EKS.SecretAccessKey,
 		}
-		err := CreateOrUpdateCredentialSecretForCluster(ctx, p.clientPrivileged, cluster, false)
+		err := CreateOrUpdateCredentialSecretForCluster(ctx, p.clientPrivileged, cluster)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateCredentialSecretForCluster(ctx c
 			ClientID:       cloud.AKS.ClientID,
 			ClientSecret:   cloud.AKS.ClientSecret,
 		}
-		err := CreateOrUpdateCredentialSecretForCluster(ctx, p.clientPrivileged, cluster, false)
+		err := CreateOrUpdateCredentialSecretForCluster(ctx, p.clientPrivileged, cluster)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**: add OpenStack credential validation. Reverte the` CreateOrUpdateCredentialSecretForCluster` method and create the new one with validation because it's used only in one place and need some extra parameters like datacenter and caBundle for the rest of the providers.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8965

```release-note
NONE
```
