### PR TITLE
retry hubble test with freshly fetched nodes

### DIFF
--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -297,6 +297,10 @@ func testUserCluster(t *testing.T, config *rest.Config) {
 
 		return true, nil
 	})
+	if err != nil {
+		t.Fatalf("hubble ui observe test failed: %v", err)
+	}
+
 }
 
 func waitForPods(t *testing.T, client *kubernetes.Clientset, namespace string, key string, names []string) error {

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -300,7 +300,6 @@ func testUserCluster(t *testing.T, config *rest.Config) {
 	if err != nil {
 		t.Fatalf("hubble ui observe test failed: %v", err)
 	}
-
 }
 
 func waitForPods(t *testing.T, client *kubernetes.Clientset, namespace string, key string, names []string) error {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It reduced flakes in Cilium e2e tests by retrying when hubble test fails. Frquently hubble tests fail with node status changes so we fetch fresh nodes for every retry. 


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
