### PR TITLE
use the same k8s client for MLA so we don't accidentally reset the global KubeAPIWarningLogger

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	grafanasdk "github.com/kubermatic/grafanasdk"
 	"go.uber.org/zap"
 
+	grafanasdk "github.com/kubermatic/grafanasdk"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -114,14 +114,15 @@ func (r *dashboardGrafanaReconciler) Reconcile(ctx context.Context, request reco
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create Grafana client: %w", err)
 	}
-	if grafanaClient == nil {
-		return reconcile.Result{}, nil
-	}
 
 	if !configMap.DeletionTimestamp.IsZero() {
 		if err := r.dashboardGrafanaController.handleDeletion(ctx, log, configMap, grafanaClient); err != nil {
 			return reconcile.Result{}, fmt.Errorf("handling deletion: %w", err)
 		}
+		return reconcile.Result{}, nil
+	}
+
+	if grafanaClient == nil {
 		return reconcile.Result{}, nil
 	}
 
@@ -168,9 +169,6 @@ func (r *dashboardGrafanaController) CleanUp(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create Grafana client: %w", err)
 	}
-	if grafanaClient == nil {
-		return nil
-	}
 	for _, configMap := range configMapList.Items {
 		if !strings.HasPrefix(configMap.GetName(), grafanaDashboardsConfigmapNamePrefix) {
 			continue
@@ -183,23 +181,25 @@ func (r *dashboardGrafanaController) CleanUp(ctx context.Context) error {
 }
 
 func (r *dashboardGrafanaController) handleDeletion(ctx context.Context, log *zap.SugaredLogger, configMap *corev1.ConfigMap, grafanaClient *grafanasdk.Client) error {
-	projectList := &kubermaticv1.ProjectList{}
-	if err := r.List(ctx, projectList); err != nil {
-		return fmt.Errorf("failed to list Projects: %w", err)
-	}
-	for _, project := range projectList.Items {
-		orgID, ok := project.GetAnnotations()[GrafanaOrgAnnotationKey]
-		if !ok {
-			// looks like corresponding Grafana Org already remove, so we can skip this project
-			log.Debugf("project %+v doesn't have grafana org annotation, skipping", project)
-			continue
+	if grafanaClient != nil {
+		projectList := &kubermaticv1.ProjectList{}
+		if err := r.List(ctx, projectList); err != nil {
+			return fmt.Errorf("failed to list Projects: %w", err)
 		}
-		id, err := strconv.ParseUint(orgID, 10, 32)
-		if err != nil {
-			return fmt.Errorf("unable to parse grafana org annotation %s: %w", orgID, err)
-		}
-		if err := deleteDashboards(ctx, log, grafanaClient.WithOrgIDHeader(uint(id)), configMap); err != nil {
-			return err
+		for _, project := range projectList.Items {
+			orgID, ok := project.GetAnnotations()[GrafanaOrgAnnotationKey]
+			if !ok {
+				// looks like corresponding Grafana Org already remove, so we can skip this project
+				log.Debugf("project %+v doesn't have grafana org annotation, skipping", project)
+				continue
+			}
+			id, err := strconv.ParseUint(orgID, 10, 32)
+			if err != nil {
+				return fmt.Errorf("unable to parse grafana org annotation %s: %w", orgID, err)
+			}
+			if err := deleteDashboards(ctx, log, grafanaClient.WithOrgIDHeader(uint(id)), configMap); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
@@ -52,7 +52,9 @@ func newTestDashboardGrafanaReconciler(t *testing.T, objects []ctrlruntimeclient
 	grafanaClient, err := grafanasdk.NewClient(ts.URL, "admin:admin", ts.Client())
 	assert.Nil(t, err)
 
-	dashboardGrafanaController := newDashboardGrafanaController(dynamicClient, kubermaticlog.Logger, "mla", grafanaClient)
+	dashboardGrafanaController := newDashboardGrafanaController(dynamicClient, kubermaticlog.Logger, "mla", func(ctx context.Context) (*grafanasdk.Client, error) {
+		return grafanaClient, nil
+	})
 	reconciler := dashboardGrafanaReconciler{
 		Client:                     dynamicClient,
 		log:                        kubermaticlog.Logger,

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -185,9 +185,6 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Grafana client: %w", err)
 	}
-	if grafanaClient == nil {
-		return nil, nil
-	}
 
 	project := &kubermaticv1.Project{}
 	err = r.Get(ctx, types.NamespacedName{Name: projectID}, project)
@@ -201,6 +198,11 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		}
 		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
+
+	if grafanaClient == nil {
+		return nil, nil
+	}
+
 	org, err := getOrgByProject(ctx, grafanaClient, project)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	grafanasdk "github.com/kubermatic/grafanasdk"
 	"github.com/stretchr/testify/assert"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -53,7 +54,12 @@ func newTestDatasourceGrafanaReconciler(t *testing.T, objects []ctrlruntimeclien
 		Build()
 	ts := httptest.NewServer(handler)
 
-	datasourceGrafanaController := newDatasourceGrafanaController(dynamicClient, ts.Client(), ts.URL, "admin:admin", "mla", kubermaticlog.Logger, "")
+	grafanaClient, err := grafanasdk.NewClient(ts.URL, "admin:admin", ts.Client())
+	if err != nil {
+		t.Fatalf("unable to initialize grafana client: %v", err)
+	}
+
+	datasourceGrafanaController := newDatasourceGrafanaController(dynamicClient, grafanaClient, "mla", kubermaticlog.Logger, "")
 	reconciler := datasourceGrafanaReconciler{
 		Client:                      dynamicClient,
 		log:                         kubermaticlog.Logger,

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -27,9 +27,9 @@ import (
 	"testing"
 	"time"
 
-	grafanasdk "github.com/kubermatic/grafanasdk"
 	"github.com/stretchr/testify/assert"
 
+	grafanasdk "github.com/kubermatic/grafanasdk"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -59,7 +59,9 @@ func newTestDatasourceGrafanaReconciler(t *testing.T, objects []ctrlruntimeclien
 		t.Fatalf("unable to initialize grafana client: %v", err)
 	}
 
-	datasourceGrafanaController := newDatasourceGrafanaController(dynamicClient, grafanaClient, "mla", kubermaticlog.Logger, "")
+	datasourceGrafanaController := newDatasourceGrafanaController(dynamicClient, func(ctx context.Context) (*grafanasdk.Client, error) {
+		return grafanaClient, nil
+	}, "mla", kubermaticlog.Logger, "")
 	reconciler := datasourceGrafanaReconciler{
 		Client:                      dynamicClient,
 		log:                         kubermaticlog.Logger,

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -65,15 +65,13 @@ func newGrafanaClientProvider(client ctrlruntimeclient.Client, httpClient *http.
 		return nil, fmt.Errorf("splitting value of %q didn't yield two but %d results", secretName, n)
 	}
 
-	if !enabled {
-		return func(ctx context.Context) (*grafanasdk.Client, error) {
-			return nil, nil
-		}, nil
-	}
-
 	return func(ctx context.Context) (*grafanasdk.Client, error) {
 		secret := corev1.Secret{}
 		if err := client.Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
+			if !enabled {
+				return nil, nil
+			}
+
 			return nil, fmt.Errorf("failed to get Grafana Secret: %w", err)
 		}
 

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -117,7 +117,7 @@ func Add(
 	orgUserGrafanaController := newOrgUserGrafanaController(mgr.GetClient(), log, grafanaClient)
 	orgGrafanaController := newOrgGrafanaController(mgr.GetClient(), log, mlaNamespace, grafanaClient)
 	alertmanagerController := newAlertmanagerController(mgr.GetClient(), log, httpClient, cortexAlertmanagerURL)
-	datasourceGrafanaController := newDatasourceGrafanaController(mgr.GetClient(), httpClient, grafanaURL, grafanaAuth, mlaNamespace, log, overwriteRegistry)
+	datasourceGrafanaController := newDatasourceGrafanaController(mgr.GetClient(), grafanaClient, mlaNamespace, log, overwriteRegistry)
 	userGrafanaController := newUserGrafanaController(mgr.GetClient(), log, grafanaClient, httpClient, grafanaURL, grafanaHeader)
 	ruleGroupController := newRuleGroupController(mgr.GetClient(), log, httpClient, cortexRulerURL, lokiRulerURL, mlaNamespace)
 	dashboardGrafanaController := newDashboardGrafanaController(mgr.GetClient(), log, mlaNamespace, grafanaClient)

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -32,7 +32,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -93,11 +92,8 @@ func Add(
 			grafanaSecret, n)
 	}
 	secret := corev1.Secret{}
-	client, err := ctrlruntimeclient.New(mgr.GetConfig(), ctrlruntimeclient.Options{})
-	if err != nil {
-		return err
-	}
-	if err := client.Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
+
+	if err := mgr.GetClient().Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
 		if !mlaEnabled {
 			return nil // do not return an error if MLA is disabled (e.g. if MLA is not installed in Seed)
 		}

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -32,6 +32,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -55,6 +56,42 @@ var (
 		rbac.ViewerGroupNamePrefix: grafanasdk.ROLE_VIEWER,
 	}
 )
+
+type grafanaClientProvider func(ctx context.Context) (*grafanasdk.Client, error)
+
+func newGrafanaClientProvider(client ctrlruntimeclient.Client, httpClient *http.Client, secretName string, grafanaURL string, enabled bool) (grafanaClientProvider, error) {
+	split := strings.Split(secretName, "/")
+	if n := len(split); n != 2 {
+		return nil, fmt.Errorf("splitting value of %q didn't yield two but %d results", secretName, n)
+	}
+
+	if !enabled {
+		return func(ctx context.Context) (*grafanasdk.Client, error) {
+			return nil, nil
+		}, nil
+	}
+
+	return func(ctx context.Context) (*grafanasdk.Client, error) {
+		secret := corev1.Secret{}
+		if err := client.Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
+			return nil, fmt.Errorf("failed to get Grafana Secret: %w", err)
+		}
+
+		adminName, ok := secret.Data[GrafanaUserKey]
+		if !ok {
+			return nil, fmt.Errorf("Grafana Secret %q does not contain %s key", secretName, GrafanaUserKey)
+		}
+
+		adminPass, ok := secret.Data[GrafanaPasswordKey]
+		if !ok {
+			return nil, fmt.Errorf("Grafana Secret %q does not contain %s key", secretName, GrafanaPasswordKey)
+		}
+
+		grafanaAuth := fmt.Sprintf("%s:%s", adminName, adminPass)
+
+		return grafanasdk.NewClient(grafanaURL, grafanaAuth, httpClient)
+	}, nil
+}
 
 // Add creates a new MLA controller that is responsible for
 // managing Monitoring, Logging and Alerting for user clusters.
@@ -86,41 +123,19 @@ func Add(
 ) error {
 	log = log.Named(ControllerName)
 
-	split := strings.Split(grafanaSecret, "/")
-	if n := len(split); n != 2 {
-		return fmt.Errorf("splitting value of %q didn't yield two but %d results",
-			grafanaSecret, n)
-	}
-	secret := corev1.Secret{}
-
-	if err := mgr.GetClient().Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
-		if !mlaEnabled {
-			return nil // do not return an error if MLA is disabled (e.g. if MLA is not installed in Seed)
-		}
-		return fmt.Errorf("failed to get Grafana Secret: %w", err)
-	}
-	adminName, ok := secret.Data[GrafanaUserKey]
-	if !ok {
-		return fmt.Errorf("Grafana Secret %q does not contain %s key", grafanaSecret, GrafanaUserKey)
-	}
-	adminPass, ok := secret.Data[GrafanaPasswordKey]
-	if !ok {
-		return fmt.Errorf("Grafana Secret %q does not contain %s key", grafanaSecret, GrafanaPasswordKey)
-	}
-	grafanaAuth := fmt.Sprintf("%s:%s", adminName, adminPass)
 	httpClient := &http.Client{Timeout: 15 * time.Second}
-	grafanaClient, err := grafanasdk.NewClient(grafanaURL, grafanaAuth, httpClient)
+	clientProvider, err := newGrafanaClientProvider(mgr.GetClient(), httpClient, grafanaSecret, grafanaURL, mlaEnabled)
 	if err != nil {
-		return fmt.Errorf("unable to initialize grafana client")
+		return fmt.Errorf("failed to prepare Grafana client: %w", err)
 	}
 
-	orgUserGrafanaController := newOrgUserGrafanaController(mgr.GetClient(), log, grafanaClient)
-	orgGrafanaController := newOrgGrafanaController(mgr.GetClient(), log, mlaNamespace, grafanaClient)
+	orgUserGrafanaController := newOrgUserGrafanaController(mgr.GetClient(), log, clientProvider)
+	orgGrafanaController := newOrgGrafanaController(mgr.GetClient(), log, mlaNamespace, clientProvider)
 	alertmanagerController := newAlertmanagerController(mgr.GetClient(), log, httpClient, cortexAlertmanagerURL)
-	datasourceGrafanaController := newDatasourceGrafanaController(mgr.GetClient(), grafanaClient, mlaNamespace, log, overwriteRegistry)
-	userGrafanaController := newUserGrafanaController(mgr.GetClient(), log, grafanaClient, httpClient, grafanaURL, grafanaHeader)
+	datasourceGrafanaController := newDatasourceGrafanaController(mgr.GetClient(), clientProvider, mlaNamespace, log, overwriteRegistry)
+	userGrafanaController := newUserGrafanaController(mgr.GetClient(), log, clientProvider, httpClient, grafanaURL, grafanaHeader)
 	ruleGroupController := newRuleGroupController(mgr.GetClient(), log, httpClient, cortexRulerURL, lokiRulerURL, mlaNamespace)
-	dashboardGrafanaController := newDashboardGrafanaController(mgr.GetClient(), log, mlaNamespace, grafanaClient)
+	dashboardGrafanaController := newDashboardGrafanaController(mgr.GetClient(), log, mlaNamespace, clientProvider)
 	ratelimitCortexController := newRatelimitCortexController(mgr.GetClient(), log, mlaNamespace)
 	ruleGroupSyncController := newRuleGroupSyncController(mgr.GetClient(), log, mlaNamespace)
 	if mlaEnabled {

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -64,7 +64,9 @@ func newTestOrgGrafanaReconciler(t *testing.T, objects []ctrlruntimeclient.Objec
 	grafanaClient, err := grafanasdk.NewClient(ts.URL, "admin:admin", ts.Client())
 	assert.Nil(t, err)
 
-	orgGrafanaController := newOrgGrafanaController(dynamicClient, kubermaticlog.Logger, "mla", grafanaClient)
+	orgGrafanaController := newOrgGrafanaController(dynamicClient, kubermaticlog.Logger, "mla", func(ctx context.Context) (*grafanasdk.Client, error) {
+		return grafanaClient, nil
+	})
 	reconciler := orgGrafanaReconciler{
 		Client:               dynamicClient,
 		log:                  kubermaticlog.Logger,

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller.go
@@ -102,8 +102,16 @@ func (r *orgUserGrafanaReconciler) Reconcile(ctx context.Context, request reconc
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
+	grafanaClient, err := r.orgUserGrafanaController.clientProvider(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to create Grafana client: %w", err)
+	}
+	if grafanaClient == nil {
+		return reconcile.Result{}, nil
+	}
+
 	if !userProjectBinding.DeletionTimestamp.IsZero() {
-		if err := r.orgUserGrafanaController.handleDeletion(ctx, userProjectBinding); err != nil {
+		if err := r.orgUserGrafanaController.handleDeletion(ctx, userProjectBinding, grafanaClient); err != nil {
 			return reconcile.Result{}, fmt.Errorf("handling deletion: %w", err)
 		}
 		return reconcile.Result{}, nil
@@ -117,7 +125,8 @@ func (r *orgUserGrafanaReconciler) Reconcile(ctx context.Context, request reconc
 	if err := r.Get(ctx, types.NamespacedName{Name: userProjectBinding.Spec.ProjectID}, project); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get project: %w", err)
 	}
-	if err := ensureOrgUser(ctx, r.orgUserGrafanaController.grafanaClient, project, userProjectBinding); err != nil {
+
+	if err := ensureOrgUser(ctx, grafanaClient, project, userProjectBinding); err != nil {
 		return reconcile.Result{}, fmt.Errorf("unable to ensure Grafana Org/User: %w", err)
 	}
 
@@ -126,16 +135,16 @@ func (r *orgUserGrafanaReconciler) Reconcile(ctx context.Context, request reconc
 
 type orgUserGrafanaController struct {
 	ctrlruntimeclient.Client
-	grafanaClient *grafanasdk.Client
-	log           *zap.SugaredLogger
+	clientProvider grafanaClientProvider
+	log            *zap.SugaredLogger
 }
 
-func newOrgUserGrafanaController(client ctrlruntimeclient.Client, log *zap.SugaredLogger, grafanaClient *grafanasdk.Client,
+func newOrgUserGrafanaController(client ctrlruntimeclient.Client, log *zap.SugaredLogger, clientProvider grafanaClientProvider,
 ) *orgUserGrafanaController {
 	return &orgUserGrafanaController{
-		Client:        client,
-		grafanaClient: grafanaClient,
-		log:           log,
+		Client:         client,
+		clientProvider: clientProvider,
+		log:            log,
 	}
 }
 
@@ -144,27 +153,34 @@ func (r *orgUserGrafanaController) CleanUp(ctx context.Context) error {
 	if err := r.List(ctx, userProjectBindingList); err != nil {
 		return err
 	}
+	grafanaClient, err := r.clientProvider(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create Grafana client: %w", err)
+	}
+	if grafanaClient == nil {
+		return nil
+	}
 	for _, userProjectBinding := range userProjectBindingList.Items {
-		if err := r.handleDeletion(ctx, &userProjectBinding); err != nil {
+		if err := r.handleDeletion(ctx, &userProjectBinding, grafanaClient); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *orgUserGrafanaController) handleDeletion(ctx context.Context, userProjectBinding *kubermaticv1.UserProjectBinding) error {
+func (r *orgUserGrafanaController) handleDeletion(ctx context.Context, userProjectBinding *kubermaticv1.UserProjectBinding, grafanaClient *grafanasdk.Client) error {
 	project := &kubermaticv1.Project{}
 	if err := r.Get(ctx, types.NamespacedName{Name: userProjectBinding.Spec.ProjectID}, project); err != nil && !kerrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get project: %w", err)
 	}
-	org, err := getOrgByProject(ctx, r.grafanaClient, project)
+	org, err := getOrgByProject(ctx, grafanaClient, project)
 	if err == nil {
-		user, err := r.grafanaClient.LookupUser(ctx, userProjectBinding.Spec.UserEmail)
+		user, err := grafanaClient.LookupUser(ctx, userProjectBinding.Spec.UserEmail)
 		if err != nil && !errors.As(err, &grafanasdk.ErrNotFound{}) {
 			return err
 		}
 		if err == nil {
-			status, err := r.grafanaClient.DeleteOrgUser(ctx, org.ID, user.ID)
+			status, err := grafanaClient.DeleteOrgUser(ctx, org.ID, user.ID)
 			if err != nil {
 				return fmt.Errorf("failed to delete org user: %w (status: %s, message: %s)", err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
 			}

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
@@ -50,7 +50,9 @@ func newTestOrgUserGrafanaReconciler(t *testing.T, objects []ctrlruntimeclient.O
 	grafanaClient, err := grafanasdk.NewClient(ts.URL, "admin:admin", ts.Client())
 	assert.Nil(t, err)
 
-	orgUserGrafanaController := newOrgUserGrafanaController(dynamicClient, kubermaticlog.Logger, grafanaClient)
+	orgUserGrafanaController := newOrgUserGrafanaController(dynamicClient, kubermaticlog.Logger, func(ctx context.Context) (*grafanasdk.Client, error) {
+		return grafanaClient, nil
+	})
 	reconciler := orgUserGrafanaReconciler{
 		Client:                   dynamicClient,
 		log:                      kubermaticlog.Logger,

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -50,7 +50,9 @@ func newTestUserGrafanaReconciler(t *testing.T, objects []ctrlruntimeclient.Obje
 	grafanaClient, err := grafanasdk.NewClient(ts.URL, "admin:admin", ts.Client())
 	assert.Nil(t, err)
 
-	userGrafanaController := newUserGrafanaController(dynamicClient, kubermaticlog.Logger, grafanaClient, ts.Client(), ts.URL, "X-WEBAUTH-USER")
+	userGrafanaController := newUserGrafanaController(dynamicClient, kubermaticlog.Logger, func(ctx context.Context) (*grafanasdk.Client, error) {
+		return grafanaClient, nil
+	}, ts.Client(), ts.URL, "X-WEBAUTH-USER")
 	reconciler := userGrafanaReconciler{
 		Client:                dynamicClient,
 		log:                   kubermaticlog.Logger,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The custom client in the MLA controller was the reason why the customized KubeAPIWarningLogger was replaced and the efforts from #9172 and #9215 were undone. This PR gets rid of the new client, because I do not why we would use the config from the manager to create a new client instead of just using the existing client.

On the road to implementing this, the MLA controller was refactored in a way where it doesn't create the Grafana client statically on boot, but rather dynamically during each reconciliation. This means the seed-ctrl-mgr will automatically react to changed Grafana credentials (though this should never happen).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
