### PR TITLE
Update secret name for S3 credentials

### DIFF
--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "s3-credentials"
+  name: "kubermatic-s3-credentials"
   namespace: "kube-system"
 type: Opaque
 data:

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "s3-credentials"
+  name: "kubermatic-s3-credentials"
   namespace: "kube-system"
 type: Opaque
 data:

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -30,13 +30,13 @@ minio:
     secretKey: '' # 64 byte long
 
     # When set to true, a Secret will be created in the given namespace.
-    # Kubermatic requires an "s3-credentials" Secret in the kube-system
+    # Kubermatic requires an "kubermatic-s3-credentials" Secret in the kube-system
     # namespace to perform usercluster etcd snapshots, _if_ the default
     # backup containers are used (see KubermaticConfiguration).
     # Otherwise, this can be disabled for example by setting
     # `--set "minio.credentials.secret=null"` when running Helm.
     secret:
-      name: s3-credentials
+      name: kubermatic-s3-credentials
       namespace: kube-system
 
   flags:

--- a/charts/s3-exporter/templates/deployment.yaml
+++ b/charts/s3-exporter/templates/deployment.yaml
@@ -50,12 +50,12 @@ spec:
           - name: ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: s3-credentials
+                name: kubermatic-s3-credentials
                 key: ACCESS_KEY_ID
           - name: SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: s3-credentials
+                name: kubermatic-s3-credentials
                 key: SECRET_ACCESS_KEY
           resources:
 {{ toYaml .Values.s3Exporter.resources | indent 12 }}

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -174,12 +174,12 @@ spec:
       - name: ACCESS_KEY_ID
         valueFrom:
           secretKeyRef:
-            name: s3-credentials
+            name: kubermatic-s3-credentials
             key: ACCESS_KEY_ID
       - name: SECRET_ACCESS_KEY
         valueFrom:
           secretKeyRef:
-            name: s3-credentials
+            name: kubermatic-s3-credentials
             key: SECRET_ACCESS_KEY
     # BackupDeleteContainer is the container used for deleting etcd snapshots from a backup location.
     # This container is only relevant when the new backup/restore controllers are enabled.
@@ -241,12 +241,12 @@ spec:
       - name: ACCESS_KEY_ID
         valueFrom:
           secretKeyRef:
-            name: s3-credentials
+            name: kubermatic-s3-credentials
             key: ACCESS_KEY_ID
       - name: SECRET_ACCESS_KEY
         valueFrom:
           secretKeyRef:
-            name: s3-credentials
+            name: kubermatic-s3-credentials
             key: SECRET_ACCESS_KEY
       volumeMounts:
       - name: etcd-backup

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -738,12 +738,12 @@ env:
 - name: ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: s3-credentials
+      name: kubermatic-s3-credentials
       key: ACCESS_KEY_ID
 - name: SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: s3-credentials
+      name: kubermatic-s3-credentials
       key: SECRET_ACCESS_KEY
 volumeMounts:
 - name: etcd-backup
@@ -829,12 +829,12 @@ env:
 - name: ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: s3-credentials
+      name: kubermatic-s3-credentials
       key: ACCESS_KEY_ID
 - name: SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: s3-credentials
+      name: kubermatic-s3-credentials
       key: SECRET_ACCESS_KEY
 `
 

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -177,7 +177,7 @@ func deployMinio(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunti
 	logger.Info("📦 Deploying Minio…")
 	sublogger := log.Prefix(logger, "   ")
 
-	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "minio"))
+	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, MinioChartName))
 	if err != nil {
 		return fmt.Errorf("failed to load Helm chart: %w", err)
 	}
@@ -204,7 +204,7 @@ func deployS3Exporter(ctx context.Context, logger *logrus.Entry, kubeClient ctrl
 	logger.Info("📦 Deploying S3 Exporter…")
 	sublogger := log.Prefix(logger, "   ")
 
-	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "s3-exporter"))
+	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, S3ExporterChartName))
 	if err != nil {
 		return fmt.Errorf("failed to load Helm chart: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
Currently, there is a conflict between the `s3-credentials` secret created by KKP and KubeOne. Both use the same secret name and deploy it in the same namespace i.e. kube-system. But the keys within the secret are different for both of them.

In a bid to solve this issue completely, we are renaming the secret in KKP first. So that the new secret `kkp-s3-credentials` only has a single consumer. The next step is to rename this in KubeOne and add a deterministic prefix `kubeone-` to the secret name.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

I have intentionally not included prefixes in the name like `kubermatic-` or called it `s3-exporter-credentials` etc. because this is created using **minio** chart and then consumed by minio and s3-exporter both.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] Secret name for S3 credentials updated to `kubermatic-s3-credentials`. If the secret `s3-credentials` was manually created instead of using the `minio` helm chart, new secret `kubermatic-s3-credentials` must be created.
```
