### PR TITLE
rename zone_suffixes to zoneSuffixes in error message

### DIFF
--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -242,7 +242,7 @@ func CloudConfig(
 		tag := fmt.Sprintf("kubernetes-cluster-%s", cluster.Name)
 
 		if len(dc.Spec.GCP.ZoneSuffixes) == 0 {
-			return "", errors.New("empty zone_suffixes")
+			return "", errors.New("empty zoneSuffixes")
 		}
 
 		localZone := dc.Spec.GCP.Region + "-" + dc.Spec.GCP.ZoneSuffixes[0]


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Rename for better error message. This one was missed during refactor.


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
