### PR TITLE
temporarily disable storage tests for AWS

### DIFF
--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1342,9 +1342,10 @@ func (r *testRunner) executeGinkgoRun(ctx context.Context, parentLog *zap.Sugare
 }
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {
+	// list does not contain AWS because since 2022-Mar-02, we were
+	// expecting problems while detaching volumes from instances
 	return cluster.Spec.Cloud.Openstack != nil ||
 		cluster.Spec.Cloud.Azure != nil ||
-		cluster.Spec.Cloud.AWS != nil ||
 		cluster.Spec.Cloud.VSphere != nil ||
 		cluster.Spec.Cloud.GCP != nil ||
 		cluster.Spec.Cloud.Hetzner != nil ||


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
For unknown reasons, storage tests currently do not work on AWS, as once the PVC is gone, AWS is unable to detach the volume, leading to a stale PV, which in turn blocks further cleanup of the KKP cluster object.

> Normal  VolumeDelete  10s (x6 over 72s)  persistentvolume-controller  error deleting EBS volume "vol-069200b78803e177d" since volume is currently attached to "i-0fece311fec5b805f"

This PR is only here to unblock our CI pipeline. We do not intend to stop supporting/testing storage support on AWS.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
