### PR TITLE
use reconciling framework in role-cloner controller

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -39,7 +39,7 @@ import (
 	rbacusercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/rbac"
 	usercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources"
 	machinecontrolerresources "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
-	rolecloner "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/role-cloner"
+	roleclonercontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/role-cloner-controller"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -349,10 +349,10 @@ func main() {
 	}
 	log.Info("Registered clusterrolelabeler controller")
 
-	if err := rolecloner.Add(rootCtx, log, mgr, isPausedChecker); err != nil {
-		log.Fatalw("Failed to register rolecloner controller", zap.Error(err))
+	if err := roleclonercontroller.Add(rootCtx, log, mgr, isPausedChecker); err != nil {
+		log.Fatalw("Failed to register role-cloner controller", zap.Error(err))
 	}
-	log.Info("Registered rolecloner controller")
+	log.Info("Registered role-cloner controller")
 
 	if err := ownerbindingcreator.Add(rootCtx, log, mgr, runOp.ownerEmail, isPausedChecker); err != nil {
 		log.Fatalw("Failed to register ownerbindingcreator controller", zap.Error(err))

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rolecloner
+package roleclonercontroller
 
 import (
 	"context"

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/doc.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /*
-Package rolecloner contains a controller that duplicates all roles with the `component=userClusterRole`
+Package roleclonercontroller contains a controller that duplicates all roles with the `component=userClusterRole`
 label that are in the kube-system namespace into all other namespaces.
 */
-package rolecloner
+package roleclonercontroller


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR does a simple refactoring to get rid of home grown object creation code. Instead let's simply use our reconciling framework.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
