### PR TITLE
remove redundant SSH key detaching during cluster deletion

### DIFF
--- a/pkg/apis/kubermatic/v1/sshkeys.go
+++ b/pkg/apis/kubermatic/v1/sshkeys.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -52,29 +53,15 @@ type SSHKeySpec struct {
 }
 
 func (sk *UserSSHKey) IsUsedByCluster(clustername string) bool {
-	if sk.Spec.Clusters == nil {
-		return false
-	}
-	for _, name := range sk.Spec.Clusters {
-		if name == clustername {
-			return true
-		}
-	}
-	return false
+	return sets.NewString(sk.Spec.Clusters...).Has(clustername)
 }
 
 func (sk *UserSSHKey) RemoveFromCluster(clustername string) {
-	for i, cl := range sk.Spec.Clusters {
-		if cl != clustername {
-			continue
-		}
-		// Don't break we don't check for duplicates when adding clusters!
-		sk.Spec.Clusters = append(sk.Spec.Clusters[:i], sk.Spec.Clusters[i+1:]...)
-	}
+	sk.Spec.Clusters = sets.NewString(sk.Spec.Clusters...).Delete(clustername).List()
 }
 
 func (sk *UserSSHKey) AddToCluster(clustername string) {
-	sk.Spec.Clusters = append(sk.Spec.Clusters, clustername)
+	sk.Spec.Clusters = sets.NewString(sk.Spec.Clusters...).Insert(clustername).List()
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -352,18 +352,6 @@ func DeleteEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	clusterSSHKeys, err := sshKeyProvider.List(project, &provider.SSHKeyListOptions{ClusterName: clusterID})
-	if err != nil {
-		return nil, common.KubernetesErrorToHTTPError(err)
-	}
-
-	for _, clusterSSHKey := range clusterSSHKeys {
-		clusterSSHKey.RemoveFromCluster(clusterID)
-		if err := UpdateClusterSSHKey(ctx, userInfoGetter, sshKeyProvider, privilegedSSHKeyProvider, clusterSSHKey, projectID); err != nil {
-			return nil, err
-		}
-	}
-
 	existingCluster, err := GetInternalCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, project, projectID, clusterID, &provider.ClusterGetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The usersshkeysynchronizer controller is already detaching SSH keys whenever a Cluster is marked for deletion. While we might argue that this is too early (makes debugging stuck clusters much harder), it at the very least makes the code in the API's DELETE endpoint redundant.

This PR removes the redundant code and also the home grown string set managing code.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
