### PR TITLE
WIP - Revert "temporarily disable storage tests for AWS (#9233)"

### DIFF
--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1342,10 +1342,9 @@ func (r *testRunner) executeGinkgoRun(ctx context.Context, parentLog *zap.Sugare
 }
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {
-	// list does not contain AWS because since 2022-Mar-02, we were
-	// expecting problems while detaching volumes from instances
 	return cluster.Spec.Cloud.Openstack != nil ||
 		cluster.Spec.Cloud.Azure != nil ||
+		cluster.Spec.Cloud.AWS != nil ||
 		cluster.Spec.Cloud.VSphere != nil ||
 		cluster.Spec.Cloud.GCP != nil ||
 		cluster.Spec.Cloud.Hetzner != nil ||


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR is a canary to test if the AWS storage tests suddenly begin to work again.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @xmudrii 