### PR TITLE
enable optional kubevirt e2e on ubuntu

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -660,6 +660,49 @@ presubmits:
           limits:
             memory: 4Gi
 
+  - name: pre-kubermatic-e2e-kubevirt-ubuntu-1.22
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubevirt: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: VERSIONS_TO_TEST
+              value: "v1.22.5"
+            - name: PROVIDER
+              value: "kubevirt"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 4Gi
+
   - name: pre-kubermatic-e2e-hetzner-ubuntu-1.22
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
regarding ref #9219, we also need to test Kubevirt on ubuntu

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
