### PR TITLE
Add context handling to some Kubernetes providers

### DIFF
--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
@@ -244,7 +244,7 @@ func (r *Reconciler) getSSHKeys(ctx context.Context, cluster *kubermaticv1.Clust
 	}
 
 	sshKeyProvider := kubernetes.NewSSHKeyProvider(nil, r)
-	keys, err := sshKeyProvider.List(project, &provider.SSHKeyListOptions{ClusterName: cluster.Name})
+	keys, err := sshKeyProvider.List(ctx, project, &provider.SSHKeyListOptions{ClusterName: cluster.Name})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get SSH keys: %w", err)
 	}

--- a/pkg/handler/auth/sa.go
+++ b/pkg/handler/auth/sa.go
@@ -55,7 +55,7 @@ func (s *ServiceAccountAuthClient) Verify(ctx context.Context, token string) (To
 	}
 
 	tokenExpiredMsg := fmt.Sprintf("sa: the token %s has been revoked for %s", customClaims.TokenID, customClaims.Email)
-	tokenList, err := s.saTokenProvider.ListUnsecured(&provider.ServiceAccountTokenListOptions{TokenID: customClaims.TokenID})
+	tokenList, err := s.saTokenProvider.ListUnsecured(ctx, &provider.ServiceAccountTokenListOptions{TokenID: customClaims.TokenID})
 	if kerrors.IsNotFound(err) {
 		return TokenClaims{}, &TokenExpiredError{msg: tokenExpiredMsg}
 	}

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -720,7 +720,7 @@ func AssignSSHKeyEndpoint(ctx context.Context, userInfoGetter provider.UserInfoG
 	// sanity check, make sure that the key belongs to the project
 	// alternatively we could examine the owner references
 	{
-		projectSSHKeys, err := sshKeyProvider.List(project, nil)
+		projectSSHKeys, err := sshKeyProvider.List(ctx, project, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -777,7 +777,7 @@ func DetachSSHKeyEndpoint(ctx context.Context, userInfoGetter provider.UserInfoG
 	// sanity check, make sure that the key belongs to the project
 	// alternatively we could examine the owner references
 	{
-		projectSSHKeys, err := sshKeyProvider.List(project, nil)
+		projectSSHKeys, err := sshKeyProvider.List(ctx, project, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -818,7 +818,7 @@ func ListSSHKeysEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGe
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	keys, err := sshKeyProvider.List(project, &provider.SSHKeyListOptions{ClusterName: clusterID})
+	keys, err := sshKeyProvider.List(ctx, project, &provider.SSHKeyListOptions{ClusterName: clusterID})
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -832,7 +832,7 @@ func UpdateClusterSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGe
 		return kubermaticerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if adminUserInfo.IsAdmin {
-		if _, err := privilegedSSHKeyProvider.UpdateUnsecured(clusterSSHKey); err != nil {
+		if _, err := privilegedSSHKeyProvider.UpdateUnsecured(ctx, clusterSSHKey); err != nil {
 			return common.KubernetesErrorToHTTPError(err)
 		}
 		return nil
@@ -841,7 +841,7 @@ func UpdateClusterSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGe
 	if err != nil {
 		return kubermaticerrors.New(http.StatusInternalServerError, err.Error())
 	}
-	if _, err = sshKeyProvider.Update(userInfo, clusterSSHKey); err != nil {
+	if _, err = sshKeyProvider.Update(ctx, userInfo, clusterSSHKey); err != nil {
 		return common.KubernetesErrorToHTTPError(err)
 	}
 	return nil
@@ -1096,13 +1096,13 @@ func getSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGetter, sshK
 		return nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedSSHKeyProvider.GetUnsecured(keyName)
+		return privilegedSSHKeyProvider.GetUnsecured(ctx, keyName)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
 	}
-	return sshKeyProvider.Get(userInfo, keyName)
+	return sshKeyProvider.Get(ctx, userInfo, keyName)
 }
 
 func convertInternalCCMStatusToExternal(cluster *kubermaticv1.Cluster, datacenter *kubermaticv1.Datacenter, incompatibilities ...*version.ProviderIncompatibility) apiv1.ExternalCCMMigrationStatus {

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -182,7 +182,7 @@ func GenerateCluster(
 
 	credentialName := body.Cluster.Credential
 	if len(credentialName) > 0 {
-		cloudSpec, err := credentialManager.SetCloudCredentials(adminUserInfo, credentialName, body.Cluster.Spec.Cloud, dc)
+		cloudSpec, err := credentialManager.SetCloudCredentials(ctx, adminUserInfo, credentialName, body.Cluster.Spec.Cloud, dc)
 		if err != nil {
 			return nil, kubermaticerrors.NewBadRequest("invalid credentials: %v", err)
 		}

--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -466,7 +466,7 @@ func getClusterForOIDCEndpoint(ctx context.Context, projectProvider provider.Pro
 	}
 	userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
 
-	project, err := getProjectForOIDCEndpoint(userInfo, projectProvider, privilegedProjectProvider, projectID)
+	project, err := getProjectForOIDCEndpoint(ctx, userInfo, projectProvider, privilegedProjectProvider, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -478,13 +478,13 @@ func getClusterForOIDCEndpoint(ctx context.Context, projectProvider provider.Pro
 	return clusterProvider.Get(userInfo, clusterID, &provider.ClusterGetOptions{})
 }
 
-func getProjectForOIDCEndpoint(userInfo *provider.UserInfo, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, projectID string) (*kubermaticv1.Project, error) {
+func getProjectForOIDCEndpoint(ctx context.Context, userInfo *provider.UserInfo, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, projectID string) (*kubermaticv1.Project, error) {
 	if userInfo.IsAdmin {
 		// get any project for admin
-		return privilegedProjectProvider.GetUnsecured(projectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
+		return privilegedProjectProvider.GetUnsecured(ctx, projectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
 	}
 
-	return projectProvider.Get(userInfo, projectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
+	return projectProvider.Get(ctx, userInfo, projectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
 }
 
 type encodeKubeConifgResponse struct {

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -81,7 +81,7 @@ func CreateMachineDeployment(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, k8cerrors.NewBadRequest("You cannot create a node deployment for KubeAdm provider")
 	}
 
-	keys, err := sshKeyProvider.List(project, &provider.SSHKeyListOptions{ClusterName: clusterID})
+	keys, err := sshKeyProvider.List(ctx, project, &provider.SSHKeyListOptions{ClusterName: clusterID})
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -490,7 +490,7 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 		return nil, fmt.Errorf("error getting dc: %w", err)
 	}
 
-	keys, err := sshKeyProvider.List(project, &provider.SSHKeyListOptions{ClusterName: clusterID})
+	keys, err := sshKeyProvider.List(ctx, project, &provider.SSHKeyListOptions{ClusterName: clusterID})
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/alibaba.go
+++ b/pkg/handler/common/provider/alibaba.go
@@ -71,7 +71,7 @@ func AlibabaInstanceTypesWithClusterCredentialsEndpoint(ctx context.Context, use
 		return nil, err
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -117,7 +117,7 @@ func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.U
 		return nil, errors.NewNotFound("cloud spec (dc) for ", clusterID)
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/azure.go
+++ b/pkg/handler/common/provider/azure.go
@@ -206,7 +206,7 @@ func AzureSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter
 	if err != nil {
 		return nil, err
 	}
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/digitalocean.go
+++ b/pkg/handler/common/provider/digitalocean.go
@@ -61,7 +61,7 @@ func DigitaloceanSizeWithClusterCredentialsEndpoint(ctx context.Context, userInf
 		return nil, err
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -59,7 +59,7 @@ func GCPSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter p
 		return nil, err
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/hetzner.go
+++ b/pkg/handler/common/provider/hetzner.go
@@ -61,7 +61,7 @@ func HetznerSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGett
 		return nil, err
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -59,7 +59,7 @@ func OpenstackSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGe
 		return nil, err
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/packet.go
+++ b/pkg/handler/common/provider/packet.go
@@ -61,7 +61,7 @@ func PacketSizesWithClusterCredentialsEndpoint(ctx context.Context, userInfoGett
 		return nil, err
 	}
 
-	settings, err := settingsProvider.GetGlobalSettings()
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -65,7 +65,7 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
-type WebsocketSettingsWriter func(providers watcher.Providers, ws *websocket.Conn)
+type WebsocketSettingsWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn)
 type WebsocketUserWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string)
 
 func (r Routing) RegisterV1Websocket(mux *mux.Router) {
@@ -99,7 +99,7 @@ func getSettingsWatchHandler(writer WebsocketSettingsWriter, providers watcher.P
 			return
 		}
 
-		go writer(providers, ws)
+		go writer(req.Context(), providers, ws)
 		requestLoggingReader(ws)
 	}
 }

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handler
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
@@ -65,7 +66,7 @@ var upgrader = websocket.Upgrader{
 }
 
 type WebsocketSettingsWriter func(providers watcher.Providers, ws *websocket.Conn)
-type WebsocketUserWriter func(providers watcher.Providers, ws *websocket.Conn, userEmail string)
+type WebsocketUserWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string)
 
 func (r Routing) RegisterV1Websocket(mux *mux.Router) {
 	providers := getProviders(r)
@@ -117,7 +118,7 @@ func getUserWatchHandler(writer WebsocketUserWriter, providers watcher.Providers
 			return
 		}
 
-		go writer(providers, ws, user.Email)
+		go writer(req.Context(), providers, ws, user.Email)
 		requestLoggingReader(ws)
 	}
 }

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -49,8 +49,12 @@ const (
 type FakePrivilegedProjectProvider struct {
 }
 
+var _ provider.PrivilegedProjectProvider = &FakePrivilegedProjectProvider{}
+
 type FakeProjectProvider struct {
 }
+
+var _ provider.ProjectProvider = &FakeProjectProvider{}
 
 func NewFakeProjectProvider() *FakeProjectProvider {
 	return &FakeProjectProvider{}
@@ -60,7 +64,7 @@ func NewFakePrivilegedProjectProvider() *FakePrivilegedProjectProvider {
 	return &FakePrivilegedProjectProvider{}
 }
 
-func (f *FakeProjectProvider) New(user []*kubermaticv1.User, name string, labels map[string]string) (*kubermaticv1.Project, error) {
+func (f *FakeProjectProvider) New(ctx context.Context, user []*kubermaticv1.User, name string, labels map[string]string) (*kubermaticv1.Project, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -68,12 +72,12 @@ func (f *FakeProjectProvider) New(user []*kubermaticv1.User, name string, labels
 //
 // Note:
 // Before deletion project's status.phase is set to ProjectTerminating.
-func (f *FakeProjectProvider) Delete(userInfo *provider.UserInfo, projectInternalName string) error {
+func (f *FakeProjectProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, projectInternalName string) error {
 	return errors.New("not implemented")
 }
 
 // Get returns the project with the given name.
-func (f *FakeProjectProvider) Get(userInfo *provider.UserInfo, projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
+func (f *FakeProjectProvider) Get(ctx context.Context, userInfo *provider.UserInfo, projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
 	if NoExistingFakeProjectID == projectInternalName || ForbiddenFakeProjectID == projectInternalName {
 		return nil, createError(http.StatusForbidden, ImpersonatedClientErrorMsg)
 	}
@@ -82,7 +86,7 @@ func (f *FakeProjectProvider) Get(userInfo *provider.UserInfo, projectInternalNa
 }
 
 // Update update an existing project and returns it.
-func (f *FakeProjectProvider) Update(userInfo *provider.UserInfo, newProject *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+func (f *FakeProjectProvider) Update(ctx context.Context, userInfo *provider.UserInfo, newProject *kubermaticv1.Project) (*kubermaticv1.Project, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -90,13 +94,13 @@ func (f *FakeProjectProvider) Update(userInfo *provider.UserInfo, newProject *ku
 // If you want to filter the result please set ProjectListOptions
 //
 // Note that the list is taken from the cache.
-func (f *FakeProjectProvider) List(options *provider.ProjectListOptions) ([]*kubermaticv1.Project, error) {
+func (f *FakeProjectProvider) List(ctx context.Context, options *provider.ProjectListOptions) ([]*kubermaticv1.Project, error) {
 	return nil, errors.New("not implemented")
 }
 
 // GetUnsecured returns the project with the given name
 // This function is unsafe in a sense that it uses privileged account to get project with the given name.
-func (f *FakePrivilegedProjectProvider) GetUnsecured(projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
+func (f *FakePrivilegedProjectProvider) GetUnsecured(ctx context.Context, projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
 	if NoExistingFakeProjectID == projectInternalName {
 		return nil, createError(http.StatusNotFound, "")
 	}
@@ -109,13 +113,13 @@ func (f *FakePrivilegedProjectProvider) GetUnsecured(projectInternalName string,
 
 // DeleteUnsecured deletes any given project
 // This function is unsafe in a sense that it uses privileged account to delete project with the given name.
-func (f *FakePrivilegedProjectProvider) DeleteUnsecured(projectInternalName string) error {
+func (f *FakePrivilegedProjectProvider) DeleteUnsecured(ctx context.Context, projectInternalName string) error {
 	return nil
 }
 
 // UpdateUnsecured update an existing project and returns it
 // This function is unsafe in a sense that it uses privileged account to update project.
-func (f *FakePrivilegedProjectProvider) UpdateUnsecured(project *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+func (f *FakePrivilegedProjectProvider) UpdateUnsecured(ctx context.Context, project *kubermaticv1.Project) (*kubermaticv1.Project, error) {
 	return project, nil
 }
 

--- a/pkg/handler/v1/admin/settings.go
+++ b/pkg/handler/v1/admin/settings.go
@@ -35,7 +35,7 @@ import (
 // KubermaticSettingsEndpoint returns global settings.
 func KubermaticSettingsEndpoint(settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		globalSettings, err := settingsProvider.GetGlobalSettings()
+		globalSettings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -47,7 +47,7 @@ func KubermaticSettingsEndpoint(settingsProvider provider.SettingsProvider) endp
 // KubermaticCustomLinksEndpoint returns custom links.
 func KubermaticCustomLinksEndpoint(settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		globalSettings, err := settingsProvider.GetGlobalSettings()
+		globalSettings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -65,7 +65,7 @@ func UpdateKubermaticSettingsEndpoint(userInfoGetter provider.UserInfoGetter, se
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		existingGlobalSettings, err := settingsProvider.GetGlobalSettings()
+		existingGlobalSettings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -85,7 +85,7 @@ func UpdateKubermaticSettingsEndpoint(userInfoGetter provider.UserInfoGetter, se
 		}
 
 		existingGlobalSettings.Spec = *patchedGlobalSettingsSpec
-		globalSettings, err := settingsProvider.UpdateGlobalSettings(userInfo, existingGlobalSettings)
+		globalSettings, err := settingsProvider.UpdateGlobalSettings(ctx, userInfo, existingGlobalSettings)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -280,7 +280,7 @@ func GetProject(ctx context.Context, userInfoGetter provider.UserInfoGetter, pro
 	}
 
 	// check first if project exist
-	adminProject, err := privilegedProjectProvider.GetUnsecured(projectID, options)
+	adminProject, err := privilegedProjectProvider.GetUnsecured(ctx, projectID, options)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func GetProject(ctx context.Context, userInfoGetter provider.UserInfoGetter, pro
 	if err != nil {
 		return nil, err
 	}
-	return projectProvider.Get(userInfo, projectID, options)
+	return projectProvider.Get(ctx, userInfo, projectID, options)
 }
 
 func GetClusterClient(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, cluster *kubermaticv1.Cluster, projectID string) (ctrlruntimeclient.Client, error) {

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -250,7 +250,7 @@ func ForwardPort(log *zap.SugaredLogger, forwarder *portforward.PortForwarder) e
 	return nil
 }
 
-func GetOwnersForProject(userInfo *provider.UserInfo, project *kubermaticv1.Project, memberProvider provider.ProjectMemberProvider, userProvider provider.UserProvider) ([]apiv1.User, error) {
+func GetOwnersForProject(ctx context.Context, userInfo *provider.UserInfo, project *kubermaticv1.Project, memberProvider provider.ProjectMemberProvider, userProvider provider.UserProvider) ([]apiv1.User, error) {
 	allProjectMembers, err := memberProvider.List(userInfo, project, &provider.ProjectMemberListOptions{SkipPrivilegeVerification: true})
 	if err != nil {
 		return nil, err
@@ -258,7 +258,7 @@ func GetOwnersForProject(userInfo *provider.UserInfo, project *kubermaticv1.Proj
 	projectOwners := []apiv1.User{}
 	for _, projectMember := range allProjectMembers {
 		if rbac.ExtractGroupPrefix(projectMember.Spec.Group) == rbac.OwnerGroupNamePrefix {
-			user, err := userProvider.UserByEmail(projectMember.Spec.UserEmail)
+			user, err := userProvider.UserByEmail(ctx, projectMember.Spec.UserEmail)
 			if err != nil {
 				continue
 			}

--- a/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -55,7 +55,7 @@ func ProxyEndpoint(
 		log := log.With("endpoint", "kubernetes-dashboard-proxy", "uri", r.URL.Path)
 		ctx := extractor(r.Context(), r)
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "could not read global settings"))
 			return

--- a/pkg/handler/v1/presets/credentials.go
+++ b/pkg/handler/v1/presets/credentials.go
@@ -78,7 +78,7 @@ func CredentialEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 		names := make([]string, 0)
 
 		providerN := parseProvider(req.ProviderName)
-		presets, err := presetProvider.GetPresets(userInfo)
+		presets, err := presetProvider.GetPresets(ctx, userInfo)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, err.Error())
 		}

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -51,7 +51,7 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, kubermaticerrors.NewBadRequest("the name of the project cannot be empty")
 		}
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/alibaba.go
+++ b/pkg/handler/v1/provider/alibaba.go
@@ -109,7 +109,7 @@ func AlibabaInstanceTypesEndpoint(presetProvider provider.PresetProvider, userIn
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -147,7 +147,7 @@ func AlibabaZonesEndpoint(presetProvider provider.PresetProvider, userInfoGetter
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -172,7 +172,7 @@ func AlibabaVSwitchesEndpoint(presetProvider provider.PresetProvider, userInfoGe
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/alibaba.go
+++ b/pkg/handler/v1/provider/alibaba.go
@@ -119,7 +119,7 @@ func AlibabaInstanceTypesEndpoint(presetProvider provider.PresetProvider, userIn
 			}
 		}
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/anexia.go
+++ b/pkg/handler/v1/provider/anexia.go
@@ -40,7 +40,7 @@ func AnexiaVlanEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -64,7 +64,7 @@ func AnexiaTemplateEndpoint(presetProvider provider.PresetProvider, userInfoGett
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/aws.go
+++ b/pkg/handler/v1/provider/aws.go
@@ -186,7 +186,7 @@ func DecodeAWSSecurityGroupsReq(c context.Context, r *http.Request) (interface{}
 func AWSSizeEndpoint(settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSSizeReq)
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/aws.go
+++ b/pkg/handler/v1/provider/aws.go
@@ -219,7 +219,7 @@ func AWSSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter provi
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -341,7 +341,7 @@ func getAWSCredentialsFromRequest(ctx context.Context, req AWSCommonReq, userInf
 	}
 
 	if len(req.Credential) > 0 {
-		preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}

--- a/pkg/handler/v1/provider/azure.go
+++ b/pkg/handler/v1/provider/azure.go
@@ -62,7 +62,7 @@ func AzureSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter pr
 				tenantID = credentials.TenantID
 			}
 		}
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/azure.go
+++ b/pkg/handler/v1/provider/azure.go
@@ -51,7 +51,7 @@ func AzureSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter pr
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -94,7 +94,7 @@ func AzureAvailabilityZonesEndpoint(presetProvider provider.PresetProvider, user
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/digitalocean.go
+++ b/pkg/handler/v1/provider/digitalocean.go
@@ -47,7 +47,7 @@ func DigitaloceanSizeEndpoint(presetProvider provider.PresetProvider, userInfoGe
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/digitalocean.go
+++ b/pkg/handler/v1/provider/digitalocean.go
@@ -56,7 +56,7 @@ func DigitaloceanSizeEndpoint(presetProvider provider.PresetProvider, userInfoGe
 			}
 		}
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/gcp.go
+++ b/pkg/handler/v1/provider/gcp.go
@@ -184,7 +184,7 @@ func GCPDiskTypesEndpoint(presetProvider provider.PresetProvider, userInfoGetter
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -215,7 +215,7 @@ func GCPSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter prov
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -249,7 +249,7 @@ func GCPZoneEndpoint(presetProvider provider.PresetProvider, seedsGetter provide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -279,7 +279,7 @@ func GCPNetworkEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -309,7 +309,7 @@ func GCPSubnetworkEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/gcp.go
+++ b/pkg/handler/v1/provider/gcp.go
@@ -223,7 +223,7 @@ func GCPSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter prov
 				sa = credentials.ServiceAccount
 			}
 		}
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/hetzner.go
+++ b/pkg/handler/v1/provider/hetzner.go
@@ -54,7 +54,7 @@ func HetznerSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter 
 				token = credentials.Token
 			}
 		}
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/hetzner.go
+++ b/pkg/handler/v1/provider/hetzner.go
@@ -46,7 +46,7 @@ func HetznerSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter 
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/openstack.go
+++ b/pkg/handler/v1/provider/openstack.go
@@ -87,7 +87,7 @@ func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, presetProvider prov
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %w", err)
 		}
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/openstack.go
+++ b/pkg/handler/v1/provider/openstack.go
@@ -64,7 +64,7 @@ func getAuthInfo(ctx context.Context, req OpenstackReq, userInfoGetter provider.
 		return userInfo, credentials, nil
 	}
 	// Preset is used
-	cred, err = getPresetCredentials(userInfo, presetName, presetProvider, token)
+	cred, err = getPresetCredentials(ctx, userInfo, presetName, presetProvider, token)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting preset credentials for OpenStack: %w", err)
 	}
@@ -438,8 +438,8 @@ func DecodeOpenstackTenantReq(_ context.Context, r *http.Request) (interface{}, 
 	return req, nil
 }
 
-func getPresetCredentials(userInfo *provider.UserInfo, presetName string, presetProvider provider.PresetProvider, token string) (*resources.OpenstackCredentials, error) {
-	p, err := presetProvider.GetPreset(userInfo, presetName)
+func getPresetCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, presetProvider provider.PresetProvider, token string) (*resources.OpenstackCredentials, error) {
+	p, err := presetProvider.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, fmt.Errorf("can not get preset %s for the user %s", presetName, userInfo.Email)
 	}

--- a/pkg/handler/v1/provider/packet.go
+++ b/pkg/handler/v1/provider/packet.go
@@ -93,7 +93,7 @@ func PacketSizesEndpoint(presetProvider provider.PresetProvider, userInfoGetter 
 			}
 		}
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/provider/packet.go
+++ b/pkg/handler/v1/provider/packet.go
@@ -83,7 +83,7 @@ func PacketSizesEndpoint(presetProvider provider.PresetProvider, userInfoGetter 
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/provider/vsphere.go
+++ b/pkg/handler/v1/provider/vsphere.go
@@ -45,7 +45,7 @@ func VsphereNetworksEndpoint(seedsGetter provider.SeedsGetter, presetProvider pr
 		password := req.Password
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -84,7 +84,7 @@ func VsphereFoldersEndpoint(seedsGetter provider.SeedsGetter, presetProvider pro
 		password := req.Password
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v1/serviceaccount/sa.go
+++ b/pkg/handler/v1/serviceaccount/sa.go
@@ -87,14 +87,14 @@ func listSA(ctx context.Context, serviceAccountProvider provider.ServiceAccountP
 	}
 
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccount.ListUnsecuredProjectServiceAccount(project, options)
+		return privilegedServiceAccount.ListUnsecuredProjectServiceAccount(ctx, project, options)
 	}
 
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountProvider.ListProjectServiceAccount(userInfo, project, options)
+	return serviceAccountProvider.ListProjectServiceAccount(ctx, userInfo, project, options)
 }
 
 func createSA(ctx context.Context, serviceAccountProvider provider.ServiceAccountProvider, privilegedServiceAccount provider.PrivilegedServiceAccountProvider, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, sa apiv1.ServiceAccount) (*kubermaticv1.User, error) {
@@ -104,14 +104,14 @@ func createSA(ctx context.Context, serviceAccountProvider provider.ServiceAccoun
 	}
 	groupName := rbac.GenerateActualGroupNameFor(project.Name, sa.Group)
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccount.CreateUnsecuredProjectServiceAccount(project, sa.Name, groupName)
+		return privilegedServiceAccount.CreateUnsecuredProjectServiceAccount(ctx, project, sa.Name, groupName)
 	}
 
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountProvider.CreateProjectServiceAccount(userInfo, project, sa.Name, groupName)
+	return serviceAccountProvider.CreateProjectServiceAccount(ctx, userInfo, project, sa.Name, groupName)
 }
 
 // ListEndpoint returns service accounts of the given project.
@@ -228,14 +228,14 @@ func updateSA(ctx context.Context, serviceAccountProvider provider.ServiceAccoun
 	}
 
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccount.UpdateUnsecuredProjectServiceAccount(sa)
+		return privilegedServiceAccount.UpdateUnsecuredProjectServiceAccount(ctx, sa)
 	}
 
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountProvider.UpdateProjectServiceAccount(userInfo, sa)
+	return serviceAccountProvider.UpdateProjectServiceAccount(ctx, userInfo, sa)
 }
 
 func getSA(ctx context.Context, serviceAccountProvider provider.ServiceAccountProvider, privilegedServiceAccount provider.PrivilegedServiceAccountProvider, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, serviceAccountID string, options *provider.ServiceAccountGetOptions) (*kubermaticv1.User, error) {
@@ -245,14 +245,14 @@ func getSA(ctx context.Context, serviceAccountProvider provider.ServiceAccountPr
 	}
 
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccount.GetUnsecuredProjectServiceAccount(serviceAccountID, options)
+		return privilegedServiceAccount.GetUnsecuredProjectServiceAccount(ctx, serviceAccountID, options)
 	}
 
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountProvider.GetProjectServiceAccount(userInfo, serviceAccountID, options)
+	return serviceAccountProvider.GetProjectServiceAccount(ctx, userInfo, serviceAccountID, options)
 }
 
 // DeleteEndpoint deletes the service account for the given project.
@@ -294,14 +294,14 @@ func deleteSA(ctx context.Context, serviceAccountProvider provider.ServiceAccoun
 	}
 
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccount.DeleteUnsecuredProjectServiceAccount(serviceAccountID)
+		return privilegedServiceAccount.DeleteUnsecuredProjectServiceAccount(ctx, serviceAccountID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return err
 	}
-	return serviceAccountProvider.DeleteProjectServiceAccount(userInfo, serviceAccountID)
+	return serviceAccountProvider.DeleteProjectServiceAccount(ctx, userInfo, serviceAccountID)
 }
 
 // addReq defines HTTP request for addServiceAccountToProject

--- a/pkg/handler/v1/serviceaccount/token.go
+++ b/pkg/handler/v1/serviceaccount/token.go
@@ -105,7 +105,7 @@ func listSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, se
 		}
 		options.LabelSelector = labelSelector
 		options.ServiceAccountID = sa.Name
-		tokens, err := privilegedServiceAccountTokenProvider.ListUnsecured(options)
+		tokens, err := privilegedServiceAccountTokenProvider.ListUnsecured(ctx, options)
 		if kerrors.IsNotFound(err) {
 			return make([]*corev1.Secret, 0), nil
 		}
@@ -116,7 +116,7 @@ func listSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, se
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountTokenProvider.List(userInfo, project, sa, options)
+	return serviceAccountTokenProvider.List(ctx, userInfo, project, sa, options)
 }
 
 func createSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, serviceAccountTokenProvider provider.ServiceAccountTokenProvider, privilegedServiceAccountTokenProvider provider.PrivilegedServiceAccountTokenProvider, sa *kubermaticv1.User, projectID, tokenName, tokenID, tokenData string) (*corev1.Secret, error) {
@@ -125,14 +125,14 @@ func createSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccountTokenProvider.CreateUnsecured(sa, projectID, tokenName, tokenID, tokenData)
+		return privilegedServiceAccountTokenProvider.CreateUnsecured(ctx, sa, projectID, tokenName, tokenID, tokenData)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountTokenProvider.Create(userInfo, sa, projectID, tokenName, tokenID, tokenData)
+	return serviceAccountTokenProvider.Create(ctx, userInfo, sa, projectID, tokenName, tokenID, tokenData)
 }
 
 // ListTokenEndpoint gets token for the service account.
@@ -264,14 +264,14 @@ func deleteSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccountTokenProvider.DeleteUnsecured(tokenID)
+		return privilegedServiceAccountTokenProvider.DeleteUnsecured(ctx, tokenID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return err
 	}
-	return serviceAccountTokenProvider.Delete(userInfo, tokenID)
+	return serviceAccountTokenProvider.Delete(ctx, userInfo, tokenID)
 }
 
 func getSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, serviceAccountTokenProvider provider.ServiceAccountTokenProvider, privilegedServiceAccountTokenProvider provider.PrivilegedServiceAccountTokenProvider, projectID, tokenID string) (*corev1.Secret, error) {
@@ -280,14 +280,14 @@ func getSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, ser
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccountTokenProvider.GetUnsecured(tokenID)
+		return privilegedServiceAccountTokenProvider.GetUnsecured(ctx, tokenID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountTokenProvider.Get(userInfo, tokenID)
+	return serviceAccountTokenProvider.Get(ctx, userInfo, tokenID)
 }
 
 func updateEndpoint(ctx context.Context, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, serviceAccountProvider provider.ServiceAccountProvider,
@@ -352,14 +352,14 @@ func updateSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedServiceAccountTokenProvider.UpdateUnsecured(token)
+		return privilegedServiceAccountTokenProvider.UpdateUnsecured(ctx, token)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return serviceAccountTokenProvider.Update(userInfo, token)
+	return serviceAccountTokenProvider.Update(ctx, userInfo, token)
 }
 
 // addTokenReq defines HTTP request for addTokenToServiceAccount

--- a/pkg/handler/v1/ssh/ssh.go
+++ b/pkg/handler/v1/ssh/ssh.go
@@ -44,7 +44,7 @@ func CreateEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		existingKeys, err := keyProvider.List(project, &provider.SSHKeyListOptions{SSHKeyName: req.Key.Name})
+		existingKeys, err := keyProvider.List(ctx, project, &provider.SSHKeyListOptions{SSHKeyName: req.Key.Name})
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -78,13 +78,13 @@ func createUserSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedSSHKeyProvider.CreateUnsecured(project, keyName, pubKey)
+		return privilegedSSHKeyProvider.CreateUnsecured(ctx, project, keyName, pubKey)
 	}
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
-	return keyProvider.Create(userInfo, project, keyName, pubKey)
+	return keyProvider.Create(ctx, userInfo, project, keyName, pubKey)
 }
 
 func DeleteEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvider provider.PrivilegedSSHKeyProvider, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
@@ -110,13 +110,13 @@ func deleteUserSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedSSHKeyProvider.DeleteUnsecured(keyName)
+		return privilegedSSHKeyProvider.DeleteUnsecured(ctx, keyName)
 	}
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return err
 	}
-	return keyProvider.Delete(userInfo, keyName)
+	return keyProvider.Delete(ctx, userInfo, keyName)
 }
 
 func ListEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
@@ -134,7 +134,7 @@ func ListEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		keys, err := keyProvider.List(project, nil)
+		keys, err := keyProvider.List(ctx, project, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/user/user.go
+++ b/pkg/handler/v1/user/user.go
@@ -56,7 +56,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		user, err := userProvider.UserByID(req.UserID)
+		user, err := userProvider.UserByID(ctx, req.UserID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -151,7 +151,7 @@ func EditEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		memberToUpdate, err := userProvider.UserByEmail(currentMemberFromRequest.Email)
+		memberToUpdate, err := userProvider.UserByEmail(ctx, currentMemberFromRequest.Email)
 		if err != nil && errors.Is(err, provider.ErrNotFound) {
 			return nil, k8cerrors.NewBadRequest("cannot add the user %s to the project %s because the user doesn't exist.", currentMemberFromRequest.Email, projectFromRequest.ID)
 		} else if err != nil {
@@ -222,7 +222,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 
 		externalUsers := []*apiv1.User{}
 		for _, memberOfProjectBinding := range membersOfProjectBindings {
-			user, err := userProvider.UserByEmail(memberOfProjectBinding.Spec.UserEmail)
+			user, err := userProvider.UserByEmail(ctx, memberOfProjectBinding.Spec.UserEmail)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -250,7 +250,7 @@ func AddEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 		apiUserFromRequest := req.Body
 		projectFromRequest := apiUserFromRequest.Projects[0]
 
-		userToInvite, err := userProvider.UserByEmail(apiUserFromRequest.Email)
+		userToInvite, err := userProvider.UserByEmail(ctx, apiUserFromRequest.Email)
 		if err != nil && errors.Is(err, provider.ErrNotFound) {
 			return nil, k8cerrors.NewBadRequest("cannot add the user %s to the project %s because the user doesn't exist.", apiUserFromRequest.Email, projectFromRequest.ID)
 		} else if err != nil {
@@ -296,7 +296,7 @@ func LogoutEndpoint(userProvider provider.UserProvider) endpoint.Endpoint {
 		if !ok {
 			return nil, k8cerrors.NewNotAuthorized()
 		}
-		return nil, userProvider.InvalidateToken(authenticatedUser, token, expiry)
+		return nil, userProvider.InvalidateToken(ctx, authenticatedUser, token, expiry)
 	}
 }
 
@@ -366,7 +366,7 @@ func PatchSettingsEndpoint(userProvider provider.UserProvider) endpoint.Endpoint
 		}
 
 		existingUser.Spec.Settings = patchedSettings
-		updatedUser, err := userProvider.UpdateUser(existingUser)
+		updatedUser, err := userProvider.UpdateUser(ctx, existingUser)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -92,7 +92,7 @@ func CreateOrUpdateEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter 
 				Namespace: bc.Namespace,
 			}
 
-			_, err = seedProvider.UpdateUnsecured(seed)
+			_, err = seedProvider.UpdateUnsecured(ctx, seed)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("error setting seed backup destination credentials: %v", err))
 			}

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -378,7 +378,7 @@ func createClusterTemplate(ctx context.Context, userInfoGetter provider.UserInfo
 
 	// SSH check
 	if len(userSSHKeys) > 0 && scope == kubermaticv1.ProjectClusterTemplateScope {
-		projectSSHKeys, err := sshKeyProvider.List(project, nil)
+		projectSSHKeys, err := sshKeyProvider.List(ctx, project, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -696,7 +696,7 @@ func createAKSNodePool(ctx context.Context, cloud *kubermaticv1.ExternalClusterC
 
 func AKSNodeVersionsWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -171,7 +171,7 @@ func getAKSCredentialsFromReq(ctx context.Context, req AKSCommonReq, userInfoGet
 	}
 
 	if len(req.Credential) > 0 {
-		preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -299,7 +299,7 @@ func getEKSCredentialsFromReq(ctx context.Context, req EKSTypesReq, userInfoGett
 
 	presetName := req.Credential
 	if len(presetName) > 0 {
-		preset, err := presetProvider.GetPreset(userInfo, presetName)
+		preset, err := presetProvider.GetPreset(ctx, userInfo, presetName)
 		if err != nil {
 			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", presetName, userInfo.Email))
 		}

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -74,7 +74,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 		}
 		var preset *kubermaticv1.Preset
 		if len(req.Credential) > 0 {
-			preset, err = presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err = presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -54,7 +54,7 @@ const (
 
 func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider, presetProvider provider.PresetProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -214,7 +214,7 @@ func (req createClusterReq) Validate() error {
 
 func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -277,7 +277,7 @@ func (req deleteClusterReq) Validate() error {
 
 func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -333,7 +333,7 @@ func (req listClusterReq) Validate() error {
 
 func GetEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -431,7 +431,7 @@ func (req GetClusterReq) Validate() error {
 
 func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -480,7 +480,7 @@ func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 
 func PatchEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -635,7 +635,7 @@ func (req updateClusterReq) Validate() error {
 
 func GetMetricsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -695,7 +695,7 @@ func GetMetricsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider 
 
 func ListEventsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -995,8 +995,8 @@ func updateCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 	return clusterProvider.Update(userInfo, cluster)
 }
 
-func AreExternalClustersEnabled(provider provider.SettingsProvider) bool {
-	settings, err := provider.GetGlobalSettings()
+func AreExternalClustersEnabled(ctx context.Context, provider provider.SettingsProvider) bool {
+	settings, err := provider.GetGlobalSettings(ctx)
 	if err != nil {
 		return false
 	}
@@ -1014,7 +1014,7 @@ type body struct {
 
 func GetKubeconfigEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -47,7 +47,7 @@ const GKENodepoolNameLabel = "cloud.google.com/gke-nodepool"
 
 func GKEImagesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -96,7 +96,7 @@ func GKEImagesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGet
 
 func GKEZonesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -153,7 +153,7 @@ func GKEZonesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 
 func GKESizesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -177,7 +177,7 @@ func GKESizesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 			return nil, err
 		}
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -188,7 +188,7 @@ func GKESizesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 
 func GKEDiskTypesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 

--- a/pkg/handler/v2/external_cluster/node.go
+++ b/pkg/handler/v2/external_cluster/node.go
@@ -82,7 +82,7 @@ func ListNodesEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider p
 
 func ListNodesMetricsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
@@ -660,7 +660,7 @@ func GetMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projec
 
 func PatchMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 

--- a/pkg/handler/v2/external_cluster/upgrade.go
+++ b/pkg/handler/v2/external_cluster/upgrade.go
@@ -36,7 +36,7 @@ import (
 
 func GetUpgradesEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		if !AreExternalClustersEnabled(settingsProvider) {
+		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 

--- a/pkg/handler/v2/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v2/kubernetes-dashboard/dashboard.go
@@ -55,7 +55,7 @@ func ProxyEndpoint(
 		log := log.With("endpoint", "kubernetes-dashboard-proxy", "uri", r.URL.Path)
 		ctx := extractor(r.Context(), r)
 
-		settings, err := settingsProvider.GetGlobalSettings()
+		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
 			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "could not read global settings"))
 			return

--- a/pkg/handler/v2/provider/aks.go
+++ b/pkg/handler/v2/provider/aks.go
@@ -242,7 +242,7 @@ func getAKSCredentialsFromReq(ctx context.Context, req AKSCommonReq, userInfoGet
 	}
 
 	if len(req.Credential) > 0 {
-		preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}

--- a/pkg/handler/v2/provider/azure.go
+++ b/pkg/handler/v2/provider/azure.go
@@ -119,7 +119,7 @@ func getAzureCredentialsFromReq(ctx context.Context, req azureCommonReq, userInf
 	}
 
 	if len(req.Credential) > 0 {
-		preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}

--- a/pkg/handler/v2/provider/gcp.go
+++ b/pkg/handler/v2/provider/gcp.go
@@ -216,7 +216,7 @@ func GKEClustersEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -238,7 +238,7 @@ func GKEImagesEndpoint(presetProvider provider.PresetProvider, userInfoGetter pr
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -260,7 +260,7 @@ func GKEValidateCredentialsEndpoint(presetProvider provider.PresetProvider, user
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v2/provider/kubevirt.go
+++ b/pkg/handler/v2/provider/kubevirt.go
@@ -58,7 +58,7 @@ func KubeVirtVMIPresetsEndpoint(presetsProvider provider.PresetProvider, userInf
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetsProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetsProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -89,7 +89,7 @@ func KubeVirtStorageClassesEndpoint(presetsProvider provider.PresetProvider, use
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(req.Credential) > 0 {
-			preset, err := presetsProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetsProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v2/provider/nutanix.go
+++ b/pkg/handler/v2/provider/nutanix.go
@@ -154,7 +154,7 @@ func NutanixClusterEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -203,7 +203,7 @@ func NutanixProjectEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
@@ -255,7 +255,7 @@ func NutanixSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 		}
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v2/provider/vsphere.go
+++ b/pkg/handler/v2/provider/vsphere.go
@@ -67,7 +67,7 @@ func VsphereDatastoreEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 		password := req.Password
 
 		if len(req.Credential) > 0 {
-			preset, err := presetProvider.GetPreset(userInfo, req.Credential)
+			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
 				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}

--- a/pkg/handler/v2/rulegroup/rulegroup.go
+++ b/pkg/handler/v2/rulegroup/rulegroup.go
@@ -154,13 +154,13 @@ func getRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, c
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedRuleGroupProvider.GetUnsecured(ruleGroupID, cluster.Status.NamespaceName)
+		return privilegedRuleGroupProvider.GetUnsecured(ctx, ruleGroupID, cluster.Status.NamespaceName)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoRuleGroupProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return alertmanagerProvider.Get(userInfo, cluster, ruleGroupID)
+	return alertmanagerProvider.Get(ctx, userInfo, cluster, ruleGroupID)
 }
 
 func listRuleGroups(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID string, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
@@ -169,13 +169,13 @@ func listRuleGroups(ctx context.Context, userInfoGetter provider.UserInfoGetter,
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedRuleGroupProvider.ListUnsecured(cluster.Status.NamespaceName, options)
+		return privilegedRuleGroupProvider.ListUnsecured(ctx, cluster.Status.NamespaceName, options)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoRuleGroupProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return alertmanagerProvider.List(userInfo, cluster, options)
+	return alertmanagerProvider.List(ctx, userInfo, cluster, options)
 }
 
 func createRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
@@ -184,13 +184,13 @@ func createRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedRuleGroupProvider.CreateUnsecured(ruleGroup)
+		return privilegedRuleGroupProvider.CreateUnsecured(ctx, ruleGroup)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoRuleGroupProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return alertmanagerProvider.Create(userInfo, ruleGroup)
+	return alertmanagerProvider.Create(ctx, userInfo, ruleGroup)
 }
 
 func updateRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
@@ -199,13 +199,13 @@ func updateRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedRuleGroupProvider.UpdateUnsecured(ruleGroup)
+		return privilegedRuleGroupProvider.UpdateUnsecured(ctx, ruleGroup)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoRuleGroupProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return alertmanagerProvider.Update(userInfo, ruleGroup)
+	return alertmanagerProvider.Update(ctx, userInfo, ruleGroup)
 }
 
 func deleteRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID, ruleGroupID string) error {
@@ -214,13 +214,13 @@ func deleteRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedRuleGroupProvider.DeleteUnsecured(ruleGroupID, cluster.Status.NamespaceName)
+		return privilegedRuleGroupProvider.DeleteUnsecured(ctx, ruleGroupID, cluster.Status.NamespaceName)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoRuleGroupProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return err
 	}
-	return alertmanagerProvider.Delete(userInfo, cluster, ruleGroupID)
+	return alertmanagerProvider.Delete(ctx, userInfo, cluster, ruleGroupID)
 }
 
 func convertAPIToInternalRuleGroup(cluster *kubermaticv1.Cluster, ruleGroup *apiv2.RuleGroup, ruleGroupID string) (*kubermaticv1.RuleGroup, error) {

--- a/pkg/handler/v2/rulegroup_admin/rulegroup.go
+++ b/pkg/handler/v2/rulegroup_admin/rulegroup.go
@@ -121,7 +121,7 @@ func getRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, r
 	if err != nil {
 		return nil, err
 	}
-	return privilegedRuleGroupProvider.GetUnsecured(ruleGroupID, namespace)
+	return privilegedRuleGroupProvider.GetUnsecured(ctx, ruleGroupID, namespace)
 }
 
 func listRuleGroups(ctx context.Context, userInfoGetter provider.UserInfoGetter, namespace string, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
@@ -129,7 +129,7 @@ func listRuleGroups(ctx context.Context, userInfoGetter provider.UserInfoGetter,
 	if err != nil {
 		return nil, err
 	}
-	return privilegedRuleGroupProvider.ListUnsecured(namespace, options)
+	return privilegedRuleGroupProvider.ListUnsecured(ctx, namespace, options)
 }
 
 func createRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
@@ -137,7 +137,7 @@ func createRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter
 	if err != nil {
 		return nil, err
 	}
-	return privilegedRuleGroupProvider.CreateUnsecured(ruleGroup)
+	return privilegedRuleGroupProvider.CreateUnsecured(ctx, ruleGroup)
 }
 
 func updateRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
@@ -145,7 +145,7 @@ func updateRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter
 	if err != nil {
 		return nil, err
 	}
-	return privilegedRuleGroupProvider.UpdateUnsecured(ruleGroup)
+	return privilegedRuleGroupProvider.UpdateUnsecured(ctx, ruleGroup)
 }
 
 func deleteRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter, ruleGroupID, namespace string) error {
@@ -153,7 +153,7 @@ func deleteRuleGroup(ctx context.Context, userInfoGetter provider.UserInfoGetter
 	if err != nil {
 		return err
 	}
-	return privilegedRuleGroupProvider.DeleteUnsecured(ruleGroupID, namespace)
+	return privilegedRuleGroupProvider.DeleteUnsecured(ctx, ruleGroupID, namespace)
 }
 
 func convertAPIToInternalRuleGroup(ruleGroup *apiv2.RuleGroup, ruleGroupID string) (*kubermaticv1.RuleGroup, error) {

--- a/pkg/handler/v2/user/user.go
+++ b/pkg/handler/v2/user/user.go
@@ -41,7 +41,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, userProvider provider.
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", userInfo.Email))
 		}
 
-		list, err := userProvider.List()
+		list, err := userProvider.List(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/handler/websocket/settings.go
+++ b/pkg/handler/websocket/settings.go
@@ -17,6 +17,7 @@ limitations under the License.
 package websocket
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/gorilla/websocket"
@@ -27,9 +28,9 @@ import (
 	"k8c.io/kubermatic/v2/pkg/watcher"
 )
 
-func WriteSettings(providers watcher.Providers, ws *websocket.Conn) {
+func WriteSettings(ctx context.Context, providers watcher.Providers, ws *websocket.Conn) {
 	// There can be a race here if the settings change between getting the initial data and setting up the subscription
-	initialSettings, err := providers.SettingsProvider.GetGlobalSettings()
+	initialSettings, err := providers.SettingsProvider.GetGlobalSettings(ctx)
 	if err != nil {
 		log.Logger.Debug(err)
 		return

--- a/pkg/handler/websocket/user.go
+++ b/pkg/handler/websocket/user.go
@@ -17,6 +17,7 @@ limitations under the License.
 package websocket
 
 import (
+	"context"
 	"encoding/json"
 
 	"code.cloudfoundry.org/go-pubsub"
@@ -28,9 +29,9 @@ import (
 	"k8c.io/kubermatic/v2/pkg/watcher"
 )
 
-func WriteUser(providers watcher.Providers, ws *websocket.Conn, userEmail string) {
+func WriteUser(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string) {
 	// There can be a race here if the user changes between getting the initial data and setting up the subscription
-	initialUser, err := providers.UserProvider.UserByEmail(userEmail)
+	initialUser, err := providers.UserProvider.UserByEmail(ctx, userEmail)
 	if err != nil {
 		log.Logger.Debug(err)
 		return

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -29,19 +29,19 @@ import (
 )
 
 // presetsGetter is a function to retrieve preset list.
-type presetsGetter = func(userInfo *provider.UserInfo) ([]kubermaticv1.Preset, error)
+type presetsGetter = func(ctx context.Context, userInfo *provider.UserInfo) ([]kubermaticv1.Preset, error)
 
 // presetCreator is a function to create a preset.
-type presetCreator = func(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+type presetCreator = func(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
 
 // presetUpdater is a function to update a preset.
-type presetUpdater = func(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+type presetUpdater = func(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
 
 // presetDeleter is a function to delete a preset.
-type presetDeleter = func(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+type presetDeleter = func(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
 
-func presetsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client) (presetsGetter, error) {
-	return func(userInfo *provider.UserInfo) ([]kubermaticv1.Preset, error) {
+func presetsGetterFactory(client ctrlruntimeclient.Client) (presetsGetter, error) {
+	return func(ctx context.Context, userInfo *provider.UserInfo) ([]kubermaticv1.Preset, error) {
 		presetList := &kubermaticv1.PresetList{}
 		if err := client.List(ctx, presetList); err != nil {
 			return nil, fmt.Errorf("failed to get presets: %w", err)
@@ -50,8 +50,8 @@ func presetsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client) 
 	}, nil
 }
 
-func presetCreatorFactory(ctx context.Context, client ctrlruntimeclient.Client) (presetCreator, error) {
-	return func(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
+func presetCreatorFactory(client ctrlruntimeclient.Client) (presetCreator, error) {
+	return func(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
 		if err := client.Create(ctx, preset); err != nil {
 			return nil, err
 		}
@@ -60,8 +60,8 @@ func presetCreatorFactory(ctx context.Context, client ctrlruntimeclient.Client) 
 	}, nil
 }
 
-func presetUpdaterFactory(ctx context.Context, client ctrlruntimeclient.Client) (presetUpdater, error) {
-	return func(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
+func presetUpdaterFactory(client ctrlruntimeclient.Client) (presetUpdater, error) {
+	return func(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
 		if err := client.Update(ctx, preset); err != nil {
 			return nil, err
 		}
@@ -70,8 +70,8 @@ func presetUpdaterFactory(ctx context.Context, client ctrlruntimeclient.Client) 
 	}, nil
 }
 
-func presetDeleterFactory(ctx context.Context, client ctrlruntimeclient.Client) (presetDeleter, error) {
-	return func(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
+func presetDeleterFactory(client ctrlruntimeclient.Client) (presetDeleter, error) {
+	return func(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
 		if err := client.Delete(ctx, preset); err != nil {
 			return &kubermaticv1.Preset{}, err
 		}
@@ -87,23 +87,25 @@ type PresetProvider struct {
 	deleter presetDeleter
 }
 
+var _ provider.PresetProvider = &PresetProvider{}
+
 func NewPresetProvider(ctx context.Context, client ctrlruntimeclient.Client) (*PresetProvider, error) {
-	getter, err := presetsGetterFactory(ctx, client)
+	getter, err := presetsGetterFactory(client)
 	if err != nil {
 		return nil, err
 	}
 
-	creator, err := presetCreatorFactory(ctx, client)
+	creator, err := presetCreatorFactory(client)
 	if err != nil {
 		return nil, err
 	}
 
-	patcher, err := presetUpdaterFactory(ctx, client)
+	patcher, err := presetUpdaterFactory(client)
 	if err != nil {
 		return nil, err
 	}
 
-	deleter, err := presetDeleterFactory(ctx, client)
+	deleter, err := presetDeleterFactory(client)
 	if err != nil {
 		return nil, err
 	}
@@ -111,22 +113,22 @@ func NewPresetProvider(ctx context.Context, client ctrlruntimeclient.Client) (*P
 	return &PresetProvider{getter, creator, patcher, deleter}, nil
 }
 
-func (m *PresetProvider) CreatePreset(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
-	return m.creator(preset)
+func (m *PresetProvider) CreatePreset(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
+	return m.creator(ctx, preset)
 }
 
-func (m *PresetProvider) UpdatePreset(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
-	return m.patcher(preset)
+func (m *PresetProvider) UpdatePreset(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
+	return m.patcher(ctx, preset)
 }
 
 // GetPresets returns presets which belong to the specific email group and for all users.
-func (m *PresetProvider) GetPresets(userInfo *provider.UserInfo) ([]kubermaticv1.Preset, error) {
-	return m.getter(userInfo)
+func (m *PresetProvider) GetPresets(ctx context.Context, userInfo *provider.UserInfo) ([]kubermaticv1.Preset, error) {
+	return m.getter(ctx, userInfo)
 }
 
 // GetPreset returns preset with the name which belong to the specific email group.
-func (m *PresetProvider) GetPreset(userInfo *provider.UserInfo, name string) (*kubermaticv1.Preset, error) {
-	presets, err := m.getter(userInfo)
+func (m *PresetProvider) GetPreset(ctx context.Context, userInfo *provider.UserInfo, name string) (*kubermaticv1.Preset, error) {
+	presets, err := m.getter(ctx, userInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +142,8 @@ func (m *PresetProvider) GetPreset(userInfo *provider.UserInfo, name string) (*k
 }
 
 // DeletePreset delete Preset.
-func (m *PresetProvider) DeletePreset(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
-	return m.deleter(preset)
+func (m *PresetProvider) DeletePreset(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error) {
+	return m.deleter(ctx, preset)
 }
 
 func filterOutPresets(userInfo *provider.UserInfo, list *kubermaticv1.PresetList) ([]kubermaticv1.Preset, error) {
@@ -165,45 +167,45 @@ func filterOutPresets(userInfo *provider.UserInfo, list *kubermaticv1.PresetList
 	return result, nil
 }
 
-func (m *PresetProvider) SetCloudCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error) {
+func (m *PresetProvider) SetCloudCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error) {
 	if cloud.VSphere != nil {
-		return m.setVsphereCredentials(userInfo, presetName, cloud, dc)
+		return m.setVsphereCredentials(ctx, userInfo, presetName, cloud, dc)
 	}
 	if cloud.Openstack != nil {
-		return m.setOpenStackCredentials(userInfo, presetName, cloud, dc)
+		return m.setOpenStackCredentials(ctx, userInfo, presetName, cloud, dc)
 	}
 	if cloud.Azure != nil {
-		return m.setAzureCredentials(userInfo, presetName, cloud)
+		return m.setAzureCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Digitalocean != nil {
-		return m.setDigitalOceanCredentials(userInfo, presetName, cloud)
+		return m.setDigitalOceanCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Packet != nil {
-		return m.setPacketCredentials(userInfo, presetName, cloud)
+		return m.setPacketCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Hetzner != nil {
-		return m.setHetznerCredentials(userInfo, presetName, cloud)
+		return m.setHetznerCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.AWS != nil {
-		return m.setAWSCredentials(userInfo, presetName, cloud)
+		return m.setAWSCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.GCP != nil {
-		return m.setGCPCredentials(userInfo, presetName, cloud)
+		return m.setGCPCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Fake != nil {
-		return m.setFakeCredentials(userInfo, presetName, cloud)
+		return m.setFakeCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Kubevirt != nil {
-		return m.setKubevirtCredentials(userInfo, presetName, cloud)
+		return m.setKubevirtCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Alibaba != nil {
-		return m.setAlibabaCredentials(userInfo, presetName, cloud)
+		return m.setAlibabaCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Anexia != nil {
-		return m.setAnexiaCredentials(userInfo, presetName, cloud)
+		return m.setAnexiaCredentials(ctx, userInfo, presetName, cloud)
 	}
 	if cloud.Nutanix != nil {
-		return m.setNutanixCredentials(userInfo, presetName, cloud)
+		return m.setNutanixCredentials(ctx, userInfo, presetName, cloud)
 	}
 
 	return nil, fmt.Errorf("can not find provider to set credentials")
@@ -213,8 +215,8 @@ func emptyCredentialError(preset, provider string) error {
 	return fmt.Errorf("the preset %s doesn't contain credential for %s provider", preset, provider)
 }
 
-func (m *PresetProvider) setFakeCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setFakeCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +228,8 @@ func (m *PresetProvider) setFakeCredentials(userInfo *provider.UserInfo, presetN
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setKubevirtCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setKubevirtCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -240,8 +242,8 @@ func (m *PresetProvider) setKubevirtCredentials(userInfo *provider.UserInfo, pre
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setGCPCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setGCPCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +259,8 @@ func (m *PresetProvider) setGCPCredentials(userInfo *provider.UserInfo, presetNa
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setAWSCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setAWSCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -282,8 +284,8 @@ func (m *PresetProvider) setAWSCredentials(userInfo *provider.UserInfo, presetNa
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setHetznerCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setHetznerCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +298,8 @@ func (m *PresetProvider) setHetznerCredentials(userInfo *provider.UserInfo, pres
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setPacketCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setPacketCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -317,8 +319,8 @@ func (m *PresetProvider) setPacketCredentials(userInfo *provider.UserInfo, prese
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setDigitalOceanCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setDigitalOceanCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -330,8 +332,8 @@ func (m *PresetProvider) setDigitalOceanCredentials(userInfo *provider.UserInfo,
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setAzureCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setAzureCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +356,8 @@ func (m *PresetProvider) setAzureCredentials(userInfo *provider.UserInfo, preset
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setOpenStackCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setOpenStackCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -389,8 +391,8 @@ func (m *PresetProvider) setOpenStackCredentials(userInfo *provider.UserInfo, pr
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setVsphereCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setVsphereCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -411,8 +413,8 @@ func (m *PresetProvider) setVsphereCredentials(userInfo *provider.UserInfo, pres
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setAlibabaCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setAlibabaCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -427,8 +429,8 @@ func (m *PresetProvider) setAlibabaCredentials(userInfo *provider.UserInfo, pres
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setAnexiaCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setAnexiaCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}
@@ -440,8 +442,8 @@ func (m *PresetProvider) setAnexiaCredentials(userInfo *provider.UserInfo, prese
 	return &cloud, nil
 }
 
-func (m *PresetProvider) setNutanixCredentials(userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
-	preset, err := m.GetPreset(userInfo, presetName)
+func (m *PresetProvider) setNutanixCredentials(ctx context.Context, userInfo *provider.UserInfo, presetName string, cloud kubermaticv1.CloudSpec) (*kubermaticv1.CloudSpec, error) {
+	preset, err := m.GetPreset(ctx, userInfo, presetName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/kubernetes/preset_test.go
+++ b/pkg/provider/kubernetes/preset_test.go
@@ -192,7 +192,7 @@ func TestGetPreset(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			preset, err := provider.GetPreset(&tc.userInfo, tc.presetName)
+			preset, err := provider.GetPreset(context.Background(), &tc.userInfo, tc.presetName)
 			if len(tc.expectedError) > 0 {
 				if err == nil {
 					t.Fatalf("expected error")
@@ -527,7 +527,7 @@ func TestGetPresets(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			presets, err := provider.GetPresets(&tc.userInfo)
+			presets, err := provider.GetPresets(context.Background(), &tc.userInfo)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -875,7 +875,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cloudResult, err := provider.SetCloudCredentials(&tc.userInfo, tc.presetName, tc.cloudSpec, tc.dc)
+			cloudResult, err := provider.SetCloudCredentials(context.Background(), &tc.userInfo, tc.presetName, tc.cloudSpec, tc.dc)
 
 			if len(tc.expectedError) > 0 {
 				if err == nil {

--- a/pkg/provider/kubernetes/project.go
+++ b/pkg/provider/kubernetes/project.go
@@ -54,11 +54,15 @@ type ProjectProvider struct {
 	clientPrivileged ctrlruntimeclient.Client
 }
 
+var _ provider.ProjectProvider = &ProjectProvider{}
+
 // PrivilegedProjectProvider represents a data structure that knows how to manage projects in a privileged way.
 type PrivilegedProjectProvider struct {
 	// treat clientPrivileged as a privileged user and use wisely
 	clientPrivileged ctrlruntimeclient.Client
 }
+
+var _ provider.PrivilegedProjectProvider = &PrivilegedProjectProvider{}
 
 // New creates a brand new project in the system with the given name
 //
@@ -66,7 +70,7 @@ type PrivilegedProjectProvider struct {
 // a user cannot own more than one project with the given name
 // since we get the list of the current projects from a cache (lister) there is a small time window
 // during which a user can create more that one project with the given name.
-func (p *ProjectProvider) New(users []*kubermaticv1.User, projectName string, labels map[string]string) (*kubermaticv1.Project, error) {
+func (p *ProjectProvider) New(ctx context.Context, users []*kubermaticv1.User, projectName string, labels map[string]string) (*kubermaticv1.Project, error) {
 	if len(users) == 0 {
 		return nil, errors.New("users are missing but required")
 	}
@@ -91,7 +95,7 @@ func (p *ProjectProvider) New(users []*kubermaticv1.User, projectName string, la
 		})
 	}
 
-	if err := p.clientPrivileged.Create(context.Background(), project); err != nil {
+	if err := p.clientPrivileged.Create(ctx, project); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +103,7 @@ func (p *ProjectProvider) New(users []*kubermaticv1.User, projectName string, la
 }
 
 // Update update a specific project for a specific user and returns the updated project.
-func (p *ProjectProvider) Update(userInfo *provider.UserInfo, newProject *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+func (p *ProjectProvider) Update(ctx context.Context, userInfo *provider.UserInfo, newProject *kubermaticv1.Project) (*kubermaticv1.Project, error) {
 	if userInfo == nil {
 		return nil, errors.New("a user is missing but required")
 	}
@@ -108,7 +112,7 @@ func (p *ProjectProvider) Update(userInfo *provider.UserInfo, newProject *kuberm
 		return nil, err
 	}
 
-	if err := masterImpersonatedClient.Update(context.Background(), newProject); err != nil {
+	if err := masterImpersonatedClient.Update(ctx, newProject); err != nil {
 		return nil, err
 	}
 	return newProject, nil
@@ -118,7 +122,7 @@ func (p *ProjectProvider) Update(userInfo *provider.UserInfo, newProject *kuberm
 //
 // Note:
 // Before deletion project's status.phase is set to ProjectTerminating.
-func (p *ProjectProvider) Delete(userInfo *provider.UserInfo, projectInternalName string) error {
+func (p *ProjectProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, projectInternalName string) error {
 	if userInfo == nil {
 		return errors.New("a user is missing but required")
 	}
@@ -128,21 +132,21 @@ func (p *ProjectProvider) Delete(userInfo *provider.UserInfo, projectInternalNam
 	}
 
 	existingProject := &kubermaticv1.Project{}
-	if err := masterImpersonatedClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
+	if err := masterImpersonatedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
 		return err
 	}
 
 	oldProject := existingProject.DeepCopy()
 	existingProject.Status.Phase = kubermaticv1.ProjectTerminating
-	if err := p.clientPrivileged.Status().Patch(context.Background(), existingProject, ctrlruntimeclient.MergeFromWithOptions(oldProject, ctrlruntimeclient.MergeFromWithOptimisticLock{})); err != nil {
+	if err := p.clientPrivileged.Status().Patch(ctx, existingProject, ctrlruntimeclient.MergeFromWithOptions(oldProject, ctrlruntimeclient.MergeFromWithOptimisticLock{})); err != nil {
 		return err
 	}
 
-	return masterImpersonatedClient.Delete(context.Background(), existingProject)
+	return masterImpersonatedClient.Delete(ctx, existingProject)
 }
 
 // Get returns the project with the given name.
-func (p *ProjectProvider) Get(userInfo *provider.UserInfo, projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
+func (p *ProjectProvider) Get(ctx context.Context, userInfo *provider.UserInfo, projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
 	if userInfo == nil {
 		return nil, errors.New("a user is missing but required")
 	}
@@ -154,7 +158,7 @@ func (p *ProjectProvider) Get(userInfo *provider.UserInfo, projectInternalName s
 		return nil, err
 	}
 	existingProject := &kubermaticv1.Project{}
-	if err := masterImpersonatedClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
+	if err := masterImpersonatedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
 		return nil, err
 	}
 	if !options.IncludeUninitialized && existingProject.Status.Phase != kubermaticv1.ProjectActive {
@@ -166,12 +170,12 @@ func (p *ProjectProvider) Get(userInfo *provider.UserInfo, projectInternalName s
 
 // GetUnsecured returns the project with the given name
 // This function is unsafe in a sense that it uses privileged account to get project with the given name.
-func (p *PrivilegedProjectProvider) GetUnsecured(projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
+func (p *PrivilegedProjectProvider) GetUnsecured(ctx context.Context, projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
 	if options == nil {
 		options = &provider.ProjectGetOptions{IncludeUninitialized: true}
 	}
 	project := &kubermaticv1.Project{}
-	if err := p.clientPrivileged.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: projectInternalName}, project); err != nil {
+	if err := p.clientPrivileged.Get(ctx, ctrlruntimeclient.ObjectKey{Name: projectInternalName}, project); err != nil {
 		return nil, err
 	}
 	if !options.IncludeUninitialized && project.Status.Phase != kubermaticv1.ProjectActive {
@@ -185,25 +189,25 @@ func (p *PrivilegedProjectProvider) GetUnsecured(projectInternalName string, opt
 //
 // Note:
 // Before deletion project's status.phase is set to ProjectTerminating.
-func (p *PrivilegedProjectProvider) DeleteUnsecured(projectInternalName string) error {
+func (p *PrivilegedProjectProvider) DeleteUnsecured(ctx context.Context, projectInternalName string) error {
 	existingProject := &kubermaticv1.Project{}
-	if err := p.clientPrivileged.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
+	if err := p.clientPrivileged.Get(ctx, ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
 		return err
 	}
 
 	oldProject := existingProject.DeepCopy()
 	existingProject.Status.Phase = kubermaticv1.ProjectTerminating
-	if err := p.clientPrivileged.Status().Patch(context.Background(), existingProject, ctrlruntimeclient.MergeFromWithOptions(oldProject, ctrlruntimeclient.MergeFromWithOptimisticLock{})); err != nil {
+	if err := p.clientPrivileged.Status().Patch(ctx, existingProject, ctrlruntimeclient.MergeFromWithOptions(oldProject, ctrlruntimeclient.MergeFromWithOptimisticLock{})); err != nil {
 		return err
 	}
 
-	return p.clientPrivileged.Delete(context.Background(), existingProject)
+	return p.clientPrivileged.Delete(ctx, existingProject)
 }
 
 // UpdateUnsecured update a specific project and returns the updated project
 // This function is unsafe in a sense that it uses privileged account to update the project.
-func (p *PrivilegedProjectProvider) UpdateUnsecured(project *kubermaticv1.Project) (*kubermaticv1.Project, error) {
-	if err := p.clientPrivileged.Update(context.Background(), project); err != nil {
+func (p *PrivilegedProjectProvider) UpdateUnsecured(ctx context.Context, project *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+	if err := p.clientPrivileged.Update(ctx, project); err != nil {
 		return nil, err
 	}
 	return project, nil
@@ -213,12 +217,12 @@ func (p *PrivilegedProjectProvider) UpdateUnsecured(project *kubermaticv1.Projec
 // If you want to filter the result please set ProjectListOptions
 //
 // Note that the list is taken from the cache.
-func (p *ProjectProvider) List(options *provider.ProjectListOptions) ([]*kubermaticv1.Project, error) {
+func (p *ProjectProvider) List(ctx context.Context, options *provider.ProjectListOptions) ([]*kubermaticv1.Project, error) {
 	if options == nil {
 		options = &provider.ProjectListOptions{}
 	}
 	projects := &kubermaticv1.ProjectList{}
-	if err := p.clientPrivileged.List(context.Background(), projects); err != nil {
+	if err := p.clientPrivileged.List(ctx, projects); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provider/kubernetes/project_test.go
+++ b/pkg/provider/kubernetes/project_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -154,7 +155,7 @@ func TestListProjects(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			result, err := target.List(tc.listOptions)
+			result, err := target.List(context.Background(), tc.listOptions)
 
 			// validate
 			if err != nil {
@@ -235,7 +236,7 @@ func TestGetUnsecuredProjects(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			result, err := target.GetUnsecured(tc.projectName, tc.getOptions)
+			result, err := target.GetUnsecured(context.Background(), tc.projectName, tc.getOptions)
 
 			if len(tc.expectedError) == 0 {
 				// validate

--- a/pkg/provider/kubernetes/rulegroup.go
+++ b/pkg/provider/kubernetes/rulegroup.go
@@ -38,6 +38,9 @@ type RuleGroupProvider struct {
 	privilegedClient ctrlruntimeclient.Client
 }
 
+var _ provider.RuleGroupProvider = &RuleGroupProvider{}
+var _ provider.PrivilegedRuleGroupProvider = &RuleGroupProvider{}
+
 // NewRuleGroupProvider returns a ruleGroup provider.
 func NewRuleGroupProvider(createSeedImpersonatedClient ImpersonationClient, privilegedClient ctrlruntimeclient.Client) *RuleGroupProvider {
 	return &RuleGroupProvider{
@@ -64,30 +67,30 @@ func RuleGroupProviderFactory(mapper meta.RESTMapper, seedKubeconfigGetter provi
 	}
 }
 
-func (r RuleGroupProvider) Create(userInfo *provider.UserInfo, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
+func (r RuleGroupProvider) Create(ctx context.Context, userInfo *provider.UserInfo, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, r.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
-	err = impersonationClient.Create(context.Background(), ruleGroup)
+	err = impersonationClient.Create(ctx, ruleGroup)
 	return ruleGroup, err
 }
 
-func (r RuleGroupProvider) List(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
+func (r RuleGroupProvider) List(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, r.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
-	return listRuleGroups(impersonationClient, cluster.Status.NamespaceName, options)
+	return listRuleGroups(ctx, impersonationClient, cluster.Status.NamespaceName, options)
 }
 
-func (r RuleGroupProvider) Get(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) (*kubermaticv1.RuleGroup, error) {
+func (r RuleGroupProvider) Get(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) (*kubermaticv1.RuleGroup, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, r.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 	ruleGroup := &kubermaticv1.RuleGroup{}
-	if err := impersonationClient.Get(context.Background(), types.NamespacedName{
+	if err := impersonationClient.Get(ctx, types.NamespacedName{
 		Name:      ruleGroupName,
 		Namespace: cluster.Status.NamespaceName,
 	}, ruleGroup); err != nil {
@@ -96,21 +99,21 @@ func (r RuleGroupProvider) Get(userInfo *provider.UserInfo, cluster *kubermaticv
 	return ruleGroup, nil
 }
 
-func (r RuleGroupProvider) Update(userInfo *provider.UserInfo, newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
+func (r RuleGroupProvider) Update(ctx context.Context, userInfo *provider.UserInfo, newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, r.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
-	err = impersonationClient.Update(context.Background(), newRuleGroup)
+	err = impersonationClient.Update(ctx, newRuleGroup)
 	return newRuleGroup, err
 }
 
-func (r RuleGroupProvider) Delete(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) error {
+func (r RuleGroupProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) error {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, r.createSeedImpersonatedClient)
 	if err != nil {
 		return err
 	}
-	return impersonationClient.Delete(context.Background(), &kubermaticv1.RuleGroup{
+	return impersonationClient.Delete(ctx, &kubermaticv1.RuleGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ruleGroupName,
 			Namespace: cluster.Status.NamespaceName,
@@ -118,9 +121,9 @@ func (r RuleGroupProvider) Delete(userInfo *provider.UserInfo, cluster *kubermat
 	})
 }
 
-func (r RuleGroupProvider) GetUnsecured(ruleGroupName, namespace string) (*kubermaticv1.RuleGroup, error) {
+func (r RuleGroupProvider) GetUnsecured(ctx context.Context, ruleGroupName, namespace string) (*kubermaticv1.RuleGroup, error) {
 	ruleGroup := &kubermaticv1.RuleGroup{}
-	if err := r.privilegedClient.Get(context.Background(), types.NamespacedName{
+	if err := r.privilegedClient.Get(ctx, types.NamespacedName{
 		Name:      ruleGroupName,
 		Namespace: namespace,
 	}, ruleGroup); err != nil {
@@ -129,22 +132,22 @@ func (r RuleGroupProvider) GetUnsecured(ruleGroupName, namespace string) (*kuber
 	return ruleGroup, nil
 }
 
-func (r RuleGroupProvider) ListUnsecured(namespace string, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
-	return listRuleGroups(r.privilegedClient, namespace, options)
+func (r RuleGroupProvider) ListUnsecured(ctx context.Context, namespace string, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
+	return listRuleGroups(ctx, r.privilegedClient, namespace, options)
 }
 
-func (r RuleGroupProvider) CreateUnsecured(ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
-	err := r.privilegedClient.Create(context.Background(), ruleGroup)
+func (r RuleGroupProvider) CreateUnsecured(ctx context.Context, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
+	err := r.privilegedClient.Create(ctx, ruleGroup)
 	return ruleGroup, err
 }
 
-func (r RuleGroupProvider) UpdateUnsecured(newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
-	err := r.privilegedClient.Update(context.Background(), newRuleGroup)
+func (r RuleGroupProvider) UpdateUnsecured(ctx context.Context, newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error) {
+	err := r.privilegedClient.Update(ctx, newRuleGroup)
 	return newRuleGroup, err
 }
 
-func (r RuleGroupProvider) DeleteUnsecured(ruleGroupName, namespace string) error {
-	return r.privilegedClient.Delete(context.Background(), &kubermaticv1.RuleGroup{
+func (r RuleGroupProvider) DeleteUnsecured(ctx context.Context, ruleGroupName, namespace string) error {
+	return r.privilegedClient.Delete(ctx, &kubermaticv1.RuleGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ruleGroupName,
 			Namespace: namespace,
@@ -152,12 +155,12 @@ func (r RuleGroupProvider) DeleteUnsecured(ruleGroupName, namespace string) erro
 	})
 }
 
-func listRuleGroups(client ctrlruntimeclient.Client, namespace string, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
+func listRuleGroups(ctx context.Context, client ctrlruntimeclient.Client, namespace string, options *provider.RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error) {
 	if options == nil {
 		options = &provider.RuleGroupListOptions{}
 	}
 	ruleGroupList := &kubermaticv1.RuleGroupList{}
-	if err := client.List(context.Background(), ruleGroupList, ctrlruntimeclient.InNamespace(namespace)); err != nil {
+	if err := client.List(ctx, ruleGroupList, ctrlruntimeclient.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 	var res []*kubermaticv1.RuleGroup

--- a/pkg/provider/kubernetes/rulegroup_test.go
+++ b/pkg/provider/kubernetes/rulegroup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -78,7 +79,7 @@ func TestGetRuleGroup(t *testing.T) {
 
 			ruleGroupProvider := kubernetes.NewRuleGroupProvider(fakeImpersonationClient, client)
 
-			ruleGroup, err := ruleGroupProvider.Get(tc.userInfo, tc.cluster, testRuleGroupName)
+			ruleGroup, err := ruleGroupProvider.Get(context.Background(), tc.userInfo, tc.cluster, testRuleGroupName)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
@@ -171,7 +172,7 @@ func TestListRuleGroup(t *testing.T) {
 
 			ruleGroupProvider := kubernetes.NewRuleGroupProvider(fakeImpersonationClient, client)
 
-			ruleGroups, err := ruleGroupProvider.List(tc.userInfo, tc.cluster, tc.listOptions)
+			ruleGroups, err := ruleGroupProvider.List(context.Background(), tc.userInfo, tc.cluster, tc.listOptions)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
@@ -244,13 +245,13 @@ func TestCreateRuleGroup(t *testing.T) {
 
 			ruleGroupProvider := kubernetes.NewRuleGroupProvider(fakeImpersonationClient, client)
 
-			_, err := ruleGroupProvider.Create(tc.userInfo, tc.expectedRuleGroup)
+			_, err := ruleGroupProvider.Create(context.Background(), tc.userInfo, tc.expectedRuleGroup)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				ruleGroup, err := ruleGroupProvider.Get(tc.userInfo, tc.cluster, tc.expectedRuleGroup.Name)
+				ruleGroup, err := ruleGroupProvider.Get(context.Background(), tc.userInfo, tc.cluster, tc.expectedRuleGroup.Name)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -305,22 +306,22 @@ func TestUpdateRuleGroup(t *testing.T) {
 
 			ruleGroupProvider := kubernetes.NewRuleGroupProvider(fakeImpersonationClient, client)
 			if len(tc.expectedError) == 0 {
-				currentRuleGroup, err := ruleGroupProvider.Get(tc.userInfo, tc.cluster, tc.expectedRuleGroup.Name)
+				currentRuleGroup, err := ruleGroupProvider.Get(context.Background(), tc.userInfo, tc.cluster, tc.expectedRuleGroup.Name)
 				if err != nil {
 					t.Fatal(err)
 				}
 				tc.expectedRuleGroup.ResourceVersion = currentRuleGroup.ResourceVersion
-				_, err = ruleGroupProvider.Update(tc.userInfo, tc.expectedRuleGroup)
+				_, err = ruleGroupProvider.Update(context.Background(), tc.userInfo, tc.expectedRuleGroup)
 				if err != nil {
 					t.Fatal(err)
 				}
-				ruleGroup, err := ruleGroupProvider.Get(tc.userInfo, tc.cluster, tc.expectedRuleGroup.Name)
+				ruleGroup, err := ruleGroupProvider.Get(context.Background(), tc.userInfo, tc.cluster, tc.expectedRuleGroup.Name)
 				if err != nil {
 					t.Fatal(err)
 				}
 				assert.Equal(t, tc.expectedRuleGroup, ruleGroup)
 			} else {
-				_, err := ruleGroupProvider.Update(tc.userInfo, tc.expectedRuleGroup)
+				_, err := ruleGroupProvider.Update(context.Background(), tc.userInfo, tc.expectedRuleGroup)
 				if err == nil {
 					t.Fatalf("expected error message")
 				}
@@ -369,12 +370,12 @@ func TestDeleteRuleGroup(t *testing.T) {
 			}
 
 			ruleGroupProvider := kubernetes.NewRuleGroupProvider(fakeImpersonationClient, client)
-			err := ruleGroupProvider.Delete(tc.userInfo, tc.cluster, tc.ruleGroupName)
+			err := ruleGroupProvider.Delete(context.Background(), tc.userInfo, tc.cluster, tc.ruleGroupName)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
 				}
-				_, err = ruleGroupProvider.Get(tc.userInfo, tc.cluster, tc.ruleGroupName)
+				_, err = ruleGroupProvider.Get(context.Background(), tc.userInfo, tc.cluster, tc.ruleGroupName)
 				assert.True(t, errors.IsNotFound(err))
 			} else {
 				if err == nil {

--- a/pkg/provider/kubernetes/sa_test.go
+++ b/pkg/provider/kubernetes/sa_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -75,7 +76,7 @@ func TestCreateProjectServiceAccount(t *testing.T) {
 			// act
 			target := kubernetes.NewServiceAccountProvider(fakeImpersonationClient, fakeClient, "localhost")
 
-			sa, err := target.CreateProjectServiceAccount(tc.userInfo, tc.project, tc.saName, tc.saGroup)
+			sa, err := target.CreateProjectServiceAccount(context.Background(), tc.userInfo, tc.project, tc.saName, tc.saGroup)
 
 			// validate
 			if err != nil {
@@ -147,7 +148,7 @@ func TestListProjectServiceAccount(t *testing.T) {
 			// act
 			target := kubernetes.NewServiceAccountProvider(fakeImpersonationClient, fakeClient, "localhost")
 
-			saList, err := target.ListProjectServiceAccount(tc.userInfo, tc.project, &provider.ServiceAccountListOptions{ServiceAccountName: tc.saName})
+			saList, err := target.ListProjectServiceAccount(context.Background(), tc.userInfo, tc.project, &provider.ServiceAccountListOptions{ServiceAccountName: tc.saName})
 			// validate
 			if err != nil {
 				t.Fatal(err)
@@ -211,7 +212,7 @@ func TestGetProjectServiceAccount(t *testing.T) {
 			// act
 			target := kubernetes.NewServiceAccountProvider(fakeImpersonationClient, fakeClient, "localhost")
 
-			sa, err := target.GetProjectServiceAccount(tc.userInfo, tc.saName, nil)
+			sa, err := target.GetProjectServiceAccount(context.Background(), tc.userInfo, tc.saName, nil)
 			// validate
 			if err != nil {
 				t.Fatal(err)
@@ -272,14 +273,14 @@ func TestUpdateProjectServiceAccount(t *testing.T) {
 			// act
 			target := kubernetes.NewServiceAccountProvider(fakeImpersonationClient, fakeClient, "localhost")
 
-			sa, err := target.GetProjectServiceAccount(tc.userInfo, tc.saName, nil)
+			sa, err := target.GetProjectServiceAccount(context.Background(), tc.userInfo, tc.saName, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			sa.Spec.Name = tc.newName
 
-			expectedSA, err := target.UpdateProjectServiceAccount(tc.userInfo, sa)
+			expectedSA, err := target.UpdateProjectServiceAccount(context.Background(), tc.userInfo, sa)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -327,12 +328,12 @@ func TestDeleteProjectServiceAccount(t *testing.T) {
 			// act
 			target := kubernetes.NewServiceAccountProvider(fakeImpersonationClient, fakeClient, "localhost")
 
-			err := target.DeleteProjectServiceAccount(tc.userInfo, tc.saName)
+			err := target.DeleteProjectServiceAccount(context.Background(), tc.userInfo, tc.saName)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			_, err = target.GetProjectServiceAccount(tc.userInfo, tc.saName, nil)
+			_, err = target.GetProjectServiceAccount(context.Background(), tc.userInfo, tc.saName, nil)
 			if err == nil {
 				t.Fatal("expected error")
 			}

--- a/pkg/provider/kubernetes/sa_token_test.go
+++ b/pkg/provider/kubernetes/sa_token_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -81,7 +82,7 @@ func TestCreateToken(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			secret, err := target.Create(tc.userInfo, tc.saToSync, tc.projectToSync, tc.tokenName, tc.tokenID, token)
+			secret, err := target.Create(context.Background(), tc.userInfo, tc.saToSync, tc.projectToSync, tc.tokenName, tc.tokenID, token)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -172,7 +173,7 @@ func TestListTokens(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			resultList, err := target.List(tc.userInfo, tc.projectToSync, tc.saToSync, &provider.ServiceAccountTokenListOptions{TokenID: tc.tokenName})
+			resultList, err := target.List(context.Background(), tc.userInfo, tc.projectToSync, tc.saToSync, &provider.ServiceAccountTokenListOptions{TokenID: tc.tokenName})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -258,7 +259,7 @@ func TestGetToken(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result, err := target.Get(tc.userInfo, tc.tokenToGet)
+			result, err := target.Get(context.Background(), tc.userInfo, tc.tokenToGet)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -334,12 +335,12 @@ func TestUpdateToken(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result, err := target.Get(tc.userInfo, tc.tokenToUpdate)
+			result, err := target.Get(context.Background(), tc.userInfo, tc.tokenToUpdate)
 			if err != nil {
 				t.Fatal(err)
 			}
 			result.Labels["name"] = tc.tokenNewName
-			updated, err := target.Update(tc.userInfo, result)
+			updated, err := target.Update(context.Background(), tc.userInfo, result)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -406,18 +407,18 @@ func TestDeleteToken(t *testing.T) {
 			}
 
 			// check if token exists first
-			existingToken, err := target.Get(tc.userInfo, tc.tokenToDelete)
+			existingToken, err := target.Get(context.Background(), tc.userInfo, tc.tokenToDelete)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// delete token
-			if err := target.Delete(tc.userInfo, existingToken.Name); err != nil {
+			if err := target.Delete(context.Background(), tc.userInfo, existingToken.Name); err != nil {
 				t.Fatal(err)
 			}
 
 			// validate
-			_, err = target.Get(tc.userInfo, tc.tokenToDelete)
+			_, err = target.Get(context.Background(), tc.userInfo, tc.tokenToDelete)
 			if !errors.IsNotFound(err) {
 				t.Fatalf("expected not found error")
 			}

--- a/pkg/provider/kubernetes/seed.go
+++ b/pkg/provider/kubernetes/seed.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -29,14 +30,16 @@ type SeedProvider struct {
 	clientPrivileged ctrlruntimeclient.Client
 }
 
+var _ provider.SeedProvider = &SeedProvider{}
+
 func NewSeedProvider(client ctrlruntimeclient.Client) *SeedProvider {
 	return &SeedProvider{
 		clientPrivileged: client,
 	}
 }
 
-func (p *SeedProvider) UpdateUnsecured(seed *kubermaticv1.Seed) (*kubermaticv1.Seed, error) {
-	if err := p.clientPrivileged.Update(context.Background(), seed); err != nil {
+func (p *SeedProvider) UpdateUnsecured(ctx context.Context, seed *kubermaticv1.Seed) (*kubermaticv1.Seed, error) {
+	if err := p.clientPrivileged.Update(ctx, seed); err != nil {
 		return nil, err
 	}
 	return seed, nil

--- a/pkg/provider/kubernetes/user_test.go
+++ b/pkg/provider/kubernetes/user_test.go
@@ -135,10 +135,10 @@ func TestAddUserTokenToBlacklist(t *testing.T) {
 
 			// act
 			target := kubernetes.NewUserProvider(fakeClient, nil)
-			if err := target.InvalidateToken(user, tc.token, tc.expiry); err != nil {
+			if err := target.InvalidateToken(ctx, user, tc.token, tc.expiry); err != nil {
 				t.Fatal(err)
 			}
-			resultList, err := target.GetInvalidatedTokens(user)
+			resultList, err := target.GetInvalidatedTokens(ctx, user)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -996,20 +996,20 @@ type RuleGroupListOptions struct {
 // RuleGroupProvider declares the set of methods for interacting with ruleGroups.
 type RuleGroupProvider interface {
 	// Get gets the given ruleGroup
-	Get(userInfo *UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) (*kubermaticv1.RuleGroup, error)
+	Get(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) (*kubermaticv1.RuleGroup, error)
 
 	// List gets a list of ruleGroups, by default it returns all ruleGroup objects.
 	// If you would like to filer the result, please set RuleGroupListOptions
-	List(userInfo *UserInfo, cluster *kubermaticv1.Cluster, options *RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error)
+	List(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, options *RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error)
 
 	// Create creates the given ruleGroup
-	Create(userInfo *UserInfo, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
+	Create(ctx context.Context, userInfo *UserInfo, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
 
 	// Update updates an ruleGroup
-	Update(userInfo *UserInfo, newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
+	Update(ctx context.Context, userInfo *UserInfo, newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
 
 	// Delete deletes the ruleGroup with the given name
-	Delete(userInfo *UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, ruleGroupName string) error
 }
 
 type PrivilegedRuleGroupProvider interface {
@@ -1017,32 +1017,32 @@ type PrivilegedRuleGroupProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(ruleGroupName, namespace string) (*kubermaticv1.RuleGroup, error)
+	GetUnsecured(ctx context.Context, ruleGroupName, namespace string) (*kubermaticv1.RuleGroup, error)
 
 	// ListUnsecured gets a list of ruleGroups, by default it returns all ruleGroup objects.
 	// If you would like to filer the result, please set RuleGroupListOptions
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resources
-	ListUnsecured(namespace string, options *RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error)
+	ListUnsecured(ctx context.Context, namespace string, options *RuleGroupListOptions) ([]*kubermaticv1.RuleGroup, error)
 
 	// CreateUnsecured creates the given ruleGroup
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
+	CreateUnsecured(ctx context.Context, ruleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
 
 	// UpdateUnsecured updates an ruleGroup
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
+	UpdateUnsecured(ctx context.Context, newRuleGroup *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
 
 	// DeleteUnsecured deletes the ruleGroup with the given name
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(ruleGroupName, namespace string) error
+	DeleteUnsecured(ctx context.Context, ruleGroupName, namespace string) error
 }
 
 // PrivilegedAllowedRegistryProvider declares the set of method for interacting with allowed registries.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -743,12 +743,12 @@ type AdminProvider interface {
 
 // PresetProvider declares the set of methods for interacting with presets.
 type PresetProvider interface {
-	CreatePreset(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
-	UpdatePreset(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
-	GetPresets(userInfo *UserInfo) ([]kubermaticv1.Preset, error)
-	GetPreset(userInfo *UserInfo, name string) (*kubermaticv1.Preset, error)
-	DeletePreset(preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
-	SetCloudCredentials(userInfo *UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error)
+	CreatePreset(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+	UpdatePreset(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+	GetPresets(ctx context.Context, userInfo *UserInfo) ([]kubermaticv1.Preset, error)
+	GetPreset(ctx context.Context, userInfo *UserInfo, name string) (*kubermaticv1.Preset, error)
+	DeletePreset(ctx context.Context, preset *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+	SetCloudCredentials(ctx context.Context, userInfo *UserInfo, presetName string, cloud kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) (*kubermaticv1.CloudSpec, error)
 }
 
 // AdmissionPluginsProvider declares the set of methods for interacting with admission plugins.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -304,13 +304,13 @@ type PrivilegedSSHKeyProvider interface {
 
 // UserProvider declares the set of methods for interacting with kubermatic users.
 type UserProvider interface {
-	UserByEmail(email string) (*kubermaticv1.User, error)
-	CreateUser(id, name, email string) (*kubermaticv1.User, error)
-	UpdateUser(user *kubermaticv1.User) (*kubermaticv1.User, error)
-	UserByID(id string) (*kubermaticv1.User, error)
-	InvalidateToken(user *kubermaticv1.User, token string, expiry apiv1.Time) error
-	GetInvalidatedTokens(user *kubermaticv1.User) ([]string, error)
-	List() ([]kubermaticv1.User, error)
+	UserByEmail(ctx context.Context, email string) (*kubermaticv1.User, error)
+	CreateUser(ctx context.Context, id, name, email string) (*kubermaticv1.User, error)
+	UpdateUser(ctx context.Context, user *kubermaticv1.User) (*kubermaticv1.User, error)
+	UserByID(ctx context.Context, id string) (*kubermaticv1.User, error)
+	InvalidateToken(ctx context.Context, user *kubermaticv1.User, token string, expiry apiv1.Time) error
+	GetInvalidatedTokens(ctx context.Context, user *kubermaticv1.User) ([]string, error)
+	List(ctx context.Context) ([]kubermaticv1.User, error)
 }
 
 // PrivilegedProjectProvider declares the set of method for interacting with kubermatic's project and uses privileged account for it.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1254,10 +1254,9 @@ type PrivilegedMLAAdminSettingProvider interface {
 }
 
 type SeedProvider interface {
-
 	// UpdateUnsecured updates a Seed
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(seed *kubermaticv1.Seed) (*kubermaticv1.Seed, error)
+	UpdateUnsecured(ctx context.Context, seed *kubermaticv1.Seed) (*kubermaticv1.Seed, error)
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -268,38 +268,38 @@ type SSHKeyProvider interface {
 	//
 	// Note:
 	// After we get the list of the keys we could try to get each individually using unprivileged account to see if the user have read access,
-	List(project *kubermaticv1.Project, options *SSHKeyListOptions) ([]*kubermaticv1.UserSSHKey, error)
+	List(ctx context.Context, project *kubermaticv1.Project, options *SSHKeyListOptions) ([]*kubermaticv1.UserSSHKey, error)
 
 	// Create creates a ssh key that belongs to the given project
-	Create(userInfo *UserInfo, project *kubermaticv1.Project, keyName, pubKey string) (*kubermaticv1.UserSSHKey, error)
+	Create(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, keyName, pubKey string) (*kubermaticv1.UserSSHKey, error)
 
 	// Delete deletes the given ssh key
-	Delete(userInfo *UserInfo, keyName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, keyName string) error
 
 	// Get returns a key with the given name
-	Get(userInfo *UserInfo, keyName string) (*kubermaticv1.UserSSHKey, error)
+	Get(ctx context.Context, userInfo *UserInfo, keyName string) (*kubermaticv1.UserSSHKey, error)
 
 	// Update simply updates the given key
-	Update(userInfo *UserInfo, newKey *kubermaticv1.UserSSHKey) (*kubermaticv1.UserSSHKey, error)
+	Update(ctx context.Context, userInfo *UserInfo, newKey *kubermaticv1.UserSSHKey) (*kubermaticv1.UserSSHKey, error)
 }
 
 // SSHKeyProvider declares the set of methods for interacting with ssh keys and uses privileged account for it.
 type PrivilegedSSHKeyProvider interface {
 	// GetUnsecured returns a key with the given name
 	// This function is unsafe in a sense that it uses privileged account to get the ssh key
-	GetUnsecured(keyName string) (*kubermaticv1.UserSSHKey, error)
+	GetUnsecured(ctx context.Context, keyName string) (*kubermaticv1.UserSSHKey, error)
 
 	// UpdateUnsecured update a specific ssh key and returns the updated ssh key
 	// This function is unsafe in a sense that it uses privileged account to update the ssh key
-	UpdateUnsecured(sshKey *kubermaticv1.UserSSHKey) (*kubermaticv1.UserSSHKey, error)
+	UpdateUnsecured(ctx context.Context, sshKey *kubermaticv1.UserSSHKey) (*kubermaticv1.UserSSHKey, error)
 
 	// Create creates a ssh key that belongs to the given project
 	// This function is unsafe in a sense that it uses privileged account to create the ssh key
-	CreateUnsecured(project *kubermaticv1.Project, keyName, pubKey string) (*kubermaticv1.UserSSHKey, error)
+	CreateUnsecured(ctx context.Context, project *kubermaticv1.Project, keyName, pubKey string) (*kubermaticv1.UserSSHKey, error)
 
 	// Delete deletes the given ssh key
 	// This function is unsafe in a sense that it uses privileged account to delete the ssh key
-	DeleteUnsecured(keyName string) error
+	DeleteUnsecured(ctx context.Context, keyName string) error
 }
 
 // UserProvider declares the set of methods for interacting with kubermatic users.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -609,11 +609,11 @@ type ServiceAccountListOptions struct {
 
 // ServiceAccountTokenProvider declares the set of methods for interacting with kubermatic service account token.
 type ServiceAccountTokenProvider interface {
-	Create(userInfo *UserInfo, sa *kubermaticv1.User, projectID, tokenName, tokenID, tokenData string) (*corev1.Secret, error)
-	List(userInfo *UserInfo, project *kubermaticv1.Project, sa *kubermaticv1.User, options *ServiceAccountTokenListOptions) ([]*corev1.Secret, error)
-	Get(userInfo *UserInfo, name string) (*corev1.Secret, error)
-	Update(userInfo *UserInfo, secret *corev1.Secret) (*corev1.Secret, error)
-	Delete(userInfo *UserInfo, name string) error
+	Create(ctx context.Context, userInfo *UserInfo, sa *kubermaticv1.User, projectID, tokenName, tokenID, tokenData string) (*corev1.Secret, error)
+	List(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, sa *kubermaticv1.User, options *ServiceAccountTokenListOptions) ([]*corev1.Secret, error)
+	Get(ctx context.Context, userInfo *UserInfo, name string) (*corev1.Secret, error)
+	Update(ctx context.Context, userInfo *UserInfo, secret *corev1.Secret) (*corev1.Secret, error)
+	Delete(ctx context.Context, userInfo *UserInfo, name string) error
 }
 
 // ServiceAccountTokenListOptions allows to set filters that will be applied to filter the result.
@@ -638,31 +638,31 @@ type PrivilegedServiceAccountTokenProvider interface {
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
 	// gets resources from the cache
-	ListUnsecured(*ServiceAccountTokenListOptions) ([]*corev1.Secret, error)
+	ListUnsecured(context.Context, *ServiceAccountTokenListOptions) ([]*corev1.Secret, error)
 
 	// CreateUnsecured creates a new token
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(sa *kubermaticv1.User, projectID, tokenName, tokenID, tokenData string) (*corev1.Secret, error)
+	CreateUnsecured(ctx context.Context, sa *kubermaticv1.User, projectID, tokenName, tokenID, tokenData string) (*corev1.Secret, error)
 
 	// GetUnsecured gets the token
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(name string) (*corev1.Secret, error)
+	GetUnsecured(ctx context.Context, name string) (*corev1.Secret, error)
 
 	// UpdateUnsecured updates the token
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	UpdateUnsecured(secret *corev1.Secret) (*corev1.Secret, error)
+	UpdateUnsecured(ctx context.Context, secret *corev1.Secret) (*corev1.Secret, error)
 
 	// DeleteUnsecured deletes the token
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(name string) error
+	DeleteUnsecured(ctx context.Context, name string) error
 }
 
 // EventRecorderProvider allows to record events for objects that can be read using K8S API.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -551,11 +551,11 @@ func DatacenterCloudProviderName(spec *kubermaticv1.DatacenterSpec) (string, err
 
 // ServiceAccountProvider declares the set of methods for interacting with kubermatic service account.
 type ServiceAccountProvider interface {
-	CreateProjectServiceAccount(userInfo *UserInfo, project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error)
-	ListProjectServiceAccount(userInfo *UserInfo, project *kubermaticv1.Project, options *ServiceAccountListOptions) ([]*kubermaticv1.User, error)
-	GetProjectServiceAccount(userInfo *UserInfo, name string, options *ServiceAccountGetOptions) (*kubermaticv1.User, error)
-	UpdateProjectServiceAccount(userInfo *UserInfo, serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error)
-	DeleteProjectServiceAccount(userInfo *UserInfo, name string) error
+	CreateProjectServiceAccount(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error)
+	ListProjectServiceAccount(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, options *ServiceAccountListOptions) ([]*kubermaticv1.User, error)
+	GetProjectServiceAccount(ctx context.Context, userInfo *UserInfo, name string, options *ServiceAccountGetOptions) (*kubermaticv1.User, error)
+	UpdateProjectServiceAccount(ctx context.Context, userInfo *UserInfo, serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error)
+	DeleteProjectServiceAccount(ctx context.Context, userInfo *UserInfo, name string) error
 }
 
 // PrivilegedServiceAccountProvider declares the set of methods for interacting with kubermatic service account.
@@ -564,32 +564,32 @@ type PrivilegedServiceAccountProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resources
-	CreateUnsecuredProjectServiceAccount(project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error)
+	CreateUnsecuredProjectServiceAccount(ctx context.Context, project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error)
 
 	// ListUnsecuredProjectServiceAccount gets all project service accounts
 	// If you want to filter the result please take a look at ServiceAccountListOptions
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resources
-	ListUnsecuredProjectServiceAccount(project *kubermaticv1.Project, options *ServiceAccountListOptions) ([]*kubermaticv1.User, error)
+	ListUnsecuredProjectServiceAccount(ctx context.Context, project *kubermaticv1.Project, options *ServiceAccountListOptions) ([]*kubermaticv1.User, error)
 
 	// GetUnsecuredProjectServiceAccount get the project service account
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecuredProjectServiceAccount(name string, options *ServiceAccountGetOptions) (*kubermaticv1.User, error)
+	GetUnsecuredProjectServiceAccount(ctx context.Context, name string, options *ServiceAccountGetOptions) (*kubermaticv1.User, error)
 
 	// UpdateUnsecuredProjectServiceAccount updates the project service account
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecuredProjectServiceAccount(serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error)
+	UpdateUnsecuredProjectServiceAccount(ctx context.Context, serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error)
 
 	// DeleteUnsecuredProjectServiceAccount deletes the project service account
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecuredProjectServiceAccount(name string) error
+	DeleteUnsecuredProjectServiceAccount(ctx context.Context, name string) error
 }
 
 // ServiceAccountGetOptions allows to set filters that will be applied to filter the get result.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -731,8 +731,8 @@ type AddonConfigProvider interface {
 
 // SettingsProvider declares the set of methods for interacting global settings.
 type SettingsProvider interface {
-	GetGlobalSettings() (*kubermaticv1.KubermaticSetting, error)
-	UpdateGlobalSettings(userInfo *UserInfo, settings *kubermaticv1.KubermaticSetting) (*kubermaticv1.KubermaticSetting, error)
+	GetGlobalSettings(ctx context.Context) (*kubermaticv1.KubermaticSetting, error)
+	UpdateGlobalSettings(ctx context.Context, userInfo *UserInfo, settings *kubermaticv1.KubermaticSetting) (*kubermaticv1.KubermaticSetting, error)
 }
 
 // AdminProvider declares the set of methods for interacting with admin.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -317,40 +317,40 @@ type UserProvider interface {
 type PrivilegedProjectProvider interface {
 	// GetUnsecured returns the project with the given name
 	// This function is unsafe in a sense that it uses privileged account to get project with the given name
-	GetUnsecured(projectInternalName string, options *ProjectGetOptions) (*kubermaticv1.Project, error)
+	GetUnsecured(ctx context.Context, projectInternalName string, options *ProjectGetOptions) (*kubermaticv1.Project, error)
 
 	// DeleteUnsecured deletes any given project
 	// This function is unsafe in a sense that it uses privileged account to delete project with the given name
-	DeleteUnsecured(projectInternalName string) error
+	DeleteUnsecured(ctx context.Context, projectInternalName string) error
 
 	// UpdateUnsecured update an existing project and returns it
 	// This function is unsafe in a sense that it uses privileged account to update project
-	UpdateUnsecured(project *kubermaticv1.Project) (*kubermaticv1.Project, error)
+	UpdateUnsecured(ctx context.Context, project *kubermaticv1.Project) (*kubermaticv1.Project, error)
 }
 
 // ProjectProvider declares the set of method for interacting with kubermatic's project.
 type ProjectProvider interface {
 	// New creates a brand new project in the system with the given name
 	// Note that a user cannot own more than one project with the given name
-	New(users []*kubermaticv1.User, name string, labels map[string]string) (*kubermaticv1.Project, error)
+	New(ctx context.Context, users []*kubermaticv1.User, name string, labels map[string]string) (*kubermaticv1.Project, error)
 
 	// Delete deletes the given project as the given user
 	//
 	// Note:
 	// Before deletion project's status.phase is set to ProjectTerminating
-	Delete(userInfo *UserInfo, projectInternalName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, projectInternalName string) error
 
 	// Get returns the project with the given name
-	Get(userInfo *UserInfo, projectInternalName string, options *ProjectGetOptions) (*kubermaticv1.Project, error)
+	Get(ctx context.Context, userInfo *UserInfo, projectInternalName string, options *ProjectGetOptions) (*kubermaticv1.Project, error)
 
 	// Update update an existing project and returns it
-	Update(userInfo *UserInfo, newProject *kubermaticv1.Project) (*kubermaticv1.Project, error)
+	Update(ctx context.Context, userInfo *UserInfo, newProject *kubermaticv1.Project) (*kubermaticv1.Project, error)
 
 	// List gets a list of projects, by default it returns all resources.
 	// If you want to filter the result please set ProjectListOptions
 	//
 	// Note that the list is taken from the cache
-	List(options *ProjectListOptions) ([]*kubermaticv1.Project, error)
+	List(ctx context.Context, options *ProjectListOptions) ([]*kubermaticv1.Project, error)
 }
 
 // UserInfo represent authenticated user.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR does some house keeping and simply adds context parameters to a number of our providers, adjusting the call stack as necessary. No logic was changed in this PR, only context parameters were added.

I stopped after a couple of providers, simply to keep the PR somewhat smaller in case I have to rebase.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
