### PR TITLE
validate openstack datacenter authURL and region

### DIFF
--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -386,6 +386,15 @@ func getOpenstackAuthURLAndRegion(userInfo *provider.UserInfo, seedsGetter provi
 	if err != nil {
 		return "", "", fmt.Errorf("failed to find datacenter %q: %w", datacenterName, err)
 	}
+
+	if len(dc.Spec.Openstack.AuthURL) == 0 {
+		return "", "", fmt.Errorf("empty authURL in datacenter %q", datacenterName)
+	}
+
+	if len(dc.Spec.Openstack.Region) == 0 {
+		return "", "", fmt.Errorf("empty region in datacenter %q", datacenterName)
+	}
+
 	return dc.Spec.Openstack.AuthURL, dc.Spec.Openstack.Region, nil
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
When these are not set you get cryptic error `unsupported protocol scheme`. Validation at `getOpenstackAuthURLAndRegion` makes obvious where the error is.  

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE. 
```
