### PR TITLE
Update tests to kind 0.12

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-8
         command:
         - make
         args:
@@ -77,7 +77,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-8
         command:
         - ./hack/ci/verify.sh
         resources:
@@ -154,7 +154,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-8
         command:
         - ./hack/ci/test-github-release.sh
         resources:
@@ -174,7 +174,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -199,7 +199,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -237,7 +237,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -279,7 +279,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -321,7 +321,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -363,7 +363,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -410,7 +410,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -456,7 +456,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -499,7 +499,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -547,7 +547,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -590,7 +590,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -633,7 +633,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -676,7 +676,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -719,7 +719,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -764,7 +764,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -809,7 +809,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -855,7 +855,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -899,7 +899,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -945,7 +945,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -991,7 +991,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1085,7 +1085,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         command:
         - "./hack/ci/run-api-e2e.sh"
         env:
@@ -1209,7 +1209,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
@@ -1247,7 +1247,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         command:
         - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
         securityContext:
@@ -1279,7 +1279,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -1317,7 +1317,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         command:
         - ./hack/run-expose-strategy-e2e-test-in-kind.sh
         securityContext:
@@ -1346,7 +1346,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -1378,7 +1378,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+      - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
         command:
         - "./hack/ci/run-offline-test.sh"
         # docker-in-docker needs privileged mode
@@ -1412,7 +1412,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -130,22 +130,6 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
 
-  - name: pre-kubermatic-verify-boilerplate
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic-labs/boilerplate:v0.2.0
-        command:
-        - ./hack/verify-boilerplate.sh
-        resources:
-          requests:
-            memory: 256Mi
-            cpu: 100m
-
   - name: pre-kubermatic-simulate-github-release
     run_if_changed: "hack/ci/github-release.sh"
     decorate: true

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -60,6 +60,7 @@ try "Spellcheck" make spellcheck
 try "Verify go.mod" make check-dependencies
 try "Verify generated documentation" ./hack/verify-docs.sh
 try "Verify license compatibility" ./hack/verify-licenses.sh
+try "Verify boilerplate" ./hack/verify-boilerplate.sh
 try "Verify Grafana dashboards" ./hack/verify-grafana-dashboards.sh
 try "Verify Prometheus rules" ./hack/verify-prometheus-rules.sh
 try "Verify User Cluster Prometheus rules" ./hack/ci/verify-user-cluster-prometheus-configs.sh


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
[kind 0.12](https://github.com/kubernetes-sigs/kind/releases/tag/v0.12.0) is out and seems to be a simple upgrade.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
