### PR TITLE
Replace all remaining background contexts in Kubernetes providers

### DIFF
--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -241,11 +241,11 @@ func createInitProviders(ctx context.Context, options serverRunOptions, masterCf
 	seedClientGetter := provider.SeedClientGetterFactory(seedKubeconfigGetter)
 	clusterProviderGetter := clusterProviderFactory(mgr.GetRESTMapper(), seedKubeconfigGetter, seedClientGetter, options)
 
-	presetProvider, err := kubernetesprovider.NewPresetProvider(ctx, client)
+	presetProvider, err := kubernetesprovider.NewPresetProvider(client)
 	if err != nil {
 		return providers{}, err
 	}
-	admissionPluginProvider := kubernetesprovider.NewAdmissionPluginsProvider(ctx, client)
+	admissionPluginProvider := kubernetesprovider.NewAdmissionPluginsProvider(client)
 	// Warm up the restMapper cache. Log but ignore errors encountered here, maybe there are stale seeds
 	go func() {
 		seeds, err := seedsGetter()

--- a/pkg/clusterdeletion/lb.go
+++ b/pkg/clusterdeletion/lb.go
@@ -143,7 +143,7 @@ func (d *Deletion) checkIfAllLoadbalancersAreGone(ctx context.Context, cluster *
 	for deletedLB := range deletedLoadBalancers {
 		selector := fields.OneTermEqualSelector("involvedObject.uid", deletedLB)
 		events := &corev1.EventList{}
-		if err := userClusterClient.List(context.Background(), events, &ctrlruntimeclient.ListOptions{FieldSelector: selector}); err != nil {
+		if err := userClusterClient.List(ctx, events, &ctrlruntimeclient.ListOptions{FieldSelector: selector}); err != nil {
 			return false, fmt.Errorf("failed to get service events: %w", err)
 		}
 		for _, event := range events.Items {

--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -537,7 +537,7 @@ func makeCluster(t *testing.T, name string, portValue uint32, addresses ...strin
 	}
 }
 
-func TestEndpointToService(t *testing.T) {
+func TestNewEndpointHandler(t *testing.T) {
 	tests := []struct {
 		name          string
 		eps           *corev1.Endpoints
@@ -584,11 +584,13 @@ func TestEndpointToService(t *testing.T) {
 				WithObjects(tt.resources...).
 				Build()
 
-			res := (&Reconciler{
+			handler := (&Reconciler{
 				Options: Options{ExposeAnnotationKey: nodeportproxy.DefaultExposeAnnotationKey},
 				Client:  client,
 				log:     log,
-			}).endpointsToService(tt.eps)
+			}).newEndpointHandler(context.Background())
+
+			res := handler(tt.eps)
 
 			if diff := deep.Equal(res, tt.expectResults); diff != nil {
 				t.Errorf("Got unexpected results. Diff to expected: %v", diff)

--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -194,9 +194,8 @@ func createSecretData(s *corev1.Secret, data map[string]string) *corev1.Secret {
 // CleanupClusterResource attempts to find a cluster-wide resource and
 // deletes it if it was found. If no resource with the given name exists,
 // nil is returned.
-func CleanupClusterResource(client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object, name string) error {
+func CleanupClusterResource(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object, name string) error {
 	key := types.NamespacedName{Name: name}
-	ctx := context.Background()
 
 	if err := client.Get(ctx, key, obj); err != nil {
 		if !kerrors.IsNotFound(err) {

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -168,11 +168,11 @@ func (r *Reconciler) cleanupDeletedConfiguration(ctx context.Context, config *ku
 
 	logger.Debug("KubermaticConfiguration was deleted, cleaning up cluster-wide resources")
 
-	if err := common.CleanupClusterResource(r, &rbacv1.ClusterRoleBinding{}, kubermatic.ClusterRoleBindingName(config)); err != nil {
+	if err := common.CleanupClusterResource(ctx, r, &rbacv1.ClusterRoleBinding{}, kubermatic.ClusterRoleBindingName(config)); err != nil {
 		return fmt.Errorf("failed to clean up ClusterRoleBinding: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.SeedAdmissionWebhookName(config)); err != nil {
+	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.SeedAdmissionWebhookName(config)); err != nil {
 		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
 	}
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -173,35 +173,35 @@ func (r *Reconciler) cleanupDeletedSeed(ctx context.Context, cfg *kubermaticv1.K
 
 	log.Debug("Seed was deleted, cleaning up cluster-wide resources")
 
-	if err := common.CleanupClusterResource(client, &rbacv1.ClusterRoleBinding{}, kubermaticseed.ClusterRoleBindingName(cfg)); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &rbacv1.ClusterRoleBinding{}, kubermaticseed.ClusterRoleBindingName(cfg)); err != nil {
 		return fmt.Errorf("failed to clean up ClusterRoleBinding: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &rbacv1.ClusterRoleBinding{}, nodeportproxy.ClusterRoleBindingName(cfg)); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &rbacv1.ClusterRoleBinding{}, nodeportproxy.ClusterRoleBindingName(cfg)); err != nil {
 		return fmt.Errorf("failed to clean up ClusterRoleBinding: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &rbacv1.ClusterRole{}, nodeportproxy.ClusterRoleName(cfg)); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &rbacv1.ClusterRole{}, nodeportproxy.ClusterRoleName(cfg)); err != nil {
 		return fmt.Errorf("failed to clean up ClusterRole: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.SeedAdmissionWebhookName(cfg)); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.SeedAdmissionWebhookName(cfg)); err != nil {
 		return fmt.Errorf("failed to clean up Seed ValidatingWebhookConfiguration: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
 		return fmt.Errorf("failed to clean up Cluster ValidatingWebhookConfiguration: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &admissionregistrationv1.MutatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
 		return fmt.Errorf("failed to clean up Cluster MutatingWebhookConfiguration: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.OSCAdmissionWebhookName); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.OSCAdmissionWebhookName); err != nil {
 		return fmt.Errorf("failed to clean up OSC ValidatingWebhookConfiguration: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.OSPAdmissionWebhookName); err != nil {
+	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.OSPAdmissionWebhookName); err != nil {
 		return fmt.Errorf("failed to clean up OSP ValidatingWebhookConfiguration: %w", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -296,7 +296,7 @@ func (r *Reconciler) getAddonManifests(ctx context.Context, log *zap.SugaredLogg
 		return nil, err
 	}
 
-	credentials, err := resources.GetCredentials(resources.NewCredentialsData(context.Background(), cluster, r.Client))
+	credentials, err := resources.GetCredentials(resources.NewCredentialsData(ctx, cluster, r.Client))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -190,7 +190,7 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	newStatus := newCluster.Status.DeepCopy()
 
 	// Here partialCluster is used to copy credentials to the new cluster
-	err := resources.CopyCredentials(resources.NewCredentialsData(context.Background(), partialCluster, r.seedClient), newCluster)
+	err := resources.CopyCredentials(resources.NewCredentialsData(ctx, partialCluster, r.seedClient), newCluster)
 	if err != nil {
 		return fmt.Errorf("failed to get credentials: %w", err)
 	}

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -130,7 +130,7 @@ func newAlertmanagerReconciler(
 		}
 		if alertmanager.Spec.ConfigSecret.Name == a.GetName() {
 			clusterList := &kubermaticv1.ClusterList{}
-			if err := client.List(context.Background(), clusterList); err != nil {
+			if err := client.List(ctx, clusterList); err != nil {
 				log.Errorw("Failed to list clusters", zap.Error(err))
 				utilruntime.HandleError(fmt.Errorf("failed to list Clusters: %w", err))
 			}

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
@@ -169,7 +169,7 @@ func (r *dashboardGrafanaController) CleanUp(ctx context.Context) error {
 
 func (r *dashboardGrafanaController) handleDeletion(ctx context.Context, log *zap.SugaredLogger, configMap *corev1.ConfigMap) error {
 	projectList := &kubermaticv1.ProjectList{}
-	if err := r.List(context.Background(), projectList); err != nil {
+	if err := r.List(ctx, projectList); err != nil {
 		return fmt.Errorf("failed to list Projects: %w", err)
 	}
 	for _, project := range projectList.Items {
@@ -193,7 +193,7 @@ func (r *dashboardGrafanaController) handleDeletion(ctx context.Context, log *za
 
 func (r *dashboardGrafanaController) ensureDashboards(ctx context.Context, log *zap.SugaredLogger, configMap *corev1.ConfigMap) error {
 	projectList := &kubermaticv1.ProjectList{}
-	if err := r.List(context.Background(), projectList); err != nil {
+	if err := r.List(ctx, projectList); err != nil {
 		return fmt.Errorf("failed to list Projects: %w", err)
 	}
 	for _, project := range projectList.Items {

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -214,7 +214,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	log.Debug("Reconciling cluster now")
 
-	data, err := r.getClusterTemplateData(context.Background(), r.Client, cluster)
+	data, err := r.getClusterTemplateData(ctx, r.Client, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -93,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *Reconciler) reconcile(ctx context.Context, allowedRegistry *kubermaticv1.AllowedRegistry) error {
 	finalizer := kubermaticapiv1.AllowedRegistryCleanupFinalizer
 
-	regSet, err := r.getRegistrySet()
+	regSet, err := r.getRegistrySet(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting registry set from AllowedRegistries: %w", err)
 	}
@@ -208,9 +208,9 @@ func allowedRegistryConstraintCreatorGetter(regSet sets.String) reconciling.Name
 	}
 }
 
-func (r *Reconciler) getRegistrySet() (sets.String, error) {
+func (r *Reconciler) getRegistrySet(ctx context.Context) (sets.String, error) {
 	var arList kubermaticv1.AllowedRegistryList
-	if err := r.masterClient.List(context.Background(), &arList); err != nil {
+	if err := r.masterClient.List(ctx, &arList); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ee/metering/report_handler.go
+++ b/pkg/ee/metering/report_handler.go
@@ -138,11 +138,11 @@ func getReportsForSeed(ctx context.Context, options minio.ListObjectsOptions, se
 
 	var reports []apiv1.MeteringReport
 
-	mcCtx, cancel := context.WithCancel(context.Background())
+	mcCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	for report := range mc.ListObjects(mcCtx, s3bucket, options) {
 		if report.Err != nil {
-			cancel()
 			return nil, errors.New(report.Err.Error())
 		}
 
@@ -155,7 +155,6 @@ func getReportsForSeed(ctx context.Context, options minio.ListObjectsOptions, se
 			break
 		}
 	}
-	cancel()
 
 	return reports, nil
 }

--- a/pkg/handler/common/addon.go
+++ b/pkg/handler/common/addon.go
@@ -191,14 +191,14 @@ func deleteAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 	}
 	if adminUserInfo.IsAdmin {
 		privilegedAddonProvider := ctx.Value(middleware.PrivilegedAddonProviderContextKey).(provider.PrivilegedAddonProvider)
-		return privilegedAddonProvider.DeleteUnsecured(cluster, addonID)
+		return privilegedAddonProvider.DeleteUnsecured(ctx, cluster, addonID)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return err
 	}
 	addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
-	return addonProvider.Delete(userInfo, cluster, addonID)
+	return addonProvider.Delete(ctx, userInfo, cluster, addonID)
 }
 
 func updateAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, addon *kubermaticv1.Addon, projectID string) (*kubermaticv1.Addon, error) {
@@ -208,14 +208,14 @@ func updateAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 	}
 	if adminUserInfo.IsAdmin {
 		privilegedAddonProvider := ctx.Value(middleware.PrivilegedAddonProviderContextKey).(provider.PrivilegedAddonProvider)
-		return privilegedAddonProvider.UpdateUnsecured(cluster, addon)
+		return privilegedAddonProvider.UpdateUnsecured(ctx, cluster, addon)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
-	return addonProvider.Update(userInfo, cluster, addon)
+	return addonProvider.Update(ctx, userInfo, cluster, addon)
 }
 
 func createAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, rawVars *runtime.RawExtension, labels map[string]string, projectID, name string) (*kubermaticv1.Addon, error) {
@@ -225,14 +225,14 @@ func createAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 	}
 	if adminUserInfo.IsAdmin {
 		privilegedAddonProvider := ctx.Value(middleware.PrivilegedAddonProviderContextKey).(provider.PrivilegedAddonProvider)
-		return privilegedAddonProvider.NewUnsecured(cluster, name, rawVars, labels)
+		return privilegedAddonProvider.NewUnsecured(ctx, cluster, name, rawVars, labels)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
-	return addonProvider.New(userInfo, cluster, name, rawVars, labels)
+	return addonProvider.New(ctx, userInfo, cluster, name, rawVars, labels)
 }
 
 func getAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID, addonID string) (*kubermaticv1.Addon, error) {
@@ -242,14 +242,14 @@ func getAddon(ctx context.Context, userInfoGetter provider.UserInfoGetter, clust
 	}
 	if adminUserInfo.IsAdmin {
 		privilegedAddonProvider := ctx.Value(middleware.PrivilegedAddonProviderContextKey).(provider.PrivilegedAddonProvider)
-		return privilegedAddonProvider.GetUnsecured(cluster, addonID)
+		return privilegedAddonProvider.GetUnsecured(ctx, cluster, addonID)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
-	return addonProvider.Get(userInfo, cluster, addonID)
+	return addonProvider.Get(ctx, userInfo, cluster, addonID)
 }
 
 func listAddons(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID string) ([]*kubermaticv1.Addon, error) {
@@ -259,14 +259,14 @@ func listAddons(ctx context.Context, userInfoGetter provider.UserInfoGetter, clu
 	}
 	if adminUserInfo.IsAdmin {
 		privilegedAddonProvider := ctx.Value(middleware.PrivilegedAddonProviderContextKey).(provider.PrivilegedAddonProvider)
-		return privilegedAddonProvider.ListUnsecured(cluster)
+		return privilegedAddonProvider.ListUnsecured(ctx, cluster)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
-	return addonProvider.List(userInfo, cluster)
+	return addonProvider.List(ctx, userInfo, cluster)
 }
 
 func convertInternalAddonToExternal(internalAddon *kubermaticv1.Addon) (*apiv1.Addon, error) {

--- a/pkg/handler/common/addon.go
+++ b/pkg/handler/common/addon.go
@@ -166,8 +166,8 @@ func DeleteAddonEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGe
 	return nil, common.KubernetesErrorToHTTPError(deleteAddon(ctx, userInfoGetter, cluster, projectID, addonID))
 }
 
-func GetAddonConfigEndpoint(addonConfigProvider provider.AddonConfigProvider, addonID string) (interface{}, error) {
-	addon, err := addonConfigProvider.Get(addonID)
+func GetAddonConfigEndpoint(ctx context.Context, addonConfigProvider provider.AddonConfigProvider, addonID string) (interface{}, error) {
+	addon, err := addonConfigProvider.Get(ctx, addonID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -175,8 +175,8 @@ func GetAddonConfigEndpoint(addonConfigProvider provider.AddonConfigProvider, ad
 	return convertInternalAddonConfigToExternal(addon)
 }
 
-func ListAddonConfigsEndpoint(addonConfigProvider provider.AddonConfigProvider) (interface{}, error) {
-	list, err := addonConfigProvider.List()
+func ListAddonConfigsEndpoint(ctx context.Context, addonConfigProvider provider.AddonConfigProvider) (interface{}, error) {
+	list, err := addonConfigProvider.List(ctx)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -72,7 +72,7 @@ func GetAdminKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.Use
 	}
 
 	if adminUserInfo.IsAdmin {
-		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForCustomerCluster(cluster)
+		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -85,9 +85,9 @@ func GetAdminKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.Use
 	}
 	if strings.HasPrefix(userInfo.Group, "viewers") {
 		filePrefix = "viewer"
-		adminClientCfg, err = clusterProvider.GetViewerKubeconfigForCustomerCluster(cluster)
+		adminClientCfg, err = clusterProvider.GetViewerKubeconfigForCustomerCluster(ctx, cluster)
 	} else {
-		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForCustomerCluster(cluster)
+		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
 	}
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
@@ -130,7 +130,7 @@ func GetOidcKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.User
 	if err != nil {
 		return nil, err
 	}
-	adminClientCfg, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(cluster)
+	adminClientCfg, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -204,7 +204,7 @@ func CreateOIDCKubeconfigEndpoint(ctx context.Context, projectProvider provider.
 			return nil, kcerrors.NewBadRequest("the token doesn't contain the mandatory \"email\" claim")
 		}
 
-		adminKubeConfig, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(cluster)
+		adminKubeConfig, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -472,10 +472,10 @@ func getClusterForOIDCEndpoint(ctx context.Context, projectProvider provider.Pro
 	}
 
 	if userInfo.IsAdmin {
-		return privilegedClusterProvider.GetUnsecured(project, clusterID, nil)
+		return privilegedClusterProvider.GetUnsecured(ctx, project, clusterID, nil)
 	}
 
-	return clusterProvider.Get(userInfo, clusterID, &provider.ClusterGetOptions{})
+	return clusterProvider.Get(ctx, userInfo, clusterID, &provider.ClusterGetOptions{})
 }
 
 func getProjectForOIDCEndpoint(ctx context.Context, userInfo *provider.UserInfo, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, projectID string) (*kubermaticv1.Project, error) {

--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -95,7 +95,7 @@ func GetAdminKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.Use
 	return &encodeKubeConifgResponse{clientCfg: adminClientCfg, filePrefix: filePrefix}, nil
 }
 
-func GetKubeconfigEndpoint(cluster *kubermaticv1.ExternalCluster, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (interface{}, error) {
+func GetKubeconfigEndpoint(ctx context.Context, cluster *kubermaticv1.ExternalCluster, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (interface{}, error) {
 	filePrefix := "external-cluster"
 
 	kubeconfigReference := cluster.Spec.KubeconfigReference
@@ -103,7 +103,7 @@ func GetKubeconfigEndpoint(cluster *kubermaticv1.ExternalCluster, privilegedClus
 		return nil, fmt.Errorf("kubeconfig not available for the Cluster")
 	}
 
-	secretKeyGetter := provider.SecretKeySelectorValueFuncFactory(context.Background(), privilegedClusterProvider.GetMasterClient())
+	secretKeyGetter := provider.SecretKeySelectorValueFuncFactory(ctx, privilegedClusterProvider.GetMasterClient())
 
 	rawKubeconfig, err := secretKeyGetter(kubeconfigReference, resources.KubeconfigSecretKey)
 	if err != nil {

--- a/pkg/handler/common/provider/aks.go
+++ b/pkg/handler/common/provider/aks.go
@@ -44,7 +44,7 @@ func ListAKSClusters(ctx context.Context, projectProvider provider.ProjectProvid
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	clusterList, err := clusterProvider.List(project)
+	clusterList, err := clusterProvider.List(ctx, project)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/provider/digitalocean.go
+++ b/pkg/handler/common/provider/digitalocean.go
@@ -71,7 +71,7 @@ func DigitaloceanSizeWithClusterCredentialsEndpoint(ctx context.Context, userInf
 
 func DigitaloceanSize(ctx context.Context, quota kubermaticv1.MachineDeploymentVMResourceQuota, token string) (apiv1.DigitaloceanSizeList, error) {
 	static := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	client := godo.NewClient(oauth2.NewClient(context.Background(), static))
+	client := godo.NewClient(oauth2.NewClient(ctx, static))
 
 	listOptions := &godo.ListOptions{
 		Page:    1,

--- a/pkg/handler/common/provider/eks.go
+++ b/pkg/handler/common/provider/eks.go
@@ -65,7 +65,7 @@ func ListEKSClusters(ctx context.Context, projectProvider provider.ProjectProvid
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	clusterList, err := clusterProvider.List(project)
+	clusterList, err := clusterProvider.List(ctx, project)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/role.go
+++ b/pkg/handler/common/role.go
@@ -41,7 +41,7 @@ func ListClusterRoleEndpoint(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	cluster, err := clusterProvider.Get(userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+	cluster, err := clusterProvider.Get(ctx, userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func ListClusterRoleNamesEndpoint(ctx context.Context, userInfoGetter provider.U
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	cluster, err := clusterProvider.Get(userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+	cluster, err := clusterProvider.Get(ctx, userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func ListRoleEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	cluster, err := clusterProvider.Get(userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+	cluster, err := clusterProvider.Get(ctx, userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func ListRoleNamesEndpoint(ctx context.Context, userInfoGetter provider.UserInfo
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	cluster, err := clusterProvider.Get(userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+	cluster, err := clusterProvider.Get(ctx, userInfo, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -311,7 +311,7 @@ func Addons(clusterProviderGetter provider.ClusterProviderGetter, addonProviderG
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			addonProvider, err := getAddonProvider(clusterProviderGetter, addonProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			addonProvider, err := getAddonProvider(ctx, clusterProviderGetter, addonProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -326,7 +326,7 @@ func PrivilegedAddons(clusterProviderGetter provider.ClusterProviderGetter, addo
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			addonProvider, err := getAddonProvider(clusterProviderGetter, addonProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			addonProvider, err := getAddonProvider(ctx, clusterProviderGetter, addonProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -337,7 +337,7 @@ func PrivilegedAddons(clusterProviderGetter provider.ClusterProviderGetter, addo
 	}
 }
 
-func getAddonProvider(clusterProviderGetter provider.ClusterProviderGetter, addonProviderGetter provider.AddonProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.AddonProvider, error) {
+func getAddonProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, addonProviderGetter provider.AddonProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.AddonProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -349,7 +349,7 @@ func getAddonProvider(clusterProviderGetter provider.ClusterProviderGetter, addo
 			if err != nil {
 				return nil, k8cerrors.NewNotFound("cluster-provider", clusterID)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}
@@ -421,7 +421,7 @@ func getClusterProviderByClusterID(ctx context.Context, seeds map[string]*kuberm
 		if err != nil {
 			return nil, ctx, k8cerrors.NewNotFound("cluster-provider", clusterID)
 		}
-		if clusterProvider.IsCluster(clusterID) {
+		if clusterProvider.IsCluster(ctx, clusterID) {
 			return clusterProvider, ctx, nil
 		}
 	}
@@ -461,7 +461,7 @@ func Constraints(clusterProviderGetter provider.ClusterProviderGetter, constrain
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			constraintProvider, err := getConstraintProvider(clusterProviderGetter, constraintProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			constraintProvider, err := getConstraintProvider(ctx, clusterProviderGetter, constraintProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -476,7 +476,7 @@ func PrivilegedConstraints(clusterProviderGetter provider.ClusterProviderGetter,
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			constraintProvider, err := getConstraintProvider(clusterProviderGetter, constraintProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			constraintProvider, err := getConstraintProvider(ctx, clusterProviderGetter, constraintProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -487,7 +487,7 @@ func PrivilegedConstraints(clusterProviderGetter provider.ClusterProviderGetter,
 	}
 }
 
-func getConstraintProvider(clusterProviderGetter provider.ClusterProviderGetter, constraintProviderGetter provider.ConstraintProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.ConstraintProvider, error) {
+func getConstraintProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, constraintProviderGetter provider.ConstraintProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.ConstraintProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -499,7 +499,7 @@ func getConstraintProvider(clusterProviderGetter provider.ClusterProviderGetter,
 			if err != nil {
 				return nil, k8cerrors.NewNotFound("cluster-provider", clusterID)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}
@@ -520,7 +520,7 @@ func Alertmanagers(clusterProviderGetter provider.ClusterProviderGetter, alertma
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			alertmanagerProvider, err := getAlertmanagerProvider(clusterProviderGetter, alertmanagerProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			alertmanagerProvider, err := getAlertmanagerProvider(ctx, clusterProviderGetter, alertmanagerProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -535,7 +535,7 @@ func PrivilegedAlertmanagers(clusterProviderGetter provider.ClusterProviderGette
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			alertmanagerProvider, err := getAlertmanagerProvider(clusterProviderGetter, alertmanagerProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			alertmanagerProvider, err := getAlertmanagerProvider(ctx, clusterProviderGetter, alertmanagerProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -546,7 +546,7 @@ func PrivilegedAlertmanagers(clusterProviderGetter provider.ClusterProviderGette
 	}
 }
 
-func getAlertmanagerProvider(clusterProviderGetter provider.ClusterProviderGetter, alertmanagerProviderGetter provider.AlertmanagerProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.AlertmanagerProvider, error) {
+func getAlertmanagerProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, alertmanagerProviderGetter provider.AlertmanagerProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.AlertmanagerProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -558,7 +558,7 @@ func getAlertmanagerProvider(clusterProviderGetter provider.ClusterProviderGette
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}
@@ -579,7 +579,7 @@ func RuleGroups(clusterProviderGetter provider.ClusterProviderGetter, ruleGroupP
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			ruleGroupProvider, err := getRuleGroupProvider(clusterProviderGetter, ruleGroupProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			ruleGroupProvider, err := getRuleGroupProvider(ctx, clusterProviderGetter, ruleGroupProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -594,7 +594,7 @@ func PrivilegedRuleGroups(clusterProviderGetter provider.ClusterProviderGetter, 
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			ruleGroupProvider, err := getRuleGroupProvider(clusterProviderGetter, ruleGroupProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			ruleGroupProvider, err := getRuleGroupProvider(ctx, clusterProviderGetter, ruleGroupProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -605,7 +605,7 @@ func PrivilegedRuleGroups(clusterProviderGetter provider.ClusterProviderGetter, 
 	}
 }
 
-func getRuleGroupProvider(clusterProviderGetter provider.ClusterProviderGetter, ruleGroupProviderGetter provider.RuleGroupProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.RuleGroupProvider, error) {
+func getRuleGroupProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, ruleGroupProviderGetter provider.RuleGroupProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.RuleGroupProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -617,7 +617,7 @@ func getRuleGroupProvider(clusterProviderGetter provider.ClusterProviderGetter, 
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}
@@ -638,7 +638,7 @@ func EtcdBackupConfig(clusterProviderGetter provider.ClusterProviderGetter, etcd
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			etcdBackupConfigProvider, err := getEtcdBackupConfigProvider(clusterProviderGetter, etcdBackupConfigProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			etcdBackupConfigProvider, err := getEtcdBackupConfigProvider(ctx, clusterProviderGetter, etcdBackupConfigProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -653,7 +653,7 @@ func PrivilegedEtcdBackupConfig(clusterProviderGetter provider.ClusterProviderGe
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			ebcProvider, err := getEtcdBackupConfigProvider(clusterProviderGetter, etcdBackupConfigProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			ebcProvider, err := getEtcdBackupConfigProvider(ctx, clusterProviderGetter, etcdBackupConfigProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -664,7 +664,7 @@ func PrivilegedEtcdBackupConfig(clusterProviderGetter provider.ClusterProviderGe
 	}
 }
 
-func getEtcdBackupConfigProvider(clusterProviderGetter provider.ClusterProviderGetter, etcdBackupConfigProviderGetter provider.EtcdBackupConfigProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.EtcdBackupConfigProvider, error) {
+func getEtcdBackupConfigProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, etcdBackupConfigProviderGetter provider.EtcdBackupConfigProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.EtcdBackupConfigProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -676,7 +676,7 @@ func getEtcdBackupConfigProvider(clusterProviderGetter provider.ClusterProviderG
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}
@@ -697,7 +697,7 @@ func EtcdRestore(clusterProviderGetter provider.ClusterProviderGetter, etcdResto
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			etcdRestoreProvider, err := getEtcdRestoreProvider(clusterProviderGetter, etcdRestoreProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			etcdRestoreProvider, err := getEtcdRestoreProvider(ctx, clusterProviderGetter, etcdRestoreProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -712,7 +712,7 @@ func PrivilegedEtcdRestore(clusterProviderGetter provider.ClusterProviderGetter,
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			erProvider, err := getEtcdRestoreProvider(clusterProviderGetter, etcdRestoreProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			erProvider, err := getEtcdRestoreProvider(ctx, clusterProviderGetter, etcdRestoreProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -723,7 +723,7 @@ func PrivilegedEtcdRestore(clusterProviderGetter provider.ClusterProviderGetter,
 	}
 }
 
-func getEtcdRestoreProvider(clusterProviderGetter provider.ClusterProviderGetter, etcdRestoreProviderGetter provider.EtcdRestoreProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.EtcdRestoreProvider, error) {
+func getEtcdRestoreProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, etcdRestoreProviderGetter provider.EtcdRestoreProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.EtcdRestoreProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -735,7 +735,7 @@ func getEtcdRestoreProvider(clusterProviderGetter provider.ClusterProviderGetter
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}
@@ -858,7 +858,7 @@ func PrivilegedMLAAdminSetting(clusterProviderGetter provider.ClusterProviderGet
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
-			privilegedMLAAdminSettingProvider, err := getPrivilegedMLAAdminSettingProvider(clusterProviderGetter, mlaAdminSettingProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
+			privilegedMLAAdminSettingProvider, err := getPrivilegedMLAAdminSettingProvider(ctx, clusterProviderGetter, mlaAdminSettingProviderGetter, seedsGetter, seedCluster.SeedName, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -868,7 +868,7 @@ func PrivilegedMLAAdminSetting(clusterProviderGetter provider.ClusterProviderGet
 	}
 }
 
-func getPrivilegedMLAAdminSettingProvider(clusterProviderGetter provider.ClusterProviderGetter, mlaAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.PrivilegedMLAAdminSettingProvider, error) {
+func getPrivilegedMLAAdminSettingProvider(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, mlaAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter, seedsGetter provider.SeedsGetter, seedName, clusterID string) (provider.PrivilegedMLAAdminSettingProvider, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, err
@@ -880,7 +880,7 @@ func getPrivilegedMLAAdminSettingProvider(clusterProviderGetter provider.Cluster
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
-			if clusterProvider.IsCluster(clusterID) {
+			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
 				break
 			}

--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -240,7 +240,7 @@ func UserInfoUnauthorized(userProjectMapper provider.ProjectMemberMapper, userPr
 				uInfo := &provider.UserInfo{Email: user.Spec.Email, IsAdmin: true}
 				return next(context.WithValue(ctx, UserInfoContextKey, uInfo), request)
 			}
-			uInfo, err := createUserInfo(user, projectID, userProjectMapper)
+			uInfo, err := createUserInfo(ctx, user, projectID, userProjectMapper)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -375,11 +375,11 @@ func TokenExtractor(o auth.TokenExtractor) transporthttp.RequestFunc {
 	}
 }
 
-func createUserInfo(user *kubermaticv1.User, projectID string, userProjectMapper provider.ProjectMemberMapper) (*provider.UserInfo, error) {
+func createUserInfo(ctx context.Context, user *kubermaticv1.User, projectID string, userProjectMapper provider.ProjectMemberMapper) (*provider.UserInfo, error) {
 	var group string
 	if projectID != "" {
 		var err error
-		group, err = userProjectMapper.MapUserToGroup(user.Spec.Email, projectID)
+		group, err = userProjectMapper.MapUserToGroup(ctx, user.Spec.Email, projectID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -206,24 +206,26 @@ type FakeConstraintTemplateProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
-func (p *FakeConstraintTemplateProvider) List() (*kubermaticv1.ConstraintTemplateList, error) {
-	return p.Provider.List()
+var _ provider.ConstraintTemplateProvider = &FakeConstraintTemplateProvider{}
+
+func (p *FakeConstraintTemplateProvider) List(ctx context.Context) (*kubermaticv1.ConstraintTemplateList, error) {
+	return p.Provider.List(ctx)
 }
 
-func (p *FakeConstraintTemplateProvider) Get(name string) (*kubermaticv1.ConstraintTemplate, error) {
-	return p.Provider.Get(name)
+func (p *FakeConstraintTemplateProvider) Get(ctx context.Context, name string) (*kubermaticv1.ConstraintTemplate, error) {
+	return p.Provider.Get(ctx, name)
 }
 
-func (p *FakeConstraintTemplateProvider) Create(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
-	return p.Provider.Create(ct)
+func (p *FakeConstraintTemplateProvider) Create(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
+	return p.Provider.Create(ctx, ct)
 }
 
-func (p *FakeConstraintTemplateProvider) Update(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
-	return p.Provider.Update(ct)
+func (p *FakeConstraintTemplateProvider) Update(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
+	return p.Provider.Update(ctx, ct)
 }
 
-func (p *FakeConstraintTemplateProvider) Delete(ct *kubermaticv1.ConstraintTemplate) error {
-	return p.Provider.Delete(ct)
+func (p *FakeConstraintTemplateProvider) Delete(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) error {
+	return p.Provider.Delete(ctx, ct)
 }
 
 type FakeConstraintProvider struct {

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -287,24 +287,24 @@ type FakePrivilegedAllowedRegistryProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
-func (p *FakePrivilegedAllowedRegistryProvider) CreateUnsecured(wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
-	return p.Provider.CreateUnsecured(wr)
+func (p *FakePrivilegedAllowedRegistryProvider) CreateUnsecured(ctx context.Context, wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
+	return p.Provider.CreateUnsecured(ctx, wr)
 }
 
-func (p *FakePrivilegedAllowedRegistryProvider) GetUnsecured(name string) (*kubermaticv1.AllowedRegistry, error) {
-	return p.Provider.GetUnsecured(name)
+func (p *FakePrivilegedAllowedRegistryProvider) GetUnsecured(ctx context.Context, name string) (*kubermaticv1.AllowedRegistry, error) {
+	return p.Provider.GetUnsecured(ctx, name)
 }
 
-func (p *FakePrivilegedAllowedRegistryProvider) ListUnsecured() (*kubermaticv1.AllowedRegistryList, error) {
-	return p.Provider.ListUnsecured()
+func (p *FakePrivilegedAllowedRegistryProvider) ListUnsecured(ctx context.Context) (*kubermaticv1.AllowedRegistryList, error) {
+	return p.Provider.ListUnsecured(ctx)
 }
 
-func (p *FakePrivilegedAllowedRegistryProvider) UpdateUnsecured(wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
-	return p.Provider.UpdateUnsecured(wr)
+func (p *FakePrivilegedAllowedRegistryProvider) UpdateUnsecured(ctx context.Context, wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
+	return p.Provider.UpdateUnsecured(ctx, wr)
 }
 
-func (p *FakePrivilegedAllowedRegistryProvider) DeleteUnsecured(name string) error {
-	return p.Provider.DeleteUnsecured(name)
+func (p *FakePrivilegedAllowedRegistryProvider) DeleteUnsecured(ctx context.Context, name string) error {
+	return p.Provider.DeleteUnsecured(ctx, name)
 }
 
 type FakeEtcdBackupConfigProvider struct {

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -137,54 +137,56 @@ type FakeExternalClusterProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
+var _ provider.ExternalClusterProvider = &FakeExternalClusterProvider{}
+
 func (p *FakeExternalClusterProvider) CreateOrUpdateCredentialSecretForCluster(ctx context.Context, cloud *apiv2.ExternalClusterCloudSpec, projectID, clusterID string) (*providerconfig.GlobalSecretKeySelector, error) {
 	return p.Provider.CreateOrUpdateCredentialSecretForCluster(ctx, cloud, projectID, clusterID)
 }
 
-func (p *FakeExternalClusterProvider) IsMetricServerAvailable(cluster *kubermaticv1.ExternalCluster) (bool, error) {
+func (p *FakeExternalClusterProvider) IsMetricServerAvailable(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (bool, error) {
 	return true, nil
 }
 
-func (p *FakeExternalClusterProvider) GetNode(cluster *kubermaticv1.ExternalCluster, nodeName string) (*corev1.Node, error) {
+func (p *FakeExternalClusterProvider) GetNode(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nodeName string) (*corev1.Node, error) {
 	node := &corev1.Node{}
-	if err := p.FakeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: nodeName}, node); err != nil {
+	if err := p.FakeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: nodeName}, node); err != nil {
 		return nil, err
 	}
 
 	return node, nil
 }
 
-func (p *FakeExternalClusterProvider) ListNodes(cluster *kubermaticv1.ExternalCluster) (*corev1.NodeList, error) {
+func (p *FakeExternalClusterProvider) ListNodes(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*corev1.NodeList, error) {
 	nodes := &corev1.NodeList{}
-	if err := p.FakeClient.List(context.Background(), nodes); err != nil {
+	if err := p.FakeClient.List(ctx, nodes); err != nil {
 		return nil, err
 	}
 
 	return nodes, nil
 }
 
-func (p *FakeExternalClusterProvider) Update(userInfo *provider.UserInfo, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error) {
-	return p.Provider.Update(userInfo, cluster)
+func (p *FakeExternalClusterProvider) Update(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error) {
+	return p.Provider.Update(ctx, userInfo, cluster)
 }
 
-func (p *FakeExternalClusterProvider) GetVersion(cluster *kubermaticv1.ExternalCluster) (*semver.Semver, error) {
+func (p *FakeExternalClusterProvider) GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*semver.Semver, error) {
 	return semver.NewSemver(DefaultKubernetesVersion)
 }
 
-func (p *FakeExternalClusterProvider) GetClient(cluster *kubermaticv1.ExternalCluster) (ctrlruntimeclient.Client, error) {
+func (p *FakeExternalClusterProvider) GetClient(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (ctrlruntimeclient.Client, error) {
 	return p.FakeClient, nil
 }
 
-func (p *FakeExternalClusterProvider) List(project *kubermaticv1.Project) (*kubermaticv1.ExternalClusterList, error) {
-	return p.Provider.List(project)
+func (p *FakeExternalClusterProvider) List(ctx context.Context, project *kubermaticv1.Project) (*kubermaticv1.ExternalClusterList, error) {
+	return p.Provider.List(ctx, project)
 }
 
-func (p *FakeExternalClusterProvider) Get(userInfo *provider.UserInfo, clusterName string) (*kubermaticv1.ExternalCluster, error) {
-	return p.Provider.Get(userInfo, clusterName)
+func (p *FakeExternalClusterProvider) Get(ctx context.Context, userInfo *provider.UserInfo, clusterName string) (*kubermaticv1.ExternalCluster, error) {
+	return p.Provider.Get(ctx, userInfo, clusterName)
 }
 
-func (p *FakeExternalClusterProvider) Delete(userInfo *provider.UserInfo, cluster *kubermaticv1.ExternalCluster) error {
-	return p.Provider.Delete(userInfo, cluster)
+func (p *FakeExternalClusterProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.ExternalCluster) error {
+	return p.Provider.Delete(ctx, userInfo, cluster)
 }
 
 func (p *FakeExternalClusterProvider) GenerateClient(cfg *clientcmdapi.Config) (ctrlruntimeclient.Client, error) {
@@ -195,8 +197,8 @@ func (p *FakeExternalClusterProvider) CreateOrUpdateKubeconfigSecretForCluster(c
 	return p.Provider.CreateOrUpdateKubeconfigSecretForCluster(ctx, cluster, kubeconfig)
 }
 
-func (p *FakeExternalClusterProvider) New(userInfo *provider.UserInfo, project *kubermaticv1.Project, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error) {
-	return p.Provider.New(userInfo, project, cluster)
+func (p *FakeExternalClusterProvider) New(ctx context.Context, userInfo *provider.UserInfo, project *kubermaticv1.Project, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error) {
+	return p.Provider.New(ctx, userInfo, project, cluster)
 }
 
 type FakeConstraintTemplateProvider struct {

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -306,24 +306,26 @@ type FakeEtcdBackupConfigProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
-func (p *FakeEtcdBackupConfigProvider) Create(userInfo *provider.UserInfo, ebc *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
-	return p.Provider.Create(userInfo, ebc)
+var _ provider.EtcdBackupConfigProvider = &FakeEtcdBackupConfigProvider{}
+
+func (p *FakeEtcdBackupConfigProvider) Create(ctx context.Context, userInfo *provider.UserInfo, ebc *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+	return p.Provider.Create(ctx, userInfo, ebc)
 }
 
-func (p *FakeEtcdBackupConfigProvider) Get(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error) {
-	return p.Provider.Get(userInfo, cluster, name)
+func (p *FakeEtcdBackupConfigProvider) Get(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error) {
+	return p.Provider.Get(ctx, userInfo, cluster, name)
 }
 
-func (p *FakeEtcdBackupConfigProvider) List(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error) {
-	return p.Provider.List(userInfo, cluster)
+func (p *FakeEtcdBackupConfigProvider) List(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error) {
+	return p.Provider.List(ctx, userInfo, cluster)
 }
 
-func (p *FakeEtcdBackupConfigProvider) Delete(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
-	return p.Provider.Delete(userInfo, cluster, name)
+func (p *FakeEtcdBackupConfigProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
+	return p.Provider.Delete(ctx, userInfo, cluster, name)
 }
 
-func (p *FakeEtcdBackupConfigProvider) Patch(userInfo *provider.UserInfo, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
-	return p.Provider.Patch(userInfo, oldConfig, newConfig)
+func (p *FakeEtcdBackupConfigProvider) Patch(ctx context.Context, userInfo *provider.UserInfo, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+	return p.Provider.Patch(ctx, userInfo, oldConfig, newConfig)
 }
 
 type FakeEtcdRestoreProvider struct {

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -331,18 +331,20 @@ type FakeEtcdRestoreProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
-func (p *FakeEtcdRestoreProvider) Create(userInfo *provider.UserInfo, ebc *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error) {
-	return p.Provider.Create(userInfo, ebc)
+var _ provider.EtcdRestoreProvider = &FakeEtcdRestoreProvider{}
+
+func (p *FakeEtcdRestoreProvider) Create(ctx context.Context, userInfo *provider.UserInfo, ebc *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error) {
+	return p.Provider.Create(ctx, userInfo, ebc)
 }
 
-func (p *FakeEtcdRestoreProvider) Get(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error) {
-	return p.Provider.Get(userInfo, cluster, name)
+func (p *FakeEtcdRestoreProvider) Get(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error) {
+	return p.Provider.Get(ctx, userInfo, cluster, name)
 }
 
-func (p *FakeEtcdRestoreProvider) List(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error) {
-	return p.Provider.List(userInfo, cluster)
+func (p *FakeEtcdRestoreProvider) List(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error) {
+	return p.Provider.List(ctx, userInfo, cluster)
 }
 
-func (p *FakeEtcdRestoreProvider) Delete(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
-	return p.Provider.Delete(userInfo, cluster, name)
+func (p *FakeEtcdRestoreProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
+	return p.Provider.Delete(ctx, userInfo, cluster, name)
 }

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -231,24 +231,26 @@ type FakeConstraintProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
-func (p *FakeConstraintProvider) List(cluster *kubermaticv1.Cluster) (*kubermaticv1.ConstraintList, error) {
-	return p.Provider.List(cluster)
+var _ provider.ConstraintProvider = &FakeConstraintProvider{}
+
+func (p *FakeConstraintProvider) List(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.ConstraintList, error) {
+	return p.Provider.List(ctx, cluster)
 }
 
-func (p *FakeConstraintProvider) Get(cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.Constraint, error) {
-	return p.Provider.Get(cluster, name)
+func (p *FakeConstraintProvider) Get(ctx context.Context, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.Constraint, error) {
+	return p.Provider.Get(ctx, cluster, name)
 }
 
-func (p *FakeConstraintProvider) Delete(cluster *kubermaticv1.Cluster, userInfo *provider.UserInfo, name string) error {
-	return p.Provider.Delete(cluster, userInfo, name)
+func (p *FakeConstraintProvider) Delete(ctx context.Context, cluster *kubermaticv1.Cluster, userInfo *provider.UserInfo, name string) error {
+	return p.Provider.Delete(ctx, cluster, userInfo, name)
 }
 
-func (p *FakeConstraintProvider) Create(userInfo *provider.UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
-	return p.Provider.Create(userInfo, constraint)
+func (p *FakeConstraintProvider) Create(ctx context.Context, userInfo *provider.UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
+	return p.Provider.Create(ctx, userInfo, constraint)
 }
 
-func (p *FakeConstraintProvider) Update(userInfo *provider.UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
-	return p.Provider.Update(userInfo, constraint)
+func (p *FakeConstraintProvider) Update(ctx context.Context, userInfo *provider.UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
+	return p.Provider.Update(ctx, userInfo, constraint)
 }
 
 type FakeDefaultConstraintProvider struct {
@@ -256,24 +258,26 @@ type FakeDefaultConstraintProvider struct {
 	FakeClient ctrlruntimeclient.Client
 }
 
-func (p *FakeDefaultConstraintProvider) Create(ct *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
-	return p.Provider.Create(ct)
+var _ provider.DefaultConstraintProvider = &FakeDefaultConstraintProvider{}
+
+func (p *FakeDefaultConstraintProvider) Create(ctx context.Context, ct *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
+	return p.Provider.Create(ctx, ct)
 }
 
-func (p *FakeDefaultConstraintProvider) List() (*kubermaticv1.ConstraintList, error) {
-	return p.Provider.List()
+func (p *FakeDefaultConstraintProvider) List(ctx context.Context) (*kubermaticv1.ConstraintList, error) {
+	return p.Provider.List(ctx)
 }
 
-func (p *FakeDefaultConstraintProvider) Get(name string) (*kubermaticv1.Constraint, error) {
-	return p.Provider.Get(name)
+func (p *FakeDefaultConstraintProvider) Get(ctx context.Context, name string) (*kubermaticv1.Constraint, error) {
+	return p.Provider.Get(ctx, name)
 }
 
-func (p *FakeDefaultConstraintProvider) Delete(name string) error {
-	return p.Provider.Delete(name)
+func (p *FakeDefaultConstraintProvider) Delete(ctx context.Context, name string) error {
+	return p.Provider.Delete(ctx, name)
 }
 
-func (p *FakeDefaultConstraintProvider) Update(constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
-	return p.Provider.Update(constraint)
+func (p *FakeDefaultConstraintProvider) Update(ctx context.Context, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error) {
+	return p.Provider.Update(ctx, constraint)
 }
 
 type FakePrivilegedAllowedRegistryProvider struct {

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -354,11 +354,11 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		return nil, fmt.Errorf("can not find clusterprovider for cluster %q", seed.Name)
 	}
 
-	credentialsManager, err := kubernetes.NewPresetProvider(ctx, fakeClient)
+	credentialsManager, err := kubernetes.NewPresetProvider(fakeClient)
 	if err != nil {
 		return nil, nil, err
 	}
-	admissionPluginProvider := kubernetes.NewAdmissionPluginsProvider(ctx, fakeClient)
+	admissionPluginProvider := kubernetes.NewAdmissionPluginsProvider(fakeClient)
 
 	if seedsGetter == nil {
 		seedsGetter = CreateTestSeedsGetter(ctx, fakeClient)

--- a/pkg/handler/v1/addon/addon.go
+++ b/pkg/handler/v1/addon/addon.go
@@ -212,7 +212,7 @@ func DeleteAddonEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 
 func ListAddonConfigsEndpoint(addonConfigProvider provider.AddonConfigProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		return handlercommon.ListAddonConfigsEndpoint(addonConfigProvider)
+		return handlercommon.ListAddonConfigsEndpoint(ctx, addonConfigProvider)
 	}
 }
 
@@ -220,6 +220,6 @@ func GetAddonConfigEndpoint(addonConfigProvider provider.AddonConfigProvider) en
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(getConfigReq)
 
-		return handlercommon.GetAddonConfigEndpoint(addonConfigProvider, req.AddonID)
+		return handlercommon.GetAddonConfigEndpoint(ctx, addonConfigProvider, req.AddonID)
 	}
 }

--- a/pkg/handler/v1/admin/admin.go
+++ b/pkg/handler/v1/admin/admin.go
@@ -37,7 +37,7 @@ func GetAdminEndpoint(userInfoGetter provider.UserInfoGetter, adminProvider prov
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		admins, err := adminProvider.GetAdmins(userInfo)
+		admins, err := adminProvider.GetAdmins(ctx, userInfo)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -68,7 +68,7 @@ func SetAdminEndpoint(userInfoGetter provider.UserInfoGetter, adminProvider prov
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		admin, err := adminProvider.SetAdmin(userInfo, req.Body.Email, req.Body.IsAdmin)
+		admin, err := adminProvider.SetAdmin(ctx, userInfo, req.Body.Email, req.Body.IsAdmin)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/admin/admission_plugin.go
+++ b/pkg/handler/v1/admin/admission_plugin.go
@@ -39,7 +39,7 @@ func ListAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admissi
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		admissionPluginList, err := admissionPluginProvider.List(userInfo)
+		admissionPluginList, err := admissionPluginProvider.List(ctx, userInfo)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -63,7 +63,7 @@ func GetAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admissio
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		admissionPlugin, err := admissionPluginProvider.Get(userInfo, req.Name)
+		admissionPlugin, err := admissionPluginProvider.Get(ctx, userInfo, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -83,7 +83,7 @@ func DeleteAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admis
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		err = admissionPluginProvider.Delete(userInfo, req.Name)
+		err = admissionPluginProvider.Delete(ctx, userInfo, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -108,7 +108,7 @@ func UpdateAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admis
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		currentPlugin, err := admissionPluginProvider.Get(userInfo, req.Name)
+		currentPlugin, err := admissionPluginProvider.Get(ctx, userInfo, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -116,7 +116,7 @@ func UpdateAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admis
 		currentPlugin.Spec.PluginName = req.Body.Plugin
 		currentPlugin.Spec.FromVersion = req.Body.FromVersion
 
-		editedAdmissionPlugin, err := admissionPluginProvider.Update(userInfo, currentPlugin)
+		editedAdmissionPlugin, err := admissionPluginProvider.Update(ctx, userInfo, currentPlugin)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/admission-plugin/admission_plugin.go
+++ b/pkg/handler/v1/admission-plugin/admission_plugin.go
@@ -33,7 +33,7 @@ import (
 func GetAdmissionPluginEndpoint(admissionPluginProvider provider.AdmissionPluginsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(admissionPluginReq)
-		pluginResponse, err := admissionPluginProvider.ListPluginNamesFromVersion(req.Version)
+		pluginResponse, err := admissionPluginProvider.ListPluginNamesFromVersion(ctx, req.Version)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -441,7 +441,7 @@ func RevokeAdminTokenEndpoint(projectProvider provider.ProjectProvider, privileg
 			return nil, err
 		}
 
-		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeAdminKubeconfig(cluster))
+		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeAdminKubeconfig(ctx, cluster))
 	}
 }
 
@@ -455,7 +455,7 @@ func RevokeViewerTokenEndpoint(projectProvider provider.ProjectProvider, privile
 			return nil, err
 		}
 
-		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeViewerKubeconfig(cluster))
+		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeViewerKubeconfig(ctx, cluster))
 	}
 }
 

--- a/pkg/handler/v1/cluster/role.go
+++ b/pkg/handler/v1/cluster/role.go
@@ -51,7 +51,7 @@ func CreateClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +86,7 @@ func CreateRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -264,7 +264,7 @@ func GetClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.End
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ func GetRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func DeleteClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func DeleteRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -463,7 +463,7 @@ func PatchRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}
@@ -558,7 +558,7 @@ func PatchClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.E
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
+		cluster, err := clusterProvider.Get(ctx, userInfo, req.ClusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -251,7 +251,7 @@ func ForwardPort(log *zap.SugaredLogger, forwarder *portforward.PortForwarder) e
 }
 
 func GetOwnersForProject(ctx context.Context, userInfo *provider.UserInfo, project *kubermaticv1.Project, memberProvider provider.ProjectMemberProvider, userProvider provider.UserProvider) ([]apiv1.User, error) {
-	allProjectMembers, err := memberProvider.List(userInfo, project, &provider.ProjectMemberListOptions{SkipPrivilegeVerification: true})
+	allProjectMembers, err := memberProvider.List(ctx, userInfo, project, &provider.ProjectMemberListOptions{SkipPrivilegeVerification: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -117,8 +117,8 @@ func (d CredentialsData) GetGlobalSecretKeySelectorValue(configVar *providerconf
 
 // GetReadyPod returns a pod matching provided label selector if it is posting ready status, error otherwise.
 // Namespace can be ensured by creating proper PodInterface client.
-func GetReadyPod(client corev1interface.PodInterface, labelSelector string) (*corev1.Pod, error) {
-	pods, err := client.List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+func GetReadyPod(ctx context.Context, client corev1interface.PodInterface, labelSelector string) (*corev1.Pod, error) {
+	pods, err := client.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod: %w", err)
 	}
@@ -141,13 +141,14 @@ func GetReadyPod(client corev1interface.PodInterface, labelSelector string) (*co
 //   to be more expensive than doing the extra round via the TCP socket:
 //   https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/transport.go#L454
 func GetPortForwarder(
+	ctx context.Context,
 	coreClient corev1interface.CoreV1Interface,
 	cfg *rest.Config,
 	namespace string,
 	labelSelector string,
 	containerPort int,
 ) (*portforward.PortForwarder, chan struct{}, error) {
-	pod, err := GetReadyPod(coreClient.Pods(namespace), labelSelector)
+	pod, err := GetReadyPod(ctx, coreClient.Pods(namespace), labelSelector)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -107,6 +107,7 @@ func ProxyEndpoint(
 
 			// Ideally we would cache these to not open a port for every single request
 			portforwarder, closeChan, err := common.GetPortForwarder(
+				ctx,
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				userCluster.Status.NamespaceName,

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -249,7 +249,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
-			clustersNumber, err := getNumberOfClustersForProject(clusterProviderGetter, seedsGetter, projectInternal)
+			clustersNumber, err := getNumberOfClustersForProject(ctx, clusterProviderGetter, seedsGetter, projectInternal)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -270,7 +270,7 @@ func getAllProjectsForAdmin(ctx context.Context, userInfo *provider.UserInfo, pr
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	clustersNumbers, err := getNumberOfClusters(clusterProviderGetter, seedsGetter)
+	clustersNumbers, err := getNumberOfClusters(ctx, clusterProviderGetter, seedsGetter)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -361,7 +361,7 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		clustersNumber, err := getNumberOfClustersForProject(clusterProviderGetter, seedsGetter, project)
+		clustersNumber, err := getNumberOfClustersForProject(ctx, clusterProviderGetter, seedsGetter, project)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -410,7 +410,7 @@ func GetEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		clustersNumber, err := getNumberOfClustersForProject(clusterProviderGetter, seedsGetter, kubermaticProject)
+		clustersNumber, err := getNumberOfClustersForProject(ctx, clusterProviderGetter, seedsGetter, kubermaticProject)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -517,7 +517,7 @@ func DecodeList(c context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
-func getNumberOfClustersForProject(clusterProviderGetter provider.ClusterProviderGetter, seedsGetter provider.SeedsGetter, project *kubermaticv1.Project) (int, error) {
+func getNumberOfClustersForProject(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, seedsGetter provider.SeedsGetter, project *kubermaticv1.Project) (int, error) {
 	var clustersNumber int
 	seeds, err := seedsGetter()
 	if err != nil {
@@ -529,7 +529,7 @@ func getNumberOfClustersForProject(clusterProviderGetter provider.ClusterProvide
 		if err != nil {
 			return clustersNumber, kubermaticerrors.NewNotFound("cluster-provider", datacenter)
 		}
-		clusters, err := clusterProvider.List(project, nil)
+		clusters, err := clusterProvider.List(ctx, project, nil)
 		if err != nil {
 			return clustersNumber, err
 		}
@@ -539,7 +539,7 @@ func getNumberOfClustersForProject(clusterProviderGetter provider.ClusterProvide
 	return clustersNumber, nil
 }
 
-func getNumberOfClusters(clusterProviderGetter provider.ClusterProviderGetter, seedsGetter provider.SeedsGetter) (map[string]int, error) {
+func getNumberOfClusters(ctx context.Context, clusterProviderGetter provider.ClusterProviderGetter, seedsGetter provider.SeedsGetter) (map[string]int, error) {
 	clustersNumber := map[string]int{}
 	seeds, err := seedsGetter()
 	if err != nil {
@@ -551,7 +551,7 @@ func getNumberOfClusters(clusterProviderGetter provider.ClusterProviderGetter, s
 		if err != nil {
 			return nil, kubermaticerrors.NewNotFound("cluster-provider", datacenter)
 		}
-		clusters, err := clusterProvider.ListAll()
+		clusters, err := clusterProvider.ListAll(ctx)
 		if err != nil {
 			return clustersNumber, err
 		}

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -91,7 +91,7 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 
 func createProjectByServiceAccount(ctx context.Context, saEmail string, projectReq projectReq, memberMapper provider.ProjectMemberMapper, userProvider provider.UserProvider, memberProvider provider.PrivilegedProjectMemberProvider, projectProvider provider.ProjectProvider) (*apiv1.Project, error) {
 	var humanUserOwnerList []*kubermaticv1.User
-	bindings, err := memberMapper.MappingsFor(saEmail)
+	bindings, err := memberMapper.MappingsFor(ctx, saEmail)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -124,7 +124,7 @@ func createProjectByServiceAccount(ctx context.Context, saEmail string, projectR
 	}
 	generatedGroupName := rbac.GenerateActualGroupNameFor(kubermaticProject.Name, rbac.ProjectManagerGroupNamePrefix)
 
-	_, err = memberProvider.CreateUnsecuredForServiceAccount(kubermaticProject, saEmail, generatedGroupName)
+	_, err = memberProvider.CreateUnsecuredForServiceAccount(ctx, kubermaticProject, saEmail, generatedGroupName)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -159,7 +159,7 @@ func validateUserProjectsLimit(ctx context.Context, user *kubermaticv1.User, set
 		return nil
 	}
 
-	userMappings, err := memberMapper.MappingsFor(user.Spec.Email)
+	userMappings, err := memberMapper.MappingsFor(ctx, user.Spec.Email)
 	if err != nil {
 		return common.KubernetesErrorToHTTPError(err)
 	}
@@ -219,7 +219,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			return getAllProjectsForAdmin(ctx, userInfo, projectProvider, memberProvider, userProvider, clusterProviderGetter, seedsGetter)
 		}
 		projects := []*apiv1.Project{}
-		userMappings, err := memberMapper.MappingsFor(userInfo.Email)
+		userMappings, err := memberMapper.MappingsFor(ctx, userInfo.Email)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/serviceaccount/sa.go
+++ b/pkg/handler/v1/serviceaccount/sa.go
@@ -144,7 +144,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 				continue
 			}
 
-			group, err := memberMapper.MapUserToGroup(sa.Spec.Email, project.Name)
+			group, err := memberMapper.MapUserToGroup(ctx, sa.Spec.Email, project.Name)
 			if err != nil {
 				errorList = append(errorList, err.Error())
 			} else {
@@ -197,7 +197,7 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			sa.Spec.Name = saFromRequest.Name
 		}
 
-		currentGroup, err := memberMapper.MapUserToGroup(sa.Spec.Email, project.Name)
+		currentGroup, err := memberMapper.MapUserToGroup(ctx, sa.Spec.Email, project.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/user/user.go
+++ b/pkg/handler/v1/user/user.go
@@ -95,14 +95,14 @@ func deleteBinding(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedMemberProvider.DeleteUnsecured(bindingID)
+		return privilegedMemberProvider.DeleteUnsecured(ctx, bindingID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return err
 	}
-	return memberProvider.Delete(userInfo, bindingID)
+	return memberProvider.Delete(ctx, userInfo, bindingID)
 }
 
 func getMemberList(ctx context.Context, userInfoGetter provider.UserInfoGetter, memberProvider provider.ProjectMemberProvider, project *kubermaticv1.Project, userEmail string) ([]*kubermaticv1.UserProjectBinding, error) {
@@ -126,7 +126,7 @@ func getMemberList(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		options = &provider.ProjectMemberListOptions{MemberEmail: userEmail, SkipPrivilegeVerification: skipPrivilegeVerification}
 	}
 
-	return memberProvider.List(userInfo, project, options)
+	return memberProvider.List(ctx, userInfo, project, options)
 }
 
 // EditEndpoint changes the group the given user/member belongs in the given project.
@@ -189,14 +189,14 @@ func updateBinding(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedMemberProvider.UpdateUnsecured(binding)
+		return privilegedMemberProvider.UpdateUnsecured(ctx, binding)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return memberProvider.Update(userInfo, binding)
+	return memberProvider.Update(ctx, userInfo, binding)
 }
 
 // ListEndpoint returns user/members of the given project.
@@ -306,14 +306,14 @@ func createBinding(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedMemberProvider.CreateUnsecured(project, email, group)
+		return privilegedMemberProvider.CreateUnsecured(ctx, project, email, group)
 	}
 
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
-	return memberProvider.Create(userInfo, project, email, group)
+	return memberProvider.Create(ctx, userInfo, project, email, group)
 }
 
 // GetEndpoint returns info about the current user.
@@ -321,7 +321,7 @@ func GetEndpoint(memberMapper provider.ProjectMemberMapper) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		authenticatedUser := ctx.Value(middleware.UserCRContextKey).(*kubermaticv1.User)
 
-		bindings, err := memberMapper.MappingsFor(authenticatedUser.Spec.Email)
+		bindings, err := memberMapper.MappingsFor(ctx, authenticatedUser.Spec.Email)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/alertmanager/alertmanager.go
+++ b/pkg/handler/v2/alertmanager/alertmanager.go
@@ -200,13 +200,13 @@ func getAlertmanagerConfig(ctx context.Context, userInfoGetter provider.UserInfo
 		return nil, nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedAlertmanagerProvider.GetUnsecured(cluster)
+		return privilegedAlertmanagerProvider.GetUnsecured(ctx, cluster)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoAlertmanagerProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, nil, err
 	}
-	return alertmanagerProvider.Get(cluster, userInfo)
+	return alertmanagerProvider.Get(ctx, cluster, userInfo)
 }
 
 func updateAlertmanagerConfig(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, alertmanager *kubermaticv1.Alertmanager, config *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
@@ -215,13 +215,13 @@ func updateAlertmanagerConfig(ctx context.Context, userInfoGetter provider.UserI
 		return nil, nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedAlertmanagerProvider.UpdateUnsecured(alertmanager, config)
+		return privilegedAlertmanagerProvider.UpdateUnsecured(ctx, alertmanager, config)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoAlertmanagerProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, nil, err
 	}
-	return alertmanagerProvider.Update(alertmanager, config, userInfo)
+	return alertmanagerProvider.Update(ctx, alertmanager, config, userInfo)
 }
 
 func resetAlertmanagerConfig(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, cluster *kubermaticv1.Cluster) error {
@@ -230,13 +230,13 @@ func resetAlertmanagerConfig(ctx context.Context, userInfoGetter provider.UserIn
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedAlertmanagerProvider.ResetUnsecured(cluster)
+		return privilegedAlertmanagerProvider.ResetUnsecured(ctx, cluster)
 	}
 	userInfo, alertmanagerProvider, err := getUserInfoAlertmanagerProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return err
 	}
-	return alertmanagerProvider.Reset(cluster, userInfo)
+	return alertmanagerProvider.Reset(ctx, cluster, userInfo)
 }
 
 func getAdminUserInfoPrivilegedAlertmanagerProvider(ctx context.Context, userInfoGetter provider.UserInfoGetter) (*provider.UserInfo, provider.PrivilegedAlertmanagerProvider, error) {

--- a/pkg/handler/v2/allowed_registry/allowed_registry.go
+++ b/pkg/handler/v2/allowed_registry/allowed_registry.go
@@ -56,7 +56,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvi
 			Spec: req.Body.AllowedRegistrySpec,
 		}
 
-		wr, err = allowedRegistryProvider.CreateUnsecured(wr)
+		wr, err = allowedRegistryProvider.CreateUnsecured(ctx, wr)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -102,7 +102,7 @@ func GetEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvider
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
-		wr, err := allowedRegistryProvider.GetUnsecured(req.AllowedRegistryName)
+		wr, err := allowedRegistryProvider.GetUnsecured(ctx, req.AllowedRegistryName)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -142,7 +142,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvide
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
-		allowedRegistryList, err := allowedRegistryProvider.ListUnsecured()
+		allowedRegistryList, err := allowedRegistryProvider.ListUnsecured(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -176,7 +176,7 @@ func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvi
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
-		err = allowedRegistryProvider.DeleteUnsecured(req.AllowedRegistryName)
+		err = allowedRegistryProvider.DeleteUnsecured(ctx, req.AllowedRegistryName)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -224,7 +224,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvid
 		}
 
 		// get WR
-		allowedRegistry, err := allowedRegistryProvider.GetUnsecured(req.AllowedRegistryName)
+		allowedRegistry, err := allowedRegistryProvider.GetUnsecured(ctx, req.AllowedRegistryName)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -256,7 +256,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvid
 		allowedRegistry.Spec = patched.Spec
 
 		// apply patch
-		allowedRegistry, err = allowedRegistryProvider.UpdateUnsecured(allowedRegistry)
+		allowedRegistry, err = allowedRegistryProvider.UpdateUnsecured(ctx, allowedRegistry)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -72,14 +72,14 @@ func CreateOrUpdateEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter 
 		bc := convertAPIToInternalBackupCredentials(&req.Body.BackupCredentials, backupDest)
 
 		// Update if already exists
-		_, err = backupCredentialsProvider.GetUnsecured(bc.Name)
+		_, err = backupCredentialsProvider.GetUnsecured(ctx, bc.Name)
 		if err != nil {
-			_, err = backupCredentialsProvider.CreateUnsecured(bc)
+			_, err = backupCredentialsProvider.CreateUnsecured(ctx, bc)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 		} else {
-			_, err = backupCredentialsProvider.UpdateUnsecured(bc)
+			_, err = backupCredentialsProvider.UpdateUnsecured(ctx, bc)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v2/cluster/cluster.go
+++ b/pkg/handler/v2/cluster/cluster.go
@@ -197,7 +197,7 @@ func RevokeAdminTokenEndpoint(projectProvider provider.ProjectProvider, privileg
 			return nil, err
 		}
 
-		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeAdminKubeconfig(cluster))
+		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeAdminKubeconfig(ctx, cluster))
 	}
 }
 
@@ -211,7 +211,7 @@ func RevokeViewerTokenEndpoint(projectProvider provider.ProjectProvider, privile
 			return nil, err
 		}
 
-		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeViewerKubeconfig(cluster))
+		return nil, common.KubernetesErrorToHTTPError(clusterProvider.RevokeViewerKubeconfig(ctx, cluster))
 	}
 }
 

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -173,7 +173,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 
 		result := apiv2.ClusterTemplateList{}
 
-		templates, err := clusterTemplateProvider.List(userInfo, project.Name)
+		templates, err := clusterTemplateProvider.List(ctx, userInfo, project.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -243,7 +243,7 @@ func getClusterTemplate(ctx context.Context, projectProvider provider.ProjectPro
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	template, err := clusterTemplateProvider.Get(userInfo, project.Name, clusterTemplateID)
+	template, err := clusterTemplateProvider.Get(ctx, userInfo, project.Name, clusterTemplateID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -400,7 +400,7 @@ func createClusterTemplate(ctx context.Context, userInfoGetter provider.UserInfo
 		}
 	}
 
-	ct, err := clusterTemplateProvider.New(adminUserInfo, newClusterTemplate, scope, project.Name)
+	ct, err := clusterTemplateProvider.New(ctx, adminUserInfo, newClusterTemplate, scope, project.Name)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -424,7 +424,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		if err := clusterTemplateProvider.Delete(userInfo, project.Name, req.ClusterTemplateID); err != nil {
+		if err := clusterTemplateProvider.Delete(ctx, userInfo, project.Name, req.ClusterTemplateID); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		return nil, nil
@@ -447,7 +447,7 @@ func CreateInstanceEndpoint(projectProvider provider.ProjectProvider, privileged
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		ct, err := clusterTemplateProvider.Get(adminUserInfo, project.Name, req.ClusterTemplateID)
+		ct, err := clusterTemplateProvider.Get(ctx, adminUserInfo, project.Name, req.ClusterTemplateID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -479,7 +479,7 @@ func CreateInstanceEndpoint(projectProvider provider.ProjectProvider, privileged
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		instance, err := clusterTemplateInstanceProvider.Create(userInfo, ct, project, req.Body.Replicas)
+		instance, err := clusterTemplateInstanceProvider.Create(ctx, userInfo, ct, project, req.Body.Replicas)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -464,7 +464,7 @@ func CreateInstanceEndpoint(projectProvider provider.ProjectProvider, privileged
 
 		if adminUserInfo.IsAdmin {
 			privilegedclusterTemplateInstanceProvider := clusterTemplateInstanceProvider.(provider.PrivilegedClusterTemplateInstanceProvider)
-			instance, err := privilegedclusterTemplateInstanceProvider.CreateUnsecured(ct, project, req.Body.Replicas)
+			instance, err := privilegedclusterTemplateInstanceProvider.CreateUnsecured(ctx, ct, project, req.Body.Replicas)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v2/constraint/constraint.go
+++ b/pkg/handler/v2/constraint/constraint.go
@@ -308,7 +308,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 		}
 
 		constraint := convertAPIToInternalConstraint(req.Body.Name, clus.Status.NamespaceName, req.Body.Spec)
-		err = validateConstraint(constraintTemplateProvider, constraint)
+		err = validateConstraint(ctx, constraintTemplateProvider, constraint)
 		if err != nil {
 			return nil, err
 		}
@@ -373,8 +373,8 @@ func DecodeCreateConstraintReq(c context.Context, r *http.Request) (interface{},
 	return req, nil
 }
 
-func validateConstraint(constraintTemplateProvider provider.ConstraintTemplateProvider, constraint *kubermaticv1.Constraint) error {
-	ct, err := constraintTemplateProvider.Get(strings.ToLower(constraint.Spec.ConstraintType))
+func validateConstraint(ctx context.Context, constraintTemplateProvider provider.ConstraintTemplateProvider, constraint *kubermaticv1.Constraint) error {
+	ct, err := constraintTemplateProvider.Get(ctx, strings.ToLower(constraint.Spec.ConstraintType))
 	if err != nil {
 		return utilerrors.NewBadRequest("Validation failed, constraint needs to have an existing constraint template: %v", err)
 	}
@@ -489,7 +489,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provi
 		// restore ResourceVersion to make patching safer and tests work more easily
 		patchedConstraint.ResourceVersion = originalConstraint.ResourceVersion
 
-		err = validateConstraint(constraintTemplateProvider, patchedConstraint)
+		err = validateConstraint(ctx, constraintTemplateProvider, patchedConstraint)
 		if err != nil {
 			return nil, err
 		}
@@ -574,7 +574,7 @@ func CreateDefaultEndpoint(userInfoGetter provider.UserInfoGetter,
 			},
 			Spec: req.Body.Spec,
 		}
-		err = validateConstraint(constraintTemplateProvider, constraint)
+		err = validateConstraint(ctx, constraintTemplateProvider, constraint)
 		if err != nil {
 			return nil, err
 		}
@@ -746,7 +746,7 @@ func PatchDefaultEndpoint(userInfoGetter provider.UserInfoGetter,
 		}
 
 		// validate
-		if err := validateConstraint(constraintTemplateProvider, patchedDC); err != nil {
+		if err := validateConstraint(ctx, constraintTemplateProvider, patchedDC); err != nil {
 			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("patched default constraint validation failed: %v", err))
 		}
 

--- a/pkg/handler/v2/constraint/constraint.go
+++ b/pkg/handler/v2/constraint/constraint.go
@@ -74,7 +74,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 
 		constraintProvider := ctx.Value(middleware.ConstraintProviderContextKey).(provider.ConstraintProvider)
 
-		constraintList, err := constraintProvider.List(clus)
+		constraintList, err := constraintProvider.List(ctx, clus)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -203,7 +203,7 @@ func GetEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provide
 		}
 
 		constraintProvider := ctx.Value(middleware.ConstraintProviderContextKey).(provider.ConstraintProvider)
-		constraint, err := constraintProvider.Get(clus, req.Name)
+		constraint, err := constraintProvider.Get(ctx, clus, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -258,7 +258,7 @@ func deleteConstraint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedConstraintProvider.DeleteUnsecured(cluster, constraintName)
+		return privilegedConstraintProvider.DeleteUnsecured(ctx, cluster, constraintName)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
@@ -266,7 +266,7 @@ func deleteConstraint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return err
 	}
 
-	return constraintProvider.Delete(cluster, userInfo, constraintName)
+	return constraintProvider.Delete(ctx, cluster, userInfo, constraintName)
 }
 
 // constraintReq defines HTTP request for a constraint endpoint
@@ -331,7 +331,7 @@ func createConstraint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedConstraintProvider.CreateUnsecured(constraint)
+		return privilegedConstraintProvider.CreateUnsecured(ctx, constraint)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
@@ -339,7 +339,7 @@ func createConstraint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 
-	return constraintProvider.Create(userInfo, constraint)
+	return constraintProvider.Create(ctx, userInfo, constraint)
 }
 
 // swagger:parameters createConstraint
@@ -450,7 +450,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provi
 		privilegedConstraintProvider := ctx.Value(middleware.PrivilegedConstraintProviderContextKey).(provider.PrivilegedConstraintProvider)
 
 		// get Constraint
-		originalConstraint, err := constraintProvider.Get(clus, req.Name)
+		originalConstraint, err := constraintProvider.Get(ctx, clus, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -510,7 +510,7 @@ func updateConstraint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedConstraintProvider.UpdateUnsecured(constraint)
+		return privilegedConstraintProvider.UpdateUnsecured(ctx, constraint)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
@@ -518,7 +518,7 @@ func updateConstraint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 
-	return constraintProvider.Update(userInfo, constraint)
+	return constraintProvider.Update(ctx, userInfo, constraint)
 }
 
 // patchConstraintReq defines HTTP request for patching constraints
@@ -579,7 +579,7 @@ func CreateDefaultEndpoint(userInfoGetter provider.UserInfoGetter,
 			return nil, err
 		}
 
-		ct, err := defaultConstraintProvider.Create(constraint)
+		ct, err := defaultConstraintProvider.Create(ctx, constraint)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -605,7 +605,7 @@ func (req defaultConstraintReq) Validate() error {
 
 func ListDefaultEndpoint(defaultConstraintProvider provider.DefaultConstraintProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		defaultConstraintList, err := defaultConstraintProvider.List()
+		defaultConstraintList, err := defaultConstraintProvider.List(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -626,7 +626,7 @@ func GetDefaultEndpoint(defaultConstraintProvider provider.DefaultConstraintProv
 			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
-		constraint, err := defaultConstraintProvider.Get(req.Name)
+		constraint, err := defaultConstraintProvider.Get(ctx, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -666,7 +666,7 @@ func DeleteDefaultEndpoint(userInfoGetter provider.UserInfoGetter, defaultConstr
 			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
-		err = defaultConstraintProvider.Delete(req.Name)
+		err = defaultConstraintProvider.Delete(ctx, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -702,7 +702,7 @@ func PatchDefaultEndpoint(userInfoGetter provider.UserInfoGetter,
 		}
 
 		// get default Constraint
-		originalDC, err := defaultConstraintProvider.Get(req.Name)
+		originalDC, err := defaultConstraintProvider.Get(ctx, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -751,7 +751,7 @@ func PatchDefaultEndpoint(userInfoGetter provider.UserInfoGetter,
 		}
 
 		// apply patch
-		patchedDC, err = defaultConstraintProvider.Update(patchedDC)
+		patchedDC, err = defaultConstraintProvider.Update(ctx, patchedDC)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/constraint_template/constraint_template.go
+++ b/pkg/handler/v2/constraint_template/constraint_template.go
@@ -39,7 +39,7 @@ import (
 
 func ListEndpoint(constraintTemplateProvider provider.ConstraintTemplateProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		constraintTemplateList, err := constraintTemplateProvider.List()
+		constraintTemplateList, err := constraintTemplateProvider.List(ctx)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -60,7 +60,7 @@ func GetEndpoint(constraintTemplateProvider provider.ConstraintTemplateProvider)
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		constraintTemplate, err := constraintTemplateProvider.Get(req.Name)
+		constraintTemplate, err := constraintTemplateProvider.Get(ctx, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -127,7 +127,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, constraintTemplatePr
 			return nil, errors.New(http.StatusBadRequest, fmt.Sprintf("create ct validation failed: %v", err))
 		}
 
-		ct, err = constraintTemplateProvider.Create(ct)
+		ct, err = constraintTemplateProvider.Create(ctx, ct)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -177,7 +177,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, constraintTemplatePro
 		}
 
 		// get CT
-		originalCT, err := constraintTemplateProvider.Get(req.Name)
+		originalCT, err := constraintTemplateProvider.Get(ctx, req.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -219,7 +219,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, constraintTemplatePro
 		}
 
 		// apply patch
-		patchedCT, err = constraintTemplateProvider.Update(patchedCT)
+		patchedCT, err = constraintTemplateProvider.Update(ctx, patchedCT)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -291,7 +291,7 @@ func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, constraintTemplatePr
 			},
 		}
 
-		err = constraintTemplateProvider.Delete(ct)
+		err = constraintTemplateProvider.Delete(ctx, ct)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
+++ b/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
@@ -473,13 +473,13 @@ func createEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInf
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdBackupConfigProvider.CreateUnsecured(etcdBackupConfig)
+		return privilegedEtcdBackupConfigProvider.CreateUnsecured(ctx, etcdBackupConfig)
 	}
 	userInfo, etcdBackupConfigProvider, err := getUserInfoEtcdBackupConfigProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdBackupConfigProvider.Create(userInfo, etcdBackupConfig)
+	return etcdBackupConfigProvider.Create(ctx, userInfo, etcdBackupConfig)
 }
 
 func getEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID, etcdBackupConfigName string) (*kubermaticv1.EtcdBackupConfig, error) {
@@ -488,13 +488,13 @@ func getEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoGe
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdBackupConfigProvider.GetUnsecured(cluster, etcdBackupConfigName)
+		return privilegedEtcdBackupConfigProvider.GetUnsecured(ctx, cluster, etcdBackupConfigName)
 	}
 	userInfo, etcdBackupConfigProvider, err := getUserInfoEtcdBackupConfigProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdBackupConfigProvider.Get(userInfo, cluster, etcdBackupConfigName)
+	return etcdBackupConfigProvider.Get(ctx, userInfo, cluster, etcdBackupConfigName)
 }
 
 func listEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID string) (*kubermaticv1.EtcdBackupConfigList, error) {
@@ -503,13 +503,13 @@ func listEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoG
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdBackupConfigProvider.ListUnsecured(cluster)
+		return privilegedEtcdBackupConfigProvider.ListUnsecured(ctx, cluster)
 	}
 	userInfo, etcdBackupConfigProvider, err := getUserInfoEtcdBackupConfigProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdBackupConfigProvider.List(userInfo, cluster)
+	return etcdBackupConfigProvider.List(ctx, userInfo, cluster)
 }
 
 func listProjectEtcdBackupConfig(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error) {
@@ -517,7 +517,7 @@ func listProjectEtcdBackupConfig(ctx context.Context, projectID string) ([]*kube
 	if privilegedEtcdBackupConfigProjectProvider == nil {
 		return nil, errors.New(http.StatusInternalServerError, "error getting privileged provider")
 	}
-	return privilegedEtcdBackupConfigProjectProvider.ListUnsecured(projectID)
+	return privilegedEtcdBackupConfigProjectProvider.ListUnsecured(ctx, projectID)
 }
 
 func deleteEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID, etcdBackupConfigName string) error {
@@ -526,13 +526,13 @@ func deleteEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInf
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdBackupConfigProvider.DeleteUnsecured(cluster, etcdBackupConfigName)
+		return privilegedEtcdBackupConfigProvider.DeleteUnsecured(ctx, cluster, etcdBackupConfigName)
 	}
 	userInfo, etcdBackupConfigProvider, err := getUserInfoEtcdBackupConfigProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return err
 	}
-	return etcdBackupConfigProvider.Delete(userInfo, cluster, etcdBackupConfigName)
+	return etcdBackupConfigProvider.Delete(ctx, userInfo, cluster, etcdBackupConfigName)
 }
 
 func patchEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
@@ -541,13 +541,13 @@ func patchEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfo
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdBackupConfigProvider.PatchUnsecured(oldConfig, newConfig)
+		return privilegedEtcdBackupConfigProvider.PatchUnsecured(ctx, oldConfig, newConfig)
 	}
 	userInfo, etcdBackupConfigProvider, err := getUserInfoEtcdBackupConfigProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdBackupConfigProvider.Patch(userInfo, oldConfig, newConfig)
+	return etcdBackupConfigProvider.Patch(ctx, userInfo, oldConfig, newConfig)
 }
 
 func getAdminUserInfoPrivilegedEtcdBackupConfigProvider(ctx context.Context, userInfoGetter provider.UserInfoGetter) (*provider.UserInfo, provider.PrivilegedEtcdBackupConfigProvider, error) {

--- a/pkg/handler/v2/etcdrestore/etcdrestore.go
+++ b/pkg/handler/v2/etcdrestore/etcdrestore.go
@@ -335,13 +335,13 @@ func createEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGett
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdRestoreProvider.CreateUnsecured(etcdRestore)
+		return privilegedEtcdRestoreProvider.CreateUnsecured(ctx, etcdRestore)
 	}
 	userInfo, etcdRestoreProvider, err := getUserInfoEtcdRestoreProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdRestoreProvider.Create(userInfo, etcdRestore)
+	return etcdRestoreProvider.Create(ctx, userInfo, etcdRestore)
 }
 
 func getEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID, etcdRestoreName string) (*kubermaticv1.EtcdRestore, error) {
@@ -350,13 +350,13 @@ func getEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGetter,
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdRestoreProvider.GetUnsecured(cluster, etcdRestoreName)
+		return privilegedEtcdRestoreProvider.GetUnsecured(ctx, cluster, etcdRestoreName)
 	}
 	userInfo, etcdRestoreProvider, err := getUserInfoEtcdRestoreProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdRestoreProvider.Get(userInfo, cluster, etcdRestoreName)
+	return etcdRestoreProvider.Get(ctx, userInfo, cluster, etcdRestoreName)
 }
 
 func listEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID string) (*kubermaticv1.EtcdRestoreList, error) {
@@ -365,13 +365,13 @@ func listEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGetter
 		return nil, err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdRestoreProvider.ListUnsecured(cluster)
+		return privilegedEtcdRestoreProvider.ListUnsecured(ctx, cluster)
 	}
 	userInfo, etcdRestoreProvider, err := getUserInfoEtcdRestoreProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return etcdRestoreProvider.List(userInfo, cluster)
+	return etcdRestoreProvider.List(ctx, userInfo, cluster)
 }
 
 func listProjectEtcdRestore(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdRestoreList, error) {
@@ -379,7 +379,7 @@ func listProjectEtcdRestore(ctx context.Context, projectID string) ([]*kubermati
 	if privilegedEtcdRestoreProjectProvider == nil {
 		return nil, errors.New(http.StatusInternalServerError, "error getting privileged provider")
 	}
-	return privilegedEtcdRestoreProjectProvider.ListUnsecured(projectID)
+	return privilegedEtcdRestoreProjectProvider.ListUnsecured(ctx, projectID)
 }
 
 func deleteEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGetter, cluster *kubermaticv1.Cluster, projectID, etcdRestoreName string) error {
@@ -388,13 +388,13 @@ func deleteEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGett
 		return err
 	}
 	if adminUserInfo.IsAdmin {
-		return privilegedEtcdRestoreProvider.DeleteUnsecured(cluster, etcdRestoreName)
+		return privilegedEtcdRestoreProvider.DeleteUnsecured(ctx, cluster, etcdRestoreName)
 	}
 	userInfo, etcdRestoreProvider, err := getUserInfoEtcdRestoreProvider(ctx, userInfoGetter, projectID)
 	if err != nil {
 		return err
 	}
-	return etcdRestoreProvider.Delete(userInfo, cluster, etcdRestoreName)
+	return etcdRestoreProvider.Delete(ctx, userInfo, cluster, etcdRestoreName)
 }
 
 func getAdminUserInfoPrivilegedEtcdRestoreProvider(ctx context.Context, userInfoGetter provider.UserInfoGetter) (*provider.UserInfo, provider.PrivilegedEtcdRestoreProvider, error) {

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -373,13 +373,13 @@ func getAKSNodePools(ctx context.Context, cluster *kubermaticv1.ExternalCluster,
 
 	poolProfiles := *aksCluster.ManagedClusterProperties.AgentPoolProfiles
 
-	return getAKSMachineDeployments(poolProfiles, cluster, clusterProvider)
+	return getAKSMachineDeployments(ctx, poolProfiles, cluster, clusterProvider)
 }
 
-func getAKSMachineDeployments(poolProfiles []containerservice.ManagedClusterAgentPoolProfile, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterMachineDeployment, error) {
+func getAKSMachineDeployments(ctx context.Context, poolProfiles []containerservice.ManagedClusterAgentPoolProfile, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterMachineDeployment, error) {
 	machineDeployments := make([]apiv2.ExternalClusterMachineDeployment, 0, len(poolProfiles))
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -429,11 +429,11 @@ func getAKSNodePool(ctx context.Context, cluster *kubermaticv1.ExternalCluster, 
 		return nil, fmt.Errorf("no nodePool found with the name: %v", nodePoolName)
 	}
 
-	return getAKSMachineDeployment(poolProfile, cluster, clusterProvider)
+	return getAKSMachineDeployment(ctx, poolProfile, cluster, clusterProvider)
 }
 
-func getAKSMachineDeployment(poolProfile containerservice.ManagedClusterAgentPoolProfile, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
-	nodes, err := clusterProvider.ListNodes(cluster)
+func getAKSMachineDeployment(ctx context.Context, poolProfile containerservice.ManagedClusterAgentPoolProfile, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -508,10 +508,10 @@ func createMachineDeploymentFromAKSNodePoll(nodePool containerservice.ManagedClu
 	return md
 }
 
-func getAKSNodes(cluster *kubermaticv1.ExternalCluster, nodePoolName string, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterNode, error) {
+func getAKSNodes(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nodePoolName string, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterNode, error) {
 	var nodesV1 []apiv2.ExternalClusterNode
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -431,7 +431,7 @@ func patchEKSCluster(oldCluster, newCluster *apiv2.ExternalCluster, secretKeySel
 	return newCluster, nil
 }
 
-func getEKSNodeGroups(cluster *kubermaticv1.ExternalCluster, secretKeySelector provider.SecretKeySelectorValueFunc, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterMachineDeployment, error) {
+func getEKSNodeGroups(ctx context.Context, cluster *kubermaticv1.ExternalCluster, secretKeySelector provider.SecretKeySelectorValueFunc, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterMachineDeployment, error) {
 	cloudSpec := cluster.Spec.CloudSpec
 	accessKeyID, secretAccessKey, err := eksprovider.GetCredentialsForCluster(*cloudSpec, secretKeySelector)
 	if err != nil {
@@ -455,7 +455,7 @@ func getEKSNodeGroups(cluster *kubermaticv1.ExternalCluster, secretKeySelector p
 
 	machineDeployments := make([]apiv2.ExternalClusterMachineDeployment, 0, len(nodeGroups))
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -486,7 +486,7 @@ func getEKSNodeGroups(cluster *kubermaticv1.ExternalCluster, secretKeySelector p
 	return machineDeployments, err
 }
 
-func getEKSNodeGroup(cluster *kubermaticv1.ExternalCluster, nodeGroupName string, secretKeySelector provider.SecretKeySelectorValueFunc, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
+func getEKSNodeGroup(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nodeGroupName string, secretKeySelector provider.SecretKeySelectorValueFunc, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
 	cloudSpec := cluster.Spec.CloudSpec
 
 	accessKeyID, secretAccessKey, err := eksprovider.GetCredentialsForCluster(*cloudSpec, secretKeySelector)
@@ -499,10 +499,10 @@ func getEKSNodeGroup(cluster *kubermaticv1.ExternalCluster, nodeGroupName string
 		return nil, err
 	}
 
-	return getEKSMachineDeployment(client, cluster, nodeGroupName, clusterProvider)
+	return getEKSMachineDeployment(ctx, client, cluster, nodeGroupName, clusterProvider)
 }
 
-func getEKSMachineDeployment(client *awsprovider.ClientSet, cluster *kubermaticv1.ExternalCluster, nodeGroupName string, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
+func getEKSMachineDeployment(ctx context.Context, client *awsprovider.ClientSet, cluster *kubermaticv1.ExternalCluster, nodeGroupName string, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
 	clusterName := cluster.Spec.CloudSpec.EKS.Name
 
 	nodeGroupInput := &eks.DescribeNodegroupInput{
@@ -516,7 +516,7 @@ func getEKSMachineDeployment(client *awsprovider.ClientSet, cluster *kubermaticv
 	}
 	nodeGroup := nodeGroupOutput.Nodegroup
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -686,10 +686,10 @@ func resizeEKSNodeGroup(client *awsprovider.ClientSet, clusterName, nodeGroupNam
 	return updateOutput, nil
 }
 
-func getEKSNodes(cluster *kubermaticv1.ExternalCluster, nodeGroupName string, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterNode, error) {
+func getEKSNodes(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nodeGroupName string, clusterProvider provider.ExternalClusterProvider) ([]apiv2.ExternalClusterNode, error) {
 	var nodesV1 []apiv2.ExternalClusterNode
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -1033,6 +1033,6 @@ func GetKubeconfigEndpoint(userInfoGetter provider.UserInfoGetter, projectProvid
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return handlercommon.GetKubeconfigEndpoint(cluster, privilegedClusterProvider)
+		return handlercommon.GetKubeconfigEndpoint(ctx, cluster, privilegedClusterProvider)
 	}
 }

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -312,7 +312,7 @@ func getGKENodePools(ctx context.Context, cluster *kubermaticv1.ExternalCluster,
 
 	machineDeployments := make([]apiv2.ExternalClusterMachineDeployment, 0, len(resp.NodePools))
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -414,7 +414,7 @@ func getGKENodes(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nod
 
 	var nodesV1 []apiv2.ExternalClusterNode
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -493,7 +493,7 @@ func getGKEMachineDeployment(ctx context.Context, svc *container.Service, projec
 		return nil, err
 	}
 
-	nodes, err := clusterProvider.ListNodes(cluster)
+	nodes, err := clusterProvider.ListNodes(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -73,7 +73,7 @@ func GKEImagesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGet
 		}
 
 		images := apiv2.GKEImageList{}
-		svc, gcpProject, err := gke.ConnectToContainerService(sa)
+		svc, gcpProject, err := gke.ConnectToContainerService(ctx, sa)
 		if err != nil {
 			return nil, err
 		}
@@ -275,7 +275,7 @@ func patchGKECluster(ctx context.Context, oldCluster, newCluster *apiv2.External
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +299,7 @@ func getGKENodePools(ctx context.Context, cluster *kubermaticv1.ExternalCluster,
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func getGKENodePool(ctx context.Context, cluster *kubermaticv1.ExternalCluster, 
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func getGKENodes(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nod
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ func deleteGKENodePool(ctx context.Context, cluster *kubermaticv1.ExternalCluste
 	if err != nil {
 		return err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return err
 	}
@@ -453,7 +453,7 @@ func patchGKEMachineDeployment(ctx context.Context, oldMD, newMD *apiv2.External
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +515,7 @@ func createGKENodePool(ctx context.Context, cluster *kubermaticv1.ExternalCluste
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +574,7 @@ func createGKENodePool(ctx context.Context, cluster *kubermaticv1.ExternalCluste
 }
 
 func createNewGKECluster(ctx context.Context, gkeCloudSpec *apiv2.GKECloudSpec) error {
-	svc, project, err := gke.ConnectToContainerService(gkeCloudSpec.ServiceAccount)
+	svc, project, err := gke.ConnectToContainerService(ctx, gkeCloudSpec.ServiceAccount)
 	if err != nil {
 		return err
 	}
@@ -675,7 +675,7 @@ func getGKEClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := gke.ConnectToContainerService(sa)
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v2/external_cluster/node.go
+++ b/pkg/handler/v2/external_cluster/node.go
@@ -64,7 +64,7 @@ func ListNodesEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider p
 			return nodesV1, nil
 		}
 
-		nodes, err := clusterProvider.ListNodes(cluster)
+		nodes, err := clusterProvider.ListNodes(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -112,13 +112,13 @@ func getClusterNodesMetrics(ctx context.Context, userInfoGetter provider.UserInf
 		return nodeMetrics, nil
 	}
 
-	isMetricServer, err := clusterProvider.IsMetricServerAvailable(cluster)
+	isMetricServer, err := clusterProvider.IsMetricServerAvailable(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
 	if isMetricServer {
-		client, err := clusterProvider.GetClient(cluster)
+		client, err := clusterProvider.GetClient(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -202,7 +202,7 @@ func GetNodeEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider pro
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		node, err := clusterProvider.GetNode(cluster, req.NodeID)
+		node, err := clusterProvider.GetNode(ctx, cluster, req.NodeID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -246,7 +246,7 @@ func ListMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, proje
 				machineDeployments = np
 			}
 			if cloud.EKS != nil {
-				np, err := getEKSNodeGroups(cluster, secretKeySelector, clusterProvider)
+				np, err := getEKSNodeGroups(ctx, cluster, secretKeySelector, clusterProvider)
 				if err != nil {
 					return nil, common.KubernetesErrorToHTTPError(err)
 				}
@@ -304,14 +304,14 @@ func getMachineDeploymentNodes(ctx context.Context, userInfoGetter provider.User
 			nodes = n
 		}
 		if cloud.EKS != nil {
-			n, err := getEKSNodes(cluster, machineDeploymentID, clusterProvider)
+			n, err := getEKSNodes(ctx, cluster, machineDeploymentID, clusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 			nodes = n
 		}
 		if cloud.AKS != nil {
-			n, err := getAKSNodes(cluster, machineDeploymentID, clusterProvider)
+			n, err := getAKSNodes(ctx, cluster, machineDeploymentID, clusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -632,7 +632,7 @@ func GetMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projec
 			secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, privilegedClusterProvider.GetMasterClient())
 
 			if cloud.EKS != nil {
-				np, err := getEKSNodeGroup(cluster, req.MachineDeploymentID, secretKeySelector, clusterProvider)
+				np, err := getEKSNodeGroup(ctx, cluster, req.MachineDeploymentID, secretKeySelector, clusterProvider)
 				if err != nil {
 					return nil, common.KubernetesErrorToHTTPError(err)
 				}
@@ -686,7 +686,7 @@ func PatchMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, proj
 			patchedMD := apiv2.ExternalClusterMachineDeployment{}
 
 			if cloud.EKS != nil {
-				md, err := getEKSNodeGroup(cluster, req.MachineDeploymentID, secretKeySelector, clusterProvider)
+				md, err := getEKSNodeGroup(ctx, cluster, req.MachineDeploymentID, secretKeySelector, clusterProvider)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/handler/v2/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v2/kubernetes-dashboard/dashboard.go
@@ -107,6 +107,7 @@ func ProxyEndpoint(
 
 			// Ideally we would cache these to not open a port for every single request
 			portforwarder, closeChan, err := common.GetPortForwarder(
+				ctx,
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				userCluster.Status.NamespaceName,

--- a/pkg/handler/v2/mla_admin_setting/mla_admin_setting.go
+++ b/pkg/handler/v2/mla_admin_setting/mla_admin_setting.go
@@ -49,7 +49,7 @@ func GetEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provide
 			return nil, utilerrors.NewNotAuthorized()
 		}
 		privilegedMLAAdminSettingProvider := ctx.Value(middleware.PrivilegedMLAAdminSettingProviderContextKey).(provider.PrivilegedMLAAdminSettingProvider)
-		mlaAdminSetting, err := privilegedMLAAdminSettingProvider.GetUnsecured(c)
+		mlaAdminSetting, err := privilegedMLAAdminSettingProvider.GetUnsecured(ctx, c)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -77,7 +77,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		resMLAAdminSetting, err := privilegedMLAAdminSettingProvider.CreateUnsecured(mlaAdminSetting)
+		resMLAAdminSetting, err := privilegedMLAAdminSettingProvider.CreateUnsecured(ctx, mlaAdminSetting)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -101,7 +101,7 @@ func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			return nil, utilerrors.NewNotAuthorized()
 		}
 		privilegedMLAAdminSettingProvider := ctx.Value(middleware.PrivilegedMLAAdminSettingProviderContextKey).(provider.PrivilegedMLAAdminSettingProvider)
-		currentMLAAdminSetting, err := privilegedMLAAdminSettingProvider.GetUnsecured(c)
+		currentMLAAdminSetting, err := privilegedMLAAdminSettingProvider.GetUnsecured(ctx, c)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -110,7 +110,7 @@ func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		currentMLAAdminSetting.Spec = newMLAAdminSetting.Spec
-		resMLAAdminSetting, err := privilegedMLAAdminSettingProvider.UpdateUnsecured(currentMLAAdminSetting)
+		resMLAAdminSetting, err := privilegedMLAAdminSettingProvider.UpdateUnsecured(ctx, currentMLAAdminSetting)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -134,7 +134,7 @@ func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			return nil, utilerrors.NewNotAuthorized()
 		}
 		privilegedMLAAdminSettingProvider := ctx.Value(middleware.PrivilegedMLAAdminSettingProviderContextKey).(provider.PrivilegedMLAAdminSettingProvider)
-		if err = privilegedMLAAdminSettingProvider.DeleteUnsecured(c); err != nil {
+		if err = privilegedMLAAdminSettingProvider.DeleteUnsecured(ctx, c); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		return nil, nil

--- a/pkg/handler/websocket/user.go
+++ b/pkg/handler/websocket/user.go
@@ -37,7 +37,7 @@ func WriteUser(ctx context.Context, providers watcher.Providers, ws *websocket.C
 		return
 	}
 
-	bindings, err := providers.MemberMapper.MappingsFor(initialUser.Spec.Email)
+	bindings, err := providers.MemberMapper.MappingsFor(ctx, initialUser.Spec.Email)
 	if err != nil {
 		log.Logger.Debug("cannot get project mappings for user %s: %v", initialUser.Name, err)
 		return
@@ -70,7 +70,7 @@ func WriteUser(ctx context.Context, providers watcher.Providers, ws *websocket.C
 				return
 			}
 
-			bindings, err := providers.MemberMapper.MappingsFor(user.Spec.Email)
+			bindings, err := providers.MemberMapper.MappingsFor(ctx, user.Spec.Email)
 			if err != nil {
 				log.Logger.Debug("cannot get project mappings for user %s: %v", user.Name, err)
 				return

--- a/pkg/provider/cloud/aws/instance_profile.go
+++ b/pkg/provider/cloud/aws/instance_profile.go
@@ -91,7 +91,7 @@ func reconcileWorkerInstanceProfile(ctx context.Context, client iamiface.IAMAPI,
 		}
 	}
 
-	return update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		cluster.Spec.Cloud.AWS.InstanceProfileName = profileName
 	})
 }

--- a/pkg/provider/cloud/aws/migrate_ownership.go
+++ b/pkg/provider/cloud/aws/migrate_ownership.go
@@ -52,7 +52,7 @@ func backfillOwnershipTags(ctx context.Context, cs *ClientSet, cluster *kubermat
 	iamTag := iamOwnershipTag(cluster.Name)
 
 	// the tag finalizer is of no use at all
-	cluster, err := updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	cluster, err := updater(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kuberneteshelper.RemoveFinalizer(cluster, tagCleanupFinalizer)
 	})
 	if err != nil {
@@ -81,7 +81,7 @@ func backfillOwnershipTags(ctx context.Context, cs *ClientSet, cluster *kubermat
 			}
 		}
 
-		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, securityGroupCleanupFinalizer)
 		})
 		if err != nil {
@@ -106,7 +106,7 @@ func backfillOwnershipTags(ctx context.Context, cs *ClientSet, cluster *kubermat
 			}
 		}
 
-		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, instanceProfileCleanupFinalizer)
 		})
 		if err != nil {
@@ -131,7 +131,7 @@ func backfillOwnershipTags(ctx context.Context, cs *ClientSet, cluster *kubermat
 			}
 		}
 
-		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, controlPlaneRoleCleanupFinalizer)
 		})
 		if err != nil {

--- a/pkg/provider/cloud/aws/provider.go
+++ b/pkg/provider/cloud/aws/provider.go
@@ -142,7 +142,7 @@ func (a *AmazonEC2) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 		return nil, fmt.Errorf("failed to get API client: %w", err)
 	}
 
-	cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kuberneteshelper.AddFinalizer(cluster, cleanupFinalizer)
 	})
 	if err != nil {
@@ -191,7 +191,7 @@ func (a *AmazonEC2) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 
 	// We put this as an annotation on the cluster to allow addons to read this
 	// information.
-	cluster, err = reconcileRegionAnnotation(cluster, update, a.dc.Region)
+	cluster, err = reconcileRegionAnnotation(ctx, cluster, update, a.dc.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (a *AmazonEC2) CleanUpCloudProvider(ctx context.Context, cluster *kubermati
 		return nil, fmt.Errorf("failed to clean up tags: %w", err)
 	}
 
-	return updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return updater(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kuberneteshelper.RemoveFinalizer(cluster, securityGroupCleanupFinalizer, controlPlaneRoleCleanupFinalizer, instanceProfileCleanupFinalizer, tagCleanupFinalizer, cleanupFinalizer)
 	})
 }

--- a/pkg/provider/cloud/aws/region.go
+++ b/pkg/provider/cloud/aws/region.go
@@ -17,16 +17,18 @@ limitations under the License.
 package aws
 
 import (
+	"context"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 )
 
-func reconcileRegionAnnotation(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, region string) (*kubermaticv1.Cluster, error) {
+func reconcileRegionAnnotation(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, region string) (*kubermaticv1.Cluster, error) {
 	if cluster.Annotations[regionAnnotationKey] == region {
 		return cluster, nil
 	}
 
-	return update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		if cluster.Annotations == nil {
 			cluster.Annotations = map[string]string{}
 		}

--- a/pkg/provider/cloud/aws/region_test.go
+++ b/pkg/provider/cloud/aws/region_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -31,7 +32,7 @@ func TestReconcileRegionAnnotation(t *testing.T) {
 
 	// reconcile
 	var err error
-	cluster, err = reconcileRegionAnnotation(cluster, updater, region)
+	cluster, err = reconcileRegionAnnotation(context.Background(), cluster, updater, region)
 	if err != nil {
 		t.Fatalf("reconcileRegionAnnotation should not have errored, but returned %v", err)
 	}
@@ -52,7 +53,7 @@ func TestReconcileRegionAnnotationFixingBadAnnotation(t *testing.T) {
 
 	// fix it
 	var err error
-	cluster, err = reconcileRegionAnnotation(cluster, updater, region)
+	cluster, err = reconcileRegionAnnotation(context.Background(), cluster, updater, region)
 	if err != nil {
 		t.Fatalf("reconcileRegionAnnotation should not have errored, but returned %v", err)
 	}

--- a/pkg/provider/cloud/aws/role.go
+++ b/pkg/provider/cloud/aws/role.go
@@ -73,7 +73,7 @@ func reconcileControlPlaneRole(ctx context.Context, client iamiface.IAMAPI, clus
 		return cluster, err
 	}
 
-	return update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		cluster.Spec.Cloud.AWS.ControlPlaneRoleARN = roleName
 	})
 }

--- a/pkg/provider/cloud/aws/route_table.go
+++ b/pkg/provider/cloud/aws/route_table.go
@@ -59,7 +59,7 @@ func reconcileRouteTable(ctx context.Context, client ec2iface.EC2API, cluster *k
 		return nil, fmt.Errorf("failed to get default route table: %w", err)
 	}
 
-	return update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		cluster.Spec.Cloud.AWS.RouteTableID = *table.RouteTableId
 	})
 }

--- a/pkg/provider/cloud/aws/security_group.go
+++ b/pkg/provider/cloud/aws/security_group.go
@@ -159,7 +159,7 @@ func reconcileSecurityGroup(ctx context.Context, client ec2iface.EC2API, cluster
 		}
 	}
 
-	return update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		cluster.Spec.Cloud.AWS.SecurityGroupID = groupID
 	})
 }

--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -70,7 +71,7 @@ func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {
 }
 
 func testClusterUpdater(cluster *kubermaticv1.Cluster) provider.ClusterUpdater {
-	return func(clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+	return func(_ context.Context, clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
 		patcher(cluster)
 		return cluster, nil
 	}

--- a/pkg/provider/cloud/aws/vpc.go
+++ b/pkg/provider/cloud/aws/vpc.go
@@ -65,7 +65,7 @@ func reconcileVPC(ctx context.Context, client ec2iface.EC2API, cluster *kubermat
 		return nil, fmt.Errorf("failed to get default VPC: %w", err)
 	}
 
-	return update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		cluster.Spec.Cloud.AWS.VPCID = *defaultVPC.VpcId
 	})
 }

--- a/pkg/provider/cloud/azure/availability_set.go
+++ b/pkg/provider/cloud/azure/availability_set.go
@@ -46,7 +46,7 @@ func reconcileAvailabilitySet(ctx context.Context, clients *ClientSet, location 
 	// if we found an availability set, we can check for the ownership tag to determine
 	// if the referenced availability set is owned by this cluster and should be reconciled
 	if !isNotFound(availabilitySet.Response) && !hasOwnershipTag(availabilitySet.Tags, cluster) {
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.AvailabilitySet = cluster.Spec.Cloud.Azure.AvailabilitySet
 		})
 	}
@@ -72,7 +72,7 @@ func reconcileAvailabilitySet(ctx context.Context, clients *ClientSet, location 
 		}
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.AvailabilitySet = cluster.Spec.Cloud.Azure.AvailabilitySet
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerAvailabilitySet)
 	})

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -130,7 +130,7 @@ func (a *Azure) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.
 				return cluster, fmt.Errorf("failed to delete security group %q: %w", cluster.Spec.Cloud.Azure.SecurityGroup, err)
 			}
 		}
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerSecurityGroup)
 		})
 		if err != nil {
@@ -146,7 +146,7 @@ func (a *Azure) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.
 				return cluster, fmt.Errorf("failed to delete route table %q: %w", cluster.Spec.Cloud.Azure.RouteTableName, err)
 			}
 		}
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerRouteTable)
 		})
 		if err != nil {
@@ -162,7 +162,7 @@ func (a *Azure) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.
 				return cluster, fmt.Errorf("failed to delete sub-network %q: %w", cluster.Spec.Cloud.Azure.SubnetName, err)
 			}
 		}
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerSubnet)
 		})
 		if err != nil {
@@ -179,7 +179,7 @@ func (a *Azure) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.
 			}
 		}
 
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerVNet)
 		})
 		if err != nil {
@@ -196,7 +196,7 @@ func (a *Azure) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.
 			}
 		}
 
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerAvailabilitySet)
 		})
 		if err != nil {
@@ -213,7 +213,7 @@ func (a *Azure) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.
 			}
 		}
 
-		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerResourceGroup)
 		})
 		if err != nil {

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -49,7 +49,7 @@ func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location st
 	// of the resource. Since there is nothing in the resource group we could compare to eventually reconcile, we
 	// skip all of that and return early if we found a resource group during our API call earlier.
 	if !isNotFound(resourceGroup.Response) {
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
 			// this is a special case; because we cannot determine if a resource group was created by
 			// the controller or not, we only add the finalizer if by the beginning of this loop, the
@@ -64,7 +64,7 @@ func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location st
 		return nil, err
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
 	})

--- a/pkg/provider/cloud/azure/route_table.go
+++ b/pkg/provider/cloud/azure/route_table.go
@@ -48,7 +48,7 @@ func reconcileRouteTable(ctx context.Context, clients *ClientSet, location strin
 	// of the resource. Since there is nothing in the route table we could compare to eventually reconcile (the subnet setting
 	// you see later on is ineffective), we skip all of that and return early if we found a route table during our API call earlier.
 	if !isNotFound(routeTable.Response) {
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.RouteTableName = cluster.Spec.Cloud.Azure.RouteTableName
 			// this is a special case; because we cannot determine if a route table was created by
 			// the controller or not, we only add the finalizer if by the beginning of this loop, the
@@ -64,7 +64,7 @@ func reconcileRouteTable(ctx context.Context, clients *ClientSet, location strin
 		return cluster, err
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.RouteTableName = cluster.Spec.Cloud.Azure.RouteTableName
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerRouteTable)
 	})

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -46,7 +46,7 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 	// if we found a security group, we can check for the ownership tag to determine
 	// if the referenced security group is owned by this cluster and should be reconciled
 	if !isNotFound(securityGroup.Response) && !hasOwnershipTag(securityGroup.Tags, cluster) {
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
 		})
 	}
@@ -77,7 +77,7 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 		}
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSecurityGroup)
 	})

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -57,7 +57,7 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 	// VNET isn't owned by KKP, we should not try to reconcile subnets and
 	// return early
 	if !isNotFound(subnet.Response) && !hasOwnershipTag(vnet.Tags, cluster) {
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
 		})
 	}
@@ -76,7 +76,7 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 		}
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSubnet)
 	})

--- a/pkg/provider/cloud/azure/utils_test.go
+++ b/pkg/provider/cloud/azure/utils_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package azure
 
 import (
+	"context"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/uuid"
@@ -85,7 +87,7 @@ func makeCluster(name string, cloudSpec *kubermaticv1.AzureCloudSpec, credential
 }
 
 func testClusterUpdater(cluster *kubermaticv1.Cluster) provider.ClusterUpdater {
-	return func(clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+	return func(_ context.Context, clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
 		patcher(cluster)
 		return cluster, nil
 	}

--- a/pkg/provider/cloud/azure/vnet.go
+++ b/pkg/provider/cloud/azure/vnet.go
@@ -50,7 +50,7 @@ func reconcileVNet(ctx context.Context, clients *ClientSet, location string, clu
 	// if we found a VNET, we can check for the ownership tag to determine
 	// if the referenced VNET is owned by this cluster and should be reconciled
 	if !isNotFound(vnet.Response) && !hasOwnershipTag(vnet.Tags, cluster) {
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.VNetName = cluster.Spec.Cloud.Azure.VNetName
 		})
 	}
@@ -70,7 +70,7 @@ func reconcileVNet(ctx context.Context, clients *ClientSet, location string, clu
 		}
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		updatedCluster.Spec.Cloud.Azure.VNetName = cluster.Spec.Cloud.Azure.VNetName
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerVNet)
 	})

--- a/pkg/provider/cloud/gcp/firewall_rules.go
+++ b/pkg/provider/cloud/gcp/firewall_rules.go
@@ -160,7 +160,7 @@ func createOrPatchFirewall(ctx context.Context,
 		}
 	}
 	if toPatch {
-		newCluster, err := update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		newCluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.AddFinalizer(cluster, finalizer)
 		})
 		if err != nil {
@@ -186,7 +186,7 @@ func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, upd
 			return nil, fmt.Errorf("failed to delete firewall rule %s: %w", selfRuleName, err)
 		}
 
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, firewallSelfCleanupFinalizer)
 		})
 		if err != nil {
@@ -201,7 +201,7 @@ func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, upd
 			return nil, fmt.Errorf("failed to delete firewall rule %s: %w", icmpRuleName, err)
 		}
 
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, firewallICMPCleanupFinalizer)
 		})
 		if err != nil {
@@ -217,7 +217,7 @@ func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, upd
 			return nil, fmt.Errorf("failed to delete firewall rule %s: %w", nodePortRuleName, err)
 		}
 
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, firewallNodePortCleanupFinalizer)
 		})
 		if err != nil {
@@ -230,7 +230,7 @@ func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, upd
 		if err != nil {
 			return nil, err
 		}
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, routesCleanupFinalizer)
 		})
 		if err != nil {

--- a/pkg/provider/cloud/gcp/provider.go
+++ b/pkg/provider/cloud/gcp/provider.go
@@ -78,7 +78,7 @@ func (g *gcp) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluste
 func (g *gcp) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, force, setTags bool) (*kubermaticv1.Cluster, error) {
 	var err error
 	if cluster.Spec.Cloud.GCP.Network == "" && cluster.Spec.Cloud.GCP.Subnetwork == "" {
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.GCP.Network = DefaultNetwork
 		})
 		if err != nil {
@@ -102,7 +102,7 @@ func (g *gcp) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluste
 
 	// add the routes cleanup finalizer
 	if !kuberneteshelper.HasFinalizer(cluster, routesCleanupFinalizer) {
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.AddFinalizer(cluster, routesCleanupFinalizer)
 		})
 		if err != nil {

--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -44,7 +44,7 @@ import (
 const allZones = "-"
 
 func GetClusterConfig(ctx context.Context, sa, clusterName, zone string) (*api.Config, error) {
-	svc, project, err := ConnectToContainerService(sa)
+	svc, project, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func GetClusterConfig(ctx context.Context, sa, clusterName, zone string) (*api.C
 		Contexts:   map[string]*api.Context{},  // Contexts is a map of referencable names to context configs
 	}
 
-	cred, err := getCredentials(sa)
+	cred, err := getCredentials(ctx, sa)
 	if err != nil {
 		return nil, fmt.Errorf("can't get credentials %w", err)
 	}
@@ -93,8 +93,7 @@ func GetClusterConfig(ctx context.Context, sa, clusterName, zone string) (*api.C
 }
 
 // ConnectToContainerService establishes a service connection to the Container Engine.
-func ConnectToContainerService(serviceAccount string) (*container.Service, string, error) {
-	ctx := context.Background()
+func ConnectToContainerService(ctx context.Context, serviceAccount string) (*container.Service, string, error) {
 	client, projectID, err := createClient(ctx, serviceAccount, container.CloudPlatformScope)
 	if err != nil {
 		return nil, "", fmt.Errorf("cannot create Google Cloud client: %w", err)
@@ -111,7 +110,7 @@ func GetGKEClusterStatus(ctx context.Context, secretKeySelector provider.SecretK
 	if err != nil {
 		return nil, err
 	}
-	svc, project, err := ConnectToContainerService(sa)
+	svc, project, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +159,7 @@ func ListGKEClusters(ctx context.Context, projectProvider provider.ProjectProvid
 		}
 	}
 
-	svc, gkeProject, err := ConnectToContainerService(sa)
+	svc, gkeProject, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return clusters, err
 	}
@@ -184,7 +183,7 @@ func ListGKEClusters(ctx context.Context, projectProvider provider.ProjectProvid
 
 func ListGKEUpgrades(ctx context.Context, sa, zone, name string) ([]*apiv1.MasterVersion, error) {
 	upgrades := make([]*apiv1.MasterVersion, 0)
-	svc, project, err := ConnectToContainerService(sa)
+	svc, project, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +240,7 @@ func ListGKEUpgrades(ctx context.Context, sa, zone, name string) ([]*apiv1.Maste
 
 func ListGKEMachineDeploymentUpgrades(ctx context.Context, sa, zone, clusterName, machineDeployment string) ([]*apiv1.MasterVersion, error) {
 	upgrades := make([]*apiv1.MasterVersion, 0)
-	svc, project, err := ConnectToContainerService(sa)
+	svc, project, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +298,7 @@ func isValidVersion(currentVersion, newVersion *semverlib.Version) bool {
 
 func ListGKEImages(ctx context.Context, sa, zone string) (apiv2.GKEImageList, error) {
 	images := apiv2.GKEImageList{}
-	svc, project, err := ConnectToContainerService(sa)
+	svc, project, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +319,7 @@ func ListGKEImages(ctx context.Context, sa, zone string) (apiv2.GKEImageList, er
 }
 
 func ValidateGKECredentials(ctx context.Context, sa string) error {
-	svc, project, err := ConnectToContainerService(sa)
+	svc, project, err := ConnectToContainerService(ctx, sa)
 	if err != nil {
 		return err
 	}
@@ -346,8 +345,7 @@ func convertGKEStatus(status string) apiv2.ExternalClusterState {
 	}
 }
 
-func getCredentials(serviceAccount string) (*google.Credentials, error) {
-	ctx := context.Background()
+func getCredentials(ctx context.Context, serviceAccount string) (*google.Credentials, error) {
 	b, err := base64.StdEncoding.DecodeString(serviceAccount)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding service account: %w", err)

--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -135,7 +135,7 @@ func ListGKEClusters(ctx context.Context, projectProvider provider.ProjectProvid
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	clusterList, err := clusterProvider.List(project)
+	clusterList, err := clusterProvider.List(ctx, project)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/provider/cloud/kubevirt/namespace.go
+++ b/pkg/provider/cloud/kubevirt/namespace.go
@@ -48,7 +48,7 @@ func reconcileNamespace(ctx context.Context, name string, cluster *kubermaticv1.
 		return cluster, fmt.Errorf("failed to reconcile Namespace: %w", err)
 	}
 
-	return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+	return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 		kuberneteshelper.AddFinalizer(updatedCluster, FinalizerNamespace)
 	})
 }

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -115,7 +115,7 @@ func (k *kubevirt) CleanUpCloudProvider(ctx context.Context, cluster *kubermatic
 		if err := deleteNamespace(ctx, cluster.Status.NamespaceName, client); err != nil && !kerrors.IsNotFound(err) {
 			return cluster, fmt.Errorf("failed to delete namespace %s: %w", cluster.Status.NamespaceName, err)
 		}
-		return update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
+		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerNamespace)
 		})
 	}

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -85,7 +85,7 @@ func (n *Nutanix) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv
 			return nil, err
 		}
 
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, categoryCleanupFinalizer)
 		})
 
@@ -151,7 +151,7 @@ func (n *Nutanix) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 		return nil, fmt.Errorf("failed to reconcile category and cluster value: %w", err)
 	}
 
-	cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kuberneteshelper.AddFinalizer(cluster, categoryCleanupFinalizer)
 	})
 

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -501,7 +501,7 @@ type fakeClusterUpdater struct {
 	c *kubermaticv1.Cluster
 }
 
-func (f *fakeClusterUpdater) update(_ string, updateFn func(c *kubermaticv1.Cluster), _ ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+func (f *fakeClusterUpdater) update(_ context.Context, _ string, updateFn func(c *kubermaticv1.Cluster), _ ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
 	updateFn(f.c)
 	return f.c, nil
 }

--- a/pkg/provider/cloud/packet/provider.go
+++ b/pkg/provider/cloud/packet/provider.go
@@ -57,10 +57,10 @@ func (p *packet) ValidateCloudSpec(_ context.Context, spec kubermaticv1.CloudSpe
 
 // InitializeCloudProvider initializes a cluster, in particular
 // updates BillingCycle to the defaultBillingCycle, if it is not set.
-func (p *packet) InitializeCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+func (p *packet) InitializeCloudProvider(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	var err error
 	if cluster.Spec.Cloud.Packet.BillingCycle == "" {
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Packet.BillingCycle = defaultBillingCycle
 		})
 		if err != nil {

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -160,7 +160,7 @@ func (v *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 			return nil, fmt.Errorf("failed to create the VM folder %q: %w", clusterFolder, err)
 		}
 
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.AddFinalizer(cluster, folderCleanupFinalizer)
 			cluster.Spec.Cloud.VSphere.Folder = clusterFolder
 		})
@@ -295,7 +295,7 @@ func (v *Provider) CleanUpCloudProvider(ctx context.Context, cluster *kubermatic
 		if err := deleteVMFolder(ctx, session, cluster.Spec.Cloud.VSphere.Folder); err != nil {
 			return nil, err
 		}
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, folderCleanupFinalizer)
 		})
 		if err != nil {

--- a/pkg/provider/kubernetes/addonconfig.go
+++ b/pkg/provider/kubernetes/addonconfig.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -29,6 +30,8 @@ type AddonConfigProvider struct {
 	client ctrlruntimeclient.Client
 }
 
+var _ provider.AddonConfigProvider = &AddonConfigProvider{}
+
 // NewAddonConfigProvider returns a new AddonConfigProvider.
 func NewAddonConfigProvider(client ctrlruntimeclient.Client) *AddonConfigProvider {
 	return &AddonConfigProvider{
@@ -37,18 +40,18 @@ func NewAddonConfigProvider(client ctrlruntimeclient.Client) *AddonConfigProvide
 }
 
 // Get addon configuration.
-func (p *AddonConfigProvider) Get(addonName string) (*kubermaticv1.AddonConfig, error) {
+func (p *AddonConfigProvider) Get(ctx context.Context, addonName string) (*kubermaticv1.AddonConfig, error) {
 	addonConfig := &kubermaticv1.AddonConfig{}
-	if err := p.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: addonName}, addonConfig); err != nil {
+	if err := p.client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: addonName}, addonConfig); err != nil {
 		return nil, err
 	}
 	return addonConfig, nil
 }
 
 // List available addon configurations.
-func (p *AddonConfigProvider) List() (*kubermaticv1.AddonConfigList, error) {
+func (p *AddonConfigProvider) List(ctx context.Context) (*kubermaticv1.AddonConfigList, error) {
 	addonConfigList := &kubermaticv1.AddonConfigList{}
-	if err := p.client.List(context.Background(), addonConfigList); err != nil {
+	if err := p.client.List(ctx, addonConfigList); err != nil {
 		return nil, err
 	}
 	return addonConfigList, nil

--- a/pkg/provider/kubernetes/admission_plugin_test.go
+++ b/pkg/provider/kubernetes/admission_plugin_test.go
@@ -225,9 +225,9 @@ func TestListAdmissionPluginsFromVersion(t *testing.T) {
 				WithObjects(tc.plugins...).
 				Build()
 
-			provider := kubernetes.NewAdmissionPluginsProvider(context.Background(), fakeClient)
+			provider := kubernetes.NewAdmissionPluginsProvider(fakeClient)
 
-			result, err := provider.ListPluginNamesFromVersion(tc.fromVersion)
+			result, err := provider.ListPluginNamesFromVersion(context.Background(), tc.fromVersion)
 			resultSet := sets.NewString(result...)
 
 			if len(tc.expectedError) > 0 {

--- a/pkg/provider/kubernetes/alertmanager.go
+++ b/pkg/provider/kubernetes/alertmanager.go
@@ -43,6 +43,9 @@ type AlertmanagerProvider struct {
 	privilegedClient ctrlruntimeclient.Client
 }
 
+var _ provider.AlertmanagerProvider = &AlertmanagerProvider{}
+var _ provider.PrivilegedAlertmanagerProvider = &AlertmanagerProvider{}
+
 // NewAlertmanagerProvider returns an alertmanager provider.
 func NewAlertmanagerProvider(createSeedImpersonatedClient ImpersonationClient, privilegedClient ctrlruntimeclient.Client) *AlertmanagerProvider {
 	return &AlertmanagerProvider{
@@ -70,51 +73,50 @@ func AlertmanagerProviderFactory(mapper meta.RESTMapper, seedKubeconfigGetter pr
 }
 
 // Get gets an Alertmanager object and Secret which contains the configuration of this Alertmanager.
-func (p *AlertmanagerProvider) Get(cluster *kubermaticv1.Cluster, userInfo *provider.UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
+func (p *AlertmanagerProvider) Get(ctx context.Context, cluster *kubermaticv1.Cluster, userInfo *provider.UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, nil, err
 	}
-	return get(impersonationClient, cluster)
+	return get(ctx, impersonationClient, cluster)
 }
 
 // Update updates an Alertmanager object and corresponding config Secret since Alertmanager and Secret will
 // be created by alertmanager configuration controller.
-func (p *AlertmanagerProvider) Update(expectedAlertmanager *kubermaticv1.Alertmanager, expectedSecret *corev1.Secret, userInfo *provider.UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
+func (p *AlertmanagerProvider) Update(ctx context.Context, expectedAlertmanager *kubermaticv1.Alertmanager, expectedSecret *corev1.Secret, userInfo *provider.UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, nil, err
 	}
-	return update(impersonationClient, expectedAlertmanager, expectedSecret)
+	return update(ctx, impersonationClient, expectedAlertmanager, expectedSecret)
 }
 
 // Reset resets corresponding config Secret of Alertmanager object to the default config. This will not remove
 // Alertmanager object, it will only delete the config secret, and alertmanager controller will create default config secret.
-func (p *AlertmanagerProvider) Reset(cluster *kubermaticv1.Cluster, userInfo *provider.UserInfo) error {
+func (p *AlertmanagerProvider) Reset(ctx context.Context, cluster *kubermaticv1.Cluster, userInfo *provider.UserInfo) error {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return err
 	}
-	return reset(impersonationClient, cluster)
+	return reset(ctx, impersonationClient, cluster)
 }
 
 // GetUnsecured gets an Alertmanager object and Secret which contains the configuration of this Alertmanager by using a privileged client.
-func (p *AlertmanagerProvider) GetUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
-	return get(p.privilegedClient, cluster)
+func (p *AlertmanagerProvider) GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
+	return get(ctx, p.privilegedClient, cluster)
 }
 
 // UpdateUnsecured updates an Alertmanager object and corresponding config Secret by using a privileged client.
-func (p *AlertmanagerProvider) UpdateUnsecured(expectedAlertmanager *kubermaticv1.Alertmanager, expectedSecret *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
-	return update(p.privilegedClient, expectedAlertmanager, expectedSecret)
+func (p *AlertmanagerProvider) UpdateUnsecured(ctx context.Context, expectedAlertmanager *kubermaticv1.Alertmanager, expectedSecret *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
+	return update(ctx, p.privilegedClient, expectedAlertmanager, expectedSecret)
 }
 
 // ResetUnsecured resets corresponding config Secret of Alertmanager object to the default config by using a privileged client.
-func (p *AlertmanagerProvider) ResetUnsecured(cluster *kubermaticv1.Cluster) error {
-	return reset(p.privilegedClient, cluster)
+func (p *AlertmanagerProvider) ResetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	return reset(ctx, p.privilegedClient, cluster)
 }
 
-func get(client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
-	ctx := context.Background()
+func get(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
 	alertmanager := &kubermaticv1.Alertmanager{}
 	if err := client.Get(ctx, types.NamespacedName{
 		Name:      resources.AlertmanagerName,
@@ -132,8 +134,7 @@ func get(client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) (*kuber
 	return alertmanager, configSecret, nil
 }
 
-func update(client ctrlruntimeclient.Client, expectedAlertmanager *kubermaticv1.Alertmanager, expectedSecret *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
-	ctx := context.Background()
+func update(ctx context.Context, client ctrlruntimeclient.Client, expectedAlertmanager *kubermaticv1.Alertmanager, expectedSecret *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error) {
 	alertmanager := &kubermaticv1.Alertmanager{}
 
 	if err := client.Get(ctx, types.NamespacedName{
@@ -160,8 +161,7 @@ func update(client ctrlruntimeclient.Client, expectedAlertmanager *kubermaticv1.
 	return alertmanager, secret, nil
 }
 
-func reset(client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
-	ctx := context.Background()
+func reset(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	alertmanager := &kubermaticv1.Alertmanager{}
 	if err := client.Get(ctx, types.NamespacedName{
 		Name:      resources.AlertmanagerName,

--- a/pkg/provider/kubernetes/alertmanager_test.go
+++ b/pkg/provider/kubernetes/alertmanager_test.go
@@ -95,7 +95,7 @@ func TestGetAlertmanager(t *testing.T) {
 
 			alertmanagerProvider := kubernetes.NewAlertmanagerProvider(fakeImpersonationClient, client)
 
-			alertmanager, configSecret, err := alertmanagerProvider.Get(tc.cluster, tc.userInfo)
+			alertmanager, configSecret, err := alertmanagerProvider.Get(context.Background(), tc.cluster, tc.userInfo)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
@@ -186,7 +186,7 @@ func TestUpdateAlertmanager(t *testing.T) {
 
 			alertmanagerProvider := kubernetes.NewAlertmanagerProvider(fakeImpersonationClient, client)
 
-			alertmanager, configSecret, err := alertmanagerProvider.Update(tc.expectedAlertmanager, tc.expectedConfigSecret, tc.userInfo)
+			alertmanager, configSecret, err := alertmanagerProvider.Update(context.Background(), tc.expectedAlertmanager, tc.expectedConfigSecret, tc.userInfo)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
@@ -268,7 +268,7 @@ func TestResetAlertmanager(t *testing.T) {
 
 			alertmanagerProvider := kubernetes.NewAlertmanagerProvider(fakeImpersonationClient, client)
 
-			err := alertmanagerProvider.Reset(tc.cluster, tc.userInfo)
+			err := alertmanagerProvider.Reset(context.Background(), tc.cluster, tc.userInfo)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/provider/kubernetes/allowed_registry.go
+++ b/pkg/provider/kubernetes/allowed_registry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +31,8 @@ type PrivilegedAllowedRegistryProvider struct {
 	clientPrivileged ctrlruntimeclient.Client
 }
 
+var _ provider.PrivilegedAllowedRegistryProvider = &PrivilegedAllowedRegistryProvider{}
+
 // NewAllowedRegistryProvider returns a allowed registry provider.
 func NewAllowedRegistryPrivilegedProvider(client ctrlruntimeclient.Client) (*PrivilegedAllowedRegistryProvider, error) {
 	return &PrivilegedAllowedRegistryProvider{
@@ -38,8 +41,8 @@ func NewAllowedRegistryPrivilegedProvider(client ctrlruntimeclient.Client) (*Pri
 }
 
 // CreateUnsecured creates a allowed registry.
-func (p *PrivilegedAllowedRegistryProvider) CreateUnsecured(wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
-	if err := p.clientPrivileged.Create(context.Background(), wr); err != nil {
+func (p *PrivilegedAllowedRegistryProvider) CreateUnsecured(ctx context.Context, wr *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
+	if err := p.clientPrivileged.Create(ctx, wr); err != nil {
 		return nil, err
 	}
 
@@ -47,22 +50,22 @@ func (p *PrivilegedAllowedRegistryProvider) CreateUnsecured(wr *kubermaticv1.All
 }
 
 // GetUnsecured gets a allowed registry.
-func (p *PrivilegedAllowedRegistryProvider) GetUnsecured(name string) (*kubermaticv1.AllowedRegistry, error) {
+func (p *PrivilegedAllowedRegistryProvider) GetUnsecured(ctx context.Context, name string) (*kubermaticv1.AllowedRegistry, error) {
 	wr := &kubermaticv1.AllowedRegistry{}
-	err := p.clientPrivileged.Get(context.Background(), types.NamespacedName{Name: name}, wr)
+	err := p.clientPrivileged.Get(ctx, types.NamespacedName{Name: name}, wr)
 	return wr, err
 }
 
 // ListUnsecured lists a allowed registries.
-func (p *PrivilegedAllowedRegistryProvider) ListUnsecured() (*kubermaticv1.AllowedRegistryList, error) {
+func (p *PrivilegedAllowedRegistryProvider) ListUnsecured(ctx context.Context) (*kubermaticv1.AllowedRegistryList, error) {
 	wrList := &kubermaticv1.AllowedRegistryList{}
-	err := p.clientPrivileged.List(context.Background(), wrList)
+	err := p.clientPrivileged.List(ctx, wrList)
 	return wrList, err
 }
 
 // UpdateUnsecured updates the allowed registry.
-func (p *PrivilegedAllowedRegistryProvider) UpdateUnsecured(ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
-	if err := p.clientPrivileged.Update(context.Background(), ar); err != nil {
+func (p *PrivilegedAllowedRegistryProvider) UpdateUnsecured(ctx context.Context, ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error) {
+	if err := p.clientPrivileged.Update(ctx, ar); err != nil {
 		return nil, err
 	}
 
@@ -70,8 +73,8 @@ func (p *PrivilegedAllowedRegistryProvider) UpdateUnsecured(ar *kubermaticv1.All
 }
 
 // DeleteUnsecured deletes a allowed registry.
-func (p *PrivilegedAllowedRegistryProvider) DeleteUnsecured(name string) error {
+func (p *PrivilegedAllowedRegistryProvider) DeleteUnsecured(ctx context.Context, name string) error {
 	wr := &kubermaticv1.AllowedRegistry{}
 	wr.Name = name
-	return p.clientPrivileged.Delete(context.Background(), wr)
+	return p.clientPrivileged.Delete(ctx, wr)
 }

--- a/pkg/provider/kubernetes/backupcredentials.go
+++ b/pkg/provider/kubernetes/backupcredentials.go
@@ -34,6 +34,8 @@ type BackupCredentialsProvider struct {
 	clientPrivileged ctrlruntimeclient.Client
 }
 
+var _ provider.BackupCredentialsProvider = &BackupCredentialsProvider{}
+
 // NewBackupCredentialsProvider returns a  backup credential provider.
 func NewBackupCredentialsProvider(client ctrlruntimeclient.Client) *BackupCredentialsProvider {
 	return &BackupCredentialsProvider{
@@ -55,21 +57,21 @@ func BackupCredentialsProviderFactory(mapper meta.RESTMapper, seedKubeconfigGett
 	}
 }
 
-func (p *BackupCredentialsProvider) CreateUnsecured(credentials *corev1.Secret) (*corev1.Secret, error) {
-	err := p.clientPrivileged.Create(context.Background(), credentials)
+func (p *BackupCredentialsProvider) CreateUnsecured(ctx context.Context, credentials *corev1.Secret) (*corev1.Secret, error) {
+	err := p.clientPrivileged.Create(ctx, credentials)
 	return credentials, err
 }
 
-func (p *BackupCredentialsProvider) GetUnsecured(credentialName string) (*corev1.Secret, error) {
+func (p *BackupCredentialsProvider) GetUnsecured(ctx context.Context, credentialName string) (*corev1.Secret, error) {
 	credentials := &corev1.Secret{}
-	err := p.clientPrivileged.Get(context.Background(), types.NamespacedName{
+	err := p.clientPrivileged.Get(ctx, types.NamespacedName{
 		Name:      credentialName,
 		Namespace: metav1.NamespaceSystem,
 	}, credentials)
 	return credentials, err
 }
 
-func (p *BackupCredentialsProvider) UpdateUnsecured(newSecret *corev1.Secret) (*corev1.Secret, error) {
-	err := p.clientPrivileged.Update(context.Background(), newSecret)
+func (p *BackupCredentialsProvider) UpdateUnsecured(ctx context.Context, newSecret *corev1.Secret) (*corev1.Secret, error) {
+	err := p.clientPrivileged.Update(ctx, newSecret)
 	return newSecret, err
 }

--- a/pkg/provider/kubernetes/cluster_internal_test.go
+++ b/pkg/provider/kubernetes/cluster_internal_test.go
@@ -75,7 +75,7 @@ func TestRevokeAdminKubeconfig(t *testing.T) {
 				userClusterConnProvider: &fakeUserClusterConnectionProvider{client: userClusterClient},
 			}
 
-			if err := p.RevokeAdminKubeconfig(tc.cluster); err != nil {
+			if err := p.RevokeAdminKubeconfig(context.Background(), tc.cluster); err != nil {
 				t.Fatalf("error calling revokeClusterAdminKubeconfig: %v", err)
 			}
 			if err := tc.verify(seedClient, userClusterClient); err != nil {

--- a/pkg/provider/kubernetes/cluster_template_instance.go
+++ b/pkg/provider/kubernetes/cluster_template_instance.go
@@ -46,6 +46,7 @@ type ClusterTemplateInstanceProvider struct {
 }
 
 var _ provider.ClusterTemplateInstanceProvider = &ClusterTemplateInstanceProvider{}
+var _ provider.PrivilegedClusterTemplateInstanceProvider = &ClusterTemplateInstanceProvider{}
 
 // ClusterTemplateInstanceProvider returns provider.
 func NewClusterTemplateInstanceProvider(createSeedImpersonatedClient ImpersonationClient, privilegedClient ctrlruntimeclient.Client) *ClusterTemplateInstanceProvider {

--- a/pkg/provider/kubernetes/cluster_test.go
+++ b/pkg/provider/kubernetes/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -119,7 +120,7 @@ func TestCreateCluster(t *testing.T) {
 				partialCluster.Finalizers = tc.expectedCluster.Finalizers
 			}
 
-			cluster, err := target.New(tc.project, tc.userInfo, partialCluster)
+			cluster, err := target.New(context.Background(), tc.project, tc.userInfo, partialCluster)
 			if len(tc.expectedError) > 0 {
 				if err == nil {
 					t.Fatalf("expected error: %s", tc.expectedError)

--- a/pkg/provider/kubernetes/constraint_template.go
+++ b/pkg/provider/kubernetes/constraint_template.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,8 @@ type ConstraintTemplateProvider struct {
 	restMapperCache                *restmapper.Cache
 }
 
+var _ provider.ConstraintTemplateProvider = &ConstraintTemplateProvider{}
+
 // NewConstraintTemplateProvider returns a constraint template provider.
 func NewConstraintTemplateProvider(createMasterImpersonatedClient ImpersonationClient, client ctrlruntimeclient.Client) (*ConstraintTemplateProvider, error) {
 	return &ConstraintTemplateProvider{
@@ -45,9 +48,9 @@ func NewConstraintTemplateProvider(createMasterImpersonatedClient ImpersonationC
 }
 
 // List gets all constraint templates.
-func (p *ConstraintTemplateProvider) List() (*kubermaticv1.ConstraintTemplateList, error) {
+func (p *ConstraintTemplateProvider) List(ctx context.Context) (*kubermaticv1.ConstraintTemplateList, error) {
 	constraintTemplates := &kubermaticv1.ConstraintTemplateList{}
-	if err := p.clientPrivileged.List(context.Background(), constraintTemplates); err != nil {
+	if err := p.clientPrivileged.List(ctx, constraintTemplates); err != nil {
 		return nil, fmt.Errorf("failed to list constraint templates: %w", err)
 	}
 
@@ -55,9 +58,9 @@ func (p *ConstraintTemplateProvider) List() (*kubermaticv1.ConstraintTemplateLis
 }
 
 // Get gets a constraint template.
-func (p *ConstraintTemplateProvider) Get(name string) (*kubermaticv1.ConstraintTemplate, error) {
+func (p *ConstraintTemplateProvider) Get(ctx context.Context, name string) (*kubermaticv1.ConstraintTemplate, error) {
 	constraintTemplate := &kubermaticv1.ConstraintTemplate{}
-	if err := p.clientPrivileged.Get(context.Background(), types.NamespacedName{Name: name}, constraintTemplate); err != nil {
+	if err := p.clientPrivileged.Get(ctx, types.NamespacedName{Name: name}, constraintTemplate); err != nil {
 		return nil, err
 	}
 
@@ -65,8 +68,8 @@ func (p *ConstraintTemplateProvider) Get(name string) (*kubermaticv1.ConstraintT
 }
 
 // Create creates a constraint template.
-func (p *ConstraintTemplateProvider) Create(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
-	if err := p.clientPrivileged.Create(context.Background(), ct); err != nil {
+func (p *ConstraintTemplateProvider) Create(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
+	if err := p.clientPrivileged.Create(ctx, ct); err != nil {
 		return nil, err
 	}
 
@@ -74,8 +77,8 @@ func (p *ConstraintTemplateProvider) Create(ct *kubermaticv1.ConstraintTemplate)
 }
 
 // Update updates a constraint template.
-func (p *ConstraintTemplateProvider) Update(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
-	if err := p.clientPrivileged.Update(context.Background(), ct); err != nil {
+func (p *ConstraintTemplateProvider) Update(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error) {
+	if err := p.clientPrivileged.Update(ctx, ct); err != nil {
 		return nil, err
 	}
 
@@ -83,6 +86,6 @@ func (p *ConstraintTemplateProvider) Update(ct *kubermaticv1.ConstraintTemplate)
 }
 
 // Delete deletes a constraint template.
-func (p *ConstraintTemplateProvider) Delete(ct *kubermaticv1.ConstraintTemplate) error {
-	return p.clientPrivileged.Delete(context.Background(), ct)
+func (p *ConstraintTemplateProvider) Delete(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) error {
+	return p.clientPrivileged.Delete(ctx, ct)
 }

--- a/pkg/provider/kubernetes/constraint_template_test.go
+++ b/pkg/provider/kubernetes/constraint_template_test.go
@@ -65,7 +65,7 @@ func TestListConstraintTemplates(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctList, err := provider.List()
+			ctList, err := provider.List(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -122,7 +122,7 @@ func TestGetConstraintTemplates(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ct, err := provider.Get("ct1")
+			ct, err := provider.Get(context.Background(), "ct1")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -162,7 +162,7 @@ func TestCreateConstraintTemplates(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ct, err := provider.Create(tc.ctToCreate)
+			ct, err := provider.Create(context.Background(), tc.ctToCreate)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -221,7 +221,7 @@ func TestUpdateConstraintTemplates(t *testing.T) {
 			updatedCT := ct.DeepCopy()
 			tc.constraintUpdate(updatedCT)
 
-			ct, err = provider.Update(updatedCT)
+			ct, err = provider.Update(context.Background(), updatedCT)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -265,7 +265,7 @@ func TestDeleteConstraintTemplates(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = provider.Delete(tc.CTtoDelete)
+			err = provider.Delete(context.Background(), tc.CTtoDelete)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/kubernetes/constraint_test.go
+++ b/pkg/provider/kubernetes/constraint_test.go
@@ -79,7 +79,7 @@ func TestListConstraints(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			constraintList, err := constraintProvider.List(tc.cluster)
+			constraintList, err := constraintProvider.List(context.Background(), tc.cluster)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -142,7 +142,7 @@ func TestGetConstraint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			constraint, err := constraintProvider.Get(tc.cluster, tc.expectedConstraint.Name)
+			constraint, err := constraintProvider.Get(context.Background(), tc.cluster, tc.expectedConstraint.Name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -193,7 +193,7 @@ func TestDeleteConstraint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = constraintProvider.Delete(tc.cluster, tc.userInfo, tc.constraintName)
+			err = constraintProvider.Delete(context.Background(), tc.cluster, tc.userInfo, tc.constraintName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -229,12 +229,12 @@ func TestCreateConstraint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = constraintProvider.Create(tc.userInfo, tc.constraint)
+			_, err = constraintProvider.Create(context.Background(), tc.userInfo, tc.constraint)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			constraint, err := constraintProvider.Get(tc.cluster, tc.constraint.Name)
+			constraint, err := constraintProvider.Get(context.Background(), tc.cluster, tc.constraint.Name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -296,7 +296,7 @@ func TestUpdateConstraint(t *testing.T) {
 			updatedConstraint := constraint.DeepCopy()
 			tc.updateConstraint(updatedConstraint)
 
-			constraint, err = constraintProvider.Update(tc.userInfo, updatedConstraint)
+			constraint, err = constraintProvider.Update(context.Background(), tc.userInfo, updatedConstraint)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -333,7 +333,7 @@ func TestCreateDefaultConstraint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			constraint, err := defaultConstraintProvider.Create(tc.ctToCreate)
+			constraint, err := defaultConstraintProvider.Create(context.Background(), tc.ctToCreate)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -382,7 +382,7 @@ func TestListDefaultConstraints(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			constraintList, err := defaultConstraintProvider.List()
+			constraintList, err := defaultConstraintProvider.List(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -443,7 +443,7 @@ func TestGetDefaultConstraint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			constraint, err := defaultConstraintProvider.Get(tc.expectedConstraint.Name)
+			constraint, err := defaultConstraintProvider.Get(context.Background(), tc.expectedConstraint.Name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -489,7 +489,7 @@ func TestDeleteDefaultConstraint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = provider.Delete(tc.CTtoDelete.Name)
+			err = provider.Delete(context.Background(), tc.CTtoDelete.Name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -545,7 +545,7 @@ func TestUpdateDefaultConstraint(t *testing.T) {
 			updatedCT := constraint.DeepCopy()
 			tc.updateConstraint(updatedCT)
 
-			constraint, err = provider.Update(updatedCT)
+			constraint, err = provider.Update(context.Background(), updatedCT)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/kubernetes/etcdbackupconfig.go
+++ b/pkg/provider/kubernetes/etcdbackupconfig.go
@@ -36,6 +36,9 @@ type EtcdBackupConfigProvider struct {
 	clientPrivileged             ctrlruntimeclient.Client
 }
 
+var _ provider.EtcdBackupConfigProvider = &EtcdBackupConfigProvider{}
+var _ provider.PrivilegedEtcdBackupConfigProvider = &EtcdBackupConfigProvider{}
+
 // NewEtcdBackupConfigProvider returns a constraint provider.
 func NewEtcdBackupConfigProvider(createSeedImpersonatedClient ImpersonationClient, client ctrlruntimeclient.Client) *EtcdBackupConfigProvider {
 	return &EtcdBackupConfigProvider{
@@ -62,56 +65,56 @@ func EtcdBackupConfigProviderFactory(mapper meta.RESTMapper, seedKubeconfigGette
 	}
 }
 
-func (p *EtcdBackupConfigProvider) Create(userInfo *provider.UserInfo, etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+func (p *EtcdBackupConfigProvider) Create(ctx context.Context, userInfo *provider.UserInfo, etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
-	err = impersonationClient.Create(context.Background(), etcdBackupConfig)
+	err = impersonationClient.Create(ctx, etcdBackupConfig)
 	return etcdBackupConfig, err
 }
 
-func (p *EtcdBackupConfigProvider) CreateUnsecured(etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
-	err := p.clientPrivileged.Create(context.Background(), etcdBackupConfig)
+func (p *EtcdBackupConfigProvider) CreateUnsecured(ctx context.Context, etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+	err := p.clientPrivileged.Create(ctx, etcdBackupConfig)
 	return etcdBackupConfig, err
 }
 
-func (p *EtcdBackupConfigProvider) Get(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error) {
+func (p *EtcdBackupConfigProvider) Get(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
 	ebc := &kubermaticv1.EtcdBackupConfig{}
-	err = impersonationClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, ebc)
+	err = impersonationClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, ebc)
 	return ebc, err
 }
 
-func (p *EtcdBackupConfigProvider) GetUnsecured(cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error) {
+func (p *EtcdBackupConfigProvider) GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error) {
 	ebc := &kubermaticv1.EtcdBackupConfig{}
-	err := p.clientPrivileged.Get(context.Background(), types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, ebc)
+	err := p.clientPrivileged.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, ebc)
 	return ebc, err
 }
 
-func (p *EtcdBackupConfigProvider) List(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error) {
+func (p *EtcdBackupConfigProvider) List(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
 	ebcList := &kubermaticv1.EtcdBackupConfigList{}
-	err = impersonationClient.List(context.Background(), ebcList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
+	err = impersonationClient.List(ctx, ebcList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
 	return ebcList, err
 }
 
-func (p *EtcdBackupConfigProvider) ListUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error) {
+func (p *EtcdBackupConfigProvider) ListUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error) {
 	ebcList := &kubermaticv1.EtcdBackupConfigList{}
-	err := p.clientPrivileged.List(context.Background(), ebcList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
+	err := p.clientPrivileged.List(ctx, ebcList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
 	return ebcList, err
 }
 
-func (p *EtcdBackupConfigProvider) Delete(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
+func (p *EtcdBackupConfigProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return err
@@ -123,31 +126,31 @@ func (p *EtcdBackupConfigProvider) Delete(userInfo *provider.UserInfo, cluster *
 			Namespace: cluster.Status.NamespaceName,
 		},
 	}
-	return impersonationClient.Delete(context.Background(), ebc)
+	return impersonationClient.Delete(ctx, ebc)
 }
 
-func (p *EtcdBackupConfigProvider) DeleteUnsecured(cluster *kubermaticv1.Cluster, name string) error {
+func (p *EtcdBackupConfigProvider) DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) error {
 	ebc := &kubermaticv1.EtcdBackupConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: cluster.Status.NamespaceName,
 		},
 	}
-	return p.clientPrivileged.Delete(context.Background(), ebc)
+	return p.clientPrivileged.Delete(ctx, ebc)
 }
 
-func (p *EtcdBackupConfigProvider) Patch(userInfo *provider.UserInfo, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+func (p *EtcdBackupConfigProvider) Patch(ctx context.Context, userInfo *provider.UserInfo, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
-	err = impersonationClient.Patch(context.Background(), newConfig, ctrlruntimeclient.MergeFrom(oldConfig))
+	err = impersonationClient.Patch(ctx, newConfig, ctrlruntimeclient.MergeFrom(oldConfig))
 	return newConfig, err
 }
 
-func (p *EtcdBackupConfigProvider) PatchUnsecured(oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
-	err := p.clientPrivileged.Patch(context.Background(), newConfig, ctrlruntimeclient.MergeFrom(oldConfig))
+func (p *EtcdBackupConfigProvider) PatchUnsecured(ctx context.Context, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error) {
+	err := p.clientPrivileged.Patch(ctx, newConfig, ctrlruntimeclient.MergeFrom(oldConfig))
 	return newConfig, err
 }
 
@@ -158,6 +161,9 @@ type EtcdBackupConfigProjectProvider struct {
 	createSeedImpersonatedClients map[string]ImpersonationClient
 	clientsPrivileged             map[string]ctrlruntimeclient.Client
 }
+
+var _ provider.EtcdBackupConfigProjectProvider = &EtcdBackupConfigProjectProvider{}
+var _ provider.PrivilegedEtcdBackupConfigProjectProvider = &EtcdBackupConfigProjectProvider{}
 
 // NewEtcdBackupConfigProjectProvider returns an etcd backupConfig global provider.
 func NewEtcdBackupConfigProjectProvider(createSeedImpersonatedClients map[string]ImpersonationClient, clients map[string]ctrlruntimeclient.Client) *EtcdBackupConfigProjectProvider {
@@ -192,7 +198,7 @@ func EtcdBackupConfigProjectProviderFactory(mapper meta.RESTMapper, seedKubeconf
 	}
 }
 
-func (p *EtcdBackupConfigProjectProvider) List(userInfo *provider.UserInfo, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error) {
+func (p *EtcdBackupConfigProjectProvider) List(ctx context.Context, userInfo *provider.UserInfo, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error) {
 	var etcdBackupConfigLists []*kubermaticv1.EtcdBackupConfigList
 	for _, createSeedImpersonationClient := range p.createSeedImpersonatedClients {
 		impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, createSeedImpersonationClient)
@@ -201,7 +207,7 @@ func (p *EtcdBackupConfigProjectProvider) List(userInfo *provider.UserInfo, proj
 		}
 
 		ebcList := &kubermaticv1.EtcdBackupConfigList{}
-		err = impersonationClient.List(context.Background(), ebcList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
+		err = impersonationClient.List(ctx, ebcList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}
@@ -211,11 +217,11 @@ func (p *EtcdBackupConfigProjectProvider) List(userInfo *provider.UserInfo, proj
 	return etcdBackupConfigLists, nil
 }
 
-func (p *EtcdBackupConfigProjectProvider) ListUnsecured(projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error) {
+func (p *EtcdBackupConfigProjectProvider) ListUnsecured(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error) {
 	var etcdBackupConfigLists []*kubermaticv1.EtcdBackupConfigList
 	for _, clientPrivileged := range p.clientsPrivileged {
 		ebcList := &kubermaticv1.EtcdBackupConfigList{}
-		err := clientPrivileged.List(context.Background(), ebcList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
+		err := clientPrivileged.List(ctx, ebcList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/kubernetes/etcdrestore.go
+++ b/pkg/provider/kubernetes/etcdrestore.go
@@ -36,6 +36,9 @@ type EtcdRestoreProvider struct {
 	clientPrivileged             ctrlruntimeclient.Client
 }
 
+var _ provider.EtcdRestoreProvider = &EtcdRestoreProvider{}
+var _ provider.PrivilegedEtcdRestoreProvider = &EtcdRestoreProvider{}
+
 // NewEtcdRestoreProvider returns a etcd restore provider.
 func NewEtcdRestoreProvider(createSeedImpersonatedClient ImpersonationClient, client ctrlruntimeclient.Client) *EtcdRestoreProvider {
 	return &EtcdRestoreProvider{
@@ -62,56 +65,56 @@ func EtcdRestoreProviderFactory(mapper meta.RESTMapper, seedKubeconfigGetter pro
 	}
 }
 
-func (p *EtcdRestoreProvider) Create(userInfo *provider.UserInfo, etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error) {
+func (p *EtcdRestoreProvider) Create(ctx context.Context, userInfo *provider.UserInfo, etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
-	err = impersonationClient.Create(context.Background(), etcdRestore)
+	err = impersonationClient.Create(ctx, etcdRestore)
 	return etcdRestore, err
 }
 
-func (p *EtcdRestoreProvider) CreateUnsecured(etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error) {
-	err := p.clientPrivileged.Create(context.Background(), etcdRestore)
+func (p *EtcdRestoreProvider) CreateUnsecured(ctx context.Context, etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error) {
+	err := p.clientPrivileged.Create(ctx, etcdRestore)
 	return etcdRestore, err
 }
 
-func (p *EtcdRestoreProvider) Get(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error) {
+func (p *EtcdRestoreProvider) Get(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
 	er := &kubermaticv1.EtcdRestore{}
-	err = impersonationClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, er)
+	err = impersonationClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, er)
 	return er, err
 }
 
-func (p *EtcdRestoreProvider) GetUnsecured(cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error) {
+func (p *EtcdRestoreProvider) GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error) {
 	er := &kubermaticv1.EtcdRestore{}
-	err := p.clientPrivileged.Get(context.Background(), types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, er)
+	err := p.clientPrivileged.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Status.NamespaceName}, er)
 	return er, err
 }
 
-func (p *EtcdRestoreProvider) List(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error) {
+func (p *EtcdRestoreProvider) List(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error) {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
 
 	erList := &kubermaticv1.EtcdRestoreList{}
-	err = impersonationClient.List(context.Background(), erList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
+	err = impersonationClient.List(ctx, erList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
 	return erList, err
 }
 
-func (p *EtcdRestoreProvider) ListUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error) {
+func (p *EtcdRestoreProvider) ListUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error) {
 	erList := &kubermaticv1.EtcdRestoreList{}
-	err := p.clientPrivileged.List(context.Background(), erList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
+	err := p.clientPrivileged.List(ctx, erList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
 	return erList, err
 }
 
-func (p *EtcdRestoreProvider) Delete(userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
+func (p *EtcdRestoreProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster, name string) error {
 	impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return err
@@ -123,17 +126,17 @@ func (p *EtcdRestoreProvider) Delete(userInfo *provider.UserInfo, cluster *kuber
 			Namespace: cluster.Status.NamespaceName,
 		},
 	}
-	return impersonationClient.Delete(context.Background(), er)
+	return impersonationClient.Delete(ctx, er)
 }
 
-func (p *EtcdRestoreProvider) DeleteUnsecured(cluster *kubermaticv1.Cluster, name string) error {
+func (p *EtcdRestoreProvider) DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) error {
 	er := &kubermaticv1.EtcdRestore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: cluster.Status.NamespaceName,
 		},
 	}
-	return p.clientPrivileged.Delete(context.Background(), er)
+	return p.clientPrivileged.Delete(ctx, er)
 }
 
 // EtcdRestoreProjectProvider struct that holds required components in order manage etcd backup restores across projects.
@@ -143,6 +146,9 @@ type EtcdRestoreProjectProvider struct {
 	createSeedImpersonatedClients map[string]ImpersonationClient
 	clientsPrivileged             map[string]ctrlruntimeclient.Client
 }
+
+var _ provider.EtcdRestoreProjectProvider = &EtcdRestoreProjectProvider{}
+var _ provider.PrivilegedEtcdRestoreProjectProvider = &EtcdRestoreProjectProvider{}
 
 // NewEtcdRestoreProjectProvider returns an etcd restore global provider.
 func NewEtcdRestoreProjectProvider(createSeedImpersonatedClients map[string]ImpersonationClient, clients map[string]ctrlruntimeclient.Client) *EtcdRestoreProjectProvider {
@@ -177,7 +183,7 @@ func EtcdRestoreProjectProviderFactory(mapper meta.RESTMapper, seedKubeconfigGet
 	}
 }
 
-func (p *EtcdRestoreProjectProvider) List(userInfo *provider.UserInfo, projectID string) ([]*kubermaticv1.EtcdRestoreList, error) {
+func (p *EtcdRestoreProjectProvider) List(ctx context.Context, userInfo *provider.UserInfo, projectID string) ([]*kubermaticv1.EtcdRestoreList, error) {
 	var etcdRestoreLists []*kubermaticv1.EtcdRestoreList
 	for _, createSeedImpersonationClient := range p.createSeedImpersonatedClients {
 		impersonationClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, createSeedImpersonationClient)
@@ -186,7 +192,7 @@ func (p *EtcdRestoreProjectProvider) List(userInfo *provider.UserInfo, projectID
 		}
 
 		erList := &kubermaticv1.EtcdRestoreList{}
-		err = impersonationClient.List(context.Background(), erList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
+		err = impersonationClient.List(ctx, erList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}
@@ -196,11 +202,11 @@ func (p *EtcdRestoreProjectProvider) List(userInfo *provider.UserInfo, projectID
 	return etcdRestoreLists, nil
 }
 
-func (p *EtcdRestoreProjectProvider) ListUnsecured(projectID string) ([]*kubermaticv1.EtcdRestoreList, error) {
+func (p *EtcdRestoreProjectProvider) ListUnsecured(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdRestoreList, error) {
 	var etcdRestoreLists []*kubermaticv1.EtcdRestoreList
 	for _, clientPrivileged := range p.clientsPrivileged {
 		erList := &kubermaticv1.EtcdRestoreList{}
-		err := clientPrivileged.List(context.Background(), erList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
+		err := clientPrivileged.List(ctx, erList, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/kubernetes/member_test.go
+++ b/pkg/provider/kubernetes/member_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestCreateBinding(t *testing.T) {
 	}
 	// act
 	target := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsProjectServiceAccount)
-	result, err := target.Create(&provider.UserInfo{Email: authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", existingProject.Name)}, existingProject, memberEmail, groupName)
+	result, err := target.Create(context.Background(), &provider.UserInfo{Email: authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", existingProject.Name)}, existingProject, memberEmail, groupName)
 
 	// validate
 	if err != nil {
@@ -136,7 +137,7 @@ func TestListBinding(t *testing.T) {
 			}
 			// act
 			target := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsProjectServiceAccount)
-			result, err := target.List(&provider.UserInfo{Email: tc.authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", tc.projectToSync.Name)}, tc.projectToSync, nil)
+			result, err := target.List(context.Background(), &provider.UserInfo{Email: tc.authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", tc.projectToSync.Name)}, tc.projectToSync, nil)
 
 			// validate
 			if err != nil {

--- a/pkg/provider/kubernetes/mla_admin_setting.go
+++ b/pkg/provider/kubernetes/mla_admin_setting.go
@@ -35,9 +35,18 @@ type PrivilegedMLAAdminSettingProvider struct {
 	privilegedClient ctrlruntimeclient.Client
 }
 
-func (p *PrivilegedMLAAdminSettingProvider) GetUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.MLAAdminSetting, error) {
+var _ provider.PrivilegedMLAAdminSettingProvider = &PrivilegedMLAAdminSettingProvider{}
+
+// NewPrivilegedMLAAdminSettingProvider returns a MLAAdminSetting provider.
+func NewPrivilegedMLAAdminSettingProvider(privilegedClient ctrlruntimeclient.Client) *PrivilegedMLAAdminSettingProvider {
+	return &PrivilegedMLAAdminSettingProvider{
+		privilegedClient: privilegedClient,
+	}
+}
+
+func (p *PrivilegedMLAAdminSettingProvider) GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.MLAAdminSetting, error) {
 	mlaAdminSetting := &kubermaticv1.MLAAdminSetting{}
-	if err := p.privilegedClient.Get(context.Background(), types.NamespacedName{
+	if err := p.privilegedClient.Get(ctx, types.NamespacedName{
 		Name:      resources.MLAAdminSettingsName,
 		Namespace: cluster.Status.NamespaceName,
 	}, mlaAdminSetting); err != nil {
@@ -46,30 +55,23 @@ func (p *PrivilegedMLAAdminSettingProvider) GetUnsecured(cluster *kubermaticv1.C
 	return mlaAdminSetting, nil
 }
 
-func (p *PrivilegedMLAAdminSettingProvider) CreateUnsecured(mlaAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error) {
-	err := p.privilegedClient.Create(context.Background(), mlaAdminSetting)
+func (p *PrivilegedMLAAdminSettingProvider) CreateUnsecured(ctx context.Context, mlaAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error) {
+	err := p.privilegedClient.Create(ctx, mlaAdminSetting)
 	return mlaAdminSetting, err
 }
 
-func (p *PrivilegedMLAAdminSettingProvider) UpdateUnsecured(newMLAAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error) {
-	err := p.privilegedClient.Update(context.Background(), newMLAAdminSetting)
+func (p *PrivilegedMLAAdminSettingProvider) UpdateUnsecured(ctx context.Context, newMLAAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error) {
+	err := p.privilegedClient.Update(ctx, newMLAAdminSetting)
 	return newMLAAdminSetting, err
 }
 
-func (p *PrivilegedMLAAdminSettingProvider) DeleteUnsecured(cluster *kubermaticv1.Cluster) error {
-	return p.privilegedClient.Delete(context.Background(), &kubermaticv1.MLAAdminSetting{
+func (p *PrivilegedMLAAdminSettingProvider) DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	return p.privilegedClient.Delete(ctx, &kubermaticv1.MLAAdminSetting{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resources.MLAAdminSettingsName,
 			Namespace: cluster.Status.NamespaceName,
 		},
 	})
-}
-
-// NewPrivilegedMLAAdminSettingProvider returns a MLAAdminSetting provider.
-func NewPrivilegedMLAAdminSettingProvider(privilegedClient ctrlruntimeclient.Client) *PrivilegedMLAAdminSettingProvider {
-	return &PrivilegedMLAAdminSettingProvider{
-		privilegedClient: privilegedClient,
-	}
 }
 
 func PrivilegedMLAAdminSettingProviderFactory(mapper meta.RESTMapper, seedKubeconfigGetter provider.SeedKubeconfigGetter) provider.PrivilegedMLAAdminSettingProviderGetter {

--- a/pkg/provider/kubernetes/mla_admin_setting_test.go
+++ b/pkg/provider/kubernetes/mla_admin_setting_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func TestGetMLAAdminSetting(t *testing.T) {
 				WithObjects(tc.existingObjects...).
 				Build()
 			mlaAdminSettingProvider := kubernetes.NewPrivilegedMLAAdminSettingProvider(client)
-			mlaAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(tc.cluster)
+			mlaAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(context.Background(), tc.cluster)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
@@ -118,12 +119,12 @@ func TestCreateMLAAdminSetting(t *testing.T) {
 				WithObjects(tc.existingObjects...).
 				Build()
 			mlaAdminSettingProvider := kubernetes.NewPrivilegedMLAAdminSettingProvider(client)
-			_, err := mlaAdminSettingProvider.CreateUnsecured(tc.expectedMLAAdminSetting)
+			_, err := mlaAdminSettingProvider.CreateUnsecured(context.Background(), tc.expectedMLAAdminSetting)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
 				}
-				mlaAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(tc.cluster)
+				mlaAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(context.Background(), tc.cluster)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -171,22 +172,22 @@ func TestUpdateMLAAdminSetting(t *testing.T) {
 				Build()
 			mlaAdminSettingProvider := kubernetes.NewPrivilegedMLAAdminSettingProvider(client)
 			if len(tc.expectedError) == 0 {
-				currentMLAAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(tc.cluster)
+				currentMLAAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(context.Background(), tc.cluster)
 				if err != nil {
 					t.Fatal(err)
 				}
 				tc.expectedMLAAdminSetting.ResourceVersion = currentMLAAdminSetting.ResourceVersion
-				_, err = mlaAdminSettingProvider.UpdateUnsecured(tc.expectedMLAAdminSetting)
+				_, err = mlaAdminSettingProvider.UpdateUnsecured(context.Background(), tc.expectedMLAAdminSetting)
 				if err != nil {
 					t.Fatal(err)
 				}
-				mlaAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(tc.cluster)
+				mlaAdminSetting, err := mlaAdminSettingProvider.GetUnsecured(context.Background(), tc.cluster)
 				if err != nil {
 					t.Fatal(err)
 				}
 				assert.Equal(t, tc.expectedMLAAdminSetting, mlaAdminSetting)
 			} else {
-				_, err := mlaAdminSettingProvider.UpdateUnsecured(tc.expectedMLAAdminSetting)
+				_, err := mlaAdminSettingProvider.UpdateUnsecured(context.Background(), tc.expectedMLAAdminSetting)
 				if err == nil {
 					t.Fatalf("expected error message")
 				}
@@ -231,12 +232,12 @@ func TestDeleteMLAAdminSetting(t *testing.T) {
 				WithObjects(tc.existingObjects...).
 				Build()
 			mlaAdminSettingProvider := kubernetes.NewPrivilegedMLAAdminSettingProvider(client)
-			err := mlaAdminSettingProvider.DeleteUnsecured(tc.cluster)
+			err := mlaAdminSettingProvider.DeleteUnsecured(context.Background(), tc.cluster)
 			if len(tc.expectedError) == 0 {
 				if err != nil {
 					t.Fatal(err)
 				}
-				_, err = mlaAdminSettingProvider.GetUnsecured(tc.cluster)
+				_, err = mlaAdminSettingProvider.GetUnsecured(context.Background(), tc.cluster)
 				assert.True(t, errors.IsNotFound(err))
 			} else {
 				if err == nil {

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -89,7 +89,7 @@ type PresetProvider struct {
 
 var _ provider.PresetProvider = &PresetProvider{}
 
-func NewPresetProvider(ctx context.Context, client ctrlruntimeclient.Client) (*PresetProvider, error) {
+func NewPresetProvider(client ctrlruntimeclient.Client) (*PresetProvider, error) {
 	getter, err := presetsGetterFactory(client)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/kubernetes/preset_test.go
+++ b/pkg/provider/kubernetes/preset_test.go
@@ -188,7 +188,7 @@ func TestGetPreset(t *testing.T) {
 				WithObjects(tc.presets...).
 				Build()
 
-			provider, err := kubernetes.NewPresetProvider(context.Background(), fakeClient)
+			provider, err := kubernetes.NewPresetProvider(fakeClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -523,7 +523,7 @@ func TestGetPresets(t *testing.T) {
 				WithObjects(tc.presets...).
 				Build()
 
-			provider, err := kubernetes.NewPresetProvider(context.Background(), fakeClient)
+			provider, err := kubernetes.NewPresetProvider(fakeClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -871,7 +871,7 @@ func TestCredentialEndpoint(t *testing.T) {
 				WithObjects(tc.presets...).
 				Build()
 
-			provider, err := kubernetes.NewPresetProvider(context.Background(), fakeClient)
+			provider, err := kubernetes.NewPresetProvider(fakeClient)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -827,19 +827,19 @@ type ConstraintTemplateProvider interface {
 	// List gets a list of constraint templates, by default it returns all resources.
 	//
 	// Note that the list is taken from the cache
-	List() (*kubermaticv1.ConstraintTemplateList, error)
+	List(ctx context.Context) (*kubermaticv1.ConstraintTemplateList, error)
 
 	// Get gets the given constraint template
-	Get(name string) (*kubermaticv1.ConstraintTemplate, error)
+	Get(ctx context.Context, name string) (*kubermaticv1.ConstraintTemplate, error)
 
 	// Create a Constraint Template
-	Create(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error)
+	Create(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error)
 
 	// Update a Constraint Template
-	Update(ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error)
+	Update(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error)
 
 	// Delete a Constraint Template
-	Delete(ct *kubermaticv1.ConstraintTemplate) error
+	Delete(ctx context.Context, ct *kubermaticv1.ConstraintTemplate) error
 }
 
 // ConstraintProvider declares the set of method for interacting with constraints.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -372,39 +372,39 @@ type ProjectMemberListOptions struct {
 // ProjectMemberProvider binds users with projects.
 type ProjectMemberProvider interface {
 	// Create creates a binding for the given member and the given project
-	Create(userInfo *UserInfo, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
+	Create(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
 
 	// List gets all members of the given project
-	List(userInfo *UserInfo, project *kubermaticv1.Project, options *ProjectMemberListOptions) ([]*kubermaticv1.UserProjectBinding, error)
+	List(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, options *ProjectMemberListOptions) ([]*kubermaticv1.UserProjectBinding, error)
 
 	// Delete deletes the given binding
 	// Note:
 	// Use List to get binding for the specific member of the given project
-	Delete(userInfo *UserInfo, bindinName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, bindinName string) error
 
 	// Update updates the given binding
-	Update(userInfo *UserInfo, binding *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error)
+	Update(ctx context.Context, userInfo *UserInfo, binding *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error)
 }
 
 // PrivilegedProjectMemberProvider binds users with projects and uses privileged account for it.
 type PrivilegedProjectMemberProvider interface {
 	// CreateUnsecured creates a binding for the given member and the given project
 	// This function is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
+	CreateUnsecured(ctx context.Context, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
 
 	// CreateUnsecuredForServiceAccount creates a binding for the given service account and the given project
 	// This function is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecuredForServiceAccount(project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
+	CreateUnsecuredForServiceAccount(ctx context.Context, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
 
 	// DeleteUnsecured deletes the given binding
 	// Note:
 	// Use List to get binding for the specific member of the given project
 	// This function is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(bindingName string) error
+	DeleteUnsecured(ctx context.Context, bindingName string) error
 
 	// UpdateUnsecured updates the given binding
 	// This function is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(binding *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error)
+	UpdateUnsecured(ctx context.Context, binding *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error)
 }
 
 // ProjectMemberMapper exposes method that knows how to map
@@ -412,11 +412,11 @@ type PrivilegedProjectMemberProvider interface {
 type ProjectMemberMapper interface {
 	// MapUserToGroup maps the given user to a specific group of the given project
 	// This function is unsafe in a sense that it uses privileged account to list all members in the system
-	MapUserToGroup(userEmail string, projectID string) (string, error)
+	MapUserToGroup(ctx context.Context, userEmail string, projectID string) (string, error)
 
 	// MappingsFor returns the list of projects (bindings) for the given user
 	// This function is unsafe in a sense that it uses privileged account to list all members in the system
-	MappingsFor(userEmail string) ([]*kubermaticv1.UserProjectBinding, error)
+	MappingsFor(ctx context.Context, userEmail string) ([]*kubermaticv1.UserProjectBinding, error)
 }
 
 // ClusterCloudProviderName returns the provider name for the given CloudSpec.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -753,11 +753,11 @@ type PresetProvider interface {
 
 // AdmissionPluginsProvider declares the set of methods for interacting with admission plugins.
 type AdmissionPluginsProvider interface {
-	List(userInfo *UserInfo) ([]kubermaticv1.AdmissionPlugin, error)
-	Get(userInfo *UserInfo, name string) (*kubermaticv1.AdmissionPlugin, error)
-	Delete(userInfo *UserInfo, name string) error
-	Update(userInfo *UserInfo, admissionPlugin *kubermaticv1.AdmissionPlugin) (*kubermaticv1.AdmissionPlugin, error)
-	ListPluginNamesFromVersion(fromVersion string) ([]string, error)
+	List(ctx context.Context, userInfo *UserInfo) ([]kubermaticv1.AdmissionPlugin, error)
+	Get(ctx context.Context, userInfo *UserInfo, name string) (*kubermaticv1.AdmissionPlugin, error)
+	Delete(ctx context.Context, userInfo *UserInfo, name string) error
+	Update(ctx context.Context, userInfo *UserInfo, admissionPlugin *kubermaticv1.AdmissionPlugin) (*kubermaticv1.AdmissionPlugin, error)
+	ListPluginNamesFromVersion(ctx context.Context, fromVersion string) ([]string, error)
 }
 
 // ExternalClusterProvider declares the set of methods for interacting with external cluster.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1051,31 +1051,31 @@ type PrivilegedAllowedRegistryProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
+	CreateUnsecured(ctx context.Context, ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
 
 	// GetUnsecured gets the given allowed registry
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(name string) (*kubermaticv1.AllowedRegistry, error)
+	GetUnsecured(ctx context.Context, name string) (*kubermaticv1.AllowedRegistry, error)
 
 	// ListUnsecured gets a list of all allowed registries
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resources
-	ListUnsecured() (*kubermaticv1.AllowedRegistryList, error)
+	ListUnsecured(ctx context.Context) (*kubermaticv1.AllowedRegistryList, error)
 
 	// UpdateUnsecured updates the allowed registry
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
+	UpdateUnsecured(ctx context.Context, ar *kubermaticv1.AllowedRegistry) (*kubermaticv1.AllowedRegistry, error)
 
 	// DeleteUnsecured deletes the allowed registry with the given name
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(name string) error
+	DeleteUnsecured(ctx context.Context, name string) error
 }
 
 // EtcdBackupConfigProvider declares the set of method for interacting with etcd backup configs.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -959,25 +959,25 @@ type PrivilegedClusterTemplateInstanceProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	CreateUnsecured(template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error)
+	CreateUnsecured(ctx context.Context, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error)
 
 	// GetUnsecured gets cluster template instance
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(name string) (*kubermaticv1.ClusterTemplateInstance, error)
+	GetUnsecured(ctx context.Context, name string) (*kubermaticv1.ClusterTemplateInstance, error)
 
 	// ListUnsecured lists cluster template instances
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	ListUnsecured(options ClusterTemplateInstanceListOptions) (*kubermaticv1.ClusterTemplateInstanceList, error)
+	ListUnsecured(ctx context.Context, options ClusterTemplateInstanceListOptions) (*kubermaticv1.ClusterTemplateInstanceList, error)
 
 	// PatchUnsecured patches cluster template instances
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	PatchUnsecured(instance *kubermaticv1.ClusterTemplateInstance) (*kubermaticv1.ClusterTemplateInstance, error)
+	PatchUnsecured(ctx context.Context, instance *kubermaticv1.ClusterTemplateInstance) (*kubermaticv1.ClusterTemplateInstance, error)
 }
 
 // ClusterTemplateInstanceListOptions allows to set filters that will be applied to filter the result.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -847,19 +847,19 @@ type ConstraintProvider interface {
 	// List gets a list of constraints
 	//
 	// Note that the list is taken from the cache
-	List(cluster *kubermaticv1.Cluster) (*kubermaticv1.ConstraintList, error)
+	List(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.ConstraintList, error)
 
 	// Get gets the given constraints
-	Get(cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.Constraint, error)
+	Get(ctx context.Context, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.Constraint, error)
 
 	// Create creates the given constraint
-	Create(userInfo *UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+	Create(ctx context.Context, userInfo *UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
 
 	// Delete deletes the given constraint
-	Delete(cluster *kubermaticv1.Cluster, userInfo *UserInfo, name string) error
+	Delete(ctx context.Context, cluster *kubermaticv1.Cluster, userInfo *UserInfo, name string) error
 
 	// Update updates the given constraint
-	Update(userInfo *UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+	Update(ctx context.Context, userInfo *UserInfo, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
 }
 
 // PrivilegedConstraintProvider declares a set of methods for interacting with constraints using a privileged client.
@@ -868,19 +868,19 @@ type PrivilegedConstraintProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+	CreateUnsecured(ctx context.Context, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
 
 	// DeleteUnsecured deletes a constraint using a privileged client
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(cluster *kubermaticv1.Cluster, name string) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) error
 
 	// UpdateUnsecured updates the given constraint using a privileged client
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+	UpdateUnsecured(ctx context.Context, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
 }
 
 // DefaultConstraintProvider declares the set of method for interacting with default constraints.
@@ -888,19 +888,19 @@ type DefaultConstraintProvider interface {
 	// List gets a list of default constraints
 	//
 	// Note that the list is taken from the cache
-	List() (*kubermaticv1.ConstraintList, error)
+	List(ctx context.Context) (*kubermaticv1.ConstraintList, error)
 
 	// Get gets the given default constraints
-	Get(name string) (*kubermaticv1.Constraint, error)
+	Get(ctx context.Context, name string) (*kubermaticv1.Constraint, error)
 
 	// Create creates the given default constraint
-	Create(constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+	Create(ctx context.Context, constraint *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
 
 	// Delete deletes the given default constraint
-	Delete(name string) error
+	Delete(ctx context.Context, name string) error
 
 	// Update a default constraint
-	Update(ct *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+	Update(ctx context.Context, ct *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
 }
 
 // AlertmanagerProvider declares the set of method for interacting with alertmanagers.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1081,19 +1081,19 @@ type PrivilegedAllowedRegistryProvider interface {
 // EtcdBackupConfigProvider declares the set of method for interacting with etcd backup configs.
 type EtcdBackupConfigProvider interface {
 	// Create creates the given etcdBackupConfig
-	Create(userInfo *UserInfo, etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
+	Create(ctx context.Context, userInfo *UserInfo, etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
 
 	// Get gets the given etcdBackupConfig
-	Get(userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error)
+	Get(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error)
 
 	// List gets a list of etcdBackupConfig for a given cluster
-	List(userInfo *UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error)
+	List(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error)
 
 	// Delete deletes the given etcdBackupConfig
-	Delete(userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) error
+	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) error
 
 	// Patch updates the given etcdBackupConfig
-	Patch(userInfo *UserInfo, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
+	Patch(ctx context.Context, userInfo *UserInfo, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
 }
 
 // PrivilegedEtcdBackupConfigProvider declares the set of method for interacting with etcd backup configs using a privileged client.
@@ -1102,31 +1102,31 @@ type PrivilegedEtcdBackupConfigProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
+	CreateUnsecured(ctx context.Context, etcdBackupConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
 
 	// GetUnsecured gets the given etcdBackupConfig
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error)
+	GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdBackupConfig, error)
 
 	// ListUnsecured gets a list of all etcdBackupConfigs for a given cluster
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to list the resources
-	ListUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error)
+	ListUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfigList, error)
 
 	// DeleteUnsecured deletes the given etcdBackupConfig
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(cluster *kubermaticv1.Cluster, name string) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) error
 
 	// PatchUnsecured patches the given etcdBackupConfig
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to patch the resource
-	PatchUnsecured(oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
+	PatchUnsecured(ctx context.Context, oldConfig, newConfig *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
 }
 
 // EtcdRestoreProvider declares the set of method for interacting with etcd backup restores.
@@ -1174,7 +1174,7 @@ type PrivilegedEtcdRestoreProvider interface {
 // EtcdBackupConfigProjectProvider declares the set of method for interacting with etcd backup configs across projects and its seeds.
 type EtcdBackupConfigProjectProvider interface {
 	// List gets a list of etcdBackupConfig for a given project
-	List(userInfo *UserInfo, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error)
+	List(ctx context.Context, userInfo *UserInfo, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error)
 }
 
 // PrivilegedEtcdBackupConfigProjectProvider declares the set of method for interacting with etcd backup configs using a privileged client across projects and its seeds.
@@ -1183,7 +1183,7 @@ type PrivilegedEtcdBackupConfigProjectProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to list the resources
-	ListUnsecured(projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error)
+	ListUnsecured(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error)
 }
 
 // EtcdRestoreProjectProvider declares the set of method for interacting with etcd backup restores across projects and its seeds.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -95,7 +95,7 @@ func (c *UpdaterOptions) Apply(opts ...UpdaterOption) *UpdaterOptions {
 }
 
 // ClusterUpdater defines a function to persist an update to a cluster.
-type ClusterUpdater func(string, func(*kubermaticv1.Cluster), ...UpdaterOption) (*kubermaticv1.Cluster, error)
+type ClusterUpdater func(context.Context, string, func(*kubermaticv1.Cluster), ...UpdaterOption) (*kubermaticv1.Cluster, error)
 
 // ClusterListOptions allows to set filters that will be applied to filter the result.
 type ClusterListOptions struct {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -725,8 +725,8 @@ type PrivilegedAddonProvider interface {
 }
 
 type AddonConfigProvider interface {
-	Get(addonName string) (*kubermaticv1.AddonConfig, error)
-	List() (*kubermaticv1.AddonConfigList, error)
+	Get(ctx context.Context, addonName string) (*kubermaticv1.AddonConfig, error)
+	List(ctx context.Context) (*kubermaticv1.AddonConfigList, error)
 }
 
 // SettingsProvider declares the set of methods for interacting global settings.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -938,18 +938,18 @@ type PrivilegedAlertmanagerProvider interface {
 
 // ClusterTemplateProvider declares the set of method for interacting with cluster templates.
 type ClusterTemplateProvider interface {
-	New(userInfo *UserInfo, newClusterTemplate *kubermaticv1.ClusterTemplate, scope, projectID string) (*kubermaticv1.ClusterTemplate, error)
-	List(userInfo *UserInfo, projectID string) ([]kubermaticv1.ClusterTemplate, error)
-	Get(userInfo *UserInfo, projectID, templateID string) (*kubermaticv1.ClusterTemplate, error)
-	Delete(userInfo *UserInfo, projectID, templateID string) error
+	New(ctx context.Context, userInfo *UserInfo, newClusterTemplate *kubermaticv1.ClusterTemplate, scope, projectID string) (*kubermaticv1.ClusterTemplate, error)
+	List(ctx context.Context, userInfo *UserInfo, projectID string) ([]kubermaticv1.ClusterTemplate, error)
+	Get(ctx context.Context, userInfo *UserInfo, projectID, templateID string) (*kubermaticv1.ClusterTemplate, error)
+	Delete(ctx context.Context, userInfo *UserInfo, projectID, templateID string) error
 }
 
 // ClusterTemplateInstanceProvider declares the set of method for interacting with cluster templates.
 type ClusterTemplateInstanceProvider interface {
-	Create(userInfo *UserInfo, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error)
-	Get(userInfo *UserInfo, name string) (*kubermaticv1.ClusterTemplateInstance, error)
-	List(userInfo *UserInfo, options ClusterTemplateInstanceListOptions) (*kubermaticv1.ClusterTemplateInstanceList, error)
-	Patch(userInfo *UserInfo, instance *kubermaticv1.ClusterTemplateInstance) (*kubermaticv1.ClusterTemplateInstance, error)
+	Create(ctx context.Context, userInfo *UserInfo, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error)
+	Get(ctx context.Context, userInfo *UserInfo, name string) (*kubermaticv1.ClusterTemplateInstance, error)
+	List(ctx context.Context, userInfo *UserInfo, options ClusterTemplateInstanceListOptions) (*kubermaticv1.ClusterTemplateInstanceList, error)
+	Patch(ctx context.Context, userInfo *UserInfo, instance *kubermaticv1.ClusterTemplateInstance) (*kubermaticv1.ClusterTemplateInstance, error)
 }
 
 // PrivilegedClusterTemplateInstanceProvider declares the set of methods for interacting with the cluster template instances

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -163,7 +163,7 @@ type ProjectListOptions struct {
 // This provider is Project and RBAC compliant.
 type ClusterProvider interface {
 	// New creates a brand new cluster that is bound to the given project
-	New(project *kubermaticv1.Project, userInfo *UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
+	New(ctx context.Context, project *kubermaticv1.Project, userInfo *UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
 
 	// List gets all clusters that belong to the given project
 	// If you want to filter the result please take a look at ClusterListOptions
@@ -171,31 +171,31 @@ type ClusterProvider interface {
 	// Note:
 	// After we get the list of clusters we could try to get each cluster individually using unprivileged account to see if the user have read access,
 	// We don't do this because we assume that if the user was able to get the project (argument) it has to have at least read access.
-	List(project *kubermaticv1.Project, options *ClusterListOptions) (*kubermaticv1.ClusterList, error)
+	List(ctx context.Context, project *kubermaticv1.Project, options *ClusterListOptions) (*kubermaticv1.ClusterList, error)
 
 	// ListAll gets all clusters for the seed
-	ListAll() (*kubermaticv1.ClusterList, error)
+	ListAll(ctx context.Context) (*kubermaticv1.ClusterList, error)
 
 	// Get returns the given cluster, it uses the projectInternalName to determine the group the user belongs to
-	Get(userInfo *UserInfo, clusterName string, options *ClusterGetOptions) (*kubermaticv1.Cluster, error)
+	Get(ctx context.Context, userInfo *UserInfo, clusterName string, options *ClusterGetOptions) (*kubermaticv1.Cluster, error)
 
 	// Update updates a cluster
-	Update(project *kubermaticv1.Project, userInfo *UserInfo, newCluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
+	Update(ctx context.Context, project *kubermaticv1.Project, userInfo *UserInfo, newCluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
 
 	// Delete deletes the given cluster
-	Delete(userInfo *UserInfo, clusterName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, clusterName string) error
 
 	// GetAdminKubeconfigForCustomerCluster returns the admin kubeconfig for the given cluster
-	GetAdminKubeconfigForCustomerCluster(cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
+	GetAdminKubeconfigForCustomerCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
 
 	// GetViewerKubeconfigForCustomerCluster returns the viewer kubeconfig for the given cluster
-	GetViewerKubeconfigForCustomerCluster(cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
+	GetViewerKubeconfigForCustomerCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
 
 	// RevokeViewerKubeconfig revokes viewer token and kubeconfig
-	RevokeViewerKubeconfig(c *kubermaticv1.Cluster) error
+	RevokeViewerKubeconfig(ctx context.Context, c *kubermaticv1.Cluster) error
 
 	// RevokeAdminKubeconfig revokes the viewer token and kubeconfig
-	RevokeAdminKubeconfig(c *kubermaticv1.Cluster) error
+	RevokeAdminKubeconfig(ctx context.Context, c *kubermaticv1.Cluster) error
 
 	// GetAdminClientForCustomerCluster returns a client to interact with all resources in the given cluster
 	//
@@ -212,7 +212,7 @@ type ClusterProvider interface {
 	GetTokenForCustomerCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (string, error)
 
 	// IsCluster checks if cluster exist with the given name
-	IsCluster(clusterName string) bool
+	IsCluster(ctx context.Context, clusterName string) bool
 
 	// GetSeedName gets the seed name of the cluster
 	GetSeedName() string
@@ -234,22 +234,22 @@ type PrivilegedClusterProvider interface {
 	// GetUnsecured returns a cluster for the project and given name.
 	//
 	// Note that the admin privileges are used to get cluster
-	GetUnsecured(project *kubermaticv1.Project, clusterName string, options *ClusterGetOptions) (*kubermaticv1.Cluster, error)
+	GetUnsecured(ctx context.Context, project *kubermaticv1.Project, clusterName string, options *ClusterGetOptions) (*kubermaticv1.Cluster, error)
 
 	// UpdateUnsecured updates a cluster.
 	//
 	// Note that the admin privileges are used to update cluster
-	UpdateUnsecured(project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
+	UpdateUnsecured(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
 
 	// DeleteUnsecured deletes a cluster.
 	//
 	// Note that the admin privileges are used to delete cluster
-	DeleteUnsecured(cluster *kubermaticv1.Cluster) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) error
 
 	// NewUnsecured creates a brand new cluster that is bound to the given project.
 	//
 	// Note that the admin privileges are used to create cluster
-	NewUnsecured(project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, userEmail string) (*kubermaticv1.Cluster, error)
+	NewUnsecured(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, userEmail string) (*kubermaticv1.Cluster, error)
 }
 
 // SSHKeyListOptions allows to set filters that will be applied to filter the result.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1232,25 +1232,25 @@ type PrivilegedMLAAdminSettingProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.MLAAdminSetting, error)
+	GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.MLAAdminSetting, error)
 
 	// CreateUnsecured creates the given MLAAdminSetting
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(mlaAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error)
+	CreateUnsecured(ctx context.Context, mlaAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error)
 
 	// UpdateUnsecured updates an MLAAdminSetting
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(newMLAAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error)
+	UpdateUnsecured(ctx context.Context, newMLAAdminSetting *kubermaticv1.MLAAdminSetting) (*kubermaticv1.MLAAdminSetting, error)
 
 	// DeleteUnsecured deletes the MLAAdminSetting with the given name
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(cluster *kubermaticv1.Cluster) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) error
 }
 
 type SeedProvider interface {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -675,20 +675,20 @@ type EventRecorderProvider interface {
 // AddonProvider declares the set of methods for interacting with addons.
 type AddonProvider interface {
 	// New creates a new addon in the given cluster
-	New(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension, labels map[string]string) (*kubermaticv1.Addon, error)
+	New(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension, labels map[string]string) (*kubermaticv1.Addon, error)
 
 	// List gets all addons that belong to the given cluster
 	// If you want to filter the result please take a look at ClusterListOptions
-	List(userInfo *UserInfo, cluster *kubermaticv1.Cluster) ([]*kubermaticv1.Addon, error)
+	List(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster) ([]*kubermaticv1.Addon, error)
 
 	// Get returns the given addon
-	Get(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string) (*kubermaticv1.Addon, error)
+	Get(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string) (*kubermaticv1.Addon, error)
 
 	// Update updates an addon
-	Update(userInfo *UserInfo, cluster *kubermaticv1.Cluster, newAddon *kubermaticv1.Addon) (*kubermaticv1.Addon, error)
+	Update(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, newAddon *kubermaticv1.Addon) (*kubermaticv1.Addon, error)
 
 	// Delete deletes the given addon
-	Delete(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string) error
 }
 
 type PrivilegedAddonProvider interface {
@@ -697,31 +697,31 @@ type PrivilegedAddonProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resources
-	ListUnsecured(cluster *kubermaticv1.Cluster) ([]*kubermaticv1.Addon, error)
+	ListUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) ([]*kubermaticv1.Addon, error)
 
 	// NewUnsecured creates a new addon in the given cluster
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	NewUnsecured(cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension, labels map[string]string) (*kubermaticv1.Addon, error)
+	NewUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension, labels map[string]string) (*kubermaticv1.Addon, error)
 
 	// GetUnsecured returns the given addon
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(cluster *kubermaticv1.Cluster, addonName string) (*kubermaticv1.Addon, error)
+	GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, addonName string) (*kubermaticv1.Addon, error)
 
 	// UpdateUnsecured updates an addon
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(cluster *kubermaticv1.Cluster, newAddon *kubermaticv1.Addon) (*kubermaticv1.Addon, error)
+	UpdateUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, newAddon *kubermaticv1.Addon) (*kubermaticv1.Addon, error)
 
 	// DeleteUnsecured deletes the given addon
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(cluster *kubermaticv1.Cluster, addonName string) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, addonName string) error
 }
 
 type AddonConfigProvider interface {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -906,13 +906,13 @@ type DefaultConstraintProvider interface {
 // AlertmanagerProvider declares the set of method for interacting with alertmanagers.
 type AlertmanagerProvider interface {
 	// Get gets the given alertmanager and the config secret
-	Get(cluster *kubermaticv1.Cluster, userInfo *UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
+	Get(ctx context.Context, cluster *kubermaticv1.Cluster, userInfo *UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
 
 	// Update updates the given alertmanager and the config secret
-	Update(alertmanager *kubermaticv1.Alertmanager, configSecret *corev1.Secret, userInfo *UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
+	Update(ctx context.Context, alertmanager *kubermaticv1.Alertmanager, configSecret *corev1.Secret, userInfo *UserInfo) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
 
 	// Reset resets the given alertmanager to default
-	Reset(cluster *kubermaticv1.Cluster, userInfo *UserInfo) error
+	Reset(ctx context.Context, cluster *kubermaticv1.Cluster, userInfo *UserInfo) error
 }
 
 // PrivilegedAlertmanagerProvider declares the set of method for interacting with alertmanagers using a privileged client.
@@ -921,19 +921,19 @@ type PrivilegedAlertmanagerProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
+	GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
 
 	// UpdateUnsecured updates the given alertmanager and the config secret using a privileged client
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(alertmanager *kubermaticv1.Alertmanager, configSecret *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
+	UpdateUnsecured(ctx context.Context, alertmanager *kubermaticv1.Alertmanager, configSecret *corev1.Secret) (*kubermaticv1.Alertmanager, *corev1.Secret, error)
 
 	// ResetUnsecured resets the given alertmanager to default using a privileged client
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to reset the resource
-	ResetUnsecured(cluster *kubermaticv1.Cluster) error
+	ResetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) error
 }
 
 // ClusterTemplateProvider declares the set of method for interacting with cluster templates.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1132,16 +1132,16 @@ type PrivilegedEtcdBackupConfigProvider interface {
 // EtcdRestoreProvider declares the set of method for interacting with etcd backup restores.
 type EtcdRestoreProvider interface {
 	// Create creates the given etcdRestore
-	Create(userInfo *UserInfo, etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error)
+	Create(ctx context.Context, userInfo *UserInfo, etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error)
 
 	// Get gets the given etcdRestore
-	Get(userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error)
+	Get(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error)
 
 	// List gets a list of etcdRestore for a given cluster
-	List(userInfo *UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error)
+	List(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error)
 
 	// Delete deletes the given etcdRestore
-	Delete(userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) error
+	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster, name string) error
 }
 
 // PrivilegedEtcdRestoreProvider declares the set of method for interacting with etcd backup configs using a privileged client.
@@ -1150,25 +1150,25 @@ type PrivilegedEtcdRestoreProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error)
+	CreateUnsecured(ctx context.Context, etcdRestore *kubermaticv1.EtcdRestore) (*kubermaticv1.EtcdRestore, error)
 
 	// GetUnsecured gets the given etcdRestore
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error)
+	GetUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) (*kubermaticv1.EtcdRestore, error)
 
 	// ListUnsecured gets a list of all etcdRestores for a given cluster
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to list the resources
-	ListUnsecured(cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error)
+	ListUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestoreList, error)
 
 	// DeleteUnsecured deletes the given etcdRestore
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resource
-	DeleteUnsecured(cluster *kubermaticv1.Cluster, name string) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.Cluster, name string) error
 }
 
 // EtcdBackupConfigProjectProvider declares the set of method for interacting with etcd backup configs across projects and its seeds.
@@ -1189,7 +1189,7 @@ type PrivilegedEtcdBackupConfigProjectProvider interface {
 // EtcdRestoreProjectProvider declares the set of method for interacting with etcd backup restores across projects and its seeds.
 type EtcdRestoreProjectProvider interface {
 	// List gets a list of etcdRestore for a given project
-	List(userInfo *UserInfo, projectID string) ([]*kubermaticv1.EtcdRestoreList, error)
+	List(ctx context.Context, userInfo *UserInfo, projectID string) ([]*kubermaticv1.EtcdRestoreList, error)
 }
 
 // PrivilegedEtcdRestoreProjectProvider declares the set of method for interacting with etcd backup configs using a privileged client across projects and its seeds.
@@ -1198,7 +1198,7 @@ type PrivilegedEtcdRestoreProjectProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to list the resources
-	ListUnsecured(projectID string) ([]*kubermaticv1.EtcdRestoreList, error)
+	ListUnsecured(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdRestoreList, error)
 }
 
 // FeatureGatesProvider declares the set of method for getting currently subset of provided feature gates.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -762,31 +762,31 @@ type AdmissionPluginsProvider interface {
 
 // ExternalClusterProvider declares the set of methods for interacting with external cluster.
 type ExternalClusterProvider interface {
-	New(userInfo *UserInfo, project *kubermaticv1.Project, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
+	New(ctx context.Context, userInfo *UserInfo, project *kubermaticv1.Project, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
 
-	Get(userInfo *UserInfo, clusterName string) (*kubermaticv1.ExternalCluster, error)
+	Get(ctx context.Context, userInfo *UserInfo, clusterName string) (*kubermaticv1.ExternalCluster, error)
 
-	Delete(userInfo *UserInfo, cluster *kubermaticv1.ExternalCluster) error
+	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.ExternalCluster) error
 
-	Update(userInfo *UserInfo, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
+	Update(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
 
-	List(project *kubermaticv1.Project) (*kubermaticv1.ExternalClusterList, error)
+	List(ctx context.Context, project *kubermaticv1.Project) (*kubermaticv1.ExternalClusterList, error)
 
 	GenerateClient(cfg *clientcmdapi.Config) (ctrlruntimeclient.Client, error)
 
-	GetClient(cluster *kubermaticv1.ExternalCluster) (ctrlruntimeclient.Client, error)
+	GetClient(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (ctrlruntimeclient.Client, error)
 
 	CreateOrUpdateKubeconfigSecretForCluster(ctx context.Context, cluster *kubermaticv1.ExternalCluster, kubeconfig string) error
 
 	CreateOrUpdateCredentialSecretForCluster(ctx context.Context, cloud *apiv2.ExternalClusterCloudSpec, projectID, clusterID string) (*providerconfig.GlobalSecretKeySelector, error)
 
-	GetVersion(cluster *kubermaticv1.ExternalCluster) (*ksemver.Semver, error)
+	GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*ksemver.Semver, error)
 
-	ListNodes(cluster *kubermaticv1.ExternalCluster) (*corev1.NodeList, error)
+	ListNodes(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*corev1.NodeList, error)
 
-	GetNode(cluster *kubermaticv1.ExternalCluster, nodeName string) (*corev1.Node, error)
+	GetNode(ctx context.Context, cluster *kubermaticv1.ExternalCluster, nodeName string) (*corev1.Node, error)
 
-	IsMetricServerAvailable(cluster *kubermaticv1.ExternalCluster) (bool, error)
+	IsMetricServerAvailable(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (bool, error)
 }
 
 // ExternalClusterProvider declares the set of methods for interacting with external cluster.
@@ -795,25 +795,25 @@ type PrivilegedExternalClusterProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resources
-	NewUnsecured(project *kubermaticv1.Project, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
+	NewUnsecured(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
 
 	// DeleteUnsecured deletes an external cluster
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to delete the resources
-	DeleteUnsecured(cluster *kubermaticv1.ExternalCluster) error
+	DeleteUnsecured(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error
 
 	// GetUnsecured gets an external cluster
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resources
-	GetUnsecured(clusterName string) (*kubermaticv1.ExternalCluster, error)
+	GetUnsecured(ctx context.Context, clusterName string) (*kubermaticv1.ExternalCluster, error)
 
 	// UpdateUnsecured updates an external cluster
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resources
-	UpdateUnsecured(cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
+	UpdateUnsecured(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*kubermaticv1.ExternalCluster, error)
 
 	// GetMasterClient returns master client
 	//

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -737,8 +737,8 @@ type SettingsProvider interface {
 
 // AdminProvider declares the set of methods for interacting with admin.
 type AdminProvider interface {
-	SetAdmin(userInfo *UserInfo, email string, isAdmin bool) (*kubermaticv1.User, error)
-	GetAdmins(userInfo *UserInfo) ([]kubermaticv1.User, error)
+	SetAdmin(ctx context.Context, userInfo *UserInfo, email string, isAdmin bool) (*kubermaticv1.User, error)
+	GetAdmins(ctx context.Context, userInfo *UserInfo) ([]kubermaticv1.User, error)
 }
 
 // PresetProvider declares the set of methods for interacting with presets.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1212,19 +1212,19 @@ type BackupCredentialsProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	CreateUnsecured(credentials *corev1.Secret) (*corev1.Secret, error)
+	CreateUnsecured(ctx context.Context, credentials *corev1.Secret) (*corev1.Secret, error)
 
 	// GetUnsecured gets the backup credentials
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	GetUnsecured(credentialName string) (*corev1.Secret, error)
+	GetUnsecured(ctx context.Context, credentialName string) (*corev1.Secret, error)
 
 	// UpdateUnsecured updates the backup credentials
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to update the resource
-	UpdateUnsecured(newSecret *corev1.Secret) (*corev1.Secret, error)
+	UpdateUnsecured(ctx context.Context, newSecret *corev1.Secret) (*corev1.Secret, error)
 }
 
 type PrivilegedMLAAdminSettingProvider interface {

--- a/pkg/provider/userinfo.go
+++ b/pkg/provider/userinfo.go
@@ -38,7 +38,7 @@ func UserInfoGetterFactory(userProjectMapper ProjectMemberMapper) (UserInfoGette
 		var group string
 		if projectID != "" {
 			var err error
-			group, err = userProjectMapper.MapUserToGroup(user.Spec.Email, projectID)
+			group, err = userProjectMapper.MapUserToGroup(ctx, user.Spec.Email, projectID)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is the sister to #9246, fixing the remaining Kubernetes providers and then a few more places. With this PR in place, we're 99% rid of background/TODO contexts :-)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
