### PR TITLE
Add proposal for container registry credential handling on user clusters

### DIFF
--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -22,7 +22,7 @@
   * [Reconciliation of all Pods running on user clusters](#reconciliation-of-all-pods-running-on-user-clusters)
   * [Setting imagePullSecrets on ServiceAccounts](#setting-imagepullsecrets-on-serviceaccounts)
   * [Extension of addon templates with imagePullSecrets](#extension-of-addon-templates-with-imagepullsecrets)
-* [Task & effort](#task-&-effort)
+* [Task and effort](#task-and-effort)
 
 ## Goals
 
@@ -248,7 +248,7 @@ Pods or ServiceAccounts in addon templates could be templated to use an imagePul
 does not cover reconciled KKP components nor user apps. So this approach would need to be combined
 with at least one of the 2 above.
 
-## Task & effort
+## Task and effort
 * Create CRD `RegistryCredentialSet`
 * [UI] Extend Admin UI by Registry Credential Management
 * [UI] Extend Project Management UI by Registry Credential Management

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -164,7 +164,7 @@ set).
 ### Agent
 
 Similar to the SSH key agent this agent watches a named Secret containing registry credentials and
-also the containerd config on the node the agent is running on. It makes sure that the containerd
+also the containerd-config on the node the agent is running on. It makes sure that the containerd-
 config always contain the selected credentials.
 
 #### Refactoring potential

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -58,7 +58,7 @@ cluster.
 
 For this first iteration the secrets referenced on `Cluster` resources need to be created manually.
 
-There is a also the possibility to define default credentlals in the `KubermaticConfiguration` at
+There is a also the possibility to define default credentials in the `KubermaticConfiguration` at
 `spec.userCluster.imagePullSecret`. If defined, this will be used for any user cluster that has no
 explicit `imagePullSecrets` set.
 
@@ -162,7 +162,7 @@ does not cover reconciled KKP components nor user apps.
 
 ### A look ahead
 
-To make this more accessible to customers we could build ontop of this and extend the KKP dashboard
+To make this more accessible to customers we could build on top of this and extend the KKP dashboard
 with an interface to manage this. Similar to the [SSH key feature][ssh key agent] container registry
 credentials could be managed from there.
 

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -1,0 +1,195 @@
+# Container Registry Credentials per User Cluster
+
+**Author**: Moritz Bracht (@dermorz)
+
+**Status**: Draft proposal; prototype in progress.
+
+## Goals
+
+Defining separate container registry credentials per user cluster so cluster owners can make use of
+their dockerhub credentials to avoid image pull limits or to access private images.
+
+## Non-Goals
+
+Setting local mirrors or private container registries for KKP components or addons.
+
+## Motivation and Background
+
+Based on the user story [#6231][] users want to be able to use their Docker Hub paid accounts to
+mitigate image pull limits. Setting this up cluster wide is currently not possible.
+
+### Current state
+
+Currently it's possible to set `spec.imagePullSecret` in the `KubermaticConfiguration`. The
+dockerconfig-json defined on this key is used in the Kubermatic Operator where the master- and the
+seed-controller create a `dockerconfigjson`-secret respectively. When creating the deployments for
+KKP master and seed components this secret gets referenced as `imagePullSecret` in all of their
+podspecs.
+
+This dockerconfig has no effect on anything running on the user clusters, so currently KKP does not
+offer a way to manage container registry credentials to be used by KKP internal components, KKP
+addons nor user deployed applications by default.
+
+### Proposed feature
+
+Similar to the SSH key feature users cluster admins are able to create sets of container registry
+credentials. Like SSH keys these credentials can be selected for user clusters. Now the kubelet uses
+all available credentials for authentication when pulling images from container registries to create
+pods of any source: KKP user cluster components, addons or user applications.
+
+There is a possibility to define a default fallback set of credentials in the
+`KubermaticConfiguration` at `spec.userCluster.imagePullSecret`. If there are no credentials
+selected for a user cluster and this value is set, it will be used as a fallback.
+
+#### Limitations
+
+1. For now only containerd is supported. Because of the [dockershim deprecation][] currently there
+   is no support planned for nodes using docker as container runtime.
+2. Only one credential set per registry can be chosen. Validation will fail if multiple credentials
+   for the same registry are chosen to avoid unexpected behavior.
+
+## Implementation
+
+There are quite some similarities to the implementation of the [SSH key feature][ssh key agent].
+Writing the containerd config on every worker node of a user cluster based on credentials managed
+and selected in the dashboard sounds quite familiar. This opens up qute some potential for
+refactoring the current SSH key agent into a more general Agent controlling files on worker node's
+filesystem.
+
+### KubermaticConfiguration
+
+A new configuration field to set default fallback registry credentials for any user cluster where no
+credentials are explicitly selected. For consisteny this could be in the format of
+`spec.imagePullSecret`:
+
+```yaml
+apiVersion: kubermatic.k8c.io/v1
+kind: KubermaticConfiguration
+metadata:
+  name: <<mykubermatic>>
+  namespace: kubermatic
+spec:
+  userCluster:
+    imagePullSecret: |-
+      {
+        "auths": {
+          "quay.io": {
+            "username": "<<QUAY_USERNAME>>",
+            "password": "<<QUAY_PASSWORD>>",
+          }
+        }
+      }
+```
+
+### Custom Resources
+
+Similar to user ssh keys the `RegistryCredentialSet` is tied to a project, so credentials created in
+one project can be used in all user clusters created in that same project.
+
+The credentials themselves are being stored in `kubernetes.io/dockerconfigjson` typed secrets which
+are referenced by `RegistryCredentialSet` resources.
+
+#### Example
+
+```yaml
+apiVersion: kubermatic.k8c.io/v1
+kind: RegistryCredentialSet
+metadata:
+  name: my-quay-credentials
+  uid: ..
+  ownerReferences:
+  - apiVersion: kubermatic.k8c.io/v1
+    kind: Project
+    name: <<PROJECT_ID>>
+    uid: ..
+spec:
+  secretRef:
+    name: my-quay-credentials
+    key: .dockerconfigjson
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-quay-credentials
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "quay.io": {
+          "auth": "<<base64(username:password)>>"
+        }
+      }
+    }
+```
+
+### Master Cluster
+
+* A controller that synchronzies selected credentials into the cluster namespace on the seed
+cluster
+
+### Seed Cluster
+
+* A controller within the user-cluster-controller-manager to set up the DaemonSet running the Agent
+on every user cluster node. (similar to usersshkeys)
+* The user-cluster-controller synchronizes selected credentials from the cluster namespace to the
+user cluster. If none is selected, it uses the default fallback credentials from the config (if
+set).
+
+### User Cluster
+
+* The DaemonSet running the Agent on every user cluster node (see above)
+
+### Agent
+
+Similar to the SSH key agent this agent watches a named Secret containing registry credentials and
+also the containerd config on the node the agent is running on. It makes sure that the containerd
+config always contain the selected credentials.
+
+#### Refactoring potential
+
+The general funtionality of the user registry credentials agent is very similar to the SSH key
+agent: They watch some kubernetes resource and local files and have a reconciliation process that
+makes sure the content of the local files always match the content of the resources.
+
+This agent could just mirror the behavior of the SSH key agent for different resources and files, so
+a good share of code might be reusable. Another direction could be to refactor the whole SSH key
+agent to become a more general "node-file-agent" that can manage all kinds of files based on
+resources.
+
+### UI
+
+* Similar to SSH key management. Details to be discussed with `#sig-ui`
+
+## Alternatives considered
+
+### Reconciliation of all Pods running on user clusters
+
+Similar to the reconciliation of master- and seed-component Deployments custom credentials can be
+injected into podspecs of Deployments and DaemonSets. In this approach the current concept of
+creators and modifiers can be used, but it only affects KKP internal components and neither KKP
+addons nor user deployed applications. This means if we decide to go with this approach, we would
+need to add handling for the not covered cases.
+
+### Setting imagePullSecrets on ServiceAccounts
+
+Instead of setting `imagePullSecret` explicitly on podspecs, it's possible to set `imagePullSecret`
+on ServiceAccounts. Every Pod created using a ServiceAccount with an imagePullSecret attached will
+automatically have this imagePullSecret set in its spec. This approach would require less
+reconciliation than reconciling Pods directly but doesn't cover anything created using
+ServiceAccounts that have been created outside of the user cluster's reconciler.
+
+### Extension of addon templates with imagePullSecrets
+
+Pods or ServiceAccounts in addon templates could be templated to use an imagePullSecret, but this
+does not cover reconciled KKP components nor user apps. So this approach would need to be combined
+with at least one of the 2 above.
+
+## Task & effort
+* tbd
+
+[#6231]: https://github.com/kubermatic/kubermatic/issues/6231
+[dockershim deprecation]: https://kubernetes.io/blog/2020/12/02/dockershim-faq/
+[ssh key agent]: https://docs.kubermatic.com/kubermatic/master/tutorials_howtos/administration/user_settings/user_ssh_key_agent/

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -135,7 +135,7 @@ See:
 https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
 
 It's not fully decided if we go with the Webhook modifying Pods or with setting imagePullSecrets on
-ServiceAccounts.
+ServiceAccounts during reconciliation.
 
 ## Alternatives considered
 
@@ -191,9 +191,19 @@ the cluster is created in.
 * **User cluster admins** can create or select credentials to be used in all kinds of Pods on the
 user cluster
 
-## Task and effort
+## Tasks and effort
 
-- tbd.
+* Implement a controller in the user-cluster-controller-manager that distributes all secrets referenced
+in the `Cluster` resource into all namespaces on the user cluster.
+  * Extend the `Cluster` CRD
+  * Implement the controller
+* Implement a mutating admission webhook that merges the imagePullSecrets from the Cluster resource
+into the imagePullSecrets of every Pod that's being created.
+  * Implement the webhook handler
+  * Package the webhook handler as image
+  * Add roll out of the webhook handler to cluster-controller in the seed-controller-user-manager
+  * Extend user-cluster-controller reconciliation with adding the MutatingWebhookConfiguration for
+  the webhook
 
 [#6231]: https://github.com/kubermatic/kubermatic/issues/6231
 [ssh key agent]: https://docs.kubermatic.com/kubermatic/master/tutorials_howtos/administration/user_settings/user_ssh_key_agent/

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -19,18 +19,18 @@
 * [Alternatives considered](#alternatives-considered)
   * [Set imagePullSecrets through an Addon](#set-imagepullsecrets-through-an-addon)
   * [Reconciliation of all Pods running on user clusters](#reconciliation-of-all-pods-running-on-user-clusters)
-  * [Extension of addon templates with imagePullSecrets](#extension-of-addon-templates-with-imagepullsecrets)
+  * [Extension of Addon templates with imagePullSecrets](#extension-of-addon-templates-with-imagepullsecrets)
   * [A look ahead](#a-look-ahead)
 * [Task and effort](#task-and-effort)
 
 ## Goals
 
-Defining separate container registry credentials per user cluster so cluster owners can make use of
-their dockerhub credentials to avoid image pull limits or to access private images.
+Defining separate container registry credentials per user cluster, so cluster owners can make use of
+their docker hub credentials to avoid image pull limits or to access private images.
 
 ## Non-Goals
 
-Setting local mirrors or private container registries for KKP components or addons.
+Setting local mirrors or private container registries for KKP components or Addons.
 
 ## Motivation and Background
 
@@ -39,15 +39,15 @@ mitigate image pull limits. Setting this up cluster wide is currently not possib
 
 ### Current state
 
-Currently it's possible to set `spec.imagePullSecret` in the `KubermaticConfiguration`. The
+Currently, it's possible to set `spec.imagePullSecret` in the `KubermaticConfiguration`. The
 dockerconfig-json defined on this key is used in the Kubermatic Operator where the master- and the
 seed-controller create a `dockerconfigjson`-secret respectively. When creating the deployments for
 KKP master and seed components this secret gets referenced as `imagePullSecret` in all of their
-podspecs.
+pod specs.
 
 This dockerconfig has no effect on anything running on the user clusters, so currently KKP does not
 offer a way to manage container registry credentials to be used by KKP internal components, KKP
-addons nor user deployed applications by default.
+Addons nor user deployed applications by default.
 
 ### Proposed feature
 
@@ -58,7 +58,7 @@ cluster.
 
 For this first iteration the secrets referenced on `Cluster` resources need to be created manually.
 
-There is a also the possibility to define default credentials in the `KubermaticConfiguration` at
+There is also the possibility to define default credentials in the `KubermaticConfiguration` at
 `spec.userCluster.imagePullSecret`. If defined, this will be used for any user cluster that has no
 explicit `imagePullSecrets` set.
 
@@ -144,20 +144,20 @@ ServiceAccounts.
 Solving this problem in an Addon would isolate the feature to everyone who really needs it and keep
 the KKP codebase mostly clean of it. The problem is, that doing this in an Addon is just too late.
 In the case where this secret needs to be set before any image is pulled, because the external IP of
-the cluster has already hit the free tier limit of image pulls on dockerhub, the user cluster would
-be broken from the get go and could not even install this addon to fix itself.
+the cluster has already hit the free tier limit of image pulls on docker hub, the user cluster would
+be broken from the get go and could not even install this Addon to fix itself.
 
 ### Reconciliation of all Pods running on user clusters
 
 Similar to the reconciliation of master- and seed-component Deployments custom credentials can be
-injected into podspecs of Deployments and DaemonSets. In this approach the current concept of
+injected into pod specs of Deployments and DaemonSets. In this approach the current concept of
 creators and modifiers can be used, but it only affects KKP internal components and neither KKP
-addons nor user deployed applications. This means if we decide to go with this approach, we would
+Addons nor user deployed applications. This means if we decide to go with this approach, we would
 need to add handling for the not covered cases.
 
-### Extension of addon templates with imagePullSecrets
+### Extension of Addon templates with imagePullSecrets
 
-Pods or ServiceAccounts in addon templates could be templated to use an imagePullSecret, but this
+Pods or ServiceAccounts in Addon templates could be templated to use an imagePullSecret, but this
 does not cover reconciled KKP components nor user apps.
 
 ### A look ahead

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -121,7 +121,7 @@ references to manage visibility and the ability to select credentials.
 apiVersion: kubermatic.k8c.io/v1
 kind: RegistryCredentialSet
 metadata:
-  name: my-quay-credentials
+  name: my-registry-credentials
   uid: ..
   ownerReferences:
   - apiVersion: kubermatic.k8c.io/v1
@@ -130,8 +130,10 @@ metadata:
     uid: ..
 spec:
   requiredEmailDomain: example.com
-  secretRef:
-    name: my-quay-credentials
+  secretRefs:
+  - name: my-registry-credentials-quay
+    key: .dockerconfigjson
+  - name: my-registry-credentials-dockerhub
     key: .dockerconfigjson
 ```
 
@@ -139,7 +141,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: my-quay-credentials
+  name: my-registry-credentials-quay
 type: kubernetes.io/dockerconfigjson
 stringData:
   .dockerconfigjson: |

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -4,6 +4,26 @@
 
 **Status**: Draft proposal; prototype in progress.
 
+
+* [Goals](#goals)
+* [Non-Goals](#non-goals)
+* [Motivation and Background](#motivation-and-background)
+  * [Current state](#current-state)
+  * [Proposed feature](#proposed-feature)
+* [Implementation](#implementation)
+  * [KubermaticConfiguration](#kubermaticconfiguration)
+  * [Custom Resources](#custom-resources)
+  * [Master Cluster](#master-cluster)
+  * [Seed Cluster](#seed-cluster)
+  * [User Cluster](#user-cluster)
+  * [Agent](#agent)
+  * [UI](#ui)
+* [Alternatives considered](#alternatives-considered)
+  * [Reconciliation of all Pods running on user clusters](#reconciliation-of-all-pods-running-on-user-clusters)
+  * [Setting imagePullSecrets on ServiceAccounts](#setting-imagepullsecrets-on-serviceaccounts)
+  * [Extension of addon templates with imagePullSecrets](#extension-of-addon-templates-with-imagepullsecrets)
+* [Task & effort](#task-&-effort)
+
 ## Goals
 
 Defining separate container registry credentials per user cluster so cluster owners can make use of

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -52,14 +52,19 @@ addons nor user deployed applications by default.
 
 ### Proposed feature
 
-Similar to the SSH key feature users cluster admins are able to create sets of container registry
-credentials. Like SSH keys these credentials can be selected for user clusters. Now the kubelet uses
-all available credentials for authentication when pulling images from container registries to create
-pods of any source: KKP user cluster components, addons or user applications.
+Similar to the [SSH key feature][ssh key agent] container registry credentials can be managed in the KKP
+dashboard.
+
+* **KKP admins** can create credentials to be made available for KKP projects
+* **KKP admins** can define default fallback credentials for KKP projects
+* **Project Owners/Editors** can create or select credentials to be made available for user clusters
+* **Project Owners/Editors** can define default fallback credentials for user clusters
+* **User cluster admins** can create or select credentials to be used in all kinds of Pods on the
+user cluster
 
 There is a possibility to define a default fallback set of credentials in the
 `KubermaticConfiguration` at `spec.userCluster.imagePullSecret`. If there are no credentials
-selected for a user cluster and this value is set, it will be used as a fallback.
+selected on any elvel, this will be used as a fallback.
 
 #### Limitations
 

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -71,15 +71,14 @@ selected for a user cluster and this value is set, it will be used as a fallback
 ## Implementation
 
 There are quite some similarities to the implementation of the [SSH key feature][ssh key agent].
-Writing the containerd config on every worker node of a user cluster based on credentials managed
-and selected in the dashboard sounds quite familiar. This opens up qute some potential for
-refactoring the current SSH key agent into a more general Agent controlling files on worker node's
-filesystem.
+Writing the containerd-config on every worker node of a user cluster based on credentials managed
+and selected in the dashboard sounds quite familiar. This opens up some potential for refactoring
+the current SSH key agent into a more general Agent controlling files on worker node's file system.
 
 ### KubermaticConfiguration
 
 A new configuration field to set default fallback registry credentials for any user cluster where no
-credentials are explicitly selected. For consisteny this could be in the format of
+credentials are explicitly selected. For consistency this could be in the format of
 `spec.imagePullSecret`:
 
 ```yaml
@@ -147,7 +146,7 @@ stringData:
 
 ### Master Cluster
 
-* A controller that synchronzies selected credentials into the cluster namespace on the seed
+* A controller that synchronizes selected credentials into the cluster namespace on the seed
 cluster
 
 ### Seed Cluster
@@ -170,7 +169,7 @@ config always contain the selected credentials.
 
 #### Refactoring potential
 
-The general funtionality of the user registry credentials agent is very similar to the SSH key
+The general functionality of the user registry credentials agent is very similar to the SSH key
 agent: They watch some kubernetes resource and local files and have a reconciliation process that
 makes sure the content of the local files always match the content of the resources.
 
@@ -208,7 +207,7 @@ does not cover reconciled KKP components nor user apps. So this approach would n
 with at least one of the 2 above.
 
 ## Task & effort
-* tbd
+* tbd.
 
 [#6231]: https://github.com/kubermatic/kubermatic/issues/6231
 [dockershim deprecation]: https://kubernetes.io/blog/2020/12/02/dockershim-faq/

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -160,13 +160,11 @@ need to add handling for the not covered cases.
 Pods or ServiceAccounts in Addon templates could be templated to use an imagePullSecret, but this
 does not cover reconciled KKP components nor user apps.
 
-### A look ahead
+### Looking ahead
 
 To make this more accessible to customers we could build on top of this and extend the KKP dashboard
 with an interface to manage this. Similar to the [SSH key feature][ssh key agent] container registry
 credentials could be managed from there.
-
-For example:
 
 #### Admin Penal
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR is adding a proposal to add container registry credential management to KKP. This is motivated by #6231.

**Special notes for your reviewer**:
Yet another iteration of this proposal after constructive discussions in #sig-cluster-mgmt.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```