### PR TITLE
update supported k8s versions

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -326,7 +326,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -370,7 +370,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -415,7 +415,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: PROVIDER
@@ -461,7 +461,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -504,7 +504,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -552,7 +552,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: DISTRIBUTIONS
           value: centos
         - name: PROVIDER
@@ -595,7 +595,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "packet"
         - name: DISTRIBUTIONS
@@ -638,7 +638,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -681,7 +681,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -724,7 +724,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "hetzner"
         - name: DISTRIBUTIONS
@@ -769,7 +769,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "openstack"
         - name: DISTRIBUTIONS
@@ -814,7 +814,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -996,7 +996,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "nutanix"
         - name: DISTRIBUTIONS
@@ -1040,7 +1040,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.5"
+          value: "v1.22.7"
         - name: PROVIDER
           value: "nutanix"
         - name: DISTRIBUTIONS
@@ -1090,7 +1090,7 @@ presubmits:
         - "./hack/ci/run-api-e2e.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.22.5
+          value: v1.22.7
         - name: KUBERMATIC_EDITION
           value: ee
         - name: SERVICE_ACCOUNT_KEY
@@ -1131,7 +1131,7 @@ presubmits:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.22.5
+              value: v1.22.7
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY
@@ -1172,7 +1172,7 @@ presubmits:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.22.5
+              value: v1.22.7
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY
@@ -1188,7 +1188,7 @@ presubmits:
               cpu: 2
             limits:
               memory: 6Gi
-  
+
   #########################################################
   # etcd-launcher e2e tests
   #########################################################
@@ -1284,7 +1284,7 @@ presubmits:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.22.5
+              value: v1.22.7
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY
@@ -1417,7 +1417,7 @@ presubmits:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.22.5
+              value: v1.22.7
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -440,7 +440,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.21.8
+    default: v1.21.10
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
@@ -504,8 +504,11 @@ spec:
     versions:
       - v1.20.13
       - v1.20.14
+      - v1.20.15
       - v1.21.8
+      - v1.21.10
       - v1.22.5
+      - v1.22.7
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -211,15 +211,18 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.21.8"),
+		Default: semver.NewSemverOrDie("v1.21.10"),
 		Versions: []semver.Semver{
 			// Kubernetes 1.20
 			newSemver("v1.20.13"),
 			newSemver("v1.20.14"),
+			newSemver("v1.20.15"),
 			// Kubernetes 1.21
 			newSemver("v1.21.8"),
+			newSemver("v1.21.10"),
 			// Kubernetes 1.22
 			newSemver("v1.22.5"),
+			newSemver("v1.22.7"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.19 =======


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Maintenance.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for Kubernetes 1.20.15, 1.21.10 and 1.22.7, set default to 1.21.10
```
