### PR TITLE
[release/v2.20] Enable Nutanix CSI requirement for new Clusters

### DIFF
--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -126,6 +126,11 @@ func (n *Nutanix) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 		}
 	}
 
+	// validate csi is set - required for new clusters
+	if spec.Nutanix.CSI == nil {
+		return errors.New("CSI not configured")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add validation for CSI configuration to exist for Nutanix

```release-note
NONE
```
