### PR TITLE
give alpha releases a nice name on Github as well

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -177,7 +177,8 @@ if [[ "$RELEASE_NAME" =~ "-" ]]; then
 fi
 
 # create a nice-sounding release name
-name=$(echo "$RELEASE_NAME" | sed --regexp-extended 's/-beta\.([0-9]+)/ (Beta \1)/')
+name=$(echo "$RELEASE_NAME" | sed --regexp-extended 's/-alpha\.([0-9]+)/ (Alpha \1)/')
+name=$(echo "$name" | sed --regexp-extended 's/-beta\.([0-9]+)/ (Beta \1)/')
 name=$(echo "$name" | sed --regexp-extended 's/-rc\.([0-9]+)/ (Release Candidate \1)/')
 
 echodate "Release name : $name"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR fixes the oversight where alpha releases would not get a nice-looking name on Github. Since we are already on 2.20 beta, backporting this to 2.20 is not needed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
