### PR TITLE
Do not use io/ioutil anymore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - bidichk
     - bodyclose
     - deadcode
+    - depguard
     - durationcheck
     - errcheck
     - errname
@@ -84,3 +85,9 @@ linters-settings:
       rules:
         json: goCamel
         yaml: goCamel
+
+  depguard:
+    include-go-root: true
+    packages:
+      - io/ioutil # https://go.dev/doc/go1.16#ioutil
+      - github.com/ghodss/yaml # use sigs.k8s.io/yaml instead

--- a/cmd/conformance-tests/custom_tests.go
+++ b/cmd/conformance-tests/custom_tests.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -255,7 +255,7 @@ func (r *testRunner) testLB(ctx context.Context, log *zap.SugaredLogger, userClu
 				log.Warnf("Failed to close response body from Hello-Kubernetes Pod during LB test (%s): %v", hostURL, err)
 			}
 		}()
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Warnf("Failed to read response body from Hello-Kubernetes Pod during LB test (%s): %v", hostURL, err)
 			return false, nil

--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -547,7 +547,7 @@ func getScenarios(opts Opts, log *zap.SugaredLogger) []testScenario {
 func setupHomeDir(log *zap.SugaredLogger) (string, []byte, error) {
 	// Setup temporary home dir (Because the e2e tests have some filenames hardcoded - which might conflict with the user files)
 	// We'll set the env-var $HOME to this directory when executing the tests
-	homeDir, err := ioutil.TempDir("/tmp", "e2e-home-")
+	homeDir, err := os.MkdirTemp("/tmp", "e2e-home-")
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to setup temporary home dir: %w", err)
 	}

--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -292,7 +291,7 @@ func main() {
 	}
 
 	if kubevirtKubeconfigFile != "" {
-		content, err := ioutil.ReadFile(kubevirtKubeconfigFile)
+		content, err := os.ReadFile(kubevirtKubeconfigFile)
 		if err != nil {
 			log.Fatalw("Failed to read kubevirt kubeconfig file", zap.Error(err))
 		}
@@ -397,7 +396,7 @@ func main() {
 	log.Infow("Enabled cloud providers", "providers", opts.providers.List())
 
 	if pubKeyPath != "" {
-		keyData, err := ioutil.ReadFile(pubKeyPath)
+		keyData, err := os.ReadFile(pubKeyPath)
 		if err != nil {
 			log.Fatalw("Failed to load ssh key", zap.Error(err))
 		}

--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -582,7 +582,7 @@ func setupHomeDir(log *zap.SugaredLogger) (string, []byte, error) {
 
 	privatePEM := pem.EncodeToMemory(&privBlock)
 	// Needs to be google_compute_engine as its hardcoded in the kubernetes e2e tests
-	if err := ioutil.WriteFile(path.Join(homeDir, ".ssh", "google_compute_engine"), privatePEM, 0400); err != nil {
+	if err := os.WriteFile(path.Join(homeDir, ".ssh", "google_compute_engine"), privatePEM, 0400); err != nil {
 		return "", nil, err
 	}
 
@@ -592,7 +592,7 @@ func setupHomeDir(log *zap.SugaredLogger) (string, []byte, error) {
 	}
 
 	pubKeyBytes := ssh.MarshalAuthorizedKey(publicRsaKey)
-	if err := ioutil.WriteFile(path.Join(homeDir, ".ssh", "google_compute_engine.pub"), pubKeyBytes, 0400); err != nil {
+	if err := os.WriteFile(path.Join(homeDir, ".ssh", "google_compute_engine.pub"), pubKeyBytes, 0400); err != nil {
 		return "", nil, err
 	}
 

--- a/cmd/conformance-tests/reports.go
+++ b/cmd/conformance-tests/reports.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -28,7 +27,7 @@ import (
 )
 
 func collectReports(name, reportsDir string) (*reporters.JUnitTestSuite, error) {
-	files, err := ioutil.ReadDir(reportsDir)
+	files, err := os.ReadDir(reportsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list files in reportsDir '%s': %w", reportsDir, err)
 	}

--- a/cmd/conformance-tests/reports.go
+++ b/cmd/conformance-tests/reports.go
@@ -48,7 +48,7 @@ func collectReports(name, reportsDir string) (*reporters.JUnitTestSuite, error) 
 		absName := path.Join(reportsDir, f.Name())
 		individualReportFiles = append(individualReportFiles, absName)
 
-		b, err := ioutil.ReadFile(absName)
+		b, err := os.ReadFile(absName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file '%s': %w", absName, err)
 		}

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1264,7 +1263,7 @@ func (r *testRunner) executeGinkgoRun(ctx context.Context, parentLog *zap.Sugare
 	}
 
 	// Make sure we write to a file instead of a byte buffer as the logs are pretty big
-	file, err := ioutil.TempFile("/tmp", run.name+"-log")
+	file, err := os.CreateTemp("/tmp", run.name+"-log")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open logfile: %w", err)
 	}

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -286,7 +286,7 @@ func (r *testRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger
 			log.Errorw("failed to marshal junit", zap.Error(err))
 			return
 		}
-		if err := ioutil.WriteFile(path.Join(r.reportsRoot, fmt.Sprintf("junit.%s.xml", scenario.Name())), b, 0644); err != nil {
+		if err := os.WriteFile(path.Join(r.reportsRoot, fmt.Sprintf("junit.%s.xml", scenario.Name())), b, 0644); err != nil {
 			log.Errorw("Failed to write junit", zap.Error(err))
 		}
 	}()
@@ -903,7 +903,7 @@ func (r *testRunner) getKubeconfig(ctx context.Context, log *zap.SugaredLogger, 
 	}
 
 	filename := path.Join(r.homeDir, fmt.Sprintf("%s-kubeconfig", cluster.Name))
-	if err := ioutil.WriteFile(filename, kubeconfig, 0644); err != nil {
+	if err := os.WriteFile(filename, kubeconfig, 0644); err != nil {
 		return "", fmt.Errorf("failed to write kubeconfig to %s: %w", filename, err)
 	}
 
@@ -931,7 +931,7 @@ func (r *testRunner) getCloudConfig(ctx context.Context, log *zap.SugaredLogger,
 	}
 
 	filename := path.Join(r.homeDir, fmt.Sprintf("%s-cloud-config", cluster.Name))
-	if err := ioutil.WriteFile(filename, []byte(cmData), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(cmData), 0644); err != nil {
 		return "", fmt.Errorf("failed to write cloud config: %w", err)
 	}
 

--- a/cmd/image-loader/addons.go
+++ b/cmd/image-loader/addons.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"go.uber.org/zap"
@@ -40,7 +40,7 @@ func getImagesFromAddons(log *zap.SugaredLogger, addonsPath string, cluster *kub
 		return nil, fmt.Errorf("failed to create addon template data: %w", err)
 	}
 
-	infos, err := ioutil.ReadDir(addonsPath)
+	infos, err := os.ReadDir(addonsPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list addons: %w", err)
 	}

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -206,7 +205,7 @@ func main() {
 }
 
 func extractAddonsFromDockerImage(ctx context.Context, log *zap.SugaredLogger, imageName string) (string, error) {
-	tempDir, err := ioutil.TempDir("", "imageloader*")
+	tempDir, err := os.MkdirTemp("", "imageloader*")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %w", err)
 	}

--- a/cmd/image-loader/operator.go
+++ b/cmd/image-loader/operator.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"go.uber.org/zap"
 
@@ -33,7 +33,7 @@ import (
 func loadKubermaticConfiguration(log *zap.SugaredLogger, filename string) (*kubermaticv1.KubermaticConfiguration, error) {
 	log.Infow("Loading KubermaticConfiguration", "file", filename)
 
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/cmd/kubermatic-api/options.go
+++ b/cmd/kubermatic-api/options.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
@@ -189,7 +189,7 @@ type providers struct {
 }
 
 func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfiguration, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/cmd/kubermatic-installer/cmd_convert_kubeconfig.go
+++ b/cmd/kubermatic-installer/cmd_convert_kubeconfig.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -152,7 +152,7 @@ func readKubeconfig(filename string) (*clientcmdapi.Config, error) {
 		defer input.Close()
 	}
 
-	content, err := ioutil.ReadAll(input)
+	content, err := io.ReadAll(input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %w", err)
 	}

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -60,7 +59,7 @@ func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfi
 		return nil, nil, errors.New("no file specified via --config flag")
 	}
 
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/kubermatic-webhook/options.go
+++ b/cmd/kubermatic-webhook/options.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"go.uber.org/zap"
 
@@ -96,7 +96,7 @@ func initApplicationOptions() (appOptions, error) {
 }
 
 func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfiguration, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -201,7 +201,7 @@ func main() {
 }
 
 func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfiguration, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/cmd/node-resource-documenter/main.go
+++ b/cmd/node-resource-documenter/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func createResources() templateResources {
 // readYAML reads a YAML file and executes the potential template.
 func readYAML(path string) ([]byte, error) {
 	log.Printf("Reading YAML file %q ...", path)
-	bs, err := ioutil.ReadFile(path)
+	bs, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/owner-remover/main.go
+++ b/cmd/owner-remover/main.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -165,7 +165,7 @@ func main() {
 		if err != nil {
 			klog.Fatal(err, string(out))
 		}
-		if err := ioutil.WriteFile(fmt.Sprintf("cluster-%s.yaml", cluster.Name), out, 0644); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("cluster-%s.yaml", cluster.Name), out, 0644); err != nil {
 			klog.Fatal(err)
 		}
 	}

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 
@@ -153,7 +152,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 	// TODO: Do not create secret and image pull secret if empty
 	dockerPullConfigJSON := []byte("{}")
 	if options.dockerPullConfigJSONFile != "" {
-		dockerPullConfigJSON, err = ioutil.ReadFile(options.dockerPullConfigJSONFile)
+		dockerPullConfigJSON, err = os.ReadFile(options.dockerPullConfigJSONFile)
 		if err != nil {
 			log.Fatalw(
 				"Failed to read docker pull config file",

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -219,7 +219,7 @@ type controllerContext struct {
 }
 
 func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfiguration, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/cmd/user-ssh-keys-agent/main.go
+++ b/cmd/user-ssh-keys-agent/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 
@@ -163,7 +162,7 @@ func createFileIfNotExist(path string, uid, gid int) error {
 }
 
 func availableHomeUsers() ([]string, error) {
-	files, err := ioutil.ReadDir("/home")
+	files, err := os.ReadDir("/home")
 	if err != nil {
 		return nil, err
 	}

--- a/codegen/godoc/main.go
+++ b/codegen/godoc/main.go
@@ -23,8 +23,8 @@ import (
 	"go/ast"
 	"go/format"
 	"go/token"
-	"io/ioutil"
 	"log"
+	"os"
 	"reflect"
 	"strings"
 
@@ -52,7 +52,7 @@ func generate(filename string, i interface{}) error {
 	snippets := generateDocumentation([]string{}, reflect.ValueOf(i))
 	code := strings.Join(snippets, "\n\n") + "\n"
 
-	return ioutil.WriteFile(filename, []byte(code), 0644)
+	return os.WriteFile(filename, []byte(code), 0644)
 }
 
 func generateDocumentation(docs []string, v reflect.Value) []string {

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -22,8 +22,8 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"text/template"
 
@@ -232,7 +232,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile("zz_generated_reconcile.go", fmtB, 0644); err != nil {
+	if err := os.WriteFile("zz_generated_reconcile.go", fmtB, 0644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -238,7 +237,7 @@ type CSIOptions struct {
 func ParseFromFolder(log *zap.SugaredLogger, overwriteRegistry string, manifestPath string, data *TemplateData) ([]runtime.RawExtension, error) {
 	var allManifests []runtime.RawExtension
 
-	infos, err := ioutil.ReadDir(manifestPath)
+	infos, err := os.ReadDir(manifestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -258,7 +258,7 @@ func ParseFromFolder(log *zap.SugaredLogger, overwriteRegistry string, manifestP
 
 		infoLog.Debug("Processing file")
 
-		fbytes, err := ioutil.ReadFile(filename)
+		fbytes, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %w", filename, err)
 		}

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"text/template"

--- a/pkg/addon/template_test.go
+++ b/pkg/addon/template_test.go
@@ -18,7 +18,6 @@ package addon
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"

--- a/pkg/addon/template_test.go
+++ b/pkg/addon/template_test.go
@@ -46,7 +46,7 @@ func testRenderAddonsForOrchestrator(t *testing.T, orchestrator string) {
 
 	clusters := []kubermaticv1.Cluster{}
 	for _, filename := range clusterFiles {
-		content, err := ioutil.ReadFile(filename)
+		content, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -408,7 +408,7 @@ func getFileDeleteFinalizer(log *zap.SugaredLogger, filename string) fileHandlin
 func (r *Reconciler) writeCombinedManifest(log *zap.SugaredLogger, manifest *bytes.Buffer, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) (string, fileHandlingDone, error) {
 	// Write combined Manifest to disk
 	manifestFilename := path.Join("/tmp", fmt.Sprintf("cluster-%s-%s.yaml", cluster.Name, addon.Name))
-	if err := ioutil.WriteFile(manifestFilename, manifest.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(manifestFilename, manifest.Bytes(), 0644); err != nil {
 		return "", nil, fmt.Errorf("failed to write combined manifest to %s: %w", manifestFilename, err)
 	}
 	log.Debugw("Wrote combined manifest", "file", manifestFilename)
@@ -423,7 +423,7 @@ func (r *Reconciler) writeAdminKubeconfig(ctx context.Context, log *zap.SugaredL
 		return "", nil, fmt.Errorf("failed to get admin kubeconfig for cluster %s: %w", cluster.Name, err)
 	}
 	kubeconfigFilename := path.Join("/tmp", fmt.Sprintf("cluster-%s-addon-%s-kubeconfig", cluster.Name, addon.Name))
-	if err := ioutil.WriteFile(kubeconfigFilename, kubeconfig, 0644); err != nil {
+	if err := os.WriteFile(kubeconfigFilename, kubeconfig, 0644); err != nil {
 		return "", nil, fmt.Errorf("failed to write admin kubeconfig for cluster %s: %w", cluster.Name, err)
 	}
 	log.Debugw("Wrote admin kubeconfig", "file", kubeconfigFilename)

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -485,7 +484,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 	}
 	defer done()
 
-	d, err := ioutil.ReadFile(manifestFilename)
+	d, err := os.ReadFile(manifestFilename)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -209,7 +209,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	if err := os.Mkdir(path.Join(addonDir, addon.Spec.Name), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifestKubeDNS), 0644); err != nil {
+	if err := os.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifestKubeDNS), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -264,7 +264,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 	if err := os.Mkdir(path.Join(addonDir, addon.Spec.Name), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifest1WithDeployment), 0644); err != nil {
+	if err := os.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifest1WithDeployment), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -303,7 +303,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 	if err := os.Mkdir(path.Join(addonDir, addon.Spec.Name), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifest1WithDeployment), 0644); err != nil {
+	if err := os.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifest1WithDeployment), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -340,7 +340,7 @@ func TestController_getAddonManifests(t *testing.T) {
 	if err := os.Mkdir(path.Join(addonDir, addon.Spec.Name), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifests[0]), 0644); err != nil {
+	if err := os.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest.yaml"), []byte(testManifests[0]), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -349,7 +349,7 @@ func TestController_getAddonManifests(t *testing.T) {
 	multilineManifest := fmt.Sprintf(`%s
 ---
 %s`, testManifests[1], testManifests[2])
-	if err := ioutil.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest2.yaml"), []byte(multilineManifest), 0644); err != nil {
+	if err := os.WriteFile(path.Join(addonDir, addon.Spec.Name, "testManifest2.yaml"), []byte(multilineManifest), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -200,7 +199,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("kube-dns")
 
-	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
+	addonDir, err := os.MkdirTemp("/tmp", "kubermatic-tests-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +254,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("test")
 
-	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
+	addonDir, err := os.MkdirTemp("/tmp", "kubermatic-tests-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +293,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("test")
 
-	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
+	addonDir, err := os.MkdirTemp("/tmp", "kubermatic-tests-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +330,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 func TestController_getAddonManifests(t *testing.T) {
 	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("test")
-	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
+	addonDir, err := os.MkdirTemp("/tmp", "kubermatic-tests-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"time"
@@ -287,7 +287,7 @@ func (r *alertmanagerController) cleanUpAlertmanagerConfiguration(ctx context.Co
 	// https://cortexmetrics.io/docs/api/#delete-alertmanager-configuration
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("status code: %d,error: %w", resp.StatusCode, err)
 		}
@@ -371,7 +371,7 @@ func (r *alertmanagerController) ensureAlertmanagerConfiguration(ctx context.Con
 	// https://cortexmetrics.io/docs/api/#set-alertmanager-configuration
 	if resp.StatusCode != http.StatusCreated {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("status code: %d,error: %w", resp.StatusCode, err)
 		}
@@ -457,7 +457,7 @@ func (r *alertmanagerController) getCurrentAlertmanagerConfig(ctx context.Contex
 		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("status code: %d,error: %w", resp.StatusCode, err)
 		}

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -184,7 +184,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 						bytes.NewBuffer([]byte(generateAlertmanagerConfig("test-user")))),
 					response: &http.Response{
 						StatusCode: http.StatusBadRequest, // any StatusCode != http.StatusCreated
-						Body:       ioutil.NopCloser(strings.NewReader(`"error validating Alertmanager config: some explanation"`))},
+						Body:       io.NopCloser(strings.NewReader(`"error validating Alertmanager config: some explanation"`))},
 				},
 			},
 			hasFinalizer:                     true,
@@ -264,7 +264,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 						nil),
 					response: &http.Response{
 						StatusCode: http.StatusBadRequest, // any StatusCode != http.StatusOK
-						Body:       ioutil.NopCloser(strings.NewReader(`"error validating Alertmanager config: some explanation"`))},
+						Body:       io.NopCloser(strings.NewReader(`"error validating Alertmanager config: some explanation"`))},
 				},
 			},
 			hasFinalizer:                     false,

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
@@ -19,7 +19,7 @@ package mla
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -117,7 +117,7 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 				{
 					name:     "set dashboard",
 					request:  httptest.NewRequest(http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -196,7 +196,7 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 				{
 					name:     "delete dashboard",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/dashboards/uid/"+"unique", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "Dashboard dashboard deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "Dashboard dashboard deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -19,7 +19,7 @@ package mla
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -113,7 +113,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get datasource by uid",
@@ -129,10 +129,10 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					request: &http.Request{
 						Method: http.MethodPost,
 						URL:    &url.URL{Path: "/api/datasources"},
-						Body:   ioutil.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get datasource by uid",
@@ -148,10 +148,10 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					request: &http.Request{
 						Method: http.MethodPost,
 						URL:    &url.URL{Path: "/api/datasources"},
-						Body:   ioutil.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -192,7 +192,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete loki datasource",
@@ -201,7 +201,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete prometheus datasource",
@@ -210,7 +210,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/prometheus-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -252,7 +252,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get loki datasource by uid",
@@ -261,17 +261,17 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "update loki datasource",
 					request: &http.Request{
 						Method: http.MethodPut,
 						URL:    &url.URL{Path: "/api/datasources/1"},
-						Body:   ioutil.NopCloser(strings.NewReader(`{"name":"Loki New Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki New Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get prometheus datasource by uid",
@@ -280,17 +280,17 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/prometheus-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "update prometheus datasource",
 					request: &http.Request{
 						Method: http.MethodPut,
 						URL:    &url.URL{Path: "/api/datasources/2"},
-						Body:   ioutil.NopCloser(strings.NewReader(`{"name":"Prometheus New Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Prometheus New Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 2}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 2}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -349,7 +349,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete loki datasource",
@@ -358,7 +358,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete prometheus datasource",
@@ -367,7 +367,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/prometheus-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -413,7 +413,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete loki datasource",
@@ -422,7 +422,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get datasource by uid",
@@ -438,10 +438,10 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					request: &http.Request{
 						Method: http.MethodPost,
 						URL:    &url.URL{Path: "/api/datasources"},
-						Body:   ioutil.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -486,7 +486,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get datasource by uid",
@@ -502,10 +502,10 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					request: &http.Request{
 						Method: http.MethodPost,
 						URL:    &url.URL{Path: "/api/datasources"},
-						Body:   ioutil.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete prometheus datasource",
@@ -514,7 +514,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/prometheus-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -364,9 +363,9 @@ func buildTestServer(t *testing.T, requests ...request) (http.Handler, func() bo
 func bodyEqual(t *testing.T, expectedRequest, request *http.Request) bool {
 	defer expectedRequest.Body.Close()
 	defer request.Body.Close()
-	expectedBody, err := ioutil.ReadAll(expectedRequest.Body)
+	expectedBody, err := io.ReadAll(expectedRequest.Body)
 	assert.Nil(t, err)
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
 	assert.Nil(t, err)
 	if bytes.Equal(expectedBody, body) {
 		return true

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -113,7 +113,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -150,12 +150,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "set dashboard",
 					request:  httptest.NewRequest(http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -186,22 +186,22 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -226,12 +226,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusConflict},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusConflict},
 				},
 				{
 					name:     "get org by name",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/name/projectName-create", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 			},
 			hasFinalizer: true,
@@ -253,12 +253,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-oldname","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-oldname","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update",
 					request:  httptest.NewRequest(http.MethodPut, "/api/orgs/1", strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusOK},
 				},
 			},
 			hasFinalizer: true,
@@ -283,7 +283,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				{
 					name:     "delete org by id",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
@@ -18,7 +18,7 @@ package mla
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -133,22 +133,22 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "lookup user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -181,22 +181,22 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "lookup user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`[{"orgId":1,"userId":1,"email":"user@email.com","login":"admin","role":"Viewer"}]`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[{"orgId":1,"userId":1,"email":"user@email.com","login":"admin","role":"Viewer"}]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update org user",
 					request:  httptest.NewRequest(http.MethodPatch, "/api/orgs/1/users/1", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User updated"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User updated"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -231,17 +231,17 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -303,7 +303,7 @@ func (r *ruleGroupController) handleDeletion(ctx context.Context, ruleGroup *kub
 	// https://cortexmetrics.io/docs/api/#delete-rule-group
 	if resp.StatusCode != http.StatusAccepted {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("status code: %d,error: %w", resp.StatusCode, err)
 		}
@@ -341,7 +341,7 @@ func (r *ruleGroupController) ensureRuleGroup(ctx context.Context, ruleGroup *ku
 	// https://cortexmetrics.io/docs/api/#set-rule-group
 	if resp.StatusCode != http.StatusAccepted {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("status code: %d,error: %w", resp.StatusCode, err)
 		}
@@ -366,7 +366,7 @@ func (r *ruleGroupController) getCurrentRuleGroup(ctx context.Context, ruleGroup
 		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("status code: %d,error: %w", resp.StatusCode, err)
 		}

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -18,7 +18,7 @@ package mla
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -89,12 +89,12 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create OAuth user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -126,34 +126,34 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create OAuth user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", ioutil.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
+					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -197,48 +197,48 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "create OAuth user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
 					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", ioutil.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
+					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -263,12 +263,12 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "lookup user",
 					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/admin/users/1", nil),
-					response: &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -184,7 +184,7 @@ func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 		}
 
 		if !bytes.Equal(actualUserSSHKeys, expectedUserSSHKeys.Bytes()) {
-			if err := ioutil.WriteFile(path, expectedUserSSHKeys.Bytes(), 0600); err != nil {
+			if err := os.WriteFile(path, expectedUserSSHKeys.Bytes(), 0600); err != nil {
 				return fmt.Errorf("failed to overwrite file in path %s: %w", path, err)
 			}
 			r.log.Infow("File has been updated successfully", "file", path)

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -178,7 +177,7 @@ func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 			return fmt.Errorf("failed updating permissions %s: %w", path, err)
 		}
 
-		actualUserSSHKeys, err := ioutil.ReadFile(path)
+		actualUserSSHKeys, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed reading file in path %s: %w", path, err)
 		}

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
@@ -19,7 +19,6 @@ package usersshkeysagent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,7 +157,7 @@ func TestReconcileUserSSHKeys(t *testing.T) {
 }
 
 func readAuthorizedKeysFile(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestReconcileUserSSHKeys(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "sshkeys")
+	tmpDir, err := os.MkdirTemp("", "sshkeys")
 	if err != nil {
 		t.Fatalf("error while creating test base dir: %v", err)
 	}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -18,7 +18,7 @@ package handler
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -48,7 +48,7 @@ func TestEncodeJSON(t *testing.T) {
 			t.Errorf("failed to encode %#v as JSON: %v", testcase.input, err)
 		}
 
-		encoded, err := ioutil.ReadAll(writer.Body)
+		encoded, err := io.ReadAll(writer.Body)
 		if err != nil {
 			t.Fatal("unable to read response body")
 		}

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -792,7 +791,7 @@ func APIUserToKubermaticUser(user apiv1.User) *kubermaticv1.User {
 // CompareWithResult a convenience function for comparing http.Body content with response.
 func CompareWithResult(t *testing.T, res *httptest.ResponseRecorder, response string) {
 	t.Helper()
-	bBytes, err := ioutil.ReadAll(res.Body)
+	bBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal("Unable to read response body")
 	}

--- a/pkg/handler/v1/admin/settings.go
+++ b/pkg/handler/v1/admin/settings.go
@@ -19,7 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -105,7 +105,7 @@ func DecodePatchKubermaticSettingsReq(c context.Context, r *http.Request) (inter
 	var req patchKubermaticSettingsReq
 	var err error
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v1/admission-plugin/admission_plugin_test.go
+++ b/pkg/handler/v1/admission-plugin/admission_plugin_test.go
@@ -19,7 +19,7 @@ package admissionplugin_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -147,7 +147,7 @@ func compareJSON(t *testing.T, res *httptest.ResponseRecorder, expectedResponseS
 	var expectedResponse interface{}
 
 	// var err error
-	bBytes, err := ioutil.ReadAll(res.Body)
+	bBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal("Unable to read response body")
 	}

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -335,7 +335,7 @@ func DecodePatchReq(c context.Context, r *http.Request) (interface{}, error) {
 	req.DCReq = dcr.(common.DCReq)
 	req.ClusterID = clusterID
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v1/cluster/role.go
+++ b/pkg/handler/v1/cluster/role.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -541,7 +541,7 @@ func DecodePatchRoleReq(c context.Context, r *http.Request) (interface{}, error)
 	}
 	req.Namespace = namespace
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 
@@ -628,7 +628,7 @@ func DecodePatchClusterRoleReq(c context.Context, r *http.Request) (interface{},
 	}
 	req.RoleID = roleID
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v1/dc/datacenter.go
+++ b/pkg/handler/v1/dc/datacenter.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -884,7 +884,7 @@ func DecodePatchDCReq(c context.Context, r *http.Request) (interface{}, error) {
 	var req patchDCReq
 
 	var err error
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v1/node/node.go
+++ b/pkg/handler/v1/node/node.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
@@ -263,7 +263,7 @@ func DecodePatchNodeDeployment(c context.Context, r *http.Request) (interface{},
 	req.NodeDeploymentID = nodeDeploymentID
 	req.DCReq = dcr.(common.DCReq)
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v1/presets/credentials_test.go
+++ b/pkg/handler/v1/presets/credentials_test.go
@@ -19,7 +19,7 @@ package presets_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -448,7 +448,7 @@ func compareJSON(t *testing.T, res *httptest.ResponseRecorder, expectedResponseS
 	var expectedResponse interface{}
 
 	// var err error
-	bBytes, err := ioutil.ReadAll(res.Body)
+	bBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal("Unable to read response body")
 	}

--- a/pkg/handler/v1/provider/openstack_test.go
+++ b/pkg/handler/v1/provider/openstack_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -462,7 +462,7 @@ func compareJSON(t *testing.T, res *httptest.ResponseRecorder, expectedResponseS
 	var expectedResponse interface{}
 
 	// var err error
-	bBytes, err := ioutil.ReadAll(res.Body)
+	bBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal("Unable to read response body")
 	}

--- a/pkg/handler/v1/serviceaccount/token.go
+++ b/pkg/handler/v1/serviceaccount/token.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"unicode/utf8"
 
@@ -550,7 +550,7 @@ func DecodePatchTokenReq(c context.Context, r *http.Request) (interface{}, error
 	req.ServiceAccountID = tokenReq.ServiceAccountID
 	req.ProjectID = tokenReq.ProjectID
 
-	req.Body, err = ioutil.ReadAll(r.Body)
+	req.Body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v1/user/user.go
+++ b/pkg/handler/v1/user/user.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/mail"
 	"strings"
@@ -548,7 +548,7 @@ func DecodePatchSettingsReq(c context.Context, r *http.Request) (interface{}, er
 	var req PatchSettingsReq
 	var err error
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/allowed_registry/allowed_registry.go
+++ b/pkg/handler/v2/allowed_registry/allowed_registry.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -203,7 +203,7 @@ func DecodePatchAllowedRegistryReq(c context.Context, r *http.Request) (interfac
 	}
 	req.getAllowedRegistryReq = wrReq.(getAllowedRegistryReq)
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/cluster/cluster.go
+++ b/pkg/handler/v2/cluster/cluster.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -387,7 +387,7 @@ func DecodePatchReq(c context.Context, r *http.Request) (interface{}, error) {
 	}
 	req.ClusterID = clusterID
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/constraint/constraint.go
+++ b/pkg/handler/v2/constraint/constraint.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -539,7 +539,7 @@ func DecodePatchConstraintReq(c context.Context, r *http.Request) (interface{}, 
 	}
 	req.constraintReq = ctReq.(constraintReq)
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 
@@ -769,7 +769,7 @@ func DecodePatchDefaultConstraintReq(c context.Context, r *http.Request) (interf
 	}
 	req.defaultConstraintReq = ctReq.(defaultConstraintReq)
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/constraint_template/constraint_template.go
+++ b/pkg/handler/v2/constraint_template/constraint_template.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -265,7 +265,7 @@ func DecodePatchConstraintTemplateReq(c context.Context, r *http.Request) (inter
 	}
 	req.constraintTemplateReq = ctReq.(constraintTemplateReq)
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -577,7 +577,7 @@ func DecodePatchReq(c context.Context, r *http.Request) (interface{}, error) {
 	}
 	req.ClusterID = clusterID
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/external_cluster/node.go
+++ b/pkg/handler/v2/external_cluster/node.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -804,7 +804,7 @@ func DecodePatchMachineDeploymentReq(c context.Context, r *http.Request) (interf
 	req.ProjectID = md.ProjectID
 	req.MachineDeploymentID = md.MachineDeploymentID
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/gatekeeperconfig/gatekeeperconfig.go
+++ b/pkg/handler/v2/gatekeeperconfig/gatekeeperconfig.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -285,7 +285,7 @@ func DecodePatchGatekeeperConfigReq(c context.Context, r *http.Request) (interfa
 	}
 	req.gatekeeperConfigReq = ctReq.(gatekeeperConfigReq)
 
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/v2/machine/machine.go
+++ b/pkg/handler/v2/machine/machine.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -389,7 +389,7 @@ func DecodePatchMachineDeployment(c context.Context, r *http.Request) (interface
 		return nil, err
 	}
 	md := rawMachineDeployment.(machineDeploymentReq)
-	if req.Patch, err = ioutil.ReadAll(r.Body); err != nil {
+	if req.Patch, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 	req.MachineDeploymentID = md.MachineDeploymentID

--- a/pkg/install/util/helm.go
+++ b/pkg/install/util/helm.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -135,7 +134,7 @@ func statusRequiresPurge(status helm.ReleaseStatus) bool {
 }
 
 func dumpHelmValues(values *yamled.Document) (string, error) {
-	f, err := ioutil.TempFile("", "helmvalues.*")
+	f, err := os.CreateTemp("", "helmvalues.*")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/cloud/openstack/internal/testing/simulator.go
+++ b/pkg/provider/cloud/openstack/internal/testing/simulator.go
@@ -19,7 +19,7 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sync"
@@ -504,7 +504,7 @@ func (s *Simulator) Handle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, string(out))
 	case http.MethodPost:
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintln(w, err.Error())
@@ -529,7 +529,7 @@ func (s *Simulator) Handle(w http.ResponseWriter, r *http.Request) {
 		s.resources[r.URL.Path] = append(s.resources[r.URL.Path], newRes)
 		s.Unlock()
 	case http.MethodPut:
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintln(w, err.Error())

--- a/pkg/resources/certificates/ca-bundle.go
+++ b/pkg/resources/certificates/ca-bundle.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -61,7 +61,7 @@ type CABundle struct {
 }
 
 func NewCABundleFromFile(filename string) (*CABundle, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -25,9 +25,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -1059,7 +1059,7 @@ func getClusterCAFromLister(ctx context.Context, namespace, name string, client 
 
 // GetCABundleFromFile returns the CA bundle from a file.
 func GetCABundleFromFile(file string) ([]*x509.Certificate, error) {
-	rawData, err := ioutil.ReadFile(file)
+	rawData, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", file, err)
 	}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -76,7 +77,7 @@ func checkTestResult(t *testing.T, resFile string, testObj interface{}) {
 	res = append([]byte("# This file has been generated, DO NOT EDIT.\n\n"), res...)
 
 	if *update {
-		if err := ioutil.WriteFile(path, res, 0644); err != nil {
+		if err := os.WriteFile(path, res, 0644); err != nil {
 			t.Fatalf("failed to update fixtures: %v", err)
 		}
 	}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +81,7 @@ func checkTestResult(t *testing.T, resFile string, testObj interface{}) {
 		}
 	}
 
-	exp, err := ioutil.ReadFile(path)
+	exp, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -284,7 +284,7 @@ func testUserCluster(t *testing.T, config *rest.Config) {
 			return false, nil
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Logf("failed to read response body:%v", err)
 			return false, nil

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -511,7 +511,7 @@ func makeScheme() *runtime.Scheme {
 }
 
 func resourcesFromYaml(filename string, s *runtime.Scheme) ([]runtime.Object, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/e2e/konnectivity/konnectivity_test.go
+++ b/pkg/test/e2e/konnectivity/konnectivity_test.go
@@ -526,7 +526,7 @@ func createUsercluster(t *testing.T) (string, string, func(), error) {
 		return "", "", nil, err
 	}
 
-	file, err := ioutil.TempFile("/tmp", "kubeconfig-")
+	file, err := os.CreateTemp("/tmp", "kubeconfig-")
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/test/e2e/konnectivity/konnectivity_test.go
+++ b/pkg/test/e2e/konnectivity/konnectivity_test.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -356,7 +356,7 @@ rules:
 			t.Fatal("alertmanager config not found")
 		}
 		if resp.StatusCode != http.StatusOK {
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("unable to read alertmanager config: %s", err.Error())
 			}

--- a/pkg/test/e2e/utils/http.go
+++ b/pkg/test/e2e/utils/http.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -115,7 +116,7 @@ func (r *retryRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 		requestClone := request.WithContext(ctx)
 
 		if bodyBytes != nil {
-			requestClone.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+			requestClone.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 
 		// perform request

--- a/pkg/test/e2e/utils/http.go
+++ b/pkg/test/e2e/utils/http.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -87,7 +86,7 @@ func (r *retryRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 	if request.Body != nil {
 		var err error
 
-		bodyBytes, err = ioutil.ReadAll(request.Body)
+		bodyBytes, err = io.ReadAll(request.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read request body: %w", err)
 		}
@@ -129,7 +128,7 @@ func (r *retryRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 
 		// ignore transient errors
 		if r.isTransientError(response) {
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			if err != nil {
 				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "HTTP %s", response.Status))
 			} else {

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,7 +42,7 @@ func CompareOutput(t *testing.T, name, output string, update bool, suffix string
 		t.Fatalf("failed to get absolute path to goldan file: %v", err)
 	}
 	if update {
-		if err := ioutil.WriteFile(golden, []byte(output), 0644); err != nil {
+		if err := os.WriteFile(golden, []byte(output), 0644); err != nil {
 			t.Fatalf("failed to write updated fixture: %v", err)
 		}
 	}

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -19,7 +19,6 @@ package test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func CompareOutput(t *testing.T, name, output string, update bool, suffix string
 			t.Fatalf("failed to write updated fixture: %v", err)
 		}
 	}
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	if err != nil {
 		t.Fatalf("failed to read .golden file: %v", err)
 	}

--- a/pkg/util/yamled/document_test.go
+++ b/pkg/util/yamled/document_test.go
@@ -18,7 +18,7 @@ package yamled
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -32,7 +32,7 @@ func getTestcaseYAML(t *testing.T, filename string) string {
 		filename = "document.yaml"
 	}
 
-	content, err := ioutil.ReadFile("testcases/" + filename)
+	content, err := os.ReadFile("testcases/" + filename)
 	if err != nil {
 		t.Fatalf("could not load document %s: %v", filename, err)
 	}

--- a/pkg/version/load.go
+++ b/pkg/version/load.go
@@ -18,7 +18,7 @@ package version
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -31,7 +31,7 @@ func LoadUpdates(path string) ([]*Update, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(bufio.NewReader(f))
+	bytes, err := io.ReadAll(bufio.NewReader(f))
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func LoadVersions(path string) ([]*Version, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(bufio.NewReader(f))
+	bytes, err := io.ReadAll(bufio.NewReader(f))
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func LoadProviderIncompatibilities(path string) ([]*ProviderIncompatibility, err
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(bufio.NewReader(f))
+	bytes, err := io.ReadAll(bufio.NewReader(f))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/version/load_test.go
+++ b/pkg/version/load_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package version
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -29,7 +28,7 @@ updates:
   to: 1.13.*
   automaticNodeUpdate: true
 `)
-	file, err := ioutil.TempFile("/tmp", "kubermatic-test")
+	file, err := os.CreateTemp("/tmp", "kubermatic-test")
 	if err != nil {
 		t.Fatalf("failed to create tempfile: %v", err)
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Go 1.16 has deprecated the package and this PR refactors our code to use the new alternatives. I also took the opportunity to enable the `depguard` linter and forbid the usage of io/ioutil in KKP.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
