### PR TITLE
Fix IPv6 AWS security group creation

### DIFF
--- a/pkg/provider/cloud/aws/security_group.go
+++ b/pkg/provider/cloud/aws/security_group.go
@@ -193,22 +193,22 @@ func getCommonSecurityGroupPermissions(securityGroupID string, ipv4Permissions, 
 	}
 
 	// tcp:22 from everywhere
-	sshPermissions := &ec2.IpPermission{
+	sshPermission := &ec2.IpPermission{
 		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(provider.DefaultSSHPort),
 		ToPort:     aws.Int64(provider.DefaultSSHPort),
 	}
 	if ipv4Permissions {
-		sshPermissions.IpRanges = []*ec2.IpRange{{
+		sshPermission.IpRanges = []*ec2.IpRange{{
 			CidrIp: aws.String("0.0.0.0/0"),
 		}}
 	}
 	if ipv6Permissions {
-		sshPermissions.Ipv6Ranges = []*ec2.Ipv6Range{{
+		sshPermission.Ipv6Ranges = []*ec2.Ipv6Range{{
 			CidrIpv6: aws.String("::/0"),
 		}}
 	}
-	permissions = append(permissions, sshPermissions)
+	permissions = append(permissions, sshPermission)
 
 	// ICMP (v4) from/to everywhere
 	if ipv4Permissions {
@@ -238,35 +238,35 @@ func getCommonSecurityGroupPermissions(securityGroupID string, ipv4Permissions, 
 }
 
 func getNodePortSecurityGroupPermissions(lowPort, highPort int, ipv4IPRange, ipv6IPRange string) []*ec2.IpPermission {
-	tcpNodePortPerms := &ec2.IpPermission{
+	tcpNodePortPermission := &ec2.IpPermission{
 		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(int64(lowPort)),
 		ToPort:     aws.Int64(int64(highPort)),
 	}
-	udpNodePortPerms := &ec2.IpPermission{
+	udpNodePortPermission := &ec2.IpPermission{
 		IpProtocol: aws.String("udp"),
 		FromPort:   aws.Int64(int64(lowPort)),
 		ToPort:     aws.Int64(int64(highPort)),
 	}
 
 	if ipv4IPRange != "" {
-		tcpNodePortPerms.IpRanges = []*ec2.IpRange{{
+		tcpNodePortPermission.IpRanges = []*ec2.IpRange{{
 			CidrIp: aws.String(ipv4IPRange),
 		}}
-		udpNodePortPerms.IpRanges = []*ec2.IpRange{{
+		udpNodePortPermission.IpRanges = []*ec2.IpRange{{
 			CidrIp: aws.String(ipv4IPRange),
 		}}
 	}
 	if ipv6IPRange != "" {
-		tcpNodePortPerms.Ipv6Ranges = []*ec2.Ipv6Range{{
+		tcpNodePortPermission.Ipv6Ranges = []*ec2.Ipv6Range{{
 			CidrIpv6: aws.String(ipv6IPRange),
 		}}
-		udpNodePortPerms.Ipv6Ranges = []*ec2.Ipv6Range{{
+		udpNodePortPermission.Ipv6Ranges = []*ec2.Ipv6Range{{
 			CidrIpv6: aws.String(ipv6IPRange),
 		}}
 	}
 
-	return []*ec2.IpPermission{tcpNodePortPerms, udpNodePortPerms}
+	return []*ec2.IpPermission{tcpNodePortPermission, udpNodePortPermission}
 }
 
 func cleanUpSecurityGroup(ctx context.Context, client ec2iface.EC2API, cluster *kubermaticv1.Cluster) error {

--- a/pkg/provider/cloud/aws/security_group_test.go
+++ b/pkg/provider/cloud/aws/security_group_test.go
@@ -79,7 +79,7 @@ func assertSecurityGroup(t *testing.T, cluster *kubermaticv1.Cluster, group *ec2
 		}
 	}
 
-	permissions := getCommonSecurityGroupPermissions(*group.GroupId, true, false)
+	permissions := getCommonSecurityGroupPermissions(*group.GroupId, true, true)
 
 	lowPort, highPort := getNodePortRange(cluster)
 	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "0.0.0.0/0")...)

--- a/pkg/provider/cloud/aws/security_group_test.go
+++ b/pkg/provider/cloud/aws/security_group_test.go
@@ -83,6 +83,7 @@ func assertSecurityGroup(t *testing.T, cluster *kubermaticv1.Cluster, group *ec2
 
 	lowPort, highPort := getNodePortRange(cluster)
 	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "0.0.0.0/0")...)
+	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "::/0")...)
 
 	stringPermissions := sets.NewString()
 	for _, perm := range permissions {

--- a/pkg/provider/cloud/aws/security_group_test.go
+++ b/pkg/provider/cloud/aws/security_group_test.go
@@ -82,8 +82,7 @@ func assertSecurityGroup(t *testing.T, cluster *kubermaticv1.Cluster, group *ec2
 	permissions := getCommonSecurityGroupPermissions(*group.GroupId, true, true)
 
 	lowPort, highPort := getNodePortRange(cluster)
-	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "0.0.0.0/0")...)
-	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "::/0")...)
+	permissions = append(permissions, getNodePortSecurityGroupPermissions(lowPort, highPort, "0.0.0.0/0", "::/0")...)
 
 	stringPermissions := sets.NewString()
 	for _, perm := range permissions {

--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -63,7 +63,10 @@ func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {
 			},
 			ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 				Pods: kubermaticv1.NetworkRanges{
-					CIDRBlocks: []string{"172.25.0.0/16"},
+					CIDRBlocks: []string{"172.25.0.0/16", "fd00::/56"},
+				},
+				Services: kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{"10.240.16.0/20", "fd03::/120"},
 				},
 			},
 		},


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fixes IPv6 AWS security group creation as AWS API differentiates between `IpRanges` and `Ipv6Ranges`. Moreover, as AWS tends to group multiple service group IP permissions with the same protocol/port number but different IP ranges together, the integration test wasn't very happy, so this change groups them in the same way.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
