### PR TITLE
Initialize VirtualMachineInstancePresets

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -219,6 +219,12 @@ func main() {
 				ResourceImportPath: "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1",
 				APIVersionPrefix:   "AppKubermaticV1",
 			},
+			{
+				ResourceName:       "VirtualMachineInstancePreset",
+				ImportAlias:        "kubevirtv1",
+				ResourceImportPath: "kubevirt.io/api/core/v1",
+				APIVersionPrefix:   "KubeVirtV1",
+			},
 		},
 	}
 

--- a/pkg/handler/common/provider/kubevirt.go
+++ b/pkg/handler/common/provider/kubevirt.go
@@ -99,6 +99,9 @@ func KubeVirtVMIPresets(kubeconfig string) (apiv2.VirtualMachineInstancePresetLi
 		return nil, err
 	}
 
+	// Add a standard preset to the list
+	vmiPresets.Items = append(vmiPresets.Items, *kubevirt.GetKubermaticStandardPreset())
+
 	res := apiv2.VirtualMachineInstancePresetList{}
 	for _, vmiPreset := range vmiPresets.Items {
 		preset, err := newAPIVirtualMachineInstancePreset(&vmiPreset)

--- a/pkg/handler/v2/provider/kubevirt_test.go
+++ b/pkg/handler/v2/provider/kubevirt_test.go
@@ -146,7 +146,9 @@ func GenKubeVirtKubermaticPreset() *kubermaticv1.Preset {
 }
 
 var (
-	presetListResponse = `[{"name":"preset-default-small-1","namespace":"default","spec":"{\"selector\":{},\"domain\":{\"resources\":{\"requests\":{\"cpu\":\"234\",\"memory\":\"123\"},\"limits\":{\"cpu\":\"456\",\"memory\":\"345\"}},\"cpu\":{\"cores\":2},\"devices\":{\"disks\":[{\"name\":\"datavolumedisk\",\"disk\":{\"bus\":\"virtio\"}},{\"name\":\"cloudinitdisk\",\"disk\":{\"bus\":\"virtio\"}}]}}}"},{"name":"preset-default-small-2","namespace":"default","spec":"{\"selector\":{},\"domain\":{\"resources\":{\"requests\":{\"cpu\":\"234\",\"memory\":\"123\"},\"limits\":{\"cpu\":\"456\",\"memory\":\"345\"}},\"cpu\":{\"cores\":2},\"devices\":{\"disks\":[{\"name\":\"datavolumedisk\",\"disk\":{\"bus\":\"virtio\"}},{\"name\":\"cloudinitdisk\",\"disk\":{\"bus\":\"virtio\"}}]}}}"}]`
+	presetListResponse = `[{"name":"preset-default-small-1","namespace":"default","spec":"{\"selector\":{},\"domain\":{\"resources\":{\"requests\":{\"cpu\":\"234\",\"memory\":\"123\"},\"limits\":{\"cpu\":\"456\",\"memory\":\"345\"}},\"cpu\":{\"cores\":2},\"devices\":{\"disks\":[{\"name\":\"datavolumedisk\",\"disk\":{\"bus\":\"virtio\"}},{\"name\":\"cloudinitdisk\",\"disk\":{\"bus\":\"virtio\"}}]}}}"},` +
+		`{"name":"preset-default-small-2","namespace":"default","spec":"{\"selector\":{},\"domain\":{\"resources\":{\"requests\":{\"cpu\":\"234\",\"memory\":\"123\"},\"limits\":{\"cpu\":\"456\",\"memory\":\"345\"}},\"cpu\":{\"cores\":2},\"devices\":{\"disks\":[{\"name\":\"datavolumedisk\",\"disk\":{\"bus\":\"virtio\"}},{\"name\":\"cloudinitdisk\",\"disk\":{\"bus\":\"virtio\"}}]}}}"},` +
+		`{"name":"kubermatic-standard","spec":"{\"selector\":{\"matchLabels\":{\"kubevirt.io/flavor\":\"kubermatic-standard\"}},\"domain\":{\"resources\":{\"requests\":{\"cpu\":\"2\",\"memory\":\"8Gi\"},\"limits\":{\"cpu\":\"2\",\"memory\":\"8Gi\"}},\"devices\":{}}}"}]`
 )
 
 func setFakeNewKubeVirtClient(objects []ctrlruntimeclient.Object) {

--- a/pkg/provider/cloud/kubevirt/preset.go
+++ b/pkg/provider/cloud/kubevirt/preset.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirt
+
+import (
+	"context"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func presetCreator(preset *kubevirtv1.VirtualMachineInstancePreset) reconciling.NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter {
+	return func() (string, reconciling.KubeVirtV1VirtualMachineInstancePresetCreator) {
+		return preset.Name, func(p *kubevirtv1.VirtualMachineInstancePreset) (*kubevirtv1.VirtualMachineInstancePreset, error) {
+			p.Labels = preset.Labels
+			p.Spec = preset.Spec
+			return p, nil
+		}
+	}
+}
+
+// reconcilePresets reconciles the VirtualMachineInstancePresets from the `default` namespace to the dedicated one.
+func reconcilePresets(ctx context.Context, namespace string, client ctrlruntimeclient.Client) error {
+	presets := &kubevirtv1.VirtualMachineInstancePresetList{}
+	if err := client.List(context.TODO(), presets, ctrlruntimeclient.InNamespace(metav1.NamespaceDefault)); err != nil {
+		return err
+	}
+
+	presets.Items = append(presets.Items, *GetKubermaticStandardPreset())
+
+	for _, preset := range presets.Items {
+		presetCreators := []reconciling.NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter{
+			presetCreator(&preset),
+		}
+		if err := reconciling.ReconcileKubeVirtV1VirtualMachineInstancePresets(ctx, presetCreators, namespace, client); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetKubermaticStandardPreset returns a standard VirtualMachineInstancePreset with 2 CPUs and 8Gi of memory.
+func GetKubermaticStandardPreset() *kubevirtv1.VirtualMachineInstancePreset {
+	cpuQuantity, err := resource.ParseQuantity("2")
+	if err != nil {
+		return nil
+	}
+	memoryQuantity, err := resource.ParseQuantity("8Gi")
+	if err != nil {
+		return nil
+	}
+	resourceList := corev1.ResourceList{
+		corev1.ResourceMemory: memoryQuantity,
+		corev1.ResourceCPU:    cpuQuantity,
+	}
+
+	return &kubevirtv1.VirtualMachineInstancePreset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubermatic-standard",
+		},
+		Spec: kubevirtv1.VirtualMachineInstancePresetSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"kubevirt.io/flavor": "kubermatic-standard"},
+			},
+			Domain: &kubevirtv1.DomainSpec{
+				Resources: kubevirtv1.ResourceRequirements{
+					Requests: resourceList,
+					Limits:   resourceList,
+				},
+			},
+		},
+	}
+}

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -102,6 +104,11 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		return cluster, err
 	}
 
+	err = reconcilePresets(ctx, cluster.Status.NamespaceName, client)
+	if err != nil {
+		return cluster, err
+	}
+
 	return cluster, nil
 }
 
@@ -139,6 +146,10 @@ func (k *kubevirt) GetClientWithRestConfigForCluster(cluster *kubermaticv1.Clust
 
 	client, restConfig, err := NewClientWithRestConfig(kubeconfig)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := kubevirtv1.AddToScheme(client.Scheme()); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
Initialisation of the VirtualMachineInstancePresets when a cluster a created.
The customer can define some VirtualMachineInstancePresets in the `default` namespace. When a cluster is created, those are cloned into the dedicated <cluter-xxxyy> dedicated namespace, allowing the VirtualMachinesInstances to match those Presets.
We also add a standard `kubermatic-standard` preset in the <cluster-xxxxyyy> namespace, which is also returned in the List VirtualMachineInstancePresets endpoint to allow the selection in the dashboard.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8490

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: initialisation of VirtualMachineInstancePresets in a dedicated namespace in the infra KubeVirt Cluster.
```
