### PR TITLE
Added autodownsampling so that Grafana finds data on longer range

### DIFF
--- a/charts/monitoring/prometheus/templates/thanos-query-deployment.yaml
+++ b/charts/monitoring/prometheus/templates/thanos-query-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         args:
         - query
         - --query.replica-label=replica
+        - --query.auto-downsampling
         - --store=dns+{{ template "name" . }}-thanos-store.{{ .Release.Namespace }}.svc.cluster.local.:10901
         ports:
         - name: http


### PR DESCRIPTION
Added autodownsampling so that Grafana finds data on longer range as suggested on [thanos issue tracker #601](https://github.com/thanos-io/thanos/issues/601) 

**What does this PR do / Why do we need it**:
Currently, our grafana does not read downsampled Thanos data. This happens due to in default mode, Thanos will respond only with raw data - which we keep only for short duration like 7days.

So effectively, we cannot make use of Thanos for long term analysis at all with current setting.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

**Special notes for your reviewer**:
Similar change was also [done](https://github.com/prometheus-operator/prometheus-operator/pull/2441) in prometheus operator

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
