### PR TITLE
new permissions granted to MC

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrole.go
@@ -58,7 +58,7 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 				{
 					APIGroups: []string{""},
 					Resources: []string{"pods"},
-					Verbs:     []string{"list", "get"},
+					Verbs:     []string{"list", "get", "delete"},
 				},
 				{
 					APIGroups: []string{""},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrole.go
@@ -99,6 +99,11 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					ResourceNames: []string{"kubernetes.io/kubelet-serving"},
 					Verbs:         []string{"approve"},
 				},
+				{
+					APIGroups: []string{"storage.k8s.io"},
+					Resources: []string{"volumeattachments"},
+					Verbs:     []string{"list", "get", "watch"},
+				},
 			}
 			return cr, nil
 		}


### PR DESCRIPTION
Signed-off-by: Mattia Lavacca <lavacca.mattia@gmail.com>

**What does this PR do / Why do we need it**:
Once MC will be bumped to 1.45.0, it will need cluster-wide permission to list volumeAttachments and delete pods in vSphere clusters.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
