### PR TITLE
Remove redundant error handling packages

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -33,7 +33,6 @@ exceptions:
   - github.com/embik/nutanix-client-go/pkg/client/v3 # MPL-2.0
   - github.com/gosimple/slug # MPL-2.0. Required for https://github.com/grafana-tools/sdk
   - github.com/hashicorp/errwrap # MPL-2.0
-  - github.com/hashicorp/go-multierror # MPL-2.0
   - github.com/hashicorp/hcl # MPL-2.0
   - github.com/hashicorp/hcl/hcl/ast # MPL-2.0
   - github.com/hashicorp/hcl/hcl/parser # MPL-2.0

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -32,7 +32,6 @@ exceptions:
   - github.com/embik/nutanix-client-go/pkg/client # MPL-2.0
   - github.com/embik/nutanix-client-go/pkg/client/v3 # MPL-2.0
   - github.com/gosimple/slug # MPL-2.0. Required for https://github.com/grafana-tools/sdk
-  - github.com/hashicorp/errwrap # MPL-2.0
   - github.com/hashicorp/hcl # MPL-2.0
   - github.com/hashicorp/hcl/hcl/ast # MPL-2.0
   - github.com/hashicorp/hcl/hcl/parser # MPL-2.0

--- a/cmd/nodeport-proxy/envoy-manager/server.go
+++ b/cmd/nodeport-proxy/envoy-manager/server.go
@@ -18,9 +18,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -71,14 +71,14 @@ func (s *Server) Start(ctx context.Context) error {
 
 	lis, err := net.Listen("tcp", s.ListenAddress)
 	if err != nil {
-		return errors.Wrap(err, "envoy control plane server failed while start listening")
+		return fmt.Errorf("envoy control plane server failed while start listening: %w", err)
 	}
 
 	registerServer(grpcServer, srv3)
 
 	s.Log.Infow("starting management service", "listen-address", s.ListenAddress)
 	if err = grpcServer.Serve(lis); err != nil {
-		return errors.Wrap(err, "envoy control plane server failed while start serving incoming connections")
+		return fmt.Errorf("envoy control plane server failed while start serving incoming connections: %w", err)
 	}
 	<-ctx.Done()
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/websocket v1.4.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hetznercloud/hcloud-go v1.33.1
 	github.com/imdario/mergo v0.3.12
 	github.com/jetstack/cert-manager v1.7.1
@@ -195,7 +194,6 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gosimple/slug v1.1.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20210802220920-c000ec35322e
 	github.com/open-policy-agent/gatekeeper v0.0.0-20201111000257-4450f08fa95e
 	github.com/packethost/packngo v0.22.0
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -233,6 +232,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/poy/onpar v1.0.1 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
 	github.com/prometheus/client_model v0.2.1-0.20200623203004-60555c9708c7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20210802220920-c000ec35322e
 	github.com/open-policy-agent/gatekeeper v0.0.0-20201111000257-4450f08fa95e
 	github.com/packethost/packngo v0.22.0
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1403,7 +1403,6 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -1425,7 +1424,6 @@ github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:
 github.com/hashicorp/go-multierror v0.0.0-20171204182908-b7773ae21874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/pkg/controller/nodeport-proxy/envoymanager/controller.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller.go
@@ -120,7 +120,7 @@ func (r *Reconciler) sync(ctx context.Context) error {
 		ctrlruntimeclient.InNamespace(r.Namespace),
 		client.MatchingFields{r.ExposeAnnotationKey: "true"},
 	); err != nil {
-		return fmt.Errorf("failed to list service's: %w", err)
+		return fmt.Errorf("failed to list services: %w", err)
 	}
 
 	// Sort services in descending order by creation timestamp, in order to

--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -224,7 +223,7 @@ func makeSNIFilterChains(service *corev1.Service, p portHostMapping) []*envoylis
 
 			tcpProxyConfigMarshalled, err := anypb.New(tcpProxyConfig)
 			if err != nil {
-				panic(errors.Wrap(err, "failed to marshal tcpProxyConfig"))
+				panic(fmt.Errorf("failed to marshal tcpProxyConfig: %w", err))
 			}
 
 			sniFilterChains = append(sniFilterChains, &envoylistenerv3.FilterChain{
@@ -346,7 +345,7 @@ func (sb *snapshotBuilder) makeTunnelingListener(vhs ...*envoyroutev3.VirtualHos
 	}
 	httpManagerConfigMarshalled, err := anypb.New(hcm)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to marshal HTTP Connection Manager"))
+		panic(fmt.Errorf("failed to marshal HTTP Connection Manager: %w", err))
 	}
 
 	sb.log.Debugf("using a listener on port %d", sb.EnvoyTunnelingListenerPort)
@@ -438,7 +437,7 @@ func (sb *snapshotBuilder) makeListenersForNodePortService(service *corev1.Servi
 
 		tcpProxyConfigMarshalled, err := anypb.New(tcpProxyConfig)
 		if err != nil {
-			panic(errors.Wrap(err, "failed to marshal tcpProxyConfig"))
+			panic(fmt.Errorf("failed to marshal tcpProxyConfig: %w", err))
 		}
 
 		sb.log.Debugw("creating NodePort listener", "service", serviceKey, "nodePort", servicePort.NodePort)
@@ -526,7 +525,7 @@ func (sb *snapshotBuilder) makeInitialResources() (listeners []envoycachetype.Re
 	healthCheckMarshalled, err := anypb.New(healthCheck)
 	if err != nil {
 		// panic as this either never occurs or cannot recover
-		panic(errors.Wrap(err, "failed to marshal HealthCheck"))
+		panic(fmt.Errorf("failed to marshal HealthCheck: %w", err))
 	}
 
 	httpConnectionManager := &envoyhttpconnectionmanagerv3.HttpConnectionManager{
@@ -573,7 +572,7 @@ func (sb *snapshotBuilder) makeInitialResources() (listeners []envoycachetype.Re
 
 	httpConnectionManagerMarshalled, err := anypb.New(httpConnectionManager)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to marshal HTTPConnectionManager"))
+		panic(fmt.Errorf("failed to marshal HTTPConnectionManager: %w", err))
 	}
 
 	listener := &envoylistenerv3.Listener{

--- a/pkg/controller/nodeport-proxy/envoymanager/utils.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils.go
@@ -22,8 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 
 	corev1 "k8s.io/api/core/v1"
@@ -130,7 +128,7 @@ func portHostMappingFromAnnotation(svc *corev1.Service) (portHostMapping, error)
 	}
 	err := json.Unmarshal([]byte(val), &m)
 	if err != nil {
-		return m, errors.Wrap(err, "failed to unmarshal port host mapping")
+		return m, fmt.Errorf("failed to unmarshal port host mapping: %w", err)
 	}
 	return m, nil
 }

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	cron "github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 
@@ -38,7 +37,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/etcd"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	errors2 "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -269,65 +268,65 @@ func (r *Reconciler) reconcile(
 ) (*reconcile.Result, error) {
 	destination := seed.GetEtcdBackupDestination(backupConfig.Spec.Destination)
 	if destination == nil {
-		return nil, errors.Errorf("cannot find backup destination %q", backupConfig.Spec.Destination)
+		return nil, fmt.Errorf("cannot find backup destination %q", backupConfig.Spec.Destination)
 	}
 	if destination.Credentials == nil {
-		return nil, errors.Errorf("credentials not set for backup destination %q", backupConfig.Spec.Destination)
+		return nil, fmt.Errorf("credentials not set for backup destination %q", backupConfig.Spec.Destination)
 	}
 
 	if err := r.ensureSecrets(ctx, cluster); err != nil {
-		return nil, errors.Wrap(err, "failed to create backup secrets")
+		return nil, fmt.Errorf("failed to create backup secrets: %w", err)
 	}
 
 	if err := r.ensureConfigMaps(ctx, cluster); err != nil {
-		return nil, errors.Wrap(err, "failed to create backup configmaps")
+		return nil, fmt.Errorf("failed to create backup configmaps: %w", err)
 	}
 
 	backupStoreContainer, err := getBackupStoreContainer(config, seed)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create backup store container")
+		return nil, fmt.Errorf("failed to create backup store container: %w", err)
 	}
 
 	backupDeleteContainer, err := getBackupDeleteContainer(config, seed)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create backup delete container")
+		return nil, fmt.Errorf("failed to create backup delete container: %w", err)
 	}
 
 	var nextReconcile, totalReconcile *reconcile.Result
 	errorReconcile := &reconcile.Result{RequeueAfter: 1 * time.Minute}
 
 	if nextReconcile, err = r.ensurePendingBackupIsScheduled(ctx, backupConfig, cluster); err != nil {
-		return errorReconcile, errors.Wrap(err, "failed to ensure next backup is scheduled")
+		return errorReconcile, fmt.Errorf("failed to ensure next backup is scheduled: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
 	if nextReconcile, err = r.startPendingBackupJobs(ctx, backupConfig, cluster, destination, backupStoreContainer); err != nil {
-		return errorReconcile, errors.Wrap(err, "failed to start pending and update running backups")
+		return errorReconcile, fmt.Errorf("failed to start pending and update running backups: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
 	if nextReconcile, err = r.startPendingBackupDeleteJobs(ctx, backupConfig, cluster, destination, backupDeleteContainer); err != nil {
-		return errorReconcile, errors.Wrap(err, "failed to start pending backup delete jobs")
+		return errorReconcile, fmt.Errorf("failed to start pending backup delete jobs: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
 	if nextReconcile, err = r.updateRunningBackupDeleteJobs(ctx, backupConfig, cluster, destination, backupDeleteContainer); err != nil {
-		return errorReconcile, errors.Wrap(err, "failed to update running backup delete jobs")
+		return errorReconcile, fmt.Errorf("failed to update running backup delete jobs: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
 	if nextReconcile, err = r.deleteFinishedBackupJobs(ctx, log, backupConfig, cluster); err != nil {
-		return errorReconcile, errors.Wrap(err, "failed to delete finished backup jobs")
+		return errorReconcile, fmt.Errorf("failed to delete finished backup jobs: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
 	if nextReconcile, err = r.handleFinalization(ctx, backupConfig); err != nil {
-		return errorReconcile, errors.Wrap(err, "failed to clean up EtcdBackupConfig")
+		return errorReconcile, fmt.Errorf("failed to clean up EtcdBackupConfig: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
@@ -383,7 +382,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 			"tracking too many backups; not scheduling new ones") {
 			// condition changed, need to persist and generate an event
 			if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-				return nil, errors.Wrap(err, "failed to update backup config")
+				return nil, fmt.Errorf("failed to update backup config: %w", err)
 			}
 			r.recorder.Event(backupConfig, corev1.EventTypeWarning, "TooManyBackups", "tracking too many backups; not scheduling new ones")
 		}
@@ -397,7 +396,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		"") {
 		// condition changed, need to persist and generate an event
 		if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-			return nil, errors.Wrap(err, "failed to update backup config")
+			return nil, fmt.Errorf("failed to update backup config: %w", err)
 		}
 		r.recorder.Event(backupConfig, corev1.EventTypeNormal, "NormalBackupCount", "backup count low enough; scheduling new backups")
 	}
@@ -433,7 +432,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 
 		schedule, err := parseCronSchedule(backupConfig.Spec.Schedule)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to Parse Schedule %v", backupConfig.Spec.Schedule)
+			return nil, fmt.Errorf("Failed to Parse Schedule %v: %w", backupConfig.Spec.Schedule, err)
 		}
 
 		now := r.clock.Now()
@@ -461,13 +460,13 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 	status := backupConfig.Status.DeepCopy()
 
 	if err := r.Update(ctx, backupConfig); err != nil {
-		return nil, errors.Wrap(err, "failed to update backup config")
+		return nil, fmt.Errorf("failed to update backup config: %w", err)
 	}
 
 	oldBackupConfig = backupConfig.DeepCopy()
 	backupConfig.Status = *status
 	if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-		return nil, errors.Wrap(err, "failed to update backup status")
+		return nil, fmt.Errorf("failed to update backup status: %w", err)
 	}
 
 	return &reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
@@ -519,7 +518,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 				err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: backup.JobName}, job)
 				if err != nil {
 					if !kerrors.IsNotFound(err) {
-						return nil, errors.Wrapf(err, "error getting job for backup %s", backup.BackupName)
+						return nil, fmt.Errorf("error getting job for backup %s: %w", backup.BackupName, err)
 					}
 					// job not found. Apparently deleted externally.
 					backup.BackupPhase = kubermaticv1.BackupStatusPhaseFailed
@@ -542,7 +541,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 			} else if backup.BackupPhase == "" && r.clock.Now().Sub(backup.ScheduledTime.Time) >= 0 && backupConfig.DeletionTimestamp == nil {
 				job := r.backupJob(backupConfig, cluster, backup, destination, storeContainer)
 				if err := r.Create(ctx, job); err != nil && !kerrors.IsAlreadyExists(err) {
-					return nil, errors.Wrapf(err, "error creating job for backup %s", backup.BackupName)
+					return nil, fmt.Errorf("error creating job for backup %s: %w", backup.BackupName, err)
 				}
 				backup.BackupPhase = kubermaticv1.BackupStatusPhaseRunning
 				kuberneteshelper.AddFinalizer(backupConfig, DeleteAllBackupsFinalizer)
@@ -554,13 +553,13 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 	status := backupConfig.Status.DeepCopy()
 
 	if err := r.Update(ctx, backupConfig); err != nil {
-		return nil, errors.Wrap(err, "failed to update backup config")
+		return nil, fmt.Errorf("failed to update backup config: %w", err)
 	}
 
 	oldBackupConfig := backupConfig.DeepCopy()
 	backupConfig.Status = *status
 	if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-		return nil, errors.Wrap(err, "failed to update backup status")
+		return nil, fmt.Errorf("failed to update backup status: %w", err)
 	}
 
 	return returnReconcile, nil
@@ -611,7 +610,7 @@ func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupCon
 
 	if modified {
 		if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-			return nil, errors.Wrap(err, "failed to update backup status")
+			return nil, fmt.Errorf("failed to update backup status: %w", err)
 		}
 
 		return &reconcile.Result{RequeueAfter: assumedJobRuntime}, nil
@@ -625,7 +624,7 @@ func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *ku
 	if deleteContainer != nil {
 		job := r.backupDeleteJob(backupConfig, cluster, backup, destination, deleteContainer)
 		if err := r.Create(ctx, job); err != nil && !kerrors.IsAlreadyExists(err) {
-			return errors.Wrapf(err, "error creating delete job for backup %s", backup.BackupName)
+			return fmt.Errorf("error creating delete job for backup %s: %w", backup.BackupName, err)
 		}
 		backup.DeletePhase = kubermaticv1.BackupStatusPhaseRunning
 	} else {
@@ -657,7 +656,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 			err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: backup.DeleteJobName}, job)
 			if err != nil {
 				if !kerrors.IsNotFound(err) {
-					return nil, errors.Wrapf(err, "error getting delete job for backup %s", backup.BackupName)
+					return nil, fmt.Errorf("error getting delete job for backup %s: %w", backup.BackupName, err)
 				}
 				// job not found. Apparently deleted, either externally or by us in a previous cycle.
 				// recreate it. We want to see a finished delete job.
@@ -674,7 +673,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 					// Ideally jobs would support recreating failed or hanging pods themselves, but
 					// they don't under all circumstances -- see https://github.com/kubernetes/kubernetes/issues/95431
 					if err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !kerrors.IsNotFound(err) {
-						return nil, errors.Wrapf(err, "backup %s: failed to delete failed delete job %s", backup.BackupName, backup.JobName)
+						return nil, fmt.Errorf("backup %s: failed to delete failed delete job %s: %w", backup.BackupName, backup.JobName, err)
 					}
 					deleteJobsToRestart = append(deleteJobsToRestart, DeleteJobToRestart{backup, fmt.Sprintf("Job failed: %s. Restarted.", cond.Message)})
 				} else {
@@ -698,7 +697,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 	}
 
 	if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-		return nil, errors.Wrap(err, "failed to update backup status")
+		return nil, fmt.Errorf("failed to update backup status: %w", err)
 	}
 
 	return returnReconcile, nil
@@ -750,11 +749,11 @@ func (r *Reconciler) deleteFinishedBackupJobs(ctx context.Context, log *zap.Suga
 				case err == nil:
 					err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground))
 					if err != nil && !kerrors.IsNotFound(err) {
-						return nil, errors.Wrapf(err, "backup %s: failed to delete backup job %s", backup.BackupName, backup.JobName)
+						return nil, fmt.Errorf("backup %s: failed to delete backup job %s: %w", backup.BackupName, backup.JobName, err)
 					}
 					backupJobDeleted = true
 				case !kerrors.IsNotFound(err):
-					return nil, errors.Wrapf(err, "backup %s: failed to get backup job %s", backup.BackupName, backup.JobName)
+					return nil, fmt.Errorf("backup %s: failed to get backup job %s: %w", backup.BackupName, backup.JobName, err)
 				}
 			}
 		}
@@ -784,11 +783,11 @@ func (r *Reconciler) deleteFinishedBackupJobs(ctx context.Context, log *zap.Suga
 				case err == nil:
 					err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground))
 					if err != nil && !kerrors.IsNotFound(err) {
-						return nil, errors.Wrapf(err, "backup %s: failed to delete job %s", backup.BackupName, backup.DeleteJobName)
+						return nil, fmt.Errorf("backup %s: failed to delete job %s: %w", backup.BackupName, backup.DeleteJobName, err)
 					}
 					deleteJobDeleted = true
 				case !kerrors.IsNotFound(err):
-					return nil, errors.Wrapf(err, "backup %s: failed to get job %s", backup.BackupName, backup.DeleteJobName)
+					return nil, fmt.Errorf("backup %s: failed to get job %s: %w", backup.BackupName, backup.DeleteJobName, err)
 				}
 			}
 		}
@@ -805,7 +804,7 @@ func (r *Reconciler) deleteFinishedBackupJobs(ctx context.Context, log *zap.Suga
 	if modified {
 		backupConfig.Status.CurrentBackups = newBackups
 		if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(oldBackupConfig)); err != nil {
-			return nil, errors.Wrap(err, "failed to update backup status")
+			return nil, fmt.Errorf("failed to update backup status: %w", err)
 		}
 	}
 
@@ -1167,7 +1166,7 @@ func parseCronSchedule(scheduleString string) (cron.Schedule, error) {
 	}()
 
 	if len(validationErrors) > 0 {
-		return nil, errors2.NewAggregate(validationErrors)
+		return nil, utilerrors.NewAggregate(validationErrors)
 	}
 
 	return schedule, nil

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -18,12 +18,12 @@ package etcdrestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/minio/minio-go/v7"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -186,15 +186,15 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 	var destination *kubermaticv1.BackupDestination
 	if restore.Spec.Destination != "" {
 		if seed.Spec.EtcdBackupRestore == nil {
-			return nil, errors.Errorf("can't find backup restore destination %q in Seed %q", restore.Spec.Destination, seed.Name)
+			return nil, fmt.Errorf("can't find backup restore destination %q in Seed %q", restore.Spec.Destination, seed.Name)
 		}
 		var ok bool
 		destination, ok = seed.Spec.EtcdBackupRestore.Destinations[restore.Spec.Destination]
 		if !ok {
-			return nil, errors.Errorf("can't find backup restore destination %q in Seed %q", restore.Spec.Destination, seed.Name)
+			return nil, fmt.Errorf("can't find backup restore destination %q in Seed %q", restore.Spec.Destination, seed.Name)
 		}
 		if destination.Credentials == nil {
-			return nil, errors.Errorf("credentials not set for backup destination %q in Seed %q", restore.Spec.Destination, seed.Name)
+			return nil, fmt.Errorf("credentials not set for backup destination %q in Seed %q", restore.Spec.Destination, seed.Name)
 		}
 	}
 

--- a/pkg/test/e2e/ccm-migration/cluster.go
+++ b/pkg/test/e2e/ccm-migration/cluster.go
@@ -176,7 +176,7 @@ func (c *ClusterJig) createProject(ctx context.Context) (*kubermaticv1.Project, 
 	}
 
 	if err := c.SeedClient.Create(ctx, project); err != nil {
-		return nil, errors.Wrap(err, "failed to create project")
+		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 
 	return project, nil

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -18,11 +18,11 @@ package exposestrategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
@@ -58,12 +58,12 @@ type AgentConfig struct {
 func (a *AgentConfig) DeployAgentPod(ctx context.Context) error {
 	agentCm := a.newAgentConfigMap(a.Namespace)
 	if err := a.Client.Create(ctx, agentCm); err != nil {
-		return errors.Wrap(err, "failed to create agent config map")
+		return fmt.Errorf("failed to create agent config map: %w", err)
 	}
 	a.AgentConfigMap = agentCm
 	agentPod := a.newAgentPod(a.Namespace)
 	if err := a.Client.Create(ctx, agentPod); err != nil {
-		return errors.Wrap(err, "failed to create agent pod")
+		return fmt.Errorf("failed to create agent pod: %w", err)
 	}
 
 	if !e2eutils.CheckPodsRunningReady(ctx, a.Client, a.Namespace, []string{agentPod.Name}, agentDeployTimeout) {
@@ -74,7 +74,7 @@ func (a *AgentConfig) DeployAgentPod(ctx context.Context) error {
 		Namespace: agentPod.Namespace,
 		Name:      agentPod.Name,
 	}, agentPod); err != nil {
-		return errors.Wrap(err, "failed to get agent pod")
+		return fmt.Errorf("failed to get agent pod: %w", err)
 	}
 	a.AgentPod = agentPod
 	return nil

--- a/pkg/test/e2e/expose-strategy/cluster.go
+++ b/pkg/test/e2e/expose-strategy/cluster.go
@@ -61,7 +61,7 @@ func (c *ClusterJig) createProject(ctx context.Context) (*kubermaticv1.Project, 
 	}
 
 	if err := c.Client.Create(ctx, project); err != nil {
-		return nil, errors.Wrap(err, "failed to create project")
+		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 
 	return project, nil
@@ -70,7 +70,7 @@ func (c *ClusterJig) createProject(ctx context.Context) (*kubermaticv1.Project, 
 func (c *ClusterJig) SetUp(ctx context.Context) error {
 	project, err := c.createProject(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to create project")
+		return fmt.Errorf("failed to create project: %w", err)
 	}
 
 	c.Log.Debugw("Creating cluster", "name", c.Name)

--- a/pkg/test/e2e/expose-strategy/cluster.go
+++ b/pkg/test/e2e/expose-strategy/cluster.go
@@ -18,9 +18,9 @@ package exposestrategy
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -123,13 +123,13 @@ func (c *ClusterJig) SetUp(ctx context.Context) error {
 		},
 	}
 	if err := c.Client.Create(ctx, c.Cluster); err != nil {
-		return errors.Wrap(err, "failed to create cluster")
+		return fmt.Errorf("failed to create cluster: %w", err)
 	}
 
 	if err := kubermaticv1helper.UpdateClusterStatus(ctx, c.Client, c.Cluster, func(c *kubermaticv1.Cluster) {
 		c.Status.UserEmail = "e2e@test.com"
 	}); err != nil {
-		return errors.Wrap(err, "failed to update cluster status")
+		return fmt.Errorf("failed to update cluster status: %w", err)
 	}
 
 	return c.waitForClusterControlPlaneReady(c.Cluster)

--- a/pkg/test/e2e/nodeport-proxy/services.go
+++ b/pkg/test/e2e/nodeport-proxy/services.go
@@ -18,10 +18,10 @@ package nodeportproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
@@ -71,7 +71,7 @@ func (n *ServiceJig) CreateServiceWithPods(ctx context.Context, svc *corev1.Serv
 	svc.Namespace = n.Namespace
 	n.Log.Debugw("Creating nodeport service", "service", svc)
 	if err := n.Client.Create(ctx, svc); err != nil {
-		return nil, errors.Wrap(err, "failed to create service of type nodeport")
+		return nil, fmt.Errorf("failed to create service of type nodeport: %w", err)
 	}
 	gomega.Expect(svc).NotTo(gomega.BeNil())
 
@@ -85,7 +85,7 @@ func (n *ServiceJig) CreateServiceWithPods(ctx context.Context, svc *corev1.Serv
 	// Wait for the pod to be ready
 	pods, err := e2eutils.WaitForPodsCreated(ctx, n.Client, int(*rc.Spec.Replicas), rc.Namespace, svc.Spec.Selector)
 	if err != nil {
-		return svc, errors.Wrap(err, "error occurred while waiting for pods to be ready")
+		return svc, fmt.Errorf("error occurred while waiting for pods to be ready: %w", err)
 	}
 	if !e2eutils.CheckPodsRunningReady(ctx, n.Client, n.Namespace, pods, podReadinessTimeout) {
 		return svc, fmt.Errorf("timeout waiting for %d pods to be ready", len(pods))

--- a/pkg/test/e2e/utils/kubernetes.go
+++ b/pkg/test/e2e/utils/kubernetes.go
@@ -19,13 +19,13 @@ package utils
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"time"
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -68,7 +68,7 @@ type TestPodConfig struct {
 func (t *TestPodConfig) DeployTestPod(ctx context.Context) error {
 	testPod := t.CreatePodFunc(t.Namespace)
 	if err := t.Client.Create(ctx, testPod); err != nil {
-		return errors.Wrap(err, "failed to create host test pod")
+		return fmt.Errorf("failed to create host test pod: %w", err)
 	}
 
 	// Use default timeout of 5 minutes if not otherwise specified.
@@ -83,7 +83,7 @@ func (t *TestPodConfig) DeployTestPod(ctx context.Context) error {
 		Namespace: testPod.Namespace,
 		Name:      testPod.Name,
 	}, testPod); err != nil {
-		return errors.Wrap(err, "failed to get host test pod")
+		return fmt.Errorf("failed to get host test pod: %w", err)
 	}
 	t.testPod = testPod
 	return nil
@@ -165,22 +165,22 @@ func GetClients() (ctrlruntimeclient.Client, rest.Interface, *rest.Config, error
 	config := ctrlruntime.GetConfigOrDie()
 	mapper, err := apiutil.NewDynamicRESTMapper(config)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to create dynamic REST mapper")
+		return nil, nil, nil, fmt.Errorf("failed to create dynamic REST mapper: %w", err)
 	}
 	gvk, err := apiutil.GVKForObject(&corev1.Pod{}, scheme)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to get pod GVK")
+		return nil, nil, nil, fmt.Errorf("failed to get pod GVK: %w", err)
 	}
 	podRestClient, err := apiutil.RESTClientForGVK(gvk, false, config, serializer.NewCodecFactory(scheme))
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to create pod rest client")
+		return nil, nil, nil, fmt.Errorf("failed to create pod rest client: %w", err)
 	}
 	c, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{
 		Mapper: mapper,
 		Scheme: scheme,
 	})
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to create client")
+		return nil, nil, nil, fmt.Errorf("failed to create client: %w", err)
 	}
 	return c, podRestClient, config, nil
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
* github.com/pkg/errors offers no big value over Go's native `%w` placeholder for us.
* github.com/hashicorp/go-multierror was only used a a fancy `[]error`, so it can go away.

This gets rid of 2 more MPL packages (MPL is always just an exception in our codebase, and fewer exceptions are good).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
