### PR TITLE
migrate from github.com/robfig/cron to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.1
-	github.com/robfig/cron v1.2.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
@@ -80,6 +80,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	k8c.io/kubeone v1.4.0
 	k8c.io/operating-system-manager v0.4.0
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0
@@ -120,11 +121,6 @@ replace (
 	k8s.io/kubectl => k8s.io/kubectl v0.23.0
 	k8s.io/kubelet => k8s.io/kubelet v0.23.0
 	k8s.io/metrics => k8s.io/metrics v0.23.0
-)
-
-require (
-	k8c.io/kubeone v1.4.0
-	kubevirt.io/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d // indirect
 )
 
 require (
@@ -295,6 +291,7 @@ require (
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/kubelet v0.22.2 // indirect
+	kubevirt.io/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk v0.2.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2095,6 +2095,8 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -566,7 +566,9 @@ func parseDuration(interval time.Duration) (string, error) {
 	// Refs:
 	// https://github.com/kubernetes/kubernetes/blob/d02cf08e27f640f09ebd489e094176fd075f3463/pkg/controller/cronjob/cronjob_controller.go#L253
 	// https://github.com/kubernetes/kubernetes/blob/d02cf08e27f640f09ebd489e094176fd075f3463/pkg/controller/cronjob/utils.go#L98
-	_, err := cron.ParseStandard(scheduleString)
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+	_, err := parser.Parse(scheduleString)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -1158,7 +1158,8 @@ func parseCronSchedule(scheduleString string) (cron.Schedule, error) {
 			}
 		}()
 
-		if res, err := cron.ParseStandard(scheduleString); err != nil {
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+		if res, err := parser.Parse(scheduleString); err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("invalid schedule: %w", err))
 		} else {
 			schedule = res

--- a/pkg/resources/etcd/backupconfig.go
+++ b/pkg/resources/etcd/backupconfig.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -74,7 +74,9 @@ func parseDuration(interval time.Duration) (string, error) {
 	// We verify the validity of the scheduleString here, because the etcd_backup_controller
 	// only does that inside its sync loop, which means it is entirely possible to create
 	// an EtcdBackupConfig with an invalid Spec.Schedule
-	_, err := cron.ParseStandard(scheduleString)
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+	_, err := parser.Parse(scheduleString)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/webhook/seed/validation.go
+++ b/pkg/webhook/seed/validation.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/features"
@@ -207,7 +207,8 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object, isDelete b
 	}
 
 	if subject.Spec.Metering != nil && subject.Spec.Metering.Schedule != "" {
-		if _, err := cron.ParseStandard(subject.Spec.Metering.Schedule); err != nil {
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+		if _, err := parser.Parse(subject.Spec.Metering.Schedule); err != nil {
 			return fmt.Errorf("invalid cron expression format: %s", subject.Spec.Metering.Schedule)
 		}
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
v3 was already released more than 2 years ago, I think it's time for us to upgrade.

I copied `cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor` from v1's definition of the "standard parser": https://github.com/robfig/cron/blob/v1/parser.go#L158-L160

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
