### PR TITLE
Adjust ETCD_INITIAL_CLUSTER during peer TLS migration

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -381,7 +381,6 @@ func initialMemberList(n int, namespace string, useTLSPeer bool, client ctrlrunt
 				)
 			}
 		}
-
 	}
 
 	return members

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -68,6 +68,7 @@ const (
 type etcdCluster struct {
 	namespace             string
 	clusterSize           int
+	clusterClient         ctrlruntimeclient.Client
 	podName               string
 	podIP                 string
 	etcdctlAPIVersion     string
@@ -75,6 +76,7 @@ type etcdCluster struct {
 	token                 string
 	enableCorruptionCheck bool
 	initialState          string
+	initialMembers        []string
 	usePeerTLSOnly        bool
 }
 
@@ -89,22 +91,24 @@ func main() {
 	}
 
 	// here we find the cluster state
-	clusterClient, err := inClusterClient(log)
+	e.clusterClient, err = inClusterClient(log)
 	if err != nil {
 		log.Panicw("failed to get in-cluster client", zap.Error(err))
 	}
 
-	if err := e.setClusterSize(clusterClient); err != nil {
+	if err := e.setClusterSize(); err != nil {
 		log.Panicw("failed to set cluster size", zap.Error(err))
 	}
 
-	if err := e.setInitialState(clusterClient, log); err != nil {
+	if err := e.setInitialState(log); err != nil {
 		log.Panicw("failed to set initialState", zap.Error(err))
 	}
 
+	e.initialMembers = initialMemberList(e.clusterSize, e.namespace, e.usePeerTLSOnly, e.clusterClient)
+
 	log.Info("initializing etcd..")
 	log.Infof("initial-state: %s", e.initialState)
-	log.Infof("initial-cluster: %s", strings.Join(initialMemberList(e.clusterSize, e.namespace, e.usePeerTLSOnly), ","))
+	log.Infof("initial-cluster: %s", strings.Join(e.initialMembers, ","))
 	if e.usePeerTLSOnly {
 		log.Info("peer-tls-mode: strict")
 	}
@@ -162,7 +166,7 @@ func main() {
 	go func() {
 		wait.Forever(func() {
 			// refresh the cluster size so the etcd-launcher is aware of scaling operations
-			if err := e.setClusterSize(clusterClient); err != nil {
+			if err := e.setClusterSize(); err != nil {
 				log.Warnw("failed to refresh cluster size", zap.Error(err))
 			} else if _, err := deleteUnwantedDeadMembers(e, log); err != nil {
 				log.Warnw("failed to remove dead members", zap.Error(err))
@@ -352,17 +356,26 @@ func (e *etcdCluster) updatePeerURLs(log *zap.SugaredLogger) error {
 	return nil
 }
 
-func initialMemberList(n int, namespace string, useTLSPeer bool) []string {
-	format := "etcd-%d=http://etcd-%d.etcd.%s.svc.cluster.local:2380"
-
-	if useTLSPeer {
-		format = "etcd-%d=https://etcd-%d.etcd.%s.svc.cluster.local:2381"
-	}
-
+func initialMemberList(n int, namespace string, useTLSPeer bool, client ctrlruntimeclient.Client) []string {
 	members := []string{}
 	for i := 0; i < n; i++ {
-		members = append(members, fmt.Sprintf(format, i, i, namespace))
+		if useTLSPeer {
+			members = append(members, fmt.Sprintf("etcd-%d=https://etcd-%d.etcd.%s.svc.cluster.local:2381", i, i, namespace))
+		} else {
+			members = append(members, fmt.Sprintf("etcd-%d=http://etcd-%d.etcd.%s.svc.cluster.local:2380", i, i, namespace))
+			// check if the pod is already annotated as TLS aware
+			var pod *corev1.Pod
+			if err := client.Get(context.Background(), types.NamespacedName{Name: "etcd", Namespace: namespace}, pod); err == nil {
+				if _, ok := pod.Annotations[resources.EtcdTLSEnabledAnnotation]; ok {
+					members = append(
+						members,
+						fmt.Sprintf("etcd-%d=https://etcd-%d.etcd.%s.svc.cluster.local:2381", i, i, namespace),
+					)
+				}
+			}
+		}
 	}
+
 	return members
 }
 
@@ -423,7 +436,7 @@ func etcdCmd(config *etcdCluster) []string {
 	cmd := []string{
 		fmt.Sprintf("--name=%s", config.podName),
 		fmt.Sprintf("--data-dir=%s", config.dataDir),
-		fmt.Sprintf("--initial-cluster=%s", strings.Join(initialMemberList(config.clusterSize, config.namespace, config.usePeerTLSOnly), ",")),
+		fmt.Sprintf("--initial-cluster=%s", strings.Join(config.initialMembers, ",")),
 		fmt.Sprintf("--initial-cluster-token=%s", config.token),
 		fmt.Sprintf("--initial-cluster-state=%s", config.initialState),
 		fmt.Sprintf("--advertise-client-urls=https://%s.etcd.%s.svc.cluster.local:2379,https://%s:2379", config.podName, config.namespace, config.podIP),
@@ -696,7 +709,7 @@ func (e *etcdCluster) restoreDatadirFromBackupIfNeeded(ctx context.Context, k8cC
 		OutputDataDir:       e.dataDir,
 		OutputWALDir:        filepath.Join(e.dataDir, "member", "wal"),
 		PeerURLs:            []string{fmt.Sprintf("https://%s.etcd.%s.svc.cluster.local:2381", e.podName, e.namespace)},
-		InitialCluster:      strings.Join(initialMemberList(e.clusterSize, e.namespace, e.usePeerTLSOnly), ","),
+		InitialCluster:      strings.Join(initialMemberList(e.clusterSize, e.namespace, e.usePeerTLSOnly, e.clusterClient), ","),
 		InitialClusterToken: e.token,
 		SkipHashCheck:       false,
 	})
@@ -709,8 +722,8 @@ func closeClient(c io.Closer, log *zap.SugaredLogger) {
 	}
 }
 
-func (e *etcdCluster) setInitialState(clusterClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
-	k8cCluster, err := getK8cCluster(clusterClient, kubernetes.ClusterNameFromNamespace(e.namespace), log)
+func (e *etcdCluster) setInitialState(log *zap.SugaredLogger) error {
+	k8cCluster, err := getK8cCluster(e.clusterClient, kubernetes.ClusterNameFromNamespace(e.namespace), log)
 	if err != nil {
 		return fmt.Errorf("failed to get user cluster: %w", err)
 	}
@@ -727,17 +740,17 @@ func (e *etcdCluster) setInitialState(clusterClient ctrlruntimeclient.Client, lo
 		// new clusters can use "strict" TLS mode for etcd (TLS-only peering connections)
 		e.usePeerTLSOnly = true
 
-		if err := e.restoreDatadirFromBackupIfNeeded(context.Background(), k8cCluster, clusterClient, log); err != nil {
+		if err := e.restoreDatadirFromBackupIfNeeded(context.Background(), k8cCluster, e.clusterClient, log); err != nil {
 			return fmt.Errorf("failed to restore datadir from backup: %w", err)
 		}
 	}
 	return nil
 }
 
-func (e *etcdCluster) setClusterSize(clusterClient ctrlruntimeclient.Client) error {
+func (e *etcdCluster) setClusterSize() error {
 	sts := &appsv1.StatefulSet{}
 
-	if err := clusterClient.Get(context.Background(), types.NamespacedName{Name: "etcd", Namespace: e.namespace}, sts); err != nil {
+	if err := e.clusterClient.Get(context.Background(), types.NamespacedName{Name: "etcd", Namespace: e.namespace}, sts); err != nil {
 		return fmt.Errorf("failed to get etcd sts: %w", err)
 	}
 	e.clusterSize = defaultClusterSize

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -364,8 +364,8 @@ func initialMemberList(n int, namespace string, useTLSPeer bool, client ctrlrunt
 		} else {
 			members = append(members, fmt.Sprintf("etcd-%d=http://etcd-%d.etcd.%s.svc.cluster.local:2380", i, i, namespace))
 			// check if the pod is already annotated as TLS aware
-			var pod *corev1.Pod
-			if err := client.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("etcd-%d", i), Namespace: namespace}, pod); err != nil {
+			var pod corev1.Pod
+			if err := client.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("etcd-%d", i), Namespace: namespace}, &pod); err != nil {
 				log.Warnw("failed to get Pod information for etcd", zap.Error(err))
 			} else {
 				if _, ok := pod.ObjectMeta.Annotations[resources.EtcdTLSEnabledAnnotation]; ok {

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -711,7 +711,7 @@ func (e *etcdCluster) restoreDatadirFromBackupIfNeeded(ctx context.Context, k8cC
 		OutputDataDir:       e.dataDir,
 		OutputWALDir:        filepath.Join(e.dataDir, "member", "wal"),
 		PeerURLs:            []string{fmt.Sprintf("https://%s.etcd.%s.svc.cluster.local:2381", e.podName, e.namespace)},
-		InitialCluster:      strings.Join(initialMemberList(e.clusterSize, e.namespace, e.usePeerTLSOnly, e.clusterClient), ","),
+		InitialCluster:      strings.Join(initialMemberList(e.clusterSize, e.namespace, e.usePeerTLSOnly, e.clusterClient, log), ","),
 		InitialClusterToken: e.token,
 		SkipHashCheck:       false,
 	})

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -1194,7 +1194,13 @@ func (c *resourcesController) ensureRBACForEtcdLauncher(ctx context.Context, cli
 		return fmt.Errorf("failed to sync etcd restore RBAC Role for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
 	}
 	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, cluster, "Secret"); err != nil {
-		return fmt.Errorf("failed to sync etcd restore RBAC ClusterRoleBinding for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
+		return fmt.Errorf("failed to sync etcd restore RBAC RoleBinding for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
+	}
+	if err := c.ensureRBACRoleForEtcdLauncher(ctx, cluster, "pods", "", "Pod"); err != nil {
+		return fmt.Errorf("failed to sync etcd restore RBAC Role for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
+	}
+	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, cluster, "Pod"); err != nil {
+		return fmt.Errorf("failed to sync etcd restore RBAC RoleBinding for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
 	}
 	if err := c.ensureRBACRoleForEtcdLauncher(ctx, cluster, "statefulsets", "apps", "StatefulSet"); err != nil {
 		return fmt.Errorf("failed to sync etcd launcher RBAC Role for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
See #9369 for more details of the problem, but the gist is: When an etcd member is removed during the peer TLS migration, `etcd-launcher` fails to rejoin the etcd ring automatically. This PR makes `etcd-launcher` consider the peer TLS migration when generating the `ETCD_INITIAL_CLUSTER` env variable for "new" / re-joining members. It does so by querying pod state from Kubernetes and generate the peer URLs for the initial cluster list based on the pod configuration.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9369

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
etcd-launcher is now capable of automatically rejoining the etcd ring when a member is removed during the peer TLS migration
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
