### PR TITLE
Add webhook to validate KubermaticConfiguration objects

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -33,6 +33,7 @@ import (
 	addonmutation "k8c.io/kubermatic/v2/pkg/webhook/addon/mutation"
 	clustermutation "k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation"
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
+	kubermaticconfigurationvalidation "k8c.io/kubermatic/v2/pkg/webhook/kubermaticconfiguration/validation"
 	mlaadminsettingmutation "k8c.io/kubermatic/v2/pkg/webhook/mlaadminsetting/mutation"
 	oscvalidation "k8c.io/kubermatic/v2/pkg/webhook/operatingsystemmanager/operatingsystemconfig/validation"
 	ospvalidation "k8c.io/kubermatic/v2/pkg/webhook/operatingsystemmanager/operatingsystemprofile/validation"
@@ -129,6 +130,14 @@ func main() {
 
 	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.Seed{}).WithValidator(seedValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup seed validation webhook", zap.Error(err))
+	}
+
+	// /////////////////////////////////////////
+	// setup KubermaticConfiguration webhooks
+
+	configValidator := kubermaticconfigurationvalidation.NewValidator()
+	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.KubermaticConfiguration{}).WithValidator(configValidator).Complete(); err != nil {
+		log.Fatalw("Failed to setup KubermaticConfiguration validation webhook", zap.Error(err))
 	}
 
 	// /////////////////////////////////////////

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -180,6 +180,10 @@ func (r *Reconciler) cleanupDeletedConfiguration(ctx context.Context, config *ku
 		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
 	}
 
+	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.KubermaticConfigurationAdmissionWebhookName(config)); err != nil {
+		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
+	}
+
 	return kubernetes.TryRemoveFinalizer(ctx, r, config, common.CleanupFinalizer)
 }
 
@@ -385,6 +389,7 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 
 	creators := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
 		common.SeedAdmissionWebhookCreator(config, r.Client),
+		common.KubermaticConfigurationAdmissionWebhookCreator(config, r.Client),
 	}
 
 	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -189,6 +189,10 @@ func (r *Reconciler) cleanupDeletedSeed(ctx context.Context, cfg *kubermaticv1.K
 		return fmt.Errorf("failed to clean up Seed ValidatingWebhookConfiguration: %w", err)
 	}
 
+	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.KubermaticConfigurationAdmissionWebhookName(cfg)); err != nil {
+		return fmt.Errorf("failed to clean up KubermaticConfiguration ValidatingWebhookConfiguration: %w", err)
+	}
+
 	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
 		return fmt.Errorf("failed to clean up Cluster ValidatingWebhookConfiguration: %w", err)
 	}
@@ -595,6 +599,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 
 	validatingWebhookCreators := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
 		common.SeedAdmissionWebhookCreator(cfg, client),
+		common.KubermaticConfigurationAdmissionWebhookCreator(cfg, client),
 		kubermaticseed.ClusterValidatingWebhookConfigurationCreator(cfg, client),
 	}
 

--- a/pkg/validation/kubermaticconfiguration.go
+++ b/pkg/validation/kubermaticconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/validation/kubermaticconfiguration.go
+++ b/pkg/validation/kubermaticconfiguration.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ValidateKubermaticConfigurationSpec(spec *kubermaticv1.KubermaticConfigurationSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// general cloud spec logic
+	if errs := ValidateKubermaticVersioningConfiguration(spec.Versions, field.NewPath("spec", "versions")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	return allErrs
+}
+
+func ValidateKubermaticVersioningConfiguration(config kubermaticv1.KubermaticVersioningConfiguration, parentFieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if config.Default == nil {
+		allErrs = append(allErrs, field.Required(parentFieldPath.Child("default"), "no default version configured"))
+	} else {
+		validDefault := false
+
+		for _, v := range config.Versions {
+			if v.Equal(config.Default) {
+				validDefault = true
+				break
+			}
+		}
+
+		if !validDefault {
+			allErrs = append(allErrs, field.Invalid(parentFieldPath.Child("default"), config.Default, "default version is not listed in the list of supported versions"))
+		}
+	}
+
+	// collect a sorted list of minor versions
+	minorSet := sets.NewInt()
+	for _, version := range config.Versions {
+		minorSet.Insert(int(version.Semver().Minor()))
+	}
+
+	minors := minorSet.List()
+
+	// if there are less than 2 versions, there is no point in checking for gaps
+	if len(minors) < 2 {
+		return allErrs
+	}
+
+	start := minors[0]
+	end := minors[len(minors)-1]
+	missing := []string{}
+
+	for minor := start; minor < end; minor++ {
+		if !minorSet.Has(minor) {
+			missing = append(missing, fmt.Sprintf("v1.%d", minor))
+		}
+	}
+
+	if len(missing) > 0 {
+		msg := fmt.Sprintf("no versions for the minor releases %s configured, cannot have gaps", strings.Join(missing, ", "))
+		allErrs = append(allErrs, field.Invalid(parentFieldPath.Child("versions"), minors, msg))
+	}
+
+	return allErrs
+}

--- a/pkg/validation/kubermaticconfiguration_test.go
+++ b/pkg/validation/kubermaticconfiguration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/validation/kubermaticconfiguration_test.go
+++ b/pkg/validation/kubermaticconfiguration_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/semver"
+)
+
+func TestValidateKubermaticConfigurationVersions(t *testing.T) {
+	testcases := []struct {
+		name           string
+		versions       []string
+		defaultVersion string
+		valid          bool
+	}{
+		{
+			name:           "vanilla, single version",
+			versions:       []string{"v1.10.5"},
+			defaultVersion: "v1.10.5",
+			valid:          true,
+		},
+		{
+			name:           "regular version update",
+			versions:       []string{"v1.10.5", "v1.11.4"},
+			defaultVersion: "v1.11.4",
+			valid:          true,
+		},
+		{
+			name:           "order does not matter",
+			versions:       []string{"v1.11.4", "v1.12.3", "1.9.2", "v1.10.8"},
+			defaultVersion: "v1.10.8",
+			valid:          true,
+		},
+		{
+			name:           "missing v1.12",
+			versions:       []string{"v1.11.4", "v1.13.3"},
+			defaultVersion: "v1.13.3",
+			valid:          false,
+		},
+		{
+			name:           "order does not matter",
+			versions:       []string{"v1.13.3", "v1.11.4"},
+			defaultVersion: "v1.11.4",
+			valid:          false,
+		},
+		{
+			name:           "large gaps are also detected",
+			versions:       []string{"v1.15.4", "v1.11.4"},
+			defaultVersion: "v1.11.4",
+			valid:          false,
+		},
+		{
+			name:           "no default configured",
+			versions:       []string{"v1.15.4", "v1.11.4"},
+			defaultVersion: "",
+			valid:          false,
+		},
+		{
+			name:           "invalid default configured",
+			versions:       []string{"v1.2.2", "v1.2.4"},
+			defaultVersion: "v1.2.3",
+			valid:          false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			config := kubermaticv1.KubermaticVersioningConfiguration{}
+			if tt.defaultVersion != "" {
+				config.Default = semver.NewSemverOrDie(tt.defaultVersion)
+			}
+
+			for _, v := range tt.versions {
+				version := semver.NewSemverOrDie(v)
+				config.Versions = append(config.Versions, *version)
+			}
+
+			errs := ValidateKubermaticVersioningConfiguration(config, nil)
+			if tt.valid {
+				if len(errs) > 0 {
+					t.Fatalf("Expected configuration to be valid, but got err: %v", errs.ToAggregate())
+				}
+			} else {
+				if len(errs) == 0 {
+					t.Fatal("Expected configuration to be invalid, but it was accepted.")
+				}
+			}
+		})
+	}
+}

--- a/pkg/webhook/kubermaticconfiguration/validation/validation.go
+++ b/pkg/webhook/kubermaticconfiguration/validation/validation.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
+	"k8c.io/kubermatic/v2/pkg/validation"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// validator for validating Kubermatic KubermaticConfiguration CRD.
+type validator struct {
+}
+
+// NewValidator returns a new KubermaticConfiguration validator.
+func NewValidator() *validator {
+	return &validator{}
+}
+
+var _ admission.CustomValidator = &validator{}
+
+func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	config, ok := obj.(*kubermaticv1.KubermaticConfiguration)
+	if !ok {
+		return errors.New("object is not a KubermaticConfiguration")
+	}
+
+	defaulted, err := defaults.DefaultConfiguration(config, zap.NewNop().Sugar())
+	if err != nil {
+		return fmt.Errorf("failed to apply default values: %w", err)
+	}
+
+	return validation.ValidateKubermaticConfigurationSpec(&defaulted.Spec).ToAggregate()
+}
+
+func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	config, ok := newObj.(*kubermaticv1.KubermaticConfiguration)
+	if !ok {
+		return errors.New("new object is not a KubermaticConfiguration")
+	}
+
+	defaulted, err := defaults.DefaultConfiguration(config, zap.NewNop().Sugar())
+	if err != nil {
+		return fmt.Errorf("failed to apply default values: %w", err)
+	}
+
+	return validation.ValidateKubermaticConfigurationSpec(&defaulted.Spec).ToAggregate()
+}
+
+func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR is part of https://github.com/kubermatic/kubermatic/issues/5949. To handle gradual deployments of the control plane, a new update controller will smartly slowly roll out first the apiserver, then the rest of the control plane etc.

To keep the review simple, I split the branch into multiple PRs and this is the third one (after #9337 and #9373).

To properly handle cluster upgrades, we must not skip minor versions, i.e. a usercluster on version 1.2 must first upgrade to 1.3, then 1.4 before finally being allowed to go to 1.5. To ensure this is possible, we need to have at least 1 version for each minor released configured, e.g. (1.2.1, 1.3.7, 1.4.5 and 1.5.2).

This PR adds a webhook to implement this validation for the KubermaticConfiguration. It's not perfect, as the webhook comes up only after the first installation, but it's still better than nothing.

In the future we might even want to check if all userclusters still are compatible, but this would require some more work and could potentially be slow (the master has to connect to all seeds), so I skipped this for now.

**Does this PR introduce a user-facing change?**:
```release-note
Add webhook to validate KubermaticConfiguration objects
```
