### PR TITLE
extend vSphere provider for default tag category

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -28871,6 +28871,11 @@
           "type": "string",
           "x-go-name": "StoragePolicy"
         },
+        "tagCategoryID": {
+          "description": "This is category for the machine deployment tags",
+          "type": "string",
+          "x-go-name": "TagCategoryID"
+        },
         "username": {
           "description": "Username is the vSphere user name.\n+optional",
           "type": "string",

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -801,6 +801,9 @@ type VSphereCloudSpec struct {
 
 	// This user will be used for everything except cloud provider functionality
 	InfraManagementUser VSphereCredentials `json:"infraManagementUser"`
+
+	// This is category for the machine deployment tags
+	TagCategoryID string `json:"tagCategoryID,omitempty"`
 }
 
 // BringYourOwnCloudSpec specifies access data for a bring your own cluster.

--- a/pkg/provider/cloud/vsphere/category.go
+++ b/pkg/provider/cloud/vsphere/category.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/vapi/tags"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+)
+
+func categoryName(cluster *kubermaticv1.Cluster) string {
+	return defaultCategory + cluster.Name
+}
+
+// createTagCategory creates the specified tag category if it does not exist yet.
+func createTagCategory(ctx context.Context, restSession *RESTSession, cluster *kubermaticv1.Cluster) (string, error) {
+	tagManager := tags.NewManager(restSession.Client)
+	categories, err := tagManager.GetCategories(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get tag categories %w", err)
+	}
+
+	defaultCategoryName := categoryName(cluster)
+
+	for _, category := range categories {
+		if category.Name == defaultCategoryName {
+			return category.ID, nil
+		}
+	}
+
+	return tagManager.CreateCategory(ctx, &tags.Category{
+		Name:        defaultCategoryName,
+		Cardinality: "MULTIPLE",
+	})
+}
+
+// deleteTagCategory deletes the tag category.
+func deleteTagCategory(ctx context.Context, restSession *RESTSession, cluster *kubermaticv1.Cluster) error {
+	tagManager := tags.NewManager(restSession.Client)
+	categories, err := tagManager.GetCategories(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get tag categories %w", err)
+	}
+
+	defaultCategoryName := categoryName(cluster)
+
+	for _, category := range categories {
+		if category.Name == defaultCategoryName {
+			return tagManager.DeleteCategory(ctx, &tags.Category{ID: category.ID})
+		}
+	}
+
+	return nil
+}

--- a/pkg/provider/cloud/vsphere/client.go
+++ b/pkg/provider/cloud/vsphere/client.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+type RESTSession struct {
+	Client *rest.Client
+}
+
+func newRESTSession(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, username, password string, caBundle *x509.CertPool) (*RESTSession, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/sdk", dc.Endpoint))
+	if err != nil {
+		return nil, err
+	}
+
+	// creating the govmoni Client in roundabout way because we need to set the proper CA bundle: reference https://github.com/vmware/govmomi/issues/1200
+	soapClient := soap.NewClient(u, dc.AllowInsecure)
+	// set our CA bundle
+	soapClient.DefaultTransport().TLSClientConfig.RootCAs = caBundle
+
+	vim25Client, err := vim25.NewClient(ctx, soapClient)
+	if err != nil {
+		return nil, err
+	}
+
+	client := rest.NewClient(vim25Client)
+
+	user := url.UserPassword(username, password)
+	if dc.InfraManagementUser != nil {
+		user = url.UserPassword(dc.InfraManagementUser.Username, dc.InfraManagementUser.Password)
+	}
+
+	if err = client.Login(ctx, user); err != nil {
+		return nil, fmt.Errorf("failed to login: %w", err)
+	}
+
+	return &RESTSession{
+		Client: client,
+	}, nil
+}
+
+// Logout closes the idling vCenter connections.
+func (s *RESTSession) Logout(ctx context.Context) {
+	if err := s.Client.Logout(ctx); err != nil {
+		utilruntime.HandleError(fmt.Errorf("vsphere REST client failed to logout: %w", err))
+	}
+}

--- a/pkg/test/e2e/utils/apiclient/models/v_sphere_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/v_sphere_cloud_spec.go
@@ -46,6 +46,9 @@ type VSphereCloudSpec struct {
 	// StoragePolicy to be used for storage provisioning
 	StoragePolicy string `json:"storagePolicy,omitempty"`
 
+	// This is category for the machine deployment tags
+	TagCategoryID string `json:"tagCategoryID,omitempty"`
+
 	// Username is the vSphere user name.
 	// +optional
 	Username string `json:"username,omitempty"`

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -915,6 +915,9 @@ spec:
                       storagePolicy:
                         description: StoragePolicy to be used for storage provisioning
                         type: string
+                      tagCategoryID:
+                        description: This is category for the machine deployment tags
+                        type: string
                       username:
                         description: Username is the vSphere user name.
                         type: string

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -877,6 +877,9 @@ spec:
                       storagePolicy:
                         description: StoragePolicy to be used for storage provisioning
                         type: string
+                      tagCategoryID:
+                        description: This is category for the machine deployment tags
+                        type: string
                       username:
                         description: Username is the vSphere user name.
                         type: string


### PR DESCRIPTION
**What does this PR do / Why do we need it**: extend vSphere provider for default tag category

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9331


```release-note
Extend vSphere provider for default tag category
```
