### PR TITLE
Handle 'default' Nutanix project as special case

### DIFF
--- a/pkg/provider/cloud/nutanix/api.go
+++ b/pkg/provider/cloud/nutanix/api.go
@@ -103,7 +103,7 @@ func GetSubnets(ctx context.Context, client *ClientSet, clusterName, projectName
 			if entity != nil {
 				if entity.Status != nil &&
 					(entity.Status.ClusterReference == nil || (entity.Status.ClusterReference.UUID != nil && *entity.Status.ClusterReference.UUID == *cluster.Metadata.UUID)) &&
-					(projectName == "" || contains(projectAllowedUUIDs, *entity.Metadata.UUID)) {
+					(projectName == "" || projectName == DefaultProject || contains(projectAllowedUUIDs, *entity.Metadata.UUID)) {
 					subnets = append(subnets, *entity)
 				}
 			}

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -39,6 +39,8 @@ const (
 	categoryDescription = "automatically created by KKP"
 	categoryValuePrefix = "kubernetes-"
 
+	DefaultProject = "default"
+
 	categoryCleanupFinalizer = "kubermatic.k8c.io/cleanup-nutanix-categories"
 )
 

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -487,7 +487,7 @@ func getNutanixProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc
 		DiskSize: nodeSpec.Cloud.Nutanix.DiskSize,
 	}
 
-	if c.Spec.Cloud.Nutanix.ProjectName != "" {
+	if c.Spec.Cloud.Nutanix.ProjectName != "" && c.Spec.Cloud.Nutanix.ProjectName != nutanixprovider.DefaultProject {
 		config.ProjectName = &providerconfig.ConfigVarString{Value: c.Spec.Cloud.Nutanix.ProjectName}
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The "default" project is a special case in Nutanix, it's the same as not defining a project at all. Since it can be selected from the UI, selecting it returns an empty list of subnets. This PR handles that case by omitting project references in downstream calls when the "default" project is selected.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9330

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Correctly handle the 'default' Nutanix project in API calls
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
