### PR TITLE
machine controller health check moved to user-cluster-ctrl-manager

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -43,7 +43,6 @@ func (r *Reconciler) clusterHealth(ctx context.Context, cluster *kubermaticv1.Cl
 		resources.ApiserverDeploymentName:             {healthStatus: &extendedHealth.Apiserver, minReady: 1},
 		resources.ControllerManagerDeploymentName:     {healthStatus: &extendedHealth.Controller, minReady: 1},
 		resources.SchedulerDeploymentName:             {healthStatus: &extendedHealth.Scheduler, minReady: 1},
-		resources.MachineControllerDeploymentName:     {healthStatus: &extendedHealth.MachineController, minReady: 1},
 		resources.OpenVPNServerDeploymentName:         {healthStatus: &extendedHealth.OpenVPN, minReady: 1},
 		resources.UserClusterControllerDeploymentName: {healthStatus: &extendedHealth.UserClusterControllerManager, minReady: 1},
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -1145,7 +1145,7 @@ func (r *reconciler) getMachineControllerHealth(ctx context.Context) (kubermatic
 		return kubermaticv1.HealthStatusDown, err
 	}
 
-	if machineControllerDeploymentHealth == kubermaticv1.HealthStatusUp || machineControllerWebhookDeploymentHealth == kubermaticv1.HealthStatusUp {
+	if machineControllerDeploymentHealth == kubermaticv1.HealthStatusUp && machineControllerWebhookDeploymentHealth == kubermaticv1.HealthStatusUp {
 		return kubermaticv1.HealthStatusUp, nil
 	}
 

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -62,6 +62,15 @@ func RoleCreator() (string, reconciling.RoleCreator) {
 				},
 			},
 			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
 				ResourceNames: []string{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The health check for the Machine controller has been moved to the user-cluster-controller-manager to ensure that:
* the `machineController` deployment is healthy
* the `machineControllerWebhook` deployment is healthy
* the `machineController` `mutatingWebhookConfiguration` has been correctly created.

The last condition is ensured by the fact that when the `healthCheck` function is called, all the needed resources have been created (among which the `machineController` `mutatingWebhookConfiguration`)

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8837 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
