### PR TITLE
remove notion of cluster types from update manager

### DIFF
--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common/vpa"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
@@ -173,13 +172,8 @@ func main() {
 	for _, clusterVersion := range clusterVersions {
 		versionLog := log.With(
 			zap.String("version", clusterVersion.Version.String()),
-			zap.String("cluster-type", clusterVersion.Type),
 		)
-		if clusterVersion.Type != "" && clusterVersion.Type != apiv1.KubernetesClusterType {
-			// TODO: Implement. https://github.com/kubermatic/kubermatic/issues/3623
-			versionLog.Warn("Skipping version because its not for Kubernetes. We only support Kubernetes at the moment")
-			continue
-		}
+
 		versionLog.Info("Collecting images...")
 		images, err := getImagesForVersion(log, clusterVersion, kubermaticConfig, o.addonsPath, kubermaticVersions, caBundle)
 		if err != nil {

--- a/cmd/image-loader/operator.go
+++ b/cmd/image-loader/operator.go
@@ -24,7 +24,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
-	"k8c.io/kubermatic/v2/pkg/semver"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version"
 
 	"sigs.k8s.io/yaml"
@@ -54,15 +53,11 @@ func loadKubermaticConfiguration(log *zap.SugaredLogger, filename string) (*kube
 func getVersionsFromKubermaticConfiguration(config *kubermaticv1.KubermaticConfiguration) []*kubermaticversion.Version {
 	versions := []*kubermaticversion.Version{}
 
-	assembleVersions := func(kind string, configuredVersions []semver.Semver) {
-		for i := range configuredVersions {
-			versions = append(versions, &kubermaticversion.Version{
-				Version: configuredVersions[i].Semver(),
-				Type:    kind,
-			})
-		}
+	for _, v := range config.Spec.Versions.Versions {
+		versions = append(versions, &kubermaticversion.Version{
+			Version: v.Semver(),
+		})
 	}
 
-	assembleVersions("kubernetes", config.Spec.Versions.Versions)
 	return versions
 }

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -8541,6 +8541,7 @@
           {
             "type": "string",
             "x-go-name": "Type",
+            "description": "Type is deprecated and not used anymore.",
             "name": "type",
             "in": "query"
           },
@@ -18533,6 +18534,7 @@
           {
             "type": "string",
             "x-go-name": "Type",
+            "description": "Type is deprecated and not used anymore.",
             "name": "type",
             "in": "query"
           }
@@ -20963,6 +20965,7 @@
           "$ref": "#/definitions/ClusterStatus"
         },
         "type": {
+          "description": "Type is deprecated and not used anymore.",
           "type": "string",
           "x-go-name": "Type"
         }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -790,10 +790,11 @@ type Cluster struct {
 	ObjectMeta      `json:",inline"`
 	Labels          map[string]string `json:"labels,omitempty"`
 	InheritedLabels map[string]string `json:"inheritedLabels,omitempty"`
-	Type            string            `json:"type"`
-	Credential      string            `json:"credential,omitempty"`
-	Spec            ClusterSpec       `json:"spec"`
-	Status          ClusterStatus     `json:"status"`
+	// Type is deprecated and not used anymore.
+	Type       string        `json:"type"`
+	Credential string        `json:"credential,omitempty"`
+	Spec       ClusterSpec   `json:"spec"`
+	Status     ClusterStatus `json:"status"`
 }
 
 // ClusterSpec defines the cluster specification.

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -1036,7 +1036,7 @@ func ValidateClusterSpec(updateManager common.UpdateManager, body apiv1.CreateCl
 	if err != nil {
 		return fmt.Errorf("failed to get the cloud provider name: %w", err)
 	}
-	versions, err := updateManager.GetVersionsV2(body.Cluster.Type, kubermaticv1.ProviderType(providerName))
+	versions, err := updateManager.GetVersionsForProvider(kubermaticv1.ProviderType(providerName))
 	if err != nil {
 		return fmt.Errorf("failed to get available cluster versions: %w", err)
 	}

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -77,7 +77,7 @@ func GetUpgradesEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGe
 
 	versionManager := version.NewFromConfiguration(config)
 
-	versions, err := versionManager.GetPossibleUpdates(cluster.Spec.Version.String(), apiv1.KubernetesClusterType, kubermaticv1.ProviderType(providerName), updateConditions...)
+	versions, err := versionManager.GetPossibleUpdates(cluster.Spec.Version.String(), kubermaticv1.ProviderType(providerName), updateConditions...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -261,7 +261,7 @@ func (r CreateReq) Validate(updateManager common.UpdateManager) error {
 	if err != nil {
 		return fmt.Errorf("failed to get the cloud provider name: %w", err)
 	}
-	versions, err := updateManager.GetVersionsV2(r.Body.Cluster.Type, kubermaticv1.ProviderType(providerName))
+	versions, err := updateManager.GetVersionsForProvider(kubermaticv1.ProviderType(providerName))
 	if err != nil {
 		return fmt.Errorf("failed to get available cluster versions: %w", err)
 	}

--- a/pkg/handler/v1/cluster/upgrade.go
+++ b/pkg/handler/v1/cluster/upgrade.go
@@ -87,7 +87,7 @@ func GetNodeUpgrades(configGetter provider.KubermaticConfigurationGetter) endpoi
 			return nil, fmt.Errorf("failed to parse control plane version: %w", err)
 		}
 
-		versions, err := version.NewFromConfiguration(config).GetVersions(req.Type)
+		versions, err := version.NewFromConfiguration(config).GetVersions()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get master versions: %w", err)
 		}
@@ -161,7 +161,7 @@ func GetMasterVersionsEndpoint(configGetter provider.KubermaticConfigurationGett
 			return nil, err
 		}
 
-		versions, err := version.NewFromConfiguration(config).GetVersions(req.Type)
+		versions, err := version.NewFromConfiguration(config).GetVersions()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get master versions: %w", err)
 		}
@@ -171,27 +171,18 @@ func GetMasterVersionsEndpoint(configGetter provider.KubermaticConfigurationGett
 
 // TypeReq represents a request that contains the cluster type.
 type TypeReq struct {
+	// Type is deprecated and not used anymore.
 	// in: query
 	Type string `json:"type"`
 }
 
 func (r TypeReq) Validate() error {
-	if handlercommon.ClusterTypes.Has(r.Type) {
-		return nil
-	}
-	return fmt.Errorf("invalid cluster type %s", r.Type)
+	return nil
 }
 
 // DecodeAddReq  decodes an HTTP request into TypeReq.
 func DecodeClusterTypeReq(c context.Context, r *http.Request) (interface{}, error) {
-	var req TypeReq
-
-	req.Type = r.URL.Query().Get("type")
-	if len(req.Type) == 0 {
-		req.Type = apiv1.KubernetesClusterType
-	}
-
-	return req, nil
+	return TypeReq{}, nil
 }
 
 func convertVersionsToExternal(versions []*version.Version) []*apiv1.MasterVersion {

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -74,11 +74,10 @@ type OIDCConfiguration struct {
 
 // UpdateManager specifies a set of methods to handle cluster versions & updates.
 type UpdateManager interface {
-	GetVersions(string) ([]*version.Version, error)
-	// TODO: GetVersionsV2 is a temporary function that will replace GetVersions once the new handler will be used by the UI (https://github.com/kubermatic/kubermatic/pull/7590)
-	GetVersionsV2(string, kubermaticv1.ProviderType, ...kubermaticv1.ConditionType) ([]*version.Version, error)
+	GetVersions() ([]*version.Version, error)
+	GetVersionsForProvider(kubermaticv1.ProviderType, ...kubermaticv1.ConditionType) ([]*version.Version, error)
 	GetDefault() (*version.Version, error)
-	GetPossibleUpdates(from, clusterType string, provider kubermaticv1.ProviderType, condition ...kubermaticv1.ConditionType) ([]*version.Version, error)
+	GetPossibleUpdates(from string, provider kubermaticv1.ProviderType, condition ...kubermaticv1.ConditionType) ([]*version.Version, error)
 }
 
 type SupportManager interface {

--- a/pkg/handler/v2/version/version.go
+++ b/pkg/handler/v2/version/version.go
@@ -37,6 +37,7 @@ type listProviderVersionsReq struct {
 	// in: path
 	// required: true
 	ProviderName string `json:"provider_name"`
+	// Type is deprecated and not used anymore.
 	// in: query
 	Type string `json:"type"`
 }
@@ -85,7 +86,7 @@ func ListVersions(configGetter provider.KubermaticConfigurationGetter) endpoint.
 			return nil, err
 		}
 
-		versions, err := version.NewFromConfiguration(config).GetVersionsV2(req.Type, kubermaticv1.ProviderType(req.ProviderName))
+		versions, err := version.NewFromConfiguration(config).GetVersionsForProvider(kubermaticv1.ProviderType(req.ProviderName))
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, err.Error())
 		}

--- a/pkg/test/e2e/utils/apiclient/client/version/list_versions_by_provider_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/version/list_versions_by_provider_parameters.go
@@ -62,7 +62,10 @@ type ListVersionsByProviderParams struct {
 	// ProviderName.
 	ProviderName string
 
-	// Type.
+	/* Type.
+
+	   Type is deprecated and not used anymore.
+	*/
 	Type *string
 
 	timeout    time.Duration

--- a/pkg/test/e2e/utils/apiclient/client/versions/get_node_upgrades_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/versions/get_node_upgrades_parameters.go
@@ -62,7 +62,10 @@ type GetNodeUpgradesParams struct {
 	// ControlPlaneVersion.
 	ControlPlaneVersion *string
 
-	// Type.
+	/* Type.
+
+	   Type is deprecated and not used anymore.
+	*/
 	Type *string
 
 	timeout    time.Duration

--- a/pkg/test/e2e/utils/apiclient/models/cluster.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster.go
@@ -49,7 +49,7 @@ type Cluster struct {
 	// Name represents human readable name for the resource
 	Name string `json:"name,omitempty"`
 
-	// type
+	// Type is deprecated and not used anymore.
 	Type string `json:"type,omitempty"`
 
 	// spec

--- a/pkg/version/helpers.go
+++ b/pkg/version/helpers.go
@@ -21,19 +21,18 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
 
 func IsSupported(version *semver.Version, provider kubermaticv1.ProviderType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
-	return checkProviderCompatibility(version, provider, v1.KubernetesClusterType, kubermaticv1.SupportOperation, incompatibilities, conditions...)
+	return checkProviderCompatibility(version, provider, kubermaticv1.SupportOperation, incompatibilities, conditions...)
 }
 
-func checkProviderCompatibility(version *semver.Version, provider kubermaticv1.ProviderType, clusterType string, operation kubermaticv1.OperationType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
+func checkProviderCompatibility(version *semver.Version, provider kubermaticv1.ProviderType, operation kubermaticv1.OperationType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
 	var compatible = true
 	var err error
 	for _, pi := range incompatibilities {
-		if pi.Provider == provider && pi.Type == clusterType && operation == pi.Operation {
+		if pi.Provider == provider && operation == pi.Operation {
 			if pi.Condition == kubermaticv1.AlwaysCondition {
 				compatible, err = CheckUnconstrained(version, pi.Version)
 				if err != nil {

--- a/pkg/version/manager_test.go
+++ b/pkg/version/manager_test.go
@@ -69,7 +69,7 @@ func TestAutomaticNodeUpdate(t *testing.T) {
 					{Version: semver.MustParse(tc.updates[0].To)},
 				},
 			}
-			version, err := m.AutomaticNodeUpdate(tc.fromVersion, "", tc.controlPlaneVersion)
+			version, err := m.AutomaticNodeUpdate(tc.fromVersion, tc.controlPlaneVersion)
 			// a simple err comparison considers them different, because they contain different
 			// semver pointers, even thought their value is equal
 			if !reflect.DeepEqual(err, tc.expectedError) {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
 
@@ -31,7 +30,6 @@ func TestAutomaticUpdate(t *testing.T) {
 	tests := []struct {
 		name            string
 		manager         *Manager
-		clusterType     string
 		versionFrom     string
 		expectedVersion string
 		expectedError   string
@@ -40,24 +38,20 @@ func TestAutomaticUpdate(t *testing.T) {
 			name:            "test best automatic update for kubernetes cluster",
 			versionFrom:     "1.10.0",
 			expectedVersion: "1.10.1",
-			clusterType:     apiv1.KubernetesClusterType,
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.10.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.10.1"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, []*Update{
 				{
 					From:      "1.10.0",
 					To:        "1.10.1",
 					Automatic: true,
-					Type:      apiv1.KubernetesClusterType,
 				},
 			}, nil),
 		},
@@ -65,31 +59,27 @@ func TestAutomaticUpdate(t *testing.T) {
 			name:            "test Kubernetes best automatic update with wild card for kubernetes cluster",
 			versionFrom:     "1.10.0",
 			expectedVersion: "1.10.1",
-			clusterType:     apiv1.KubernetesClusterType,
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.10.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.10.1"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, []*Update{
 				{
 					From:      "1.10.*",
 					To:        "1.10.1",
 					Automatic: true,
-					Type:      apiv1.KubernetesClusterType,
 				},
 			}, nil),
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			updateVersion, err := tc.manager.AutomaticControlplaneUpdate(tc.versionFrom, tc.clusterType)
+			updateVersion, err := tc.manager.AutomaticControlplaneUpdate(tc.versionFrom)
 
 			if len(tc.expectedError) > 0 {
 				if err == nil {
@@ -116,25 +106,21 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 	tests := []struct {
 		name             string
 		manager          *Manager
-		clusterType      string
 		conditions       []kubermaticv1.ConditionType
 		provider         kubermaticv1.ProviderType
 		expectedVersions []*Version
 	}{
 		{
-			name:        "No incompatibility for given provider",
-			provider:    kubermaticv1.AWSCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
+			name:     "No incompatibility for given provider",
+			provider: kubermaticv1.AWSCloudProvider,
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, nil,
 				[]*ProviderIncompatibility{
@@ -142,7 +128,6 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 						Provider:  kubermaticv1.VSphereCloudProvider,
 						Version:   "1.22.*",
 						Operation: kubermaticv1.CreateOperation,
-						Type:      apiv1.KubernetesClusterType,
 					},
 				}),
 			expectedVersions: []*Version{
@@ -155,19 +140,16 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			},
 		},
 		{
-			name:        "Always Incompatibility for given provider",
-			provider:    kubermaticv1.VSphereCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
+			name:     "Always Incompatibility for given provider",
+			provider: kubermaticv1.VSphereCloudProvider,
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, nil,
 				[]*ProviderIncompatibility{
@@ -176,7 +158,6 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 						Version:   "1.22.*",
 						Operation: kubermaticv1.CreateOperation,
 						Condition: kubermaticv1.AlwaysCondition,
-						Type:      apiv1.KubernetesClusterType,
 					},
 				}),
 			expectedVersions: []*Version{
@@ -186,20 +167,17 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			},
 		},
 		{
-			name:        "Matching Incompatibility for given provider",
-			provider:    kubermaticv1.VSphereCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
-			conditions:  []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
+			name:       "Matching Incompatibility for given provider",
+			provider:   kubermaticv1.VSphereCloudProvider,
+			conditions: []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, nil,
 				[]*ProviderIncompatibility{
@@ -208,7 +186,6 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 						Version:   "1.22.*",
 						Operation: kubermaticv1.CreateOperation,
 						Condition: kubermaticv1.ExternalCloudProviderCondition,
-						Type:      apiv1.KubernetesClusterType,
 					},
 				}),
 			expectedVersions: []*Version{
@@ -218,19 +195,16 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			},
 		},
 		{
-			name:        "Multiple Incompatibilities for different providers",
-			provider:    kubermaticv1.VSphereCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
+			name:     "Multiple Incompatibilities for different providers",
+			provider: kubermaticv1.VSphereCloudProvider,
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, nil,
 				[]*ProviderIncompatibility{
@@ -239,14 +213,12 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 						Version:   "1.21.*",
 						Operation: kubermaticv1.CreateOperation,
 						Condition: kubermaticv1.AlwaysCondition,
-						Type:      apiv1.KubernetesClusterType,
 					},
 					{
 						Provider:  kubermaticv1.AWSCloudProvider,
 						Version:   "1.22.*",
 						Operation: kubermaticv1.CreateOperation,
 						Condition: kubermaticv1.AlwaysCondition,
-						Type:      apiv1.KubernetesClusterType,
 					},
 				}),
 			expectedVersions: []*Version{
@@ -258,7 +230,7 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			availableVersions, err := tc.manager.GetVersionsV2(tc.clusterType, tc.provider, tc.conditions...)
+			availableVersions, err := tc.manager.GetVersionsForProvider(tc.provider, tc.conditions...)
 			if err != nil {
 				t.Fatalf("unexpected error %s", err)
 			}
@@ -297,7 +269,6 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 	tests := []struct {
 		name             string
 		manager          *Manager
-		clusterType      string
 		provider         kubermaticv1.ProviderType
 		fromVersion      string
 		conditions       []kubermaticv1.ConditionType
@@ -306,31 +277,26 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 		{
 			name:        "Check with no incompatibility for given provider",
 			provider:    kubermaticv1.AWSCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
 			fromVersion: "1.21.0",
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, []*Update{
 				{
 					From:      "1.21.*",
 					To:        "1.22.*",
 					Automatic: true,
-					Type:      apiv1.KubernetesClusterType,
 				},
 			}, []*ProviderIncompatibility{
 				{
 					Provider:  kubermaticv1.VSphereCloudProvider,
 					Version:   "1.22.*",
-					Type:      apiv1.KubernetesClusterType,
 					Condition: kubermaticv1.AlwaysCondition,
 					Operation: kubermaticv1.CreateOperation,
 				},
@@ -344,32 +310,27 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 		{
 			name:        "Check with conditioned Incompatibility for given provider",
 			provider:    kubermaticv1.VSphereCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
 			fromVersion: "1.21.0",
 			conditions:  []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, []*Update{
 				{
 					From:      "1.21.*",
 					To:        "1.22.*",
 					Automatic: true,
-					Type:      apiv1.KubernetesClusterType,
 				},
 			}, []*ProviderIncompatibility{
 				{
 					Provider:  kubermaticv1.VSphereCloudProvider,
 					Version:   "1.22.*",
-					Type:      apiv1.KubernetesClusterType,
 					Operation: kubermaticv1.UpdateOperation,
 					Condition: kubermaticv1.ExternalCloudProviderCondition,
 				},
@@ -379,31 +340,26 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 		{
 			name:        "Check with unconditioned Incompatibility for given provider",
 			provider:    kubermaticv1.VSphereCloudProvider,
-			clusterType: apiv1.KubernetesClusterType,
 			fromVersion: "1.21.0",
 			manager: New([]*Version{
 				{
 					Version: semver.MustParse("1.21.0"),
 					Default: true,
-					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.22.0"),
 					Default: false,
-					Type:    apiv1.KubernetesClusterType,
 				},
 			}, []*Update{
 				{
 					From:      "1.21.*",
 					To:        "1.22.*",
 					Automatic: true,
-					Type:      apiv1.KubernetesClusterType,
 				},
 			}, []*ProviderIncompatibility{
 				{
 					Provider:  kubermaticv1.VSphereCloudProvider,
 					Version:   "1.22.*",
-					Type:      apiv1.KubernetesClusterType,
 					Condition: kubermaticv1.ExternalCloudProviderCondition,
 				},
 			}),
@@ -416,7 +372,7 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			availableVersions, err := tc.manager.GetPossibleUpdates(tc.fromVersion, tc.clusterType, tc.provider, tc.conditions...)
+			availableVersions, err := tc.manager.GetPossibleUpdates(tc.fromVersion, tc.provider, tc.conditions...)
 			if err != nil {
 				t.Fatalf("unexpected error %s", err)
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The concept of different cluster types has been removed at least in 2.20, if not much earlier (openshift support has been long, looooong abandoned for KKP). This PR removes the remnants from the UpdateManager and renames the "GetVersionsV2" to a more permanent name, seeing how we will probably not soon get rid of it.

I marked the "Type" field in our API as deprecated and removed all related code, so that even bogus values will not a validation error anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
