### PR TITLE
Add version label to control plane components

### DIFF
--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +29,7 @@ const (
 	NameLabel = "app.kubernetes.io/name"
 
 	// VersionLabel is the label containing the application's version.
-	VersionLabel = "app.kubernetes.io/version"
+	VersionLabel = resources.VersionLabel
 
 	// InstanceLabel is A unique name identifying the instance of an application.
 	InstanceLabel = "app.kubernetes.io/instance"

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -74,7 +74,11 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 			volumes := getVolumes(data.IsKonnectivityEnabled())
 			volumeMounts := getVolumeMounts(data.IsKonnectivityEnabled())
 
-			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			version := data.Cluster().Spec.Version.Semver()
+
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, map[string]string{
+				resources.VersionLabel: version.String(),
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -138,7 +142,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 			apiserverContainer := &corev1.Container{
 				Name:    resources.ApiserverDeploymentName,
-				Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-apiserver:v" + data.Cluster().Spec.Version.String(),
+				Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-apiserver:v" + version.String(),
 				Command: []string{"/usr/local/bin/kube-apiserver"},
 				Env:     envVars,
 				Args:    flags,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -60,6 +60,8 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Name = resources.ControllerManagerDeploymentName
 			dep.Labels = resources.BaseAppLabels(name, nil)
 
+			version := data.Cluster().Spec.Version.Semver()
+
 			flags, err := getFlags(data)
 			if err != nil {
 				return nil, err
@@ -90,7 +92,9 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				volumes = append(volumes, serviceAccountVolume)
 			}
 
-			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, map[string]string{
+				resources.VersionLabel: version.String(),
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +149,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-controller-manager:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-controller-manager:v" + version.String(),
 					Command: []string{"/usr/local/bin/kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -377,6 +377,8 @@ const (
 	AppLabelKey = "app"
 	// ClusterLabelKey defines the label key for the cluster name.
 	ClusterLabelKey = "cluster"
+	// VersionLabel is the label containing the application's version.
+	VersionLabel = "app.kubernetes.io/version"
 
 	// EtcdClusterSize defines the size of the etcd to use.
 	EtcdClusterSize = 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.20.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.20.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.21.0
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.21.0
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        app.kubernetes.io/version: 1.22.1
         audit-config-configmap-revision: "123456"
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: controller-manager
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        app.kubernetes.io/version: 1.22.1
         ca-bundle-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cluster: de-test-01


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR is part of #5949. To handle gradual deployments of the control plane, a new update controller will smartly slowly roll out first the apiserver, then the rest of the control plane etc.

To keep the review simple, I split the branch into multiple PRs and this is the second one (after #9337). This PR adds a version label to the control plane components, so that the new update controller will be able to easily and reliably tell which version is currently active, without having to rely on parding Docker images.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
