### PR TITLE
run lint job when Go dependencies change

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -89,7 +89,7 @@ presubmits:
           value: ee
 
   - name: pre-kubermatic-lint
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    run_if_changed: "^(cmd/|codegen/|hack/|pkg/|go.mod|go.sum)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
When updating dependencies, functions can become deprecated. This is something the lint job can catch, and so we should run it for go.mod/sum changes as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
