### PR TITLE
refactoring provider cluster spec

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13159,6 +13159,13 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13170,13 +13177,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
           }
         ],
         "responses": {
@@ -18974,9 +18974,6 @@
           "type": "string",
           "x-go-name": "ClientSecret"
         },
-        "clusterSpec": {
-          "$ref": "#/definitions/AKSClusterSpec"
-        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -22315,9 +22312,6 @@
           "type": "string",
           "x-go-name": "AccessKeyID"
         },
-        "clusterSpec": {
-          "$ref": "#/definitions/EKSClusterSpec"
-        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -23086,6 +23080,15 @@
       "type": "object",
       "title": "ExternalClusterSpec defines the external cluster specification.",
       "properties": {
+        "aksclusterSpec": {
+          "$ref": "#/definitions/AKSClusterSpec"
+        },
+        "eksclusterSpec": {
+          "$ref": "#/definitions/EKSClusterSpec"
+        },
+        "gkeclusterSpec": {
+          "$ref": "#/definitions/GKEClusterSpec"
+        },
         "version": {
           "$ref": "#/definitions/Semver"
         }
@@ -23524,9 +23527,6 @@
     "GKECloudSpec": {
       "type": "object",
       "properties": {
-        "clusterSpec": {
-          "$ref": "#/definitions/GKEClusterSpec"
-        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -28511,6 +28511,9 @@
           "description": "Name is human readable name for the external cluster",
           "type": "string",
           "x-go-name": "Name"
+        },
+        "spec": {
+          "$ref": "#/definitions/ExternalClusterSpec"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/handler/v2/external_cluster"

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -434,6 +434,10 @@ type ExternalClusterStatus struct {
 type ExternalClusterSpec struct {
 	// Version desired version of the kubernetes master components
 	Version ksemver.Semver `json:"version,omitempty"`
+
+	GKEClusterSpec *GKEClusterSpec `json:"gkeclusterSpec,omitempty"`
+	EKSClusterSpec *EKSClusterSpec `json:"eksclusterSpec,omitempty"`
+	AKSClusterSpec *AKSClusterSpec `json:"aksclusterSpec,omitempty"`
 }
 
 // ExternalClusterCloudSpec represents an object holding cluster cloud details
@@ -553,18 +557,16 @@ type KubeOneNutanixCloudSpec struct {
 }
 
 type GKECloudSpec struct {
-	Name           string          `json:"name"`
-	ServiceAccount string          `json:"serviceAccount,omitempty"`
-	Zone           string          `json:"zone"`
-	ClusterSpec    *GKEClusterSpec `json:"clusterSpec,omitempty"`
+	Name           string `json:"name"`
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+	Zone           string `json:"zone"`
 }
 
 type EKSCloudSpec struct {
-	Name            string          `json:"name"`
-	AccessKeyID     string          `json:"accessKeyID,omitempty" required:"true"`
-	SecretAccessKey string          `json:"secretAccessKey,omitempty" required:"true"`
-	Region          string          `json:"region" required:"true"`
-	ClusterSpec     *EKSClusterSpec `json:"clusterSpec,omitempty"`
+	Name            string `json:"name"`
+	AccessKeyID     string `json:"accessKeyID,omitempty" required:"true"`
+	SecretAccessKey string `json:"secretAccessKey,omitempty" required:"true"`
+	Region          string `json:"region" required:"true"`
 }
 
 type EKSClusterSpec struct {
@@ -594,13 +596,12 @@ type EKSClusterSpec struct {
 }
 
 type AKSCloudSpec struct {
-	Name           string          `json:"name"`
-	TenantID       string          `json:"tenantID,omitempty" required:"true"`
-	SubscriptionID string          `json:"subscriptionID,omitempty" required:"true"`
-	ClientID       string          `json:"clientID,omitempty" required:"true"`
-	ClientSecret   string          `json:"clientSecret,omitempty" required:"true"`
-	ResourceGroup  string          `json:"resourceGroup" required:"true"`
-	ClusterSpec    *AKSClusterSpec `json:"clusterSpec,omitempty"`
+	Name           string `json:"name"`
+	TenantID       string `json:"tenantID,omitempty" required:"true"`
+	SubscriptionID string `json:"subscriptionID,omitempty" required:"true"`
+	ClientID       string `json:"clientID,omitempty" required:"true"`
+	ClientSecret   string `json:"clientSecret,omitempty" required:"true"`
+	ResourceGroup  string `json:"resourceGroup" required:"true"`
 }
 
 // AKSClusterSpec Azure Kubernetes Service cluster.

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -283,7 +283,7 @@ func checkCreateClusterReqValidity(aksclusterSpec *apiv2.AKSClusterSpec) error {
 	return checkCreatePoolReqValidity(agentPoolProfiles)
 }
 
-func createOrImportAKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, aksClusterSpec *apiv2.AKSClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
+func createOrImportAKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, spec *apiv2.ExternalClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	// check whether required fields for cluster import are provided
 	fields := reflect.ValueOf(cloud.AKS).Elem()
 	for i := 0; i < fields.NumField(); i++ {
@@ -293,11 +293,11 @@ func createOrImportAKSCluster(ctx context.Context, name string, userInfoGetter p
 		}
 	}
 
-	if aksClusterSpec != nil {
-		if err := checkCreateClusterReqValidity(aksClusterSpec); err != nil {
+	if spec != nil && spec.AKSClusterSpec != nil {
+		if err := checkCreateClusterReqValidity(spec.AKSClusterSpec); err != nil {
 			return nil, err
 		}
-		if err := createNewAKSCluster(ctx, aksClusterSpec, cloud.AKS); err != nil {
+		if err := createNewAKSCluster(ctx, spec.AKSClusterSpec, cloud.AKS); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -372,7 +372,7 @@ func createNewEKSCluster(ctx context.Context, eksClusterSpec *apiv2.EKSClusterSp
 	return nil
 }
 
-func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, eksClusterSpec *apiv2.EKSClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
+func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, spec *apiv2.ExternalClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	fields := reflect.ValueOf(cloud.EKS).Elem()
 	for i := 0; i < fields.NumField(); i++ {
 		yourjsonTags := fields.Type().Field(i).Tag.Get("required")
@@ -381,8 +381,8 @@ func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter p
 		}
 	}
 
-	if eksClusterSpec != nil {
-		if err := createNewEKSCluster(ctx, eksClusterSpec, cloud.EKS); err != nil {
+	if spec != nil && spec.EKSClusterSpec != nil {
+		if err := createNewEKSCluster(ctx, spec.EKSClusterSpec, cloud.EKS); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -339,13 +339,13 @@ func DecodeEKSReq(c context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
-func createNewEKSCluster(ctx context.Context, eksCloudSpec *apiv2.EKSCloudSpec) error {
+func createNewEKSCluster(ctx context.Context, eksClusterSpec *apiv2.EKSClusterSpec, eksCloudSpec *apiv2.EKSCloudSpec) error {
 	client, err := awsprovider.GetClientSet(eksCloudSpec.AccessKeyID, eksCloudSpec.SecretAccessKey, "", "", eksCloudSpec.Region)
 	if err != nil {
 		return err
 	}
 
-	clusterSpec := eksCloudSpec.ClusterSpec
+	clusterSpec := eksClusterSpec
 
 	fields := reflect.ValueOf(clusterSpec).Elem()
 	for i := 0; i < fields.NumField(); i++ {
@@ -372,7 +372,7 @@ func createNewEKSCluster(ctx context.Context, eksCloudSpec *apiv2.EKSCloudSpec) 
 	return nil
 }
 
-func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
+func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, eksClusterSpec *apiv2.EKSClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	fields := reflect.ValueOf(cloud.EKS).Elem()
 	for i := 0; i < fields.NumField(); i++ {
 		yourjsonTags := fields.Type().Field(i).Tag.Get("required")
@@ -381,8 +381,8 @@ func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter p
 		}
 	}
 
-	if cloud.EKS.ClusterSpec != nil {
-		if err := createNewEKSCluster(ctx, cloud.EKS); err != nil {
+	if eksClusterSpec != nil {
+		if err := createNewEKSCluster(ctx, eksClusterSpec, cloud.EKS); err != nil {
 			return nil, err
 		}
 	}
@@ -873,7 +873,7 @@ func getEKSClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 		}
 	}
 
-	apiCluster.Cloud.EKS.ClusterSpec = clusterSpec
+	apiCluster.Spec.EKSClusterSpec = clusterSpec
 	return apiCluster, nil
 }
 

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -72,6 +72,7 @@ type body struct {
 	// Kubeconfig Base64 encoded kubeconfig
 	Kubeconfig string                          `json:"kubeconfig,omitempty"`
 	Cloud      *apiv2.ExternalClusterCloudSpec `json:"cloud,omitempty"`
+	Spec       *apiv2.ExternalClusterSpec      `json:"spec,omitempty"`
 }
 
 func DecodeCreateReq(c context.Context, r *http.Request) (interface{}, error) {
@@ -174,6 +175,7 @@ func CreateEndpoint(
 		}
 
 		cloud := req.Body.Cloud
+		spec := req.Body.Spec
 
 		// connect cluster by kubeconfig
 		if cloud == nil {
@@ -219,7 +221,7 @@ func CreateEndpoint(
 					req.Body.Cloud.GKE.ServiceAccount = credentials.ServiceAccount
 				}
 			}
-			createdCluster, err := createOrImportGKECluster(ctx, req.Body.Name, userInfoGetter, project, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := createOrImportGKECluster(ctx, req.Body.Name, userInfoGetter, project, spec.GKEClusterSpec, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -236,7 +238,7 @@ func CreateEndpoint(
 				}
 			}
 
-			createdCluster, err := createOrImportEKSCluster(ctx, req.Body.Name, userInfoGetter, project, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := createOrImportEKSCluster(ctx, req.Body.Name, userInfoGetter, project, spec.EKSClusterSpec, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -256,7 +258,7 @@ func CreateEndpoint(
 				}
 			}
 
-			createdCluster, err := createOrImportAKSCluster(ctx, req.Body.Name, userInfoGetter, project, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := createOrImportAKSCluster(ctx, req.Body.Name, userInfoGetter, project, spec.AKSClusterSpec, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -221,7 +221,7 @@ func CreateEndpoint(
 					req.Body.Cloud.GKE.ServiceAccount = credentials.ServiceAccount
 				}
 			}
-			createdCluster, err := createOrImportGKECluster(ctx, req.Body.Name, userInfoGetter, project, spec.GKEClusterSpec, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := createOrImportGKECluster(ctx, req.Body.Name, userInfoGetter, project, spec, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -238,7 +238,7 @@ func CreateEndpoint(
 				}
 			}
 
-			createdCluster, err := createOrImportEKSCluster(ctx, req.Body.Name, userInfoGetter, project, spec.EKSClusterSpec, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := createOrImportEKSCluster(ctx, req.Body.Name, userInfoGetter, project, spec, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -258,7 +258,7 @@ func CreateEndpoint(
 				}
 			}
 
-			createdCluster, err := createOrImportAKSCluster(ctx, req.Body.Name, userInfoGetter, project, spec.AKSClusterSpec, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := createOrImportAKSCluster(ctx, req.Body.Name, userInfoGetter, project, spec, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -109,7 +109,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		// scenario 5
 		{
 			Name:                   "scenario 5: create GKE cluster",
-			Body:                   `{"name":"test", "cloud":{"gke":{"name":"gke-cluster","serviceAccount":"abc","zone":"abc"}}}`,
+			Body:                   `{"name":"test","spec":{}, "cloud":{"gke":{"name":"gke-cluster","serviceAccount":"abc","zone":"abc"}}}`,
 			ExpectedResponse:       `{"id":"%s","name":"test","creationTimestamp":"0001-01-01T00:00:00Z","labels":{"project-id":"my-first-project-ID"},"spec":{},"cloud":{"gke":{"name":"gke-cluster","zone":"abc"}},"status":{"state":"PROVISIONING"}}`,
 			RewriteClusterID:       true,
 			HTTPStatus:             http.StatusCreated,
@@ -119,7 +119,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:                   "scenario 6: create GKE cluster with empty zone",
-			Body:                   `{"name":"test", "cloud":{"gke":{"name":"gke-cluster","serviceAccount":"abc"}}}`,
+			Body:                   `{"name":"test","spec":{}, "cloud":{"gke":{"name":"gke-cluster","serviceAccount":"abc"}}}`,
 			ExpectedResponse:       `{"error":{"code":400,"message":"the GKE cluster name, zone or service account can not be empty"}}`,
 			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,
@@ -128,7 +128,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:                   "scenario 7: create GKE cluster with empty SA",
-			Body:                   `{"name":"test", "cloud":{"gke":{"name":"gke-cluster","zone":"abc"}}}`,
+			Body:                   `{"name":"test","spec":{}, "cloud":{"gke":{"name":"gke-cluster","zone":"abc"}}}`,
 			ExpectedResponse:       `{"error":{"code":400,"message":"the GKE cluster name, zone or service account can not be empty"}}`,
 			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,
@@ -137,7 +137,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:                   "scenario 8: create EKS cluster",
-			Body:                   `{"name":"test", "cloud":{"eks":{"name":"eks-cluster","accessKeyID":"abc","secretAccessKey": "abc", "region":"abc"}}}`,
+			Body:                   `{"name":"test","spec":{}, "cloud":{"eks":{"name":"eks-cluster","accessKeyID":"abc","secretAccessKey": "abc", "region":"abc"}}}`,
 			ExpectedResponse:       `{"id":"%s","name":"test","creationTimestamp":"0001-01-01T00:00:00Z","labels":{"project-id":"my-first-project-ID"},"spec":{},"cloud":{"eks":{"name":"eks-cluster","region":"abc"}},"status":{"state":"PROVISIONING"}}`,
 			RewriteClusterID:       true,
 			HTTPStatus:             http.StatusCreated,
@@ -147,7 +147,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:                   "scenario 9: create EKS cluster with empty region",
-			Body:                   `{"name":"test", "cloud":{"eks":{"name":"eks-cluster","accessKeyID":"abc","secretAccessKey": "abc"}}}`,
+			Body:                   `{"name":"test","spec":{}, "cloud":{"eks":{"name":"eks-cluster","accessKeyID":"abc","secretAccessKey": "abc"}}}`,
 			ExpectedResponse:       `{"error":{"code":400,"message":"required field is missing: Region"}}`,
 			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,
@@ -156,7 +156,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		{
 			Name:                   "scenario 10: create EKS cluster with empty AccessKeyID or SecretAccessKey",
-			Body:                   `{"name":"test", "cloud":{"eks":{"name":"eks-cluster","region":"abc"}}}`,
+			Body:                   `{"name":"test","spec":{}, "cloud":{"eks":{"name":"eks-cluster","region":"abc"}}}`,
 			ExpectedResponse:       `{"error":{"code":400,"message":"required field is missing: AccessKeyID"}}`,
 			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -242,13 +242,13 @@ func listGKEDiskTypes(ctx context.Context, sa string, zone string) (apiv1.GCPDis
 	return diskTypes, err
 }
 
-func createOrImportGKECluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, gkeClusterSpec *apiv2.GKEClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
+func createOrImportGKECluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, spec *apiv2.ExternalClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	if cloud.GKE.Name == "" || cloud.GKE.Zone == "" || cloud.GKE.ServiceAccount == "" {
 		return nil, errors.NewBadRequest("the GKE cluster name, zone or service account can not be empty")
 	}
 
-	if gkeClusterSpec != nil {
-		if err := createNewGKECluster(ctx, gkeClusterSpec, cloud.GKE); err != nil {
+	if spec != nil && spec.GKEClusterSpec != nil {
+		if err := createNewGKECluster(ctx, spec.GKEClusterSpec, cloud.GKE); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -242,13 +242,13 @@ func listGKEDiskTypes(ctx context.Context, sa string, zone string) (apiv1.GCPDis
 	return diskTypes, err
 }
 
-func createOrImportGKECluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
+func createOrImportGKECluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, gkeClusterSpec *apiv2.GKEClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	if cloud.GKE.Name == "" || cloud.GKE.Zone == "" || cloud.GKE.ServiceAccount == "" {
 		return nil, errors.NewBadRequest("the GKE cluster name, zone or service account can not be empty")
 	}
 
-	if cloud.GKE.ClusterSpec != nil {
-		if err := createNewGKECluster(ctx, cloud.GKE); err != nil {
+	if gkeClusterSpec != nil {
+		if err := createNewGKECluster(ctx, gkeClusterSpec, cloud.GKE); err != nil {
 			return nil, err
 		}
 	}
@@ -573,14 +573,14 @@ func createGKENodePool(ctx context.Context, cluster *kubermaticv1.ExternalCluste
 	return &machineDeployment, nil
 }
 
-func createNewGKECluster(ctx context.Context, gkeCloudSpec *apiv2.GKECloudSpec) error {
+func createNewGKECluster(ctx context.Context, gkeClusterSpec *apiv2.GKEClusterSpec, gkeCloudSpec *apiv2.GKECloudSpec) error {
 	svc, project, err := gke.ConnectToContainerService(ctx, gkeCloudSpec.ServiceAccount)
 	if err != nil {
 		return err
 	}
 
 	createRequest := &container.CreateClusterRequest{
-		Cluster: genGKECluster(gkeCloudSpec),
+		Cluster: genGKECluster(gkeClusterSpec, gkeCloudSpec),
 	}
 
 	req := svc.Projects.Zones.Clusters.Create(project, gkeCloudSpec.Zone, createRequest)
@@ -592,72 +592,72 @@ func createNewGKECluster(ctx context.Context, gkeCloudSpec *apiv2.GKECloudSpec) 
 	return nil
 }
 
-func genGKECluster(gkeCloudSpec *apiv2.GKECloudSpec) *container.Cluster {
+func genGKECluster(gkeClusterSpec *apiv2.GKEClusterSpec, gkeCloudSpec *apiv2.GKECloudSpec) *container.Cluster {
 	newCluster := &container.Cluster{
-		ClusterIpv4Cidr:       gkeCloudSpec.ClusterSpec.ClusterIpv4Cidr,
-		InitialClusterVersion: gkeCloudSpec.ClusterSpec.InitialClusterVersion,
-		InitialNodeCount:      gkeCloudSpec.ClusterSpec.InitialNodeCount,
-		Locations:             gkeCloudSpec.ClusterSpec.Locations,
+		ClusterIpv4Cidr:       gkeClusterSpec.ClusterIpv4Cidr,
+		InitialClusterVersion: gkeClusterSpec.InitialClusterVersion,
+		InitialNodeCount:      gkeClusterSpec.InitialNodeCount,
+		Locations:             gkeClusterSpec.Locations,
 		Name:                  gkeCloudSpec.Name,
-		Network:               gkeCloudSpec.ClusterSpec.Network,
-		Subnetwork:            gkeCloudSpec.ClusterSpec.Subnetwork,
-		TpuIpv4CidrBlock:      gkeCloudSpec.ClusterSpec.TpuIpv4CidrBlock,
-		EnableKubernetesAlpha: gkeCloudSpec.ClusterSpec.EnableKubernetesAlpha,
-		EnableTpu:             gkeCloudSpec.ClusterSpec.EnableTpu,
+		Network:               gkeClusterSpec.Network,
+		Subnetwork:            gkeClusterSpec.Subnetwork,
+		TpuIpv4CidrBlock:      gkeClusterSpec.TpuIpv4CidrBlock,
+		EnableKubernetesAlpha: gkeClusterSpec.EnableKubernetesAlpha,
+		EnableTpu:             gkeClusterSpec.EnableTpu,
 		Autopilot: &container.Autopilot{
-			Enabled: gkeCloudSpec.ClusterSpec.Autopilot,
+			Enabled: gkeClusterSpec.Autopilot,
 		},
 		VerticalPodAutoscaling: &container.VerticalPodAutoscaling{
-			Enabled: gkeCloudSpec.ClusterSpec.VerticalPodAutoscaling,
+			Enabled: gkeClusterSpec.VerticalPodAutoscaling,
 		},
 	}
-	if gkeCloudSpec.ClusterSpec.NodeConfig != nil {
+	if gkeClusterSpec.NodeConfig != nil {
 		newCluster.NodeConfig = &container.NodeConfig{
-			DiskSizeGb:    gkeCloudSpec.ClusterSpec.NodeConfig.DiskSizeGb,
-			DiskType:      gkeCloudSpec.ClusterSpec.NodeConfig.DiskType,
-			ImageType:     gkeCloudSpec.ClusterSpec.NodeConfig.ImageType,
-			Labels:        gkeCloudSpec.ClusterSpec.NodeConfig.Labels,
-			LocalSsdCount: gkeCloudSpec.ClusterSpec.NodeConfig.LocalSsdCount,
-			MachineType:   gkeCloudSpec.ClusterSpec.NodeConfig.MachineType,
-			Preemptible:   gkeCloudSpec.ClusterSpec.NodeConfig.Preemptible,
+			DiskSizeGb:    gkeClusterSpec.NodeConfig.DiskSizeGb,
+			DiskType:      gkeClusterSpec.NodeConfig.DiskType,
+			ImageType:     gkeClusterSpec.NodeConfig.ImageType,
+			Labels:        gkeClusterSpec.NodeConfig.Labels,
+			LocalSsdCount: gkeClusterSpec.NodeConfig.LocalSsdCount,
+			MachineType:   gkeClusterSpec.NodeConfig.MachineType,
+			Preemptible:   gkeClusterSpec.NodeConfig.Preemptible,
 		}
 	}
-	if gkeCloudSpec.ClusterSpec.Autoscaling != nil {
+	if gkeClusterSpec.Autoscaling != nil {
 		newCluster.Autoscaling = &container.ClusterAutoscaling{
-			AutoprovisioningLocations:  gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningLocations,
-			EnableNodeAutoprovisioning: gkeCloudSpec.ClusterSpec.Autoscaling.EnableNodeAutoprovisioning,
+			AutoprovisioningLocations:  gkeClusterSpec.Autoscaling.AutoprovisioningLocations,
+			EnableNodeAutoprovisioning: gkeClusterSpec.Autoscaling.EnableNodeAutoprovisioning,
 		}
-		if gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults != nil {
+		if gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults != nil {
 			newCluster.Autoscaling.AutoprovisioningNodePoolDefaults = &container.AutoprovisioningNodePoolDefaults{
-				BootDiskKmsKey: gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.BootDiskKmsKey,
-				DiskSizeGb:     gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.DiskSizeGb,
-				DiskType:       gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.DiskType,
-				MinCpuPlatform: gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.MinCpuPlatform,
-				OauthScopes:    gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.OauthScopes,
-				ServiceAccount: gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ServiceAccount,
+				BootDiskKmsKey: gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.BootDiskKmsKey,
+				DiskSizeGb:     gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.DiskSizeGb,
+				DiskType:       gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.DiskType,
+				MinCpuPlatform: gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.MinCpuPlatform,
+				OauthScopes:    gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.OauthScopes,
+				ServiceAccount: gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ServiceAccount,
 			}
-			if gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.Management != nil {
+			if gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.Management != nil {
 				newCluster.Autoscaling.AutoprovisioningNodePoolDefaults.Management = &container.NodeManagement{
-					AutoRepair:  gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.Management.AutoRepair,
-					AutoUpgrade: gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.Management.AutoUpgrade,
+					AutoRepair:  gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.Management.AutoRepair,
+					AutoUpgrade: gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.Management.AutoUpgrade,
 				}
 			}
-			if gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings != nil {
+			if gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings != nil {
 				newCluster.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings = &container.UpgradeSettings{
-					MaxSurge:       gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings.MaxSurge,
-					MaxUnavailable: gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings.MaxUnavailable,
+					MaxSurge:       gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings.MaxSurge,
+					MaxUnavailable: gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.UpgradeSettings.MaxUnavailable,
 				}
 			}
-			if gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig != nil {
+			if gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig != nil {
 				newCluster.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig = &container.ShieldedInstanceConfig{
-					EnableIntegrityMonitoring: gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig.EnableIntegrityMonitoring,
-					EnableSecureBoot:          gkeCloudSpec.ClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig.EnableSecureBoot,
+					EnableIntegrityMonitoring: gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig.EnableIntegrityMonitoring,
+					EnableSecureBoot:          gkeClusterSpec.Autoscaling.AutoprovisioningNodePoolDefaults.ShieldedInstanceConfig.EnableSecureBoot,
 				}
 			}
 		}
-		if len(gkeCloudSpec.ClusterSpec.Autoscaling.ResourceLimits) != 0 {
-			newCluster.Autoscaling.ResourceLimits = make([]*container.ResourceLimit, len(gkeCloudSpec.ClusterSpec.Autoscaling.ResourceLimits))
-			for _, rl := range gkeCloudSpec.ClusterSpec.Autoscaling.ResourceLimits {
+		if len(gkeClusterSpec.Autoscaling.ResourceLimits) != 0 {
+			newCluster.Autoscaling.ResourceLimits = make([]*container.ResourceLimit, len(gkeClusterSpec.Autoscaling.ResourceLimits))
+			for _, rl := range gkeClusterSpec.Autoscaling.ResourceLimits {
 				newCluster.Autoscaling.ResourceLimits = append(newCluster.Autoscaling.ResourceLimits, &container.ResourceLimit{
 					Maximum:      rl.Maximum,
 					Minimum:      rl.Minimum,
@@ -764,7 +764,7 @@ func getGKEClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 		}
 	}
 
-	apiCluster.Cloud.GKE.ClusterSpec = clusterSpec
+	apiCluster.Spec.GKEClusterSpec = clusterSpec
 
 	return apiCluster, nil
 }

--- a/pkg/test/e2e/utils/apiclient/models/a_k_s_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/a_k_s_cloud_spec.go
@@ -8,7 +8,6 @@ package models
 import (
 	"context"
 
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -35,67 +34,15 @@ type AKSCloudSpec struct {
 
 	// tenant ID
 	TenantID string `json:"tenantID,omitempty"`
-
-	// cluster spec
-	ClusterSpec *AKSClusterSpec `json:"clusterSpec,omitempty"`
 }
 
 // Validate validates this a k s cloud spec
 func (m *AKSCloudSpec) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateClusterSpec(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
 	return nil
 }
 
-func (m *AKSCloudSpec) validateClusterSpec(formats strfmt.Registry) error {
-	if swag.IsZero(m.ClusterSpec) { // not required
-		return nil
-	}
-
-	if m.ClusterSpec != nil {
-		if err := m.ClusterSpec.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("clusterSpec")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-// ContextValidate validate this a k s cloud spec based on the context it is used
+// ContextValidate validates this a k s cloud spec based on context it is used
 func (m *AKSCloudSpec) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.contextValidateClusterSpec(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *AKSCloudSpec) contextValidateClusterSpec(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.ClusterSpec != nil {
-		if err := m.ClusterSpec.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("clusterSpec")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/test/e2e/utils/apiclient/models/body.go
+++ b/pkg/test/e2e/utils/apiclient/models/body.go
@@ -26,6 +26,9 @@ type Body struct {
 
 	// cloud
 	Cloud *ExternalClusterCloudSpec `json:"cloud,omitempty"`
+
+	// spec
+	Spec *ExternalClusterSpec `json:"spec,omitempty"`
 }
 
 // Validate validates this body
@@ -33,6 +36,10 @@ func (m *Body) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateCloud(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSpec(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -59,11 +66,32 @@ func (m *Body) validateCloud(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Body) validateSpec(formats strfmt.Registry) error {
+	if swag.IsZero(m.Spec) { // not required
+		return nil
+	}
+
+	if m.Spec != nil {
+		if err := m.Spec.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("spec")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this body based on the context it is used
 func (m *Body) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.contextValidateCloud(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSpec(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -79,6 +107,20 @@ func (m *Body) contextValidateCloud(ctx context.Context, formats strfmt.Registry
 		if err := m.Cloud.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cloud")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Body) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Spec != nil {
+		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("spec")
 			}
 			return err
 		}

--- a/pkg/test/e2e/utils/apiclient/models/e_k_s_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/e_k_s_cloud_spec.go
@@ -8,7 +8,6 @@ package models
 import (
 	"context"
 
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -29,67 +28,15 @@ type EKSCloudSpec struct {
 
 	// secret access key
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
-
-	// cluster spec
-	ClusterSpec *EKSClusterSpec `json:"clusterSpec,omitempty"`
 }
 
 // Validate validates this e k s cloud spec
 func (m *EKSCloudSpec) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateClusterSpec(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
 	return nil
 }
 
-func (m *EKSCloudSpec) validateClusterSpec(formats strfmt.Registry) error {
-	if swag.IsZero(m.ClusterSpec) { // not required
-		return nil
-	}
-
-	if m.ClusterSpec != nil {
-		if err := m.ClusterSpec.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("clusterSpec")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-// ContextValidate validate this e k s cloud spec based on the context it is used
+// ContextValidate validates this e k s cloud spec based on context it is used
 func (m *EKSCloudSpec) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.contextValidateClusterSpec(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *EKSCloudSpec) contextValidateClusterSpec(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.ClusterSpec != nil {
-		if err := m.ClusterSpec.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("clusterSpec")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/test/e2e/utils/apiclient/models/external_cluster_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/external_cluster_spec.go
@@ -18,6 +18,15 @@ import (
 // swagger:model ExternalClusterSpec
 type ExternalClusterSpec struct {
 
+	// akscluster spec
+	AksclusterSpec *AKSClusterSpec `json:"aksclusterSpec,omitempty"`
+
+	// ekscluster spec
+	EksclusterSpec *EKSClusterSpec `json:"eksclusterSpec,omitempty"`
+
+	// gkecluster spec
+	GkeclusterSpec *GKEClusterSpec `json:"gkeclusterSpec,omitempty"`
+
 	// version
 	Version Semver `json:"version,omitempty"`
 }
@@ -26,6 +35,18 @@ type ExternalClusterSpec struct {
 func (m *ExternalClusterSpec) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAksclusterSpec(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateEksclusterSpec(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateGkeclusterSpec(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateVersion(formats); err != nil {
 		res = append(res, err)
 	}
@@ -33,6 +54,57 @@ func (m *ExternalClusterSpec) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ExternalClusterSpec) validateAksclusterSpec(formats strfmt.Registry) error {
+	if swag.IsZero(m.AksclusterSpec) { // not required
+		return nil
+	}
+
+	if m.AksclusterSpec != nil {
+		if err := m.AksclusterSpec.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("aksclusterSpec")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ExternalClusterSpec) validateEksclusterSpec(formats strfmt.Registry) error {
+	if swag.IsZero(m.EksclusterSpec) { // not required
+		return nil
+	}
+
+	if m.EksclusterSpec != nil {
+		if err := m.EksclusterSpec.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("eksclusterSpec")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ExternalClusterSpec) validateGkeclusterSpec(formats strfmt.Registry) error {
+	if swag.IsZero(m.GkeclusterSpec) { // not required
+		return nil
+	}
+
+	if m.GkeclusterSpec != nil {
+		if err := m.GkeclusterSpec.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("gkeclusterSpec")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -55,6 +127,18 @@ func (m *ExternalClusterSpec) validateVersion(formats strfmt.Registry) error {
 func (m *ExternalClusterSpec) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateAksclusterSpec(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateEksclusterSpec(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGkeclusterSpec(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateVersion(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -62,6 +146,48 @@ func (m *ExternalClusterSpec) ContextValidate(ctx context.Context, formats strfm
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ExternalClusterSpec) contextValidateAksclusterSpec(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.AksclusterSpec != nil {
+		if err := m.AksclusterSpec.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("aksclusterSpec")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ExternalClusterSpec) contextValidateEksclusterSpec(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.EksclusterSpec != nil {
+		if err := m.EksclusterSpec.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("eksclusterSpec")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ExternalClusterSpec) contextValidateGkeclusterSpec(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.GkeclusterSpec != nil {
+		if err := m.GkeclusterSpec.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("gkeclusterSpec")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/test/e2e/utils/apiclient/models/g_k_e_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/g_k_e_cloud_spec.go
@@ -8,7 +8,6 @@ package models
 import (
 	"context"
 
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -26,67 +25,15 @@ type GKECloudSpec struct {
 
 	// zone
 	Zone string `json:"zone,omitempty"`
-
-	// cluster spec
-	ClusterSpec *GKEClusterSpec `json:"clusterSpec,omitempty"`
 }
 
 // Validate validates this g k e cloud spec
 func (m *GKECloudSpec) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateClusterSpec(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
 	return nil
 }
 
-func (m *GKECloudSpec) validateClusterSpec(formats strfmt.Registry) error {
-	if swag.IsZero(m.ClusterSpec) { // not required
-		return nil
-	}
-
-	if m.ClusterSpec != nil {
-		if err := m.ClusterSpec.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("clusterSpec")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-// ContextValidate validate this g k e cloud spec based on the context it is used
+// ContextValidate validates this g k e cloud spec based on context it is used
 func (m *GKECloudSpec) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.contextValidateClusterSpec(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *GKECloudSpec) contextValidateClusterSpec(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.ClusterSpec != nil {
-		if err := m.ClusterSpec.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("clusterSpec")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
move the provider cluster spec object from provider cloud spec to the external cluster spec

"closes #9341"

```release-note
NONE
```
