### PR TITLE
Fix buildah not using gocache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export GO111MODULE = on
 export KUBERMATIC_EDITION ?= ce
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
-CMD = $(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
+CMD ?= $(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS ?= -v
 GOOS ?= $(shell go env GOOS)
 TAGS ?= $(shell git describe --tags --always)

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -26,10 +26,10 @@ ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
 
 WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
-RUN make -C ./cmd/user-ssh-keys-agent build
+RUN CMD="user-ssh-keys-agent" make build
 
 FROM docker.io/alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY --from=builder /go/src/k8c.io/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

It turns out that GOCACHE is not working if we build the user-ssh-keys-agent binary from the `cmd/user-ssh-keys-agent directory` instead of the root directory. I've tried investigating this, but I couldn't find the root cause. I've been able to reproduce the issue with buildah, Docker, and locally.

This PR modifies the multiarch Dockerfile for `user-ssh-keys-agent` to invoke the build from the root directory. With this change, the time needed to build the multiarch Docker images is 2-3 minutes instead of 15 minutes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```