### PR TITLE
fix user cluster owner

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster_template_instance.go
+++ b/pkg/apis/kubermatic/v1/cluster_template_instance.go
@@ -26,6 +26,9 @@ const (
 	ClusterTemplateInstanceKindName = "ClusterTemplateInstance"
 )
 
+// ClusterTemplateInstanceOwnerAnnotationKey represents the user cluster owner.
+const ClusterTemplateInstanceOwnerAnnotationKey = "owner"
+
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -186,6 +186,13 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	}
 	partialCluster.Spec = template.Spec
 
+	if instance.Annotations != nil && instance.Annotations[kubermaticv1.ClusterTemplateInstanceOwnerAnnotationKey] != "" {
+		if template.Annotations == nil {
+			template.Annotations = map[string]string{}
+		}
+		template.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey] = instance.Annotations[kubermaticv1.ClusterTemplateInstanceOwnerAnnotationKey]
+	}
+
 	newCluster := genNewCluster(template, instance, r.workerName)
 	newStatus := newCluster.Status.DeepCopy()
 

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
@@ -61,9 +61,9 @@ func TestReconcile(t *testing.T) {
 				Name: "my-first-project-ID-ctID2",
 			},
 			expectedClusters: []*kubermaticv1.Cluster{
-				genCluster("ct2-0", "john@acme.com", *test.GenClusterTemplateInstance(projectName, "ctID2", 3)),
-				genCluster("ct2-1", "john@acme.com", *test.GenClusterTemplateInstance(projectName, "ctID2", 3)),
-				genCluster("ct2-2", "john@acme.com", *test.GenClusterTemplateInstance(projectName, "ctID2", 3)),
+				genCluster("ct2-0", "bob@acme.com", *test.GenClusterTemplateInstance(projectName, "ctID2", "bob@acme.com", 3)),
+				genCluster("ct2-1", "bob@acme.com", *test.GenClusterTemplateInstance(projectName, "ctID2", "bob@acme.com", 3)),
+				genCluster("ct2-2", "bob@acme.com", *test.GenClusterTemplateInstance(projectName, "ctID2", "bob@acme.com", 3)),
 			},
 			seedClient: fakectrlruntimeclient.
 				NewClientBuilder().
@@ -73,9 +73,9 @@ func TestReconcile(t *testing.T) {
 					test.GenClusterTemplate("ct2", "ctID2", "", kubermaticv1.GlobalClusterTemplateScope, "john@acme.com"),
 					test.GenClusterTemplate("ct3", "ctID3", projectName, kubermaticv1.UserClusterTemplateScope, "john@acme.com"),
 					test.GenClusterTemplate("ct4", "ctID4", projectName, kubermaticv1.ProjectClusterTemplateScope, "john@acme.com"),
-					test.GenClusterTemplateInstance(projectName, "ctID1", 2),
-					test.GenClusterTemplateInstance(projectName, "ctID2", 3),
-					test.GenClusterTemplateInstance(projectName, "ctID3", 10),
+					test.GenClusterTemplateInstance(projectName, "ctID1", "bob@acme.com", 2),
+					test.GenClusterTemplateInstance(projectName, "ctID2", "bob@acme.com", 3),
+					test.GenClusterTemplateInstance(projectName, "ctID3", "bob@acme.com", 10),
 				).
 				Build(),
 		},

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1852,11 +1852,12 @@ func GenClusterTemplate(name, id, projectID, scope, userEmail string) *kubermati
 	}
 }
 
-func GenClusterTemplateInstance(projectID, templateID string, replicas int64) *kubermaticv1.ClusterTemplateInstance {
+func GenClusterTemplateInstance(projectID, templateID, owner string, replicas int64) *kubermaticv1.ClusterTemplateInstance {
 	return &kubermaticv1.ClusterTemplateInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("%s-%s", projectID, templateID),
-			Labels: map[string]string{kubernetes.ClusterTemplateLabelKey: templateID, kubermaticv1.ProjectIDLabelKey: projectID},
+			Name:        fmt.Sprintf("%s-%s", projectID, templateID),
+			Labels:      map[string]string{kubernetes.ClusterTemplateLabelKey: templateID, kubermaticv1.ProjectIDLabelKey: projectID},
+			Annotations: map[string]string{kubermaticv1.ClusterTemplateInstanceOwnerAnnotationKey: owner},
 		},
 		Spec: kubermaticv1.ClusterTemplateInstanceSpec{
 			ProjectID:         projectID,

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -464,7 +464,7 @@ func CreateInstanceEndpoint(projectProvider provider.ProjectProvider, privileged
 
 		if adminUserInfo.IsAdmin {
 			privilegedclusterTemplateInstanceProvider := clusterTemplateInstanceProvider.(provider.PrivilegedClusterTemplateInstanceProvider)
-			instance, err := privilegedclusterTemplateInstanceProvider.CreateUnsecured(ctx, ct, project, req.Body.Replicas)
+			instance, err := privilegedclusterTemplateInstanceProvider.CreateUnsecured(ctx, adminUserInfo, ct, project, req.Body.Replicas)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/provider/kubernetes/cluster_template_instance.go
+++ b/pkg/provider/kubernetes/cluster_template_instance.go
@@ -79,24 +79,25 @@ func (r ClusterTemplateInstanceProvider) Create(ctx context.Context, userInfo *p
 	if err != nil {
 		return nil, err
 	}
-	instance := createClusterTemplateInstance(template, project, replicas)
+	instance := createClusterTemplateInstance(userInfo, template, project, replicas)
 
 	err = impersonationClient.Create(ctx, instance)
 	return instance, err
 }
 
-func (r ClusterTemplateInstanceProvider) CreateUnsecured(ctx context.Context, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error) {
-	instance := createClusterTemplateInstance(template, project, replicas)
+func (r ClusterTemplateInstanceProvider) CreateUnsecured(ctx context.Context, userInfo *provider.UserInfo, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error) {
+	instance := createClusterTemplateInstance(userInfo, template, project, replicas)
 
 	err := r.privilegedClient.Create(ctx, instance)
 	return instance, err
 }
 
-func createClusterTemplateInstance(template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) *kubermaticv1.ClusterTemplateInstance {
+func createClusterTemplateInstance(userInfo *provider.UserInfo, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) *kubermaticv1.ClusterTemplateInstance {
 	instance := &kubermaticv1.ClusterTemplateInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   GetClusterTemplateInstanceName(project.Name, template.Name),
-			Labels: map[string]string{ClusterTemplateLabelKey: template.Name},
+			Name:        GetClusterTemplateInstanceName(project.Name, template.Name),
+			Labels:      map[string]string{ClusterTemplateLabelKey: template.Name},
+			Annotations: map[string]string{kubermaticv1.ClusterTemplateInstanceOwnerAnnotationKey: userInfo.Email},
 		},
 		Spec: kubermaticv1.ClusterTemplateInstanceSpec{
 			ProjectID:           project.Name,

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -965,7 +965,7 @@ type PrivilegedClusterTemplateInstanceProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to get the resource
-	CreateUnsecured(ctx context.Context, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error)
+	CreateUnsecured(ctx context.Context, userInfo *UserInfo, template *kubermaticv1.ClusterTemplate, project *kubermaticv1.Project, replicas int64) (*kubermaticv1.ClusterTemplateInstance, error)
 
 	// GetUnsecured gets cluster template instance
 	//


### PR DESCRIPTION
**What does this PR do / Why do we need it**: fix user cluster owner. The template contains the user name who created the template but not the user cluster owner. This PR extends the cluster template instance for the cluster owner.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9380

```release-note
Fix user cluster owner when you create a cluster from the template
```
