### PR TITLE
rewrite storeuploader to use cobra

### DIFF
--- a/cmd/s3-storeuploader/README.md
+++ b/cmd/s3-storeuploader/README.md
@@ -1,29 +1,36 @@
-# S3 storer
+# S3 Store Uploader
 
-```bash
-NAME:
-   S3 storer
-
-USAGE:
-   s3-storeuploader [global options] command [command options] [arguments...]
-
-VERSION:
-   v1.0.0
-
-DESCRIPTION:
-   Helper tool to backup files to S3 and maintain a given number of revisions
-
-COMMANDS:
-     store                 Stores the given file on S3
-     delete-old-revisions  Deletes backups which are older than max-revisions
-     delete-all            deletes all backups of the filename
-     help, h               Shows a list of commands or help for one command
-
-GLOBAL OPTIONS:
-   --help, -h     show help
-   --version, -v  print the version
 ```
+Helper tool to backup files to S3 and maintain a given number of revisions
 
+Usage:
+  s3-storeuploader [command]
+
+Available Commands:
+  completion           generate the autocompletion script for the specified shell
+  delete-all           Deletes all backups of the filename
+  delete-old-revisions Deletes backups which are older than max-revisions
+  help                 Help about any command
+  store                Stores the given file on S3
+
+Flags:
+      --access-key-id string       S3 access key ID ($ACCESS_KEY_ID)
+  -b, --bucket string              S3 bucket in which to store the snapshots (default "kubermatic-backups")
+      --ca-bundle string           Filename of the CA bundle to use (if not given, default system certificates are used)
+      --create-bucket              Create the bucket if it does not exist yet
+  -e, --endpoint string            S3 endpoint
+  -f, --file string                Path to the file to store in S3 (default "/backup/snapshot.db")
+  -h, --help                       help for s3-storeuploader
+      --log-debug                  Enables debug logging
+      --log-format string          Log format, one of JSON, Console (default "JSON")
+      --max-revisions int          Maximum number of revisions of the file to keep in S3. Older ones will be deleted (default 20)
+  -p, --prefix string              Prefix to use for all objects stored in S3
+      --secret-access-key string   S3 secret access key ($SECRET_ACCESS_KEY)
+      --secure                     Enable TLS validation
+  -v, --version                    version for s3-storeuploader
+
+Use "s3-storeuploader [command] --help" for more information about a command.
+```
 
 # Building the docker image
 

--- a/cmd/s3-storeuploader/main.go
+++ b/cmd/s3-storeuploader/main.go
@@ -17,12 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"crypto/x509"
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/log"
@@ -30,162 +29,105 @@ import (
 	"k8c.io/kubermatic/v2/pkg/storeuploader"
 )
 
-var logger *zap.SugaredLogger
+type options struct {
+	Endpoint string
+	Secure   bool
+	CABundle string
+
+	AccessKeyID     string
+	SecretAccessKey string
+
+	Bucket       string
+	CreateBucket bool
+	Prefix       string
+	File         string
+	MaxRevisions int
+
+	LogOptions log.Options
+}
 
 func main() {
-	app := cli.NewApp()
-	app.Name = "S3 storer"
-	app.Usage = ""
-	app.Version = "v0.1.6"
-	app.Description = "Helper tool to backup files to S3 and maintain a given number of revisions"
-
-	endpointFlag := cli.StringFlag{
-		Name:  "endpoint, e",
-		Value: "",
-		Usage: "S3 endpoint",
-	}
-	accessKeyIDFlag := cli.StringFlag{
-		Name:   "access-key-id",
-		Value:  "",
-		EnvVar: "ACCESS_KEY_ID",
-		Usage:  "S3 AccessKeyID",
-	}
-	secretAccessKeyFlag := cli.StringFlag{
-		Name:   "secret-access-key",
-		Value:  "",
-		EnvVar: "SECRET_ACCESS_KEY",
-		Usage:  "S3 SecretAccessKey",
-	}
-	bucketFlag := cli.StringFlag{
-		Name:  "bucket, b",
-		Value: "kubermatic-backups",
-		Usage: "S3 bucket in which to store the snapshots",
-	}
-	prefixFlag := cli.StringFlag{
-		Name:  "prefix, p",
-		Value: "",
-		Usage: "Prefix to use for all objects stored in S3",
-	}
-	fileFlag := cli.StringFlag{
-		Name:  "file, f",
-		Value: "/backup/snapshot.db",
-		Usage: "Path to the file to store in S3",
-	}
-	secureFlag := cli.BoolFlag{
-		Name:  "secure",
-		Usage: "Enable tls validation",
-	}
-	caBundleFlag := cli.StringFlag{
-		Name:  "ca-bundle",
-		Usage: "Filename of the CA bundle to use (if not given, default system certificates are used)",
-	}
-	createBucketFlag := cli.BoolFlag{
-		Name:  "create-bucket",
-		Usage: "creates the bucket if it does not exist yet",
-	}
-	maxRevisionsFlag := cli.IntFlag{
-		Name:  "max-revisions",
-		Value: 20,
-		Usage: "Maximum number of revisions of the file to keep in S3. Older ones will be deleted",
+	opt := options{
+		Bucket:       "kubermatic-backups",
+		File:         "/backup/snapshot.db",
+		MaxRevisions: 20,
+		LogOptions:   log.NewDefaultOptions(),
 	}
 
-	logDebugFlag := cli.BoolFlag{
-		Name:  "log-debug",
-		Usage: "Enables more verbose logging",
-	}
+	var (
+		logger   *zap.SugaredLogger
+		uploader *storeuploader.StoreUploader
+	)
 
-	defaultLogFormat := log.FormatJSON
-	logFormatFlag := cli.GenericFlag{
-		Name:  "log-format",
-		Value: &defaultLogFormat,
-		Usage: fmt.Sprintf("Use one of [%v] to change the log output", log.AvailableFormats),
-	}
-
-	app.Flags = []cli.Flag{
-		logDebugFlag,
-		logFormatFlag,
-	}
-
-	app.Commands = []cli.Command{
-		{
-			Name:   "store",
-			Usage:  "Stores the given file on S3",
-			Action: store,
-			Flags: []cli.Flag{
-				endpointFlag,
-				secureFlag,
-				caBundleFlag,
-				accessKeyIDFlag,
-				secretAccessKeyFlag,
-				bucketFlag,
-				prefixFlag,
-				fileFlag,
-				createBucketFlag,
-			},
-		},
-		{
-			Name:   "delete-old-revisions",
-			Usage:  "Deletes backups which are older than max-revisions",
-			Action: deleteOldRevisions,
-			Flags: []cli.Flag{
-				endpointFlag,
-				secureFlag,
-				caBundleFlag,
-				accessKeyIDFlag,
-				secretAccessKeyFlag,
-				bucketFlag,
-				prefixFlag,
-				maxRevisionsFlag,
-				fileFlag, // unused but kept for BC compatibility with old cleanup scripts
-			},
-		},
-		{
-			Name:   "delete-all",
-			Usage:  "deletes all backups of the filename",
-			Action: deleteAll,
-			Flags: []cli.Flag{
-				endpointFlag,
-				secureFlag,
-				caBundleFlag,
-				accessKeyIDFlag,
-				secretAccessKeyFlag,
-				bucketFlag,
-				prefixFlag,
-			},
-		},
-	}
-
-	// setup logging
-	app.Before = func(c *cli.Context) error {
-		format := c.GlobalGeneric("log-format").(*log.Format)
-		rawLog := log.New(c.GlobalBool("log-debug"), *format)
-		logger = rawLog.Sugar()
-
-		return nil
-	}
-
-	defer func() {
-		if logger != nil {
-			if err := logger.Sync(); err != nil {
-				fmt.Println(err)
+	rootCmd := &cobra.Command{
+		Use:           "s3-storeuploader",
+		Short:         "Helper tool to backup files to S3 and maintain a given number of revisions",
+		Version:       "v0.2.0",
+		SilenceErrors: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) (err error) {
+			if opt.AccessKeyID == "" {
+				opt.AccessKeyID = os.Getenv("ACCESS_KEY_ID")
 			}
-		}
-	}()
 
-	err := app.Run(os.Args)
-	// Only log failures when the logger has been setup, otherwise
-	// we know it's been a CLI parsing failure and the cli package
-	// has already output the error and printed the usage hints.
-	if err != nil && logger != nil {
+			if opt.SecretAccessKey == "" {
+				opt.SecretAccessKey = os.Getenv("SECRET_ACCESS_KEY")
+			}
+
+			logger = log.New(opt.LogOptions.Debug, opt.LogOptions.Format).Sugar()
+			uploader, err = getUploaderFromCtx(logger, opt)
+			return
+		},
+	}
+
+	pFlags := rootCmd.PersistentFlags()
+	pFlags.StringVarP(&opt.Endpoint, "endpoint", "e", opt.Endpoint, "S3 endpoint")
+	pFlags.StringVar(&opt.AccessKeyID, "access-key-id", "", "S3 access key ID ($ACCESS_KEY_ID)")
+	pFlags.StringVar(&opt.SecretAccessKey, "secret-access-key", "", "S3 secret access key ($SECRET_ACCESS_KEY)")
+	pFlags.StringVarP(&opt.Bucket, "bucket", "b", opt.Bucket, "S3 bucket in which to store the snapshots")
+	pFlags.StringVarP(&opt.Prefix, "prefix", "p", opt.Prefix, "Prefix to use for all objects stored in S3")
+	pFlags.StringVarP(&opt.File, "file", "f", opt.File, "Path to the file to store in S3")
+	pFlags.BoolVar(&opt.Secure, "secure", opt.Secure, "Enable TLS validation")
+	pFlags.BoolVar(&opt.CreateBucket, "create-bucket", opt.CreateBucket, "Create the bucket if it does not exist yet")
+	pFlags.IntVar(&opt.MaxRevisions, "max-revisions", opt.MaxRevisions, "Maximum number of revisions of the file to keep in S3. Older ones will be deleted")
+	pFlags.StringVar(&opt.CABundle, "ca-bundle", opt.CABundle, "Filename of the CA bundle to use (if not given, default system certificates are used)")
+	opt.LogOptions.AddPFlags(pFlags)
+
+	rootCmd.AddCommand(
+		&cobra.Command{
+			Use:   "store",
+			Short: "Stores the given file on S3",
+			RunE: func(c *cobra.Command, args []string) error {
+				return uploader.Store(c.Context(), opt.File, opt.Bucket, opt.Prefix, opt.CreateBucket)
+			},
+		},
+
+		&cobra.Command{
+			Use:   "delete-old-revisions",
+			Short: "Deletes backups which are older than max-revisions",
+			RunE: func(c *cobra.Command, args []string) error {
+				return uploader.DeleteOldBackups(c.Context(), opt.Bucket, opt.Prefix, opt.MaxRevisions)
+			},
+		},
+
+		&cobra.Command{
+			Use:   "delete-all",
+			Short: "Deletes all backups of the filename",
+			RunE: func(c *cobra.Command, args []string) error {
+				return uploader.DeleteAll(c.Context(), opt.Bucket, opt.Prefix)
+			},
+		},
+	)
+
+	if err := rootCmd.Execute(); err != nil {
 		logger.Fatalw("Failed to run command", zap.Error(err))
 	}
 }
 
-func getUploaderFromCtx(c *cli.Context) (*storeuploader.StoreUploader, error) {
+func getUploaderFromCtx(log *zap.SugaredLogger, opt options) (*storeuploader.StoreUploader, error) {
 	var rootCAs *x509.CertPool
 
-	if caBundleFile := c.String("ca-bundle"); caBundleFile != "" {
-		bundle, err := certificates.NewCABundleFromFile(caBundleFile)
+	if opt.CABundle != "" {
+		bundle, err := certificates.NewCABundleFromFile(opt.CABundle)
 		if err != nil {
 			return nil, fmt.Errorf("cannot open CA bundle: %w", err)
 		}
@@ -194,11 +136,11 @@ func getUploaderFromCtx(c *cli.Context) (*storeuploader.StoreUploader, error) {
 	}
 
 	uploader, err := storeuploader.New(
-		c.String("endpoint"),
-		c.Bool("secure"),
-		c.String("access-key-id"),
-		c.String("secret-access-key"),
-		logger,
+		opt.Endpoint,
+		opt.Secure,
+		opt.AccessKeyID,
+		opt.SecretAccessKey,
+		log,
 		rootCAs,
 	)
 	if err != nil {
@@ -206,46 +148,4 @@ func getUploaderFromCtx(c *cli.Context) (*storeuploader.StoreUploader, error) {
 	}
 
 	return uploader, nil
-}
-
-func store(c *cli.Context) error {
-	uploader, err := getUploaderFromCtx(c)
-	if err != nil {
-		return err
-	}
-
-	return uploader.Store(
-		context.Background(),
-		c.String("file"),
-		c.String("bucket"),
-		c.String("prefix"),
-		c.Bool("create-bucket"),
-	)
-}
-
-func deleteOldRevisions(c *cli.Context) error {
-	uploader, err := getUploaderFromCtx(c)
-	if err != nil {
-		return err
-	}
-
-	return uploader.DeleteOldBackups(
-		context.Background(),
-		c.String("bucket"),
-		c.String("prefix"),
-		c.Int("max-revisions"),
-	)
-}
-
-func deleteAll(c *cli.Context) error {
-	uploader, err := getUploaderFromCtx(c)
-	if err != nil {
-		return err
-	}
-
-	return uploader.DeleteAll(
-		context.Background(),
-		c.String("bucket"),
-		c.String("prefix"),
-	)
 }

--- a/cmd/s3-storeuploader/main.go
+++ b/cmd/s3-storeuploader/main.go
@@ -77,6 +77,13 @@ func main() {
 			uploader, err = getUploaderFromCtx(logger, opt)
 			return
 		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			if logger != nil {
+				return logger.Sync()
+			}
+
+			return nil
+		},
 	}
 
 	pFlags := rootCmd.PersistentFlags()

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -54,6 +55,11 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.Var(&o.Format, "log-format", "Log format, one of "+AvailableFormats.String())
 }
 
+func (o *Options) AddPFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.Debug, "log-debug", o.Debug, "Enables debug logging")
+	fs.Var(&o.Format, "log-format", "Log format, one of "+AvailableFormats.String())
+}
+
 func (o *Options) Validate() error {
 	if !AvailableFormats.Contains(o.Format) {
 		return fmt.Errorf("invalid log-format specified %q; available: %s", o.Format, AvailableFormats.String())
@@ -62,6 +68,11 @@ func (o *Options) Validate() error {
 }
 
 type Format string
+
+// Type implements the pflag.Value interfaces.
+func (f *Format) Type() string {
+	return "string"
+}
 
 // String implements the cli.Value and flag.Value interfaces.
 func (f *Format) String() string {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We want to move away from urfave/cli due to its super weird un unpredicatble and error prone parsing of CLI flags. This PR is a step towards that goal, refactoring the S3 store uploader to use Cobra instead.

I chose not to use viper to get the env variables, because viper and cobra together are weird and do not work the way one would expect when using `..Var` functions (see https://github.com/spf13/viper/issues/461). It's much clearer to just use `os.Getenv` and be done with it.

This is part of #8995.

**Does this PR introduce a user-facing change?**:
```release-note
s3-storeuploader uses Cobra instead of urfave/cli, but the CLI flags are identical, so no changes to backup containers should be necessary.
```
