### PR TITLE
rewrite installer to use cobra

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -21,12 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
@@ -45,115 +46,98 @@ import (
 )
 
 var (
-	minHelmVersion = semver.MustParse("v3.0.0")
-
-	deployForceFlag = cli.BoolFlag{
-		Name:  "force",
-		Usage: "Perform Helm upgrades even when the release is up-to-date",
-	}
-	deployConfigFlag = cli.StringFlag{
-		Name:   "config",
-		Usage:  "Full path to the KubermaticConfiguration YAML file",
-		EnvVar: "CONFIG_YAML",
-	}
-	deployHelmValuesFlag = cli.StringFlag{
-		Name:   "helm-values",
-		Usage:  "Full path to the Helm values.yaml used for customizing all charts",
-		EnvVar: "VALUES_YAML",
-	}
-	deployKubeconfigFlag = cli.StringFlag{
-		Name:   "kubeconfig",
-		Usage:  "Full path to where a kubeconfig with cluster-admin permissions for the target cluster",
-		EnvVar: "KUBECONFIG",
-	}
-	deployKubeContextFlag = cli.StringFlag{
-		Name:   "kube-context",
-		Usage:  "Context to use from the given kubeconfig",
-		EnvVar: "KUBE_CONTEXT",
-	}
-	deployHelmTimeoutFlag = cli.DurationFlag{
-		Name:  "helm-timeout",
-		Usage: "Time to wait for Helm operations to finish",
-		Value: 5 * time.Minute,
-	}
-	deployHelmBinaryFlag = cli.StringFlag{
-		Name:   "helm-binary",
-		Usage:  "Full path to the Helm 3 binary to use",
-		Value:  "helm",
-		EnvVar: "HELM_BINARY",
-	}
-	deployStorageClassFlag = cli.StringFlag{
-		Name:  "storageclass",
-		Usage: fmt.Sprintf("Type of StorageClass to create (one of %v)", common.SupportedStorageClassProviders().List()),
-	}
-	enableCertManagerV2MigrationFlag = cli.BoolFlag{
-		Name:  "migrate-cert-manager",
-		Usage: "enable the migration for cert-manager CRDs from v1alpha2 to v1",
-	}
-	enableCertManagerUpstreamMigrationFlag = cli.BoolFlag{
-		Name:  "migrate-upstream-cert-manager",
-		Usage: "enable the migration for cert-manager to chart version 2.1.0+",
-	}
-	enableNginxIngressMigrationFlag = cli.BoolFlag{
-		Name:  "migrate-upstream-nginx-ingress",
-		Usage: "enable the migration procedure for nginx-ingress-controller (upgrade from v1.3.0+)",
-	}
-	migrateOpenstackCSIdriversFlag = cli.BoolFlag{
-		Name:  "migrate-openstack-csidrivers",
-		Usage: "(kubermatic-seed STACK only) enable the data migration of CSIDriver of openstack user-clusters",
-	}
-	migrateLogrotateFlag = cli.BoolFlag{
-		Name:  "migrate-logrotate",
-		Usage: "enable the data migration to delete the logrotate addon",
-	}
-	disableTelemetryFlag = cli.BoolFlag{
-		Name:  "disable-telemetry",
-		Usage: "disable telemetry agents",
-	}
+	MinHelmVersion = semver.MustParse("v3.0.0")
 )
 
-func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) cli.Command {
-	return cli.Command{
-		Name:      "deploy",
-		Usage:     "Installs or upgrades the current installation to the installer's built-in version",
-		Action:    DeployAction(logger, versions),
-		ArgsUsage: "[STACK=kubermatic-master]",
-		Flags: []cli.Flag{
-			deployForceFlag,
-			deployConfigFlag,
-			deployHelmValuesFlag,
-			deployKubeconfigFlag,
-			deployKubeContextFlag,
-			deployHelmTimeoutFlag,
-			deployHelmBinaryFlag,
-			deployStorageClassFlag,
-			enableCertManagerV2MigrationFlag,
-			enableCertManagerUpstreamMigrationFlag,
-			enableNginxIngressMigrationFlag,
-			migrateOpenstackCSIdriversFlag,
-			migrateLogrotateFlag,
-			disableTelemetryFlag,
-		},
-	}
+type DeployOptions struct {
+	Options
+
+	Config string
+
+	Kubeconfig  string
+	KubeContext string
+
+	HelmBinary  string
+	HelmValues  string
+	HelmTimeout time.Duration
+	Force       bool
+
+	StorageClass     string
+	DisableTelemetry bool
+
+	MigrateCertManager         bool
+	MigrateUpstreamCertManager bool
+	MigrateNginx               bool
+	MigrateOpenstackCSI        bool
+	MigrateLogrotate           bool
 }
 
-func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cli.ActionFunc {
-	return handleErrors(logger, setupLogger(logger, func(ctx *cli.Context) error {
+func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *cobra.Command {
+	opt := DeployOptions{
+		HelmTimeout: 5 * time.Minute,
+		HelmBinary:  "helm",
+	}
+
+	cmd := &cobra.Command{
+		Use:          "deploy [kubermatic-master | kubermatic-seed]",
+		Short:        "installs or upgrades the current installation to the installer's built-in version",
+		Long:         "Installs or upgrades the current installation to the installer's built-in version",
+		RunE:         DeployFunc(logger, versions, &opt),
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			options.CopyInto(&opt.Options)
+
+			if opt.Config == "" {
+				opt.Config = os.Getenv("CONFIG_YAML")
+			}
+			if opt.Kubeconfig == "" {
+				opt.Kubeconfig = os.Getenv("KUBECONFIG")
+			}
+			if opt.KubeContext == "" {
+				opt.KubeContext = os.Getenv("KUBE_CONTEXT")
+			}
+			if opt.HelmValues == "" {
+				opt.HelmValues = os.Getenv("HELM_VALUES")
+			}
+			if opt.HelmBinary == "" {
+				opt.HelmBinary = os.Getenv("HELM_BINARY")
+			}
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&opt.Config, "config", "", "full path to the KubermaticConfiguration YAML file")
+	cmd.PersistentFlags().StringVar(&opt.Kubeconfig, "kubeconfig", "", "full path to where a kubeconfig with cluster-admin permissions for the target cluster")
+	cmd.PersistentFlags().StringVar(&opt.KubeContext, "kube-context", "", "context to use from the given kubeconfig")
+
+	cmd.PersistentFlags().StringVar(&opt.HelmValues, "helm-values", "", "full path to the Helm values.yaml used for customizing all charts")
+	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
+	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "full path to the Helm 3 binary to use")
+	cmd.PersistentFlags().BoolVar(&opt.Force, "force", false, "perform Helm upgrades even when the release is up-to-date")
+
+	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", common.SupportedStorageClassProviders().List()))
+	cmd.PersistentFlags().BoolVar(&opt.DisableTelemetry, "disable-telemetry", false, "disable telemetry agents")
+
+	cmd.PersistentFlags().BoolVar(&opt.MigrateCertManager, "migrate-cert-manager", false, "enable the migration for cert-manager CRDs from v1alpha2 to v1")
+	cmd.PersistentFlags().BoolVar(&opt.MigrateUpstreamCertManager, "migrate-upstream-cert-manager", false, "enable the migration for cert-manager to chart version 2.1.0+")
+	cmd.PersistentFlags().BoolVar(&opt.MigrateNginx, "migrate-upstream-nginx-ingress", false, "enable the migration procedure for nginx-ingress-controller (upgrade from v1.3.0+)")
+	cmd.PersistentFlags().BoolVar(&opt.MigrateOpenstackCSI, "migrate-openstack-csidrivers", false, "(kubermatic-seed only) enable the data migration of CSIDriver of openstack user-clusters")
+	cmd.PersistentFlags().BoolVar(&opt.MigrateLogrotate, "migrate-logrotate", false, "enable the data migration to delete the logrotate addon")
+
+	return cmd
+}
+
+func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt *DeployOptions) cobraFuncE {
+	return handleErrors(logger, func(cmd *cobra.Command, args []string) error {
 		fields := logrus.Fields{
 			"version": versions.Kubermatic,
 			"edition": edition.KubermaticEdition,
 		}
-		if ctx.GlobalBool("verbose") {
+		if opt.Verbose {
 			fields["git"] = versions.KubermaticCommit
 		}
 
 		// error out early if there is no useful Helm binary
-		kubeconfig := ctx.String(deployKubeconfigFlag.Name)
-		kubeContext := ctx.String(deployKubeContextFlag.Name)
-		helmTimeout := ctx.Duration(deployHelmTimeoutFlag.Name)
-		helmBinary := ctx.String(deployHelmBinaryFlag.Name)
-
-		helmClient, err := helm.NewCLI(helmBinary, kubeconfig, kubeContext, helmTimeout, logger)
+		helmClient, err := helm.NewCLI(opt.HelmBinary, opt.Kubeconfig, opt.KubeContext, opt.HelmTimeout, logger)
 		if err != nil {
 			return fmt.Errorf("failed to create Helm client: %w", err)
 		}
@@ -163,19 +147,21 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			return fmt.Errorf("failed to check Helm version: %w", err)
 		}
 
-		if helmVersion.LessThan(minHelmVersion) {
+		if helmVersion.LessThan(MinHelmVersion) {
 			return fmt.Errorf(
-				"the installer requires Helm >= %s, but detected %q as %s (use --%s or $%s to override)",
-				minHelmVersion,
-				helmBinary,
+				"the installer requires Helm >= %s, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
+				MinHelmVersion,
+				opt.HelmBinary,
 				helmVersion,
-				deployHelmBinaryFlag.Name,
-				deployHelmBinaryFlag.EnvVar)
+			)
+		}
+
+		stackName := ""
+		if len(args) > 0 {
+			stackName = args[0]
 		}
 
 		var kubermaticStack stack.Stack
-		stackName := ctx.Args().First()
-
 		switch stackName {
 		case "kubermatic-seed":
 			kubermaticStack = kubermaticseed.NewStack()
@@ -188,34 +174,34 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		logger.WithFields(fields).Info("🚀 Initializing installer…")
 
 		// load config files
-		if len(kubeconfig) == 0 {
-			return fmt.Errorf("no kubeconfig (--%s or $%s) given", deployKubeconfigFlag.Name, deployKubeconfigFlag.EnvVar)
+		if len(opt.Kubeconfig) == 0 {
+			return errors.New("no kubeconfig (--kubeconfig or $KUBECONFIG) given")
 		}
 
-		kubermaticConfig, rawKubermaticConfig, err := loadKubermaticConfiguration(ctx.String(deployConfigFlag.Name))
+		kubermaticConfig, rawKubermaticConfig, err := loadKubermaticConfiguration(opt.Config)
 		if err != nil {
 			return fmt.Errorf("failed to load KubermaticConfiguration: %w", err)
 		}
 
-		helmValues, err := loadHelmValues(ctx.String(deployHelmValuesFlag.Name))
+		helmValues, err := loadHelmValues(opt.HelmValues)
 		if err != nil {
 			return fmt.Errorf("failed to load Helm values: %w", err)
 		}
 
-		opt := stack.DeployOptions{
+		deployOptions := stack.DeployOptions{
 			HelmClient:                         helmClient,
 			HelmValues:                         helmValues,
 			KubermaticConfiguration:            kubermaticConfig,
 			RawKubermaticConfiguration:         rawKubermaticConfig,
-			StorageClassProvider:               ctx.String(deployStorageClassFlag.Name),
-			ForceHelmReleaseUpgrade:            ctx.Bool(deployForceFlag.Name),
-			ChartsDirectory:                    ctx.GlobalString(chartsDirectoryFlag.Name),
-			EnableCertManagerV2Migration:       ctx.Bool(enableCertManagerV2MigrationFlag.Name),
-			EnableCertManagerUpstreamMigration: ctx.Bool(enableCertManagerUpstreamMigrationFlag.Name),
-			EnableNginxIngressMigration:        ctx.Bool(enableNginxIngressMigrationFlag.Name),
-			EnableOpenstackCSIDriverMigration:  ctx.Bool(migrateOpenstackCSIdriversFlag.Name),
-			EnableLogrotateMigration:           ctx.Bool(migrateLogrotateFlag.Name),
-			DisableTelemetry:                   ctx.Bool(disableTelemetryFlag.Name),
+			StorageClassProvider:               opt.StorageClass,
+			ForceHelmReleaseUpgrade:            opt.Force,
+			ChartsDirectory:                    opt.ChartsDirectory,
+			EnableCertManagerV2Migration:       opt.MigrateCertManager,
+			EnableCertManagerUpstreamMigration: opt.MigrateUpstreamCertManager,
+			EnableNginxIngressMigration:        opt.MigrateNginx,
+			EnableOpenstackCSIDriverMigration:  opt.MigrateOpenstackCSI,
+			EnableLogrotateMigration:           opt.MigrateLogrotate,
+			DisableTelemetry:                   opt.DisableTelemetry,
 		}
 
 		// validate the configuration
@@ -223,7 +209,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 
 		subLogger := log.Prefix(logrus.NewEntry(logger), "   ")
 
-		kubermaticConfig, helmValues, validationErrors := kubermaticStack.ValidateConfiguration(kubermaticConfig, helmValues, opt, subLogger)
+		kubermaticConfig, helmValues, validationErrors := kubermaticStack.ValidateConfiguration(kubermaticConfig, helmValues, deployOptions, subLogger)
 		if len(validationErrors) > 0 {
 			logger.Error("⛔ The provided configuration files are invalid:")
 
@@ -237,7 +223,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		logger.Info("✅ Provided configuration is valid.")
 
 		// prepapre Kubernetes and Helm clients
-		ctrlConfig, err := ctrlruntimeconfig.GetConfigWithContext(kubeContext)
+		ctrlConfig, err := ctrlruntimeconfig.GetConfigWithContext(opt.KubeContext)
 		if err != nil {
 			return fmt.Errorf("failed to get config: %w", err)
 		}
@@ -291,16 +277,16 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			return fmt.Errorf("failed to create Seed kubeconfig getter: %w", err)
 		}
 
-		opt.KubermaticConfiguration = kubermaticConfig
-		opt.HelmValues = helmValues
-		opt.KubeClient = kubeClient
-		opt.Logger = subLogger
-		opt.SeedsGetter = seedsGetter
-		opt.SeedClientGetter = provider.SeedClientGetterFactory(seedKubeconfigGetter)
+		deployOptions.KubermaticConfiguration = kubermaticConfig
+		deployOptions.HelmValues = helmValues
+		deployOptions.KubeClient = kubeClient
+		deployOptions.Logger = subLogger
+		deployOptions.SeedsGetter = seedsGetter
+		deployOptions.SeedClientGetter = provider.SeedClientGetterFactory(seedKubeconfigGetter)
 
 		logger.Info("🚦 Validating existing installation…")
 
-		if errs := kubermaticStack.ValidateState(appContext, opt); errs != nil {
+		if errs := kubermaticStack.ValidateState(appContext, deployOptions); errs != nil {
 			logger.Error("⛔ Cannot proceed with the installation:")
 
 			for _, e := range errs {
@@ -314,14 +300,14 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 
 		logger.Infof("🛫 Deploying %s…", kubermaticStack.Name())
 
-		if err := kubermaticStack.Deploy(appContext, opt); err != nil {
+		if err := kubermaticStack.Deploy(appContext, deployOptions); err != nil {
 			return err
 		}
 
 		logger.Infof("🛬 Installation completed successfully. %s", greeting())
 
 		return nil
-	}))
+	})
 }
 
 func greeting() string {

--- a/cmd/kubermatic-installer/cmd_print.go
+++ b/cmd/kubermatic-installer/cmd_print.go
@@ -17,35 +17,39 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 
 	"k8c.io/kubermatic/v2/docs"
 )
 
-func PrintCommand() cli.Command {
-	return cli.Command{
-		Name:        "print",
-		Usage:       "Prints example configuration manifest",
-		UsageText:   "kubermatic-installer print <resource>",
-		Description: "Print an example configuration manifest with defaults for the given resource.\n   Supported resources are \"seed\" and \"kubermaticconfiguration\".",
-		ArgsUsage:   "Supported resources are \"seed\" and \"kubermaticconfiguration\".",
-		Action:      PrintAction(),
+func PrintCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "print [config | kubermaticconfiguration]",
+		Short: "prints example configuration manifest",
+		Long:  "Print an example configuration manifest with defaults for the given resource.\n   Supported resources are \"seed\" and \"kubermaticconfiguration\".",
+		RunE:  PrintFunc(),
 	}
+
+	return cmd
 }
 
-func PrintAction() cli.ActionFunc {
-	return func(ctx *cli.Context) error {
-		arg := strings.ToLower(ctx.Args().First())
+func PrintFunc() cobraFuncE {
+	return func(cmd *cobra.Command, args []string) error {
+		arg := ""
+		if len(args) > 0 {
+			arg = strings.ToLower(args[0])
+		}
 
 		switch arg {
 		case "", "config", "kubermaticconfiguration":
-			println(docs.ExampleKubermaticConfiguration)
+			fmt.Println(docs.ExampleKubermaticConfiguration)
 		case "seed":
-			println(docs.ExampleSeedConfiguration)
+			fmt.Println(docs.ExampleSeedConfiguration)
 		default:
-			println(ctx.Command.ArgsUsage)
+			return cmd.Usage()
 		}
 
 		return nil

--- a/cmd/kubermatic-installer/cmd_version.go
+++ b/cmd/kubermatic-installer/cmd_version.go
@@ -24,41 +24,47 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/util/edition"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 )
 
-var (
-	versionShortFlag = cli.BoolFlag{
-		Name:  "short",
-		Usage: "Omit git and chart information",
-	}
-)
+type VersionOptions struct {
+	Options
 
-func VersionCommand(logger *logrus.Logger, versions kubermaticversion.Versions) cli.Command {
-	return cli.Command{
-		Name:   "version",
-		Usage:  "Prints the installer's version",
-		Action: VersionAction(logger, versions),
-		Flags: []cli.Flag{
-			versionShortFlag,
-		},
-	}
+	Short bool
 }
 
-func VersionAction(logger *logrus.Logger, versions kubermaticversion.Versions) cli.ActionFunc {
-	return handleErrors(logger, setupLogger(logger, func(ctx *cli.Context) error {
+func VersionCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *cobra.Command {
+	opt := VersionOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "prints the installer's version",
+		RunE:  VersionFunc(logger, versions, &opt),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			options.CopyInto(&opt.Options)
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.PersistentFlags().BoolVarP(&opt.Short, "short", "s", false, "omit git and chart information")
+
+	return cmd
+}
+
+func VersionFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt *VersionOptions) cobraFuncE {
+	return handleErrors(logger, func(cmd *cobra.Command, args []string) error {
 		name := fmt.Sprintf("Kubermatic %s Installer", edition.KubermaticEdition)
 
-		if ctx.Bool(versionShortFlag.Name) {
+		if opt.Short {
 			fmt.Printf("%s %s\n", name, versions.Kubermatic)
 			return nil
 		}
 
-		charts, err := loadCharts(ctx.GlobalString(chartsDirectoryFlag.Name))
+		charts, err := loadCharts(opt.ChartsDirectory)
 		if err != nil {
 			return fmt.Errorf("failed to determine installer chart state: %w", err)
 		}
@@ -100,7 +106,7 @@ func VersionAction(logger *logrus.Logger, versions kubermaticversion.Versions) c
 		}
 
 		return nil
-	}))
+	})
 }
 
 // HelmCharts is used to sort Helm charts by their name.

--- a/cmd/kubermatic-installer/main_ce.go
+++ b/cmd/kubermatic-installer/main_ce.go
@@ -22,7 +22,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 
 	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -31,20 +31,13 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func commands(logger *logrus.Logger, versions kubermaticversion.Versions) []cli.Command {
-	return []cli.Command{
-		VersionCommand(logger, versions),
+func addCommands(cmd *cobra.Command, logger *logrus.Logger, versions kubermaticversion.Versions) {
+	cmd.AddCommand(
+		ConvertKubeconfigCommand(logger),
 		DeployCommand(logger, versions),
 		PrintCommand(),
-		ConvertKubeconfigCommand(logger),
-	}
-}
-
-func flags() []cli.Flag {
-	return []cli.Flag{
-		verboseFlag,
-		chartsDirectoryFlag,
-	}
+		VersionCommand(logger, versions),
+	)
 }
 
 func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client) (provider.SeedsGetter, error) {

--- a/cmd/kubermatic-installer/main_ee.go
+++ b/cmd/kubermatic-installer/main_ee.go
@@ -22,7 +22,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 
 	eeinstaller "k8c.io/kubermatic/v2/pkg/ee/cmd/kubermatic-installer"
 	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
@@ -32,20 +32,13 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func commands(logger *logrus.Logger, versions kubermaticversion.Versions) []cli.Command {
-	return []cli.Command{
-		VersionCommand(logger, versions),
-		DeployCommand(logger, versions),
+func addCommands(cmd *cobra.Command, logger *logrus.Logger, versions kubermaticversion.Versions) {
+	cmd.AddCommand(
 		ConvertKubeconfigCommand(logger),
+		DeployCommand(logger, versions),
 		PrintCommand(),
-	}
-}
-
-func flags() []cli.Flag {
-	return []cli.Flag{
-		verboseFlag,
-		chartsDirectoryFlag,
-	}
+		VersionCommand(logger, versions),
+	)
 }
 
 func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client) (provider.SeedsGetter, error) {

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
@@ -32,25 +32,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func handleErrors(logger *logrus.Logger, action cli.ActionFunc) cli.ActionFunc {
-	return func(ctx *cli.Context) error {
-		err := action(ctx)
+type cobraFuncE func(cmd *cobra.Command, args []string) error
+
+func handleErrors(logger *logrus.Logger, action cobraFuncE) cobraFuncE {
+	return func(cmd *cobra.Command, args []string) error {
+		err := action(cmd, args)
 		if err != nil {
 			logger.Errorf("❌ Operation failed: %v.", err)
-			err = cli.NewExitError("", 1)
 		}
 
 		return err
-	}
-}
-
-func setupLogger(logger *logrus.Logger, action cli.ActionFunc) cli.ActionFunc {
-	return func(ctx *cli.Context) error {
-		if ctx.GlobalBool("verbose") {
-			logger.SetLevel(logrus.DebugLevel)
-		}
-
-		return action(ctx)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/urfave/cli v1.22.5
 	github.com/vmware/govmomi v0.27.4
 	go.etcd.io/etcd/api/v3 v3.5.1
 	go.etcd.io/etcd/client/pkg/v3 v3.5.1
@@ -150,7 +149,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/coreos/ignition v0.35.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
@@ -237,7 +235,6 @@ require (
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/shirou/gopsutil/v3 v3.21.10 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -668,11 +668,9 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/prometheus-operator v0.35.0/go.mod h1:XHYZUStZWcwd1yk/1DjZv/fywqKIyAJ6pSwvIr+v9BQ=
 github.com/cpu/goacmedns v0.0.3/go.mod h1:4MipLkI+qScwqtVxcNO6okBhbgRrr7/tKXUSgSL0teQ=
 github.com/cpu/goacmedns v0.1.1/go.mod h1:MuaouqEhPAHxsbqjgnck5zeghuwBP1dLnPoobeGqugQ=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -2204,7 +2202,6 @@ github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvf
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
@@ -2421,7 +2418,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This convert the installer to use cobra. I kept it simple and did not add things like auto-completion, dedicated validation stuff etc.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8995.

**Does this PR introduce a user-facing change?**:
```release-note
The kubermatic-installer uses Cobra instead of urfave/cli, but the CLI flags are identical, so no changes to scripts or automation should be necessary.
```
