### PR TITLE
Add dual-stack support for GCP firewall rules

### DIFF
--- a/pkg/provider/cloud/gcp/firewall_rules.go
+++ b/pkg/provider/cloud/gcp/firewall_rules.go
@@ -34,6 +34,12 @@ import (
 )
 
 const (
+	selfRuleNamePattern         = "firewall-%s-self"
+	icmpRuleNamePattern         = "firewall-%s-icmp"
+	icmpIPv6RuleNamePattern     = "firewall-%s-icmp-ipv6"
+	nodePortRuleNamePattern     = "firewall-%s-nodeport"
+	nodePortIPv6RuleNamePattern = "firewall-%s-nodeport-ipv6"
+
 	ipv6ICMPProtoNumber = "58" // IANA-assigned Internet Protocol Number for IPv6-ICMP
 )
 
@@ -47,14 +53,16 @@ func reconcileFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, 
 
 	firewallService := compute.NewFirewallsService(svc)
 	tag := fmt.Sprintf("kubernetes-cluster-%s", cluster.Name)
-	selfRuleName := fmt.Sprintf("firewall-%s-self", cluster.Name)
-	icmpRuleName := fmt.Sprintf("firewall-%s-icmp", cluster.Name)
-	nodePortRuleName := fmt.Sprintf("firewall-%s-nodeport", cluster.Name)
+	selfRuleName := fmt.Sprintf(selfRuleNamePattern, cluster.Name)
+	icmpRuleName := fmt.Sprintf(icmpRuleNamePattern, cluster.Name)
+	icmpIPv6RuleName := fmt.Sprintf(icmpIPv6RuleNamePattern, cluster.Name)
+	nodePortRuleName := fmt.Sprintf(nodePortRuleNamePattern, cluster.Name)
+	nodePortIPv6RuleName := fmt.Sprintf(nodePortIPv6RuleNamePattern, cluster.Name)
 
-	ipv4Permissions := network.IsIPv4OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
-	ipv6Permissions := network.IsIPv6OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
+	ipv4Rules := network.IsIPv4OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
+	ipv6Rules := network.IsIPv6OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
 
-	// allow all common IP protocols from within the cluster
+	// Allow all common IP protocols from within the cluster.
 	var allowedProtocols = []*compute.FirewallAllowed{
 		{
 			IPProtocol: "tcp",
@@ -75,45 +83,38 @@ func reconcileFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, 
 			IPProtocol: "ipip",
 		},
 	}
-	if ipv4Permissions {
+	if ipv4Rules {
 		allowedProtocols = append(allowedProtocols, &compute.FirewallAllowed{IPProtocol: "icmp"})
 	}
-	if ipv6Permissions {
+	if ipv6Rules {
 		allowedProtocols = append(allowedProtocols, &compute.FirewallAllowed{IPProtocol: ipv6ICMPProtoNumber})
 	}
-	err := createOrPatchFirewall(ctx, firewallService, projectID, selfRuleName, tag, tag, allowedProtocols, nil, update, cluster, firewallSelfCleanupFinalizer)
+	err := createOrPatchFirewall(ctx, firewallService, projectID, selfRuleName, tag, tag, allowedProtocols, "", update, cluster, firewallSelfCleanupFinalizer)
 	if err != nil {
 		return err
 	}
 
-	// allow ICMP from anywhere
-	allowedProtocols = []*compute.FirewallAllowed{}
-	var allowedIPRanges []string
-	if ipv4Permissions {
-		allowedProtocols = append(allowedProtocols, &compute.FirewallAllowed{IPProtocol: "icmp"})
-		allowedIPRanges = append(allowedIPRanges, "0.0.0.0/0")
+	// Allow ICMP from anywhere.
+	// Note that mixture of IPv4 and IPv6 in the same rule is not allowed by GCP,
+	// so we need to create a separate rule for each IP family.
+	if ipv4Rules {
+		err = createOrPatchFirewall(ctx, firewallService, projectID, icmpRuleName, tag, "",
+			[]*compute.FirewallAllowed{{IPProtocol: "icmp"}}, "0.0.0.0/0", update, cluster, firewallICMPCleanupFinalizer)
+		if err != nil {
+			return err
+		}
 	}
-	if ipv6Permissions {
-		allowedProtocols = append(allowedProtocols, &compute.FirewallAllowed{IPProtocol: ipv6ICMPProtoNumber})
-		allowedIPRanges = append(allowedIPRanges, "::/0")
-	}
-	err = createOrPatchFirewall(ctx, firewallService, projectID, icmpRuleName, tag, "", allowedProtocols, allowedIPRanges, update, cluster, firewallICMPCleanupFinalizer)
-	if err != nil {
-		return err
+	if ipv6Rules {
+		err = createOrPatchFirewall(ctx, firewallService, projectID, icmpIPv6RuleName, tag, "",
+			[]*compute.FirewallAllowed{{IPProtocol: ipv6ICMPProtoNumber}}, "::/0", update, cluster, firewallICMPCleanupFinalizer)
+		if err != nil {
+			return err
+		}
 	}
 
-	// allow NodePort ranges
-	allowedIPRanges = []string{}
-	if cluster.Spec.Cloud.GCP.NodePortsAllowedIPRange != "" {
-		allowedIPRanges = append(allowedIPRanges, cluster.Spec.Cloud.GCP.NodePortsAllowedIPRange)
-	} else {
-		if ipv4Permissions {
-			allowedIPRanges = append(allowedIPRanges, "0.0.0.0/0")
-		}
-		if ipv6Permissions {
-			allowedIPRanges = append(allowedIPRanges, "::/0")
-		}
-	}
+	// Allow all ports from the NodePort range.
+	// Note that mixture of IPv4 and IPv6 in the same rule is not allowed by GCP,
+	// so we need to create a separate rule for each IP family.
 	allowedProtocols = []*compute.FirewallAllowed{
 		{
 			IPProtocol: "tcp",
@@ -124,9 +125,27 @@ func reconcileFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, 
 			Ports:      []string{fmt.Sprintf("%d-%d", nodePortRangeLow, nodePortRangeHigh)},
 		},
 	}
-	err = createOrPatchFirewall(ctx, firewallService, projectID, nodePortRuleName, tag, "", allowedProtocols, allowedIPRanges, update, cluster, firewallNodePortCleanupFinalizer)
-	if err != nil {
-		return err
+	if cluster.Spec.Cloud.GCP.NodePortsAllowedIPRange != "" {
+		err = createOrPatchFirewall(ctx, firewallService, projectID, nodePortRuleName, tag, "",
+			allowedProtocols, cluster.Spec.Cloud.GCP.NodePortsAllowedIPRange, update, cluster, firewallNodePortCleanupFinalizer)
+		if err != nil {
+			return err
+		}
+	} else {
+		if ipv4Rules {
+			err = createOrPatchFirewall(ctx, firewallService, projectID, nodePortRuleName, tag, "",
+				allowedProtocols, "0.0.0.0/0", update, cluster, firewallNodePortCleanupFinalizer)
+			if err != nil {
+				return err
+			}
+		}
+		if ipv6Rules {
+			err = createOrPatchFirewall(ctx, firewallService, projectID, nodePortIPv6RuleName, tag, "",
+				allowedProtocols, "::/0", update, cluster, firewallNodePortCleanupFinalizer)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -139,7 +158,7 @@ func createOrPatchFirewall(ctx context.Context,
 	targetTag string,
 	sourceTag string,
 	protocols []*compute.FirewallAllowed,
-	allowedIPRanges []string,
+	allowedIPRange string,
 	update provider.ClusterUpdater,
 	cluster *kubermaticv1.Cluster,
 	finalizer string) error {
@@ -152,7 +171,9 @@ func createOrPatchFirewall(ctx context.Context,
 	if sourceTag != "" {
 		firewall.SourceTags = []string{sourceTag}
 	}
-	firewall.SourceRanges = allowedIPRanges
+	if allowedIPRange != "" {
+		firewall.SourceRanges = []string{allowedIPRange}
+	}
 
 	existingFirewall, err := firewallService.Get(projectID, firewallName).Context(ctx).Do()
 	switch {
@@ -197,13 +218,17 @@ func createOrPatchFirewall(ctx context.Context,
 func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, log *zap.SugaredLogger, svc *compute.Service, projectID string) (*kubermaticv1.Cluster, error) {
 	firewallService := compute.NewFirewallsService(svc)
 
-	selfRuleName := fmt.Sprintf("firewall-%s-self", cluster.Name)
-	icmpRuleName := fmt.Sprintf("firewall-%s-icmp", cluster.Name)
-	nodePortRuleName := fmt.Sprintf("firewall-%s-nodeport", cluster.Name)
+	selfRuleName := fmt.Sprintf(selfRuleNamePattern, cluster.Name)
+	icmpRuleName := fmt.Sprintf(icmpRuleNamePattern, cluster.Name)
+	icmpIPv6RuleName := fmt.Sprintf(icmpIPv6RuleNamePattern, cluster.Name)
+	nodePortRuleName := fmt.Sprintf(nodePortRuleNamePattern, cluster.Name)
+	nodePortIPv6RuleName := fmt.Sprintf(nodePortIPv6RuleNamePattern, cluster.Name)
+
+	ipv4Rules := network.IsIPv4OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
+	ipv6Rules := network.IsIPv6OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
 
 	if kuberneteshelper.HasFinalizer(cluster, firewallSelfCleanupFinalizer) {
 		_, err := firewallService.Delete(projectID, selfRuleName).Context(ctx).Do()
-		// we ignore a Google API "not found" error
 		if err != nil && !isHTTPError(err, http.StatusNotFound) {
 			return nil, fmt.Errorf("failed to delete firewall rule %s: %w", selfRuleName, err)
 		}
@@ -217,12 +242,20 @@ func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, upd
 	}
 
 	if kuberneteshelper.HasFinalizer(cluster, firewallICMPCleanupFinalizer) {
-		_, err := firewallService.Delete(projectID, icmpRuleName).Context(ctx).Do()
-		// we ignore a Google API "not found" error
-		if err != nil && !isHTTPError(err, http.StatusNotFound) {
-			return nil, fmt.Errorf("failed to delete firewall rule %s: %w", icmpRuleName, err)
+		if ipv4Rules {
+			_, err := firewallService.Delete(projectID, icmpRuleName).Context(ctx).Do()
+			if err != nil && !isHTTPError(err, http.StatusNotFound) {
+				return nil, fmt.Errorf("failed to delete firewall rule %s: %w", icmpRuleName, err)
+			}
+		}
+		if ipv6Rules {
+			_, err := firewallService.Delete(projectID, icmpIPv6RuleName).Context(ctx).Do()
+			if err != nil && !isHTTPError(err, http.StatusNotFound) {
+				return nil, fmt.Errorf("failed to delete firewall rule %s: %w", icmpRuleName, err)
+			}
 		}
 
+		var err error
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, firewallICMPCleanupFinalizer)
 		})
@@ -233,12 +266,20 @@ func deleteFirewallRules(ctx context.Context, cluster *kubermaticv1.Cluster, upd
 
 	// remove the nodeport firewall rule
 	if kuberneteshelper.HasFinalizer(cluster, firewallNodePortCleanupFinalizer) {
-		_, err := firewallService.Delete(projectID, nodePortRuleName).Context(ctx).Do()
-		// we ignore a Google API "not found" error
-		if err != nil && !isHTTPError(err, http.StatusNotFound) {
-			return nil, fmt.Errorf("failed to delete firewall rule %s: %w", nodePortRuleName, err)
+		if ipv4Rules {
+			_, err := firewallService.Delete(projectID, nodePortRuleName).Context(ctx).Do()
+			if err != nil && !isHTTPError(err, http.StatusNotFound) {
+				return nil, fmt.Errorf("failed to delete firewall rule %s: %w", nodePortRuleName, err)
+			}
+		}
+		if ipv6Rules {
+			_, err := firewallService.Delete(projectID, nodePortIPv6RuleName).Context(ctx).Do()
+			if err != nil && !isHTTPError(err, http.StatusNotFound) {
+				return nil, fmt.Errorf("failed to delete firewall rule %s: %w", nodePortRuleName, err)
+			}
 		}
 
+		var err error
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, firewallNodePortCleanupFinalizer)
 		})


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds dual-stack support for GCP firewall rules managed by KKP.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9383  

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add dual-stack support for GCP firewall rules
```
