### PR TITLE
user-cluster api-server: add a retry limit to check if etcd is running

### DIFF
--- a/pkg/resources/etcd/etcdrunning/etcdrunning.go
+++ b/pkg/resources/etcd/etcdrunning/etcdrunning.go
@@ -39,8 +39,8 @@ func Container(etcdEndpoints []string, data etcdRunningData) corev1.Container {
 		Command: []string{
 			"/bin/sh",
 			"-ec",
-			// Write a key to etcd. If we have quorum it will succeed.
-			fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
+			// Write a key to etcd. If we have quorum it will succeed. after 100 retries the script return an error
+			fmt.Sprintf("for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' put kubermatic/quorum-check something; then echo \"etcd ready\"; exit 0; fi; echo \"waiting for etcd. retry=$i/100\"; sleep 2; done; echo \"error: etcd not ready\"; exit 1;", strings.Join(etcdEndpoints, ",")),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -344,11 +344,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -346,11 +346,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -346,11 +346,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -334,11 +334,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -336,11 +336,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -336,11 +336,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -330,11 +330,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -330,11 +330,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -330,11 +330,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -334,11 +334,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -336,11 +336,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -336,11 +336,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -330,11 +330,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -334,11 +334,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -336,11 +336,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.4.3
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -332,11 +332,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -336,11 +336,12 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+        - 'for i in $(seq 1 100); do if ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
-          done;
+          --dial-timeout=2s --endpoints=''https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379''
+          put kubermatic/quorum-check something; then echo "etcd ready"; exit 0; fi;
+          echo "waiting for etcd. retry=$i/100"; sleep 2; done; echo "error: etcd
+          not ready"; exit 1;'
         image: gcr.io/etcd-development/etcd:v3.5.1
         name: etcd-running
         resources: {}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

> apiserver starts with etcd-running initContainer. Since etcd-running container has infinite loop, it circumvents any possibility of "retry" by kubernetes. So, if for any reason, etcd-running initContainer fails to complete, cluster never gets provisioned


This PR adds a retry limit, if this limit is reached the script exit with an error. IMHO restarting the container will not help to fix anything but having the init-container in `InitCrashLoopBack`  state put in evidence that something is wrong and help the user to debug. 


Example of success after  some failure:
```
{"level":"warn","ts":"2022-03-22T08:34:33.970Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-c577f2ed-93c4-494e-9725-2b10af1b8048/etcd-0.etcd.cluster-6lstnh6z57.svc.cluster.local.:2379","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: lookup etcd-1.etcd.cluster-6lstnh6z57.svc.cluster.local. on 10.47.240.10:53: no such host\""}
Error: context deadline exceeded
waiting for etcd. retry=5/100
{"level":"warn","ts":"2022-03-22T08:34:40.987Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-a4d85ddc-5060-4932-8278-b4819e5fb841/etcd-0.etcd.cluster-6lstnh6z57.svc.cluster.local.:2379","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: lookup etcd-2.etcd.cluster-6lstnh6z57.svc.cluster.local. on 10.47.240.10:53: no such host\""}
Error: context deadline exceeded
waiting for etcd. retry=6/100
OK
etcd ready
```

Example of failure (retry limit reached):
```
{"level":"warn","ts":"2022-03-22T08:48:38.600Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-2322e28f-2aea-48c0-bdf6-3e168a7e44b6/etcd-0.etcd.cluster-6lstnh6z57.svc.cluster.local.:2379","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: lookup etcd-1.etcd.cluster-6lstnh6z57.svc.cluster.local. on 10.47.240.10:53: no such host\""}
Error: context deadline exceeded
waiting for etcd. retry=100/100
error: etcd not ready

```
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8684 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
init-container `etcd-running` that check if etcd is ready before starting api-server has now a retry limit.
```
