### PR TITLE
WIP added validation webhook for project owner

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -37,6 +37,7 @@ import (
 	mlaadminsettingmutation "k8c.io/kubermatic/v2/pkg/webhook/mlaadminsetting/mutation"
 	oscvalidation "k8c.io/kubermatic/v2/pkg/webhook/operatingsystemmanager/operatingsystemconfig/validation"
 	ospvalidation "k8c.io/kubermatic/v2/pkg/webhook/operatingsystemmanager/operatingsystemprofile/validation"
+	projectvalidation "k8c.io/kubermatic/v2/pkg/webhook/project/validation"
 	seedwebhook "k8c.io/kubermatic/v2/pkg/webhook/seed"
 	usersshkeymutation "k8c.io/kubermatic/v2/pkg/webhook/usersshkey/mutation"
 	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
@@ -151,6 +152,13 @@ func main() {
 
 	// mutation cannot, because we require separate defaulting for CREATE and UPDATE operations
 	clustermutation.NewAdmissionHandler(mgr.GetClient(), configGetter, seedGetter, caPool).SetupWebhookWithManager(mgr)
+
+	// /////////////////////////////////////////
+	// setup Project webhook
+	projectValidator := projectvalidation.NewValidator(mgr.GetClient())
+	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.Project{}).WithValidator(projectValidator).Complete(); err != nil {
+		log.Fatalw("Failed to setup Project validation webhook", zap.Error(err))
+	}
 
 	// /////////////////////////////////////////
 	// setup Addon webhook

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -52,6 +52,9 @@ const (
 	// UserSSHKeyAdmissionWebhookName is the name of the mutation webhook for UserSSHKeys.
 	UserSSHKeyAdmissionWebhookName = "kubermatic-usersshkeys"
 
+	// ProjectAdmissionWebhookName is the name of the validation webhook for Projects.
+	ProjectAdmissionWebhookName = "kubermatic-project"
+
 	// we use a shared certificate/CA for all webhooks, because multiple webhooks
 	// run in the same controller manager so it's much easier if they all use the
 	// same certs.

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -72,7 +72,7 @@ func WebhookClusterRoleCreator(cfg *kubermaticv1.KubermaticConfiguration) reconc
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"kubermatic.k8c.io"},
-					Resources: []string{"clustertemplates", "projects"},
+					Resources: []string{"clustertemplates", "projects", "users"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			}

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -390,6 +390,7 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 	creators := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
 		common.SeedAdmissionWebhookCreator(config, r.Client),
 		common.KubermaticConfigurationAdmissionWebhookCreator(config, r.Client),
+		kubermatic.ProjectAdmissionWebhookCreator(config, r.Client),
 	}
 
 	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {

--- a/pkg/webhook/project/validation/validation.go
+++ b/pkg/webhook/project/validation/validation.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// validator for validating Kubermatic Project CRD.
+type validator struct {
+	client ctrlruntimeclient.Client
+}
+
+// NewValidator returns a new cluster validator.
+func NewValidator(client ctrlruntimeclient.Client) *validator {
+	return &validator{
+		client: client,
+	}
+}
+
+var _ admission.CustomValidator = &validator{}
+
+func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	project, ok := obj.(*kubermaticv1.Project)
+	if !ok {
+		return errors.New("object is not a Project")
+	}
+
+	// Projects need to have a User owner, because based on it all the RBACs are created by the rbac-controller-manager
+	return v.validateProjectOwner(ctx, project)
+}
+
+func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	newProject, ok := newObj.(*kubermaticv1.Project)
+	if !ok {
+		return errors.New("new object is not a Project")
+	}
+
+	// Projects need to have a User owner, because based on it all the RBACs are created by the rbac-controller-manager
+	return v.validateProjectOwner(ctx, newProject)
+}
+
+func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (v *validator) validateProjectOwner(ctx context.Context, project *kubermaticv1.Project) error {
+	metaPath := field.NewPath("meta", "ownerReferences")
+
+	if len(project.OwnerReferences) == 0 {
+		return field.Required(metaPath, "User owner ref for project required")
+	}
+
+	userOwnerRefPresent := false
+	for _, ownerRef := range project.OwnerReferences {
+		if ownerRef.Kind != kubermaticv1.UserKindName {
+			continue
+		}
+		userOwnerRefPresent = true
+
+		var user kubermaticv1.User
+		if err := v.client.Get(ctx, types.NamespacedName{Name: ownerRef.Name}, &user); err != nil {
+			if kerrors.IsNotFound(err) {
+				return field.Invalid(metaPath.Child("name"), ownerRef.Name, "no such user exists")
+			}
+
+			return field.InternalError(metaPath, fmt.Errorf("failed to get user: %w", err))
+		}
+	}
+
+	if !userOwnerRefPresent {
+		return field.Required(metaPath, "User owner ref for project required")
+	}
+
+	return nil
+}

--- a/pkg/webhook/project/validation/validation_test.go
+++ b/pkg/webhook/project/validation/validation_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name              string
+		projectToValidate *kubermaticv1.Project
+		existingUsers     []*kubermaticv1.User
+		op                admissionv1.Operation
+		errExpected       bool
+	}{
+		{
+			name:              "Creating a project with a proper user owner ref should be possible",
+			projectToValidate: genProject("success", test.GenDefaultUser()),
+			existingUsers:     []*kubermaticv1.User{test.GenDefaultUser()},
+			op:                admissionv1.Create,
+		},
+		{
+			name:              "Creating a project with a owner ref for a user which doesn't exist should be refused",
+			projectToValidate: genProject("success", test.GenDefaultUser()),
+			existingUsers:     []*kubermaticv1.User{},
+			op:                admissionv1.Create,
+			errExpected:       true,
+		},
+		{
+			name:              "Creating a project without a owner ref should be refused",
+			projectToValidate: genProject("success", nil),
+			existingUsers:     []*kubermaticv1.User{},
+			op:                admissionv1.Create,
+			errExpected:       true,
+		},
+		{
+			name: "Creating a project with other owner refs but no user owner ref should be refused",
+			projectToValidate: func() *kubermaticv1.Project {
+				pr := genProject("success", nil)
+				pr.OwnerReferences = []v1.OwnerReference{
+					{Name: "bob", Kind: "Bob"},
+				}
+				return pr
+			}(),
+			existingUsers: []*kubermaticv1.User{},
+			op:            admissionv1.Create,
+			errExpected:   true,
+		},
+		{
+			name:              "Deleting a project should work without any check",
+			projectToValidate: genProject("success", nil),
+			op:                admissionv1.Delete,
+		},
+		{
+			name:              "Updating a project with a proper user owner ref should be possible",
+			projectToValidate: genProject("success", test.GenDefaultUser()),
+			existingUsers:     []*kubermaticv1.User{test.GenDefaultUser()},
+			op:                admissionv1.Update,
+		},
+		{
+			name:              "Creating a project with a owner ref for a user which doesn't exist should be refused",
+			projectToValidate: genProject("success", test.GenDefaultUser()),
+			existingUsers:     []*kubermaticv1.User{},
+			op:                admissionv1.Update,
+			errExpected:       true,
+		},
+		{
+			name:              "Creating a project without a owner ref should be refused",
+			projectToValidate: genProject("success", nil),
+			existingUsers:     []*kubermaticv1.User{},
+			op:                admissionv1.Update,
+			errExpected:       true,
+		},
+		{
+			name: "Creating a project with other owner refs but no user owner ref should be refused",
+			projectToValidate: func() *kubermaticv1.Project {
+				pr := genProject("success", nil)
+				pr.OwnerReferences = []v1.OwnerReference{
+					{Name: "bob", Kind: "Bob"},
+				}
+				return pr
+			}(),
+			existingUsers: []*kubermaticv1.User{},
+			op:            admissionv1.Update,
+			errExpected:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				obj []ctrlruntimeclient.Object
+				err error
+			)
+			ctx := context.Background()
+
+			for _, s := range tc.existingUsers {
+				obj = append(obj, s)
+			}
+
+			client := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(obj...).
+				Build()
+
+			validator := NewValidator(client)
+
+			switch tc.op {
+			case admissionv1.Create:
+				err = validator.ValidateCreate(ctx, tc.projectToValidate)
+			case admissionv1.Update:
+				err = validator.ValidateUpdate(ctx, nil, tc.projectToValidate)
+			case admissionv1.Delete:
+				err = validator.ValidateDelete(ctx, tc.projectToValidate)
+			}
+
+			if (err != nil) != tc.errExpected {
+				t.Fatalf("Expected err: %t, but got err: %v", tc.errExpected, err)
+			}
+		})
+	}
+}
+
+func genProject(name string, user *kubermaticv1.User) *kubermaticv1.Project {
+	project := &kubermaticv1.Project{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kubermaticv1.ProjectSpec{
+			Name: name,
+		},
+	}
+
+	if user != nil {
+		project.OwnerReferences = []v1.OwnerReference{
+			{
+				Name: user.Name,
+				Kind: kubermaticv1.UserKindName,
+			},
+		}
+	}
+
+	return project
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds a validation webhook for Projects, where it checks that Projects have a proper User OwnerReference. Without it, the UserProjectBindings are not created, and the whole rbac magic that KKP does gets messed up.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9367 


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a validation webhook for Projects which makes sure that Projects have a valid User OwnerReference.
```
