### PR TITLE
Add phases to Cluster objects

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -31,6 +31,9 @@ spec:
     - jsonPath: .spec.cloud.dc
       name: Datacenter
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .spec.pause
       name: Paused
       type: boolean
@@ -1978,6 +1981,17 @@ spec:
               namespaceName:
                 description: NamespaceName defines the namespace the control plane
                   of this cluster is deployed in
+                type: string
+              phase:
+                description: Phase is a description of the current cluster status,
+                  summarizing the various conditions, possible active updates etc.
+                  This field is for informational purpose only and no logic should
+                  be tied to the phase.
+                enum:
+                - Creating
+                - Updating
+                - Running
+                - Terminating
                 type: string
               userEmail:
                 description: UserEmail contains the email of the owner of this cluster

--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -27,6 +27,7 @@ import (
 	autoupdatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/auto-update-controller"
 	backupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/backup"
 	cloudcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
+	clusterphasecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-phase-controller"
 	clustertemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-template-controller"
 	seedconstraintsynchronizer "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/constraint-controller"
 	constrainttemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/constraint-template-controller"
@@ -65,6 +66,7 @@ var AllControllers = map[string]controllerCreator{
 	mla.ControllerName:                            createMLAController,
 	clustertemplatecontroller.ControllerName:      createClusterTemplateController,
 	projectcontroller.ControllerName:              createProjectController,
+	clusterphasecontroller.ControllerName:         createClusterPhaseController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -239,6 +241,15 @@ func createUpdateController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.configGetter,
+		ctrlCtx.log,
+		ctrlCtx.versions,
+	)
+}
+
+func createClusterPhaseController(ctrlCtx *controllerContext) error {
+	return clusterphasecontroller.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.log,
 		ctrlCtx.versions,
 	)

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -148,12 +148,17 @@ kubermaticOperator:
   image:
     repository: "quay.io/kubermatic/kubermatic$REPOSUFFIX"
     tag: "$KUBERMATIC_VERSION"
+
 minio:
   storageClass: 'kubermatic-fast'
   certificateSecret: 'minio-tls-cert'
   credentials:
     accessKey: "FXcD7s0tFOPuTv6jaZARJDouc2Hal8E0"
     secretKey: "wdEZGTnhkgBDTDetaHFuizs3pwXHvWTs"
+
+nginx:
+  controller:
+    replicaCount: 1
 EOF
 
 # append custom Dex configuration

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -153,6 +153,10 @@ minio:
   credentials:
     accessKey: test
     secretKey: testtest
+
+nginx:
+  controller:
+    replicaCount: 1
 EOF
 
 # append custom Dex configuration

--- a/hack/ci/setup-kubermatic-mla-in-kind.sh
+++ b/hack/ci/setup-kubermatic-mla-in-kind.sh
@@ -147,6 +147,10 @@ kubermaticOperator:
   image:
     repository: "quay.io/kubermatic/kubermatic$REPOSUFFIX"
     tag: "$KUBERMATIC_VERSION"
+
+nginx:
+  controller:
+    replicaCount: 1
 EOF
 
 # append custom Dex configuration

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -85,6 +85,7 @@ var ProtectedClusterLabels = sets.NewString(WorkerNameLabelKey, ProjectIDLabelKe
 // +kubebuilder:printcolumn:JSONPath=".spec.version",name="Version",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.cloud.providerName",name="Provider",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.cloud.dc",name="Datacenter",type="string"
+// +kubebuilder:printcolumn:JSONPath=".status.phase",name="Phase",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.pause",name="Paused",type="boolean"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
@@ -336,6 +337,18 @@ type ClusterCondition struct {
 	Message string `json:"message,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Creating;Updating;Running;Terminating
+
+type ClusterPhase string
+
+// These are the valid phases of a project.
+const (
+	ClusterCreating    ClusterPhase = "Creating"
+	ClusterUpdating    ClusterPhase = "Updating"
+	ClusterRunning     ClusterPhase = "Running"
+	ClusterTerminating ClusterPhase = "Terminating"
+)
+
 // ClusterStatus stores status information about a cluster.
 type ClusterStatus struct {
 	// +optional
@@ -376,6 +389,11 @@ type ClusterStatus struct {
 	// controllers and the API
 	// +optional
 	Conditions map[ClusterConditionType]ClusterCondition `json:"conditions,omitempty"`
+	// Phase is a description of the current cluster status, summarizing the various conditions,
+	// possible active updates etc. This field is for informational purpose only and no logic
+	// should be tied to the phase.
+	// +optional
+	Phase ClusterPhase `json:"phase,omitempty"`
 
 	// CloudMigrationRevision describes the latest version of the migration that has been done
 	// It is used to avoid redundant and potentially costly migrations

--- a/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterphasecontroller
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	updatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/update-controller"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kkp-cluster-phase-controller"
+)
+
+type Reconciler struct {
+	ctrlruntimeclient.Client
+
+	recorder record.EventRecorder
+	log      *zap.SugaredLogger
+	versions kubermatic.Versions
+}
+
+// Add creates a new update controller.
+func Add(mgr manager.Manager, numWorkers int, log *zap.SugaredLogger, versions kubermatic.Versions) error {
+	reconciler := &Reconciler{
+		Client: mgr.GetClient(),
+
+		recorder: mgr.GetEventRecorderFor(ControllerName),
+		log:      log,
+		versions: versions,
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: numWorkers,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request.Name)
+	log.Debug("Reconciling")
+
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	err := r.reconcile(ctx, log, cluster)
+	if err != nil {
+		log.Errorw("Failed to reconcile", zap.Error(err))
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
+	// deletion timestamp overrides everything else
+	if cluster.DeletionTimestamp != nil {
+		return r.setClusterPhase(ctx, cluster, kubermaticv1.ClusterTerminating)
+	}
+
+	// if this cluster was never fully reconciled (yet), it is in Creating phase
+	if !kubermaticv1helper.IsClusterInitialized(cluster, r.versions) {
+		return r.setClusterPhase(ctx, cluster, kubermaticv1.ClusterCreating)
+	}
+
+	// if there is a pending update condition, the cluster is in Updating phase
+	cond, exists := cluster.Status.Conditions[kubermaticv1.ClusterConditionUpdateProgress]
+	if exists && cond.Reason != updatecontroller.ClusterConditionUpToDate {
+		return r.setClusterPhase(ctx, cluster, kubermaticv1.ClusterUpdating)
+	}
+
+	// in the absence of more smarter logic, every other status is just "Running"
+	// (going to something like "Reconciling" whenever the control plane is unhealthy
+	// might cause maaaaany status changes)
+	return r.setClusterPhase(ctx, cluster, kubermaticv1.ClusterRunning)
+}
+
+func (r *Reconciler) setClusterPhase(ctx context.Context, cluster *kubermaticv1.Cluster, phase kubermaticv1.ClusterPhase) error {
+	return kubermaticv1helper.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
+		c.Status.Phase = phase
+	})
+}

--- a/pkg/controller/seed-controller-manager/cluster-phase-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/cluster-phase-controller/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package clusterphasecontroller contains a controller that updates the
+Phase on a Cluster object, based on the ClusterStatus.
+*/
+package clusterphasecontroller


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Inspired by the new update controller, this PR introduces cluster phases, similar to how projects already have phases. This PR adds a new field to the ClusterStatus (`Phase`) and defines a couple of possible phases:

- `Terminating` if the deletion timestamp is not nil.
- `Creating` if the `ClusterInitialized` condition wasn't set yet.
- `Updating` if an update status indicates that the control plane is being updated.
- `Running` else.

I chose not to take the cluster health into account, as I fear we would be constantly flip-flopping between Running and Reconciling.

**Does this PR introduce a user-facing change?**:
```release-note
Clusters now have a phase (creating, updating, running, terminating) to allow getting a quick overview over the health on a seed cluster.
```
