### PR TITLE
Do not reference GOPATH or go get in dev environment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Thanks for taking the time to join our community and start contributing!
 ### Development environment
 
 ```bash
-git clone git@github.com:kubermatic/kubermatic
+git clone git@github.com:kubermatic/kubermatic.git
 cd kubermatic
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,16 +73,8 @@ Thanks for taking the time to join our community and start contributing!
 ### Development environment
 
 ```bash
-mkdir -p $(go env GOPATH)/src/k8c.io
-cd $(go env GOPATH)/src/k8c.io
 git clone git@github.com:kubermatic/kubermatic
 cd kubermatic
-```
-
-Or alternatively:
-
-```bash
-go get k8c.io/kubermatic
 ```
 
 There are a couple of scripts in the `hacks` directory to aid in running the components locally


### PR DESCRIPTION

**What does this PR do / Why do we need it**:
It's 2022, let's not recommend downloading kubermatic source code into `GOPATH` or via `go get` anymore. It's not needed and `go get` doesn't even seem to work that way anymore.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9415

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>

