### PR TITLE
fix creating vsphere clusters

### DIFF
--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -49,7 +49,11 @@ func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluste
 		return cluster.Spec.Cloud.Hetzner.Network != "" || dc.Spec.Hetzner.Network != ""
 
 	case cluster.Spec.Cloud.VSphere != nil:
-		supported, err := version.IsSupported(cluster.Status.Versions.ControlPlane.Semver(), kubermaticv1.VSphereCloudProvider, incompatibilities, kubermaticv1.ExternalCloudProviderCondition)
+		v := cluster.Status.Versions.ControlPlane
+		if v == "" {
+			v = cluster.Spec.Version
+		}
+		supported, err := version.IsSupported(v.Semver(), kubermaticv1.VSphereCloudProvider, incompatibilities, kubermaticv1.ExternalCloudProviderCondition)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Since introducing the ClusterVersionsStatus, we switched to using it everywhere. However this function that is fixed in this PR is also called during cluster _creation_, where under no circumstances the ClusterVersionsStatus exist. So in those cases, we have to rely on the spec.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
