### PR TITLE
Add usersshkey.Spec.Project to allow easier GitOps management

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.owner
       name: Owner
       type: string
+    - jsonPath: .spec.project
+      name: Project
+      type: string
     - jsonPath: .spec.fingerprint
       name: Fingerprint
       type: string
@@ -48,22 +51,35 @@ spec:
           spec:
             properties:
               clusters:
+                description: Clusters is the list of cluster names that this SSH key
+                  is assigned to.
                 items:
                   type: string
                 type: array
               fingerprint:
+                description: Fingerprint is calculated on the server-side and doesn't
+                  need to be set by clients.
                 type: string
               name:
+                description: Name is the human readable name for this SSH key.
                 type: string
               owner:
+                description: Owner is the name of the User object that owns this SSH
+                  key. This field is immutable.
+                type: string
+              project:
+                description: Project is the name of the Project object that this SSH
+                  key belongs to. This field is immutable.
                 type: string
               publicKey:
+                description: PublicKey is the SSH public key.
                 type: string
             required:
             - clusters
             - fingerprint
             - name
             - owner
+            - project
             - publicKey
             type: object
         type: object

--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -165,7 +165,7 @@ func main() {
 	// /////////////////////////////////////////
 	// setup UserSSHKey webhooks
 
-	usersshkeymutation.NewAdmissionHandler().SetupWebhookWithManager(mgr)
+	usersshkeymutation.NewAdmissionHandler(mgr.GetClient()).SetupWebhookWithManager(mgr)
 
 	// /////////////////////////////////////////
 	// setup OSM webhooks

--- a/pkg/apis/kubermatic/v1/sshkeys.go
+++ b/pkg/apis/kubermatic/v1/sshkeys.go
@@ -34,6 +34,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:JSONPath=".spec.name",name="HumanReadableName",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.owner",name="Owner",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.project",name="Project",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.fingerprint",name="Fingerprint",type="string"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
@@ -46,11 +47,21 @@ type UserSSHKey struct {
 }
 
 type SSHKeySpec struct {
-	Owner       string   `json:"owner"`
-	Name        string   `json:"name"`
-	Fingerprint string   `json:"fingerprint"`
-	PublicKey   string   `json:"publicKey"`
-	Clusters    []string `json:"clusters"`
+	// Name is the human readable name for this SSH key.
+	Name string `json:"name"`
+	// Owner is the name of the User object that owns this SSH key.
+	// This field is immutable.
+	Owner string `json:"owner"`
+	// Project is the name of the Project object that this SSH key belongs to.
+	// This field is immutable.
+	Project string `json:"project"`
+	// Clusters is the list of cluster names that this SSH key is assigned to.
+	Clusters []string `json:"clusters"`
+	// Fingerprint is calculated on the server-side and doesn't need to be set
+	// by clients.
+	Fingerprint string `json:"fingerprint"`
+	// PublicKey is the SSH public key.
+	PublicKey string `json:"publicKey"`
 }
 
 func (sk *UserSSHKey) IsUsedByCluster(clustername string) bool {

--- a/pkg/handler/v1/cluster/cluster_test.go
+++ b/pkg/handler/v1/cluster/cluster_test.go
@@ -236,33 +236,19 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "key-display-name",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -289,33 +275,19 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "key-display-name",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -342,33 +314,19 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "key-display-name",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -453,37 +411,23 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 				// add ssh keys
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+						Name:              "key-c08aa5c7abf34504f18552846485267d-yafn",
 						CreationTimestamp: metav1.NewTime(creationTime),
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "yafn",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+						Name:              "key-abc-yafn",
 						CreationTimestamp: metav1.NewTime(creationTime.Add(time.Minute)),
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "abcd",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
@@ -550,16 +494,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
@@ -583,14 +520,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       "differentProject",
-							},
-						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{
+						Project: "differentProject",
 					},
 				},
 			),
@@ -613,16 +545,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
@@ -646,16 +571,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},

--- a/pkg/handler/v1/ssh/ssh_test.go
+++ b/pkg/handler/v1/ssh/ssh_test.go
@@ -366,19 +366,12 @@ func TestCreateSSHKeysEndpoint(t *testing.T) {
 func genSSHKey(creationTime time.Time, keyID string, keyName string, projectID string, clusters ...string) *kubermaticv1.UserSSHKey {
 	return &kubermaticv1.UserSSHKey{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("key-%s-%s", keyID, keyName),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "kubermatic.k8c.io/v1",
-					Kind:       "Project",
-					UID:        "",
-					Name:       projectID,
-				},
-			},
+			Name:              fmt.Sprintf("key-%s-%s", keyID, keyName),
 			CreationTimestamp: metav1.NewTime(creationTime),
 		},
 		Spec: kubermaticv1.SSHKeySpec{
 			Name:     keyName,
+			Project:  projectID,
 			Clusters: clusters,
 		},
 	}

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -749,32 +749,18 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -798,32 +784,18 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -1779,33 +1751,19 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "key-display-name",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -1832,33 +1790,19 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "key-display-name",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -1885,33 +1829,19 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "key-display-name",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{"clusterAbcID"},
 					},
 				},
@@ -1974,16 +1904,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
@@ -2007,14 +1930,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       "differentProject",
-							},
-						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{
+						Project: "differentProject",
 					},
 				},
 			),
@@ -2037,16 +1955,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
@@ -2070,16 +1981,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
@@ -2161,37 +2065,23 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 				// add ssh keys
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+						Name:              "key-c08aa5c7abf34504f18552846485267d-yafn",
 						CreationTimestamp: metav1.NewTime(creationTime),
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "yafn",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "key-abc-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+						Name:              "key-abc-yafn",
 						CreationTimestamp: metav1.NewTime(creationTime.Add(time.Minute)),
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "abcd",
+						Project:  test.GenDefaultProject().Name,
 						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},

--- a/pkg/handler/v2/cluster_template/cluster_template_test.go
+++ b/pkg/handler/v2/cluster_template/cluster_template_test.go
@@ -113,14 +113,9 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{
+						Project: test.GenDefaultProject().Name,
 					},
 				},
 			),
@@ -139,14 +134,9 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{
+						Project: test.GenDefaultProject().Name,
 					},
 				},
 			),
@@ -762,14 +752,9 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{
+						Project: test.GenDefaultProject().Name,
 					},
 				},
 			),
@@ -788,14 +773,9 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "key-c08aa5c7abf34504f18552846485267d-yafn",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8c.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       test.GenDefaultProject().Name,
-							},
-						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{
+						Project: test.GenDefaultProject().Name,
 					},
 				},
 			),

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -237,6 +237,11 @@ func (s *MasterStack) deployKubermaticOperator(ctx context.Context, logger *logr
 		return fmt.Errorf("failed to deploy CRDs: %w", err)
 	}
 
+	sublogger.Info("Migrating UserSSHKeys…")
+	if err := s.migrateUserSSHKeyProjects(ctx, kubeClient, sublogger, opt); err != nil {
+		return fmt.Errorf("failed to migrate keys: %w", err)
+	}
+
 	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, KubermaticOperatorNamespace); err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
@@ -267,6 +272,52 @@ func (*MasterStack) InstallKubermaticCRDs(ctx context.Context, client ctrlruntim
 	// install VPA CRDs
 	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "k8s.io")); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// migrateUserSSHKeyProjects takes care of setting spec.project (see #9421) on all existing SSH keys
+// based on their owner references. This must happen before the new webhooks are installed.
+// The keys are updated on the master cluster and are then synced downstream by the project
+// controller. This syncing will fail as long as the seed clusters are not also updated (at least
+// the CRDs), so in this sense it's safe to do it on the master.
+// This function can be removed in KKP 2.22.
+func (*MasterStack) migrateUserSSHKeyProjects(ctx context.Context, client ctrlruntimeclient.Client, logger logrus.FieldLogger, opt stack.DeployOptions) error {
+	keys := &kubermaticv1.UserSSHKeyList{}
+	if err := client.List(ctx, keys); err != nil {
+		return fmt.Errorf("failed to list UserSSHKeys: %w", err)
+	}
+
+	apiVersion := kubermaticv1.SchemeGroupVersion.String()
+	kind := kubermaticv1.ProjectKindName
+
+	for _, key := range keys.Items {
+		if key.Spec.Project != "" {
+			continue
+		}
+
+		projectID := ""
+		for _, ref := range key.OwnerReferences {
+			if ref.APIVersion == apiVersion && ref.Kind == kind {
+				if projectID != "" {
+					return fmt.Errorf("key %s has multiple owner references to Projects, this should not be possible; reduce the owner refs to a single Project reference", key.Name)
+				}
+
+				projectID = ref.Name
+			}
+		}
+
+		if projectID == "" {
+			return fmt.Errorf("key %s no project owner reference, cannot determine project association", key.Name)
+		}
+
+		oldKey := key.DeepCopy()
+		key.Spec.Project = projectID
+
+		if err := client.Patch(ctx, &key, ctrlruntimeclient.MergeFrom(oldKey)); err != nil {
+			return fmt.Errorf("failed to update key %s: %w", key.Name, err)
+		}
 	}
 
 	return nil

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -268,4 +269,21 @@ func ContainerFromString(containerSpec string) (*corev1.Container, error) {
 	}
 
 	return container, nil
+}
+
+func SortOwnerReferences(refs []metav1.OwnerReference) {
+	sort.Slice(refs, func(i, j int) bool {
+		refA := refs[i]
+		refB := refs[j]
+
+		if refA.APIVersion != refB.APIVersion {
+			return refA.APIVersion < refB.APIVersion
+		}
+
+		if refA.Kind != refB.Kind {
+			return refA.Kind < refB.Kind
+		}
+
+		return refA.Name < refB.Name
+	})
 }

--- a/pkg/webhook/usersshkey/mutation/mutation.go
+++ b/pkg/webhook/usersshkey/mutation/mutation.go
@@ -19,6 +19,7 @@ package mutation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -26,22 +27,30 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // AdmissionHandler for mutating Kubermatic Cluster CRD.
 type AdmissionHandler struct {
+	client  ctrlruntimeclient.Client
 	log     logr.Logger
 	decoder *admission.Decoder
 }
 
 // NewAdmissionHandler returns a new UserSSHKey AdmissionHandler.
-func NewAdmissionHandler() *AdmissionHandler {
-	return &AdmissionHandler{}
+func NewAdmissionHandler(client ctrlruntimeclient.Client) *AdmissionHandler {
+	return &AdmissionHandler{
+		client: client,
+	}
 }
 
 func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
@@ -68,10 +77,13 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		err := h.applyDefaults(ctx, sshKey, nil)
-		if err != nil {
+		if err := h.applyDefaults(ctx, sshKey, nil); err != nil {
 			h.log.Info("usersshkey mutation failed", "error", err)
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("usersshkey mutation request %s failed: %w", req.UID, err))
+		}
+
+		if err := h.ensureProjectRelation(ctx, sshKey, nil); err != nil {
+			return webhook.Errored(http.StatusBadRequest, err)
 		}
 
 	case admissionv1.Update:
@@ -82,11 +94,13 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		// apply defaults to the existing sshKey
-		err := h.applyDefaults(ctx, sshKey, oldKey)
-		if err != nil {
+		if err := h.applyDefaults(ctx, sshKey, oldKey); err != nil {
 			h.log.Info("usersshkey mutation failed", "error", err)
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("usersshkey mutation request %s failed: %w", req.UID, err))
+		}
+
+		if err := h.ensureProjectRelation(ctx, sshKey, oldKey); err != nil {
+			return webhook.Errored(http.StatusBadRequest, err)
 		}
 
 	case admissionv1.Delete:
@@ -108,4 +122,70 @@ func (h *AdmissionHandler) applyDefaults(ctx context.Context, key *kubermaticv1.
 	_, err := defaulting.DefaultUserSSHKey(key, oldKey)
 
 	return err
+}
+
+func (h *AdmissionHandler) ensureProjectRelation(ctx context.Context, key *kubermaticv1.UserSSHKey, oldKey *kubermaticv1.UserSSHKey) error {
+	isUpdate := oldKey != nil
+
+	if isUpdate && key.Spec.Project != oldKey.Spec.Project {
+		return errors.New("cannot change the project for an UserSSHKey object")
+	}
+
+	// this should never occur due to OpenAPI validation
+	if key.Spec.Project == "" {
+		return errors.New("project name must be configured")
+	}
+
+	project := &kubermaticv1.Project{}
+	if err := h.client.Get(ctx, types.NamespacedName{Name: key.Spec.Project}, project); err != nil {
+		if kerrors.IsNotFound(err) {
+			// during key creation, we enforce the project association;
+			// during updates we are more relaxed and only require that the association isn't changed,
+			// so that if a project gets removed before the key (for whatever reason), then
+			// the cluster cleanup can still progress and is not blocked by the webhook
+			if isUpdate {
+				return nil
+			}
+
+			return errors.New("no such project exists")
+		}
+
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	// Do not check the project phase, as projects only get Active after being successfully
+	// reconciled. This requires the owner user to be setup properly as well, which in turn
+	// requires owner references to be setup. All of this is super annoying when doing
+	// GitOps. Instead we rely on _eventual_ consistency and only check that the project
+	// exists and is not being deleted.
+	if !isUpdate && project.DeletionTimestamp != nil {
+		return errors.New("project is in deletion, cannot create new clusters in it")
+	}
+
+	// ensure the key has exactly 1 OwnerRef to a Project and that this ownerRef points to the
+	// correct Project
+	ownerRefs := []metav1.OwnerReference{}
+	apiVersion := kubermaticv1.SchemeGroupVersion.String()
+	kind := kubermaticv1.ProjectKindName
+
+	for _, ref := range key.OwnerReferences {
+		// skip all project owner refs
+		if ref.Kind == kind && ref.APIVersion == apiVersion {
+			continue
+		}
+
+		ownerRefs = append(ownerRefs, ref)
+	}
+
+	ownerRefs = append(ownerRefs, metav1.OwnerReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		UID:        project.UID,
+		Name:       project.Name,
+	})
+
+	kubernetes.SortOwnerReferences(ownerRefs)
+	key.SetOwnerReferences(ownerRefs)
+
+	return nil
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
To make it easier to apply UserSSHKeys with `kubectl`, using OwnerReferences is not the best option. This PR adds a new field to UserSSHKeys and uses that for all the logic. The existing mutation webhook ensures the owner ref so that deletion works just as before.

The kubermatic installer was extended to auto-migrate all UserSSHKeys on the master cluster. From there the sync controller will try to mirror that onto seeds, but fail because the seeds might not have the new CRDs (but also not the new webhook, which would reject keys without project). Once the seeds are updated, the mirroring should continue as normal.

I tested the procedure in kind:

* create empty kind cluster
* install old UserSSHKey CRD
* create UserSSHKey (without project at this point)
* update UserSSHKey CRD
* edit the existing key to fill in the project

So I think it's fine to "break the API" by adding a new required field.

This is part of #9439.

**Does this PR introduce a user-facing change?**:
```release-note
UserSSHKey.Spec.Project was added, making it easier to manage SSH keys declaratively. Existing UserSSHKey objects must be migrated, the kubermatic-installer takes care of that during the upgrade.
```
