### PR TITLE
Allow volume expansion on OpenStack cinder-csi StorageClass

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -85,6 +85,7 @@ metadata:
   name: cinder-csi
 provisioner: cinder.csi.openstack.org
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 {{ else }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Allows volume expansion on OpenStack cinder-csi StorageClass.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow volume expansion on OpenStack cinder-csi StorageClass
```
