### PR TITLE
Cleanup RuleGroup Cluster ref

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -39,7 +39,7 @@ spec:
             properties:
               cluster:
                 description: Cluster is the reference to the cluster the ruleGroup
-                  should be created in.
+                  should be created in. All fields except for the name are ignored.
                 properties:
                   apiVersion:
                     description: API version of the referent.

--- a/pkg/apis/kubermatic/v1/rulegroup.go
+++ b/pkg/apis/kubermatic/v1/rulegroup.go
@@ -45,7 +45,8 @@ type RuleGroupSpec struct {
 	IsDefault bool `json:"isDefault,omitempty"`
 	// RuleGroupType is the type of this ruleGroup applies to. It can be `Metrics` or `Logs`.
 	RuleGroupType RuleGroupType `json:"ruleGroupType"`
-	// Cluster is the reference to the cluster the ruleGroup should be created in.
+	// Cluster is the reference to the cluster the ruleGroup should be created in. All fields
+	// except for the name are ignored.
 	Cluster corev1.ObjectReference `json:"cluster"`
 	// Data contains the RuleGroup data. Ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group
 	Data []byte `json:"data"`

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -222,12 +222,7 @@ func ruleGroupCreatorGetter(ruleGroup *kubermaticv1.RuleGroup, cluster *kubermat
 			r.Spec = kubermaticv1.RuleGroupSpec{
 				RuleGroupType: ruleGroup.Spec.RuleGroupType,
 				Cluster: corev1.ObjectReference{
-					Kind:            kubermaticv1.ClusterKindName,
-					Namespace:       "",
-					Name:            cluster.Name,
-					UID:             cluster.UID,
-					APIVersion:      cluster.APIVersion,
-					ResourceVersion: cluster.ResourceVersion,
+					Name: cluster.Name,
 				},
 				Data: ruleGroup.Spec.Data,
 			}

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1888,10 +1888,7 @@ func GenRuleGroup(name, clusterName string, ruleGroupType kubermaticv1.RuleGroup
 			RuleGroupType: ruleGroupType,
 			IsDefault:     isDefault,
 			Cluster: corev1.ObjectReference{
-				Kind:       kubermaticv1.ClusterKindName,
-				Namespace:  "",
-				Name:       clusterName,
-				APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+				Name: clusterName,
 			},
 			Data: GenerateTestRuleGroupData(name),
 		},
@@ -1910,10 +1907,8 @@ func GenAdminRuleGroup(name, namespace string, ruleGroupType kubermaticv1.RuleGr
 		},
 		Spec: kubermaticv1.RuleGroupSpec{
 			RuleGroupType: ruleGroupType,
-			Cluster: corev1.ObjectReference{
-				Kind: kubermaticv1.ClusterKindName,
-			},
-			Data: GenerateTestRuleGroupData(name),
+			Cluster:       corev1.ObjectReference{},
+			Data:          GenerateTestRuleGroupData(name),
 		},
 	}
 }

--- a/pkg/handler/v2/rulegroup/rulegroup.go
+++ b/pkg/handler/v2/rulegroup/rulegroup.go
@@ -232,12 +232,7 @@ func convertAPIToInternalRuleGroup(cluster *kubermaticv1.Cluster, ruleGroup *api
 		Spec: kubermaticv1.RuleGroupSpec{
 			RuleGroupType: ruleGroup.Type,
 			Cluster: corev1.ObjectReference{
-				Kind:            kubermaticv1.ClusterKindName,
-				Namespace:       "",
-				Name:            cluster.Name,
-				UID:             cluster.UID,
-				APIVersion:      cluster.APIVersion,
-				ResourceVersion: cluster.ResourceVersion,
+				Name: cluster.Name,
 			},
 			Data:      ruleGroup.Data,
 			IsDefault: ruleGroup.IsDefault,

--- a/pkg/handler/v2/rulegroup_admin/rulegroup.go
+++ b/pkg/handler/v2/rulegroup_admin/rulegroup.go
@@ -164,10 +164,8 @@ func convertAPIToInternalRuleGroup(ruleGroup *apiv2.RuleGroup, ruleGroupID strin
 		},
 		Spec: kubermaticv1.RuleGroupSpec{
 			RuleGroupType: ruleGroup.Type,
-			Cluster: corev1.ObjectReference{
-				Kind: kubermaticv1.ClusterKindName,
-			},
-			Data: ruleGroup.Data,
+			Cluster:       corev1.ObjectReference{},
+			Data:          ruleGroup.Data,
 			// all rule group created here should be default
 			IsDefault: true,
 		},


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Kubernetes documentation says regarding ObjectReferences:

> New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.

We are now more or less stuck with an ObjectReference here, but at least we can document that only the name is ever relevant.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
