### PR TITLE
Re-enable AWS Storage Tests

### DIFF
--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -468,9 +468,9 @@ func (r *TestRunner) testCluster(
 	log.Info("Starting to test cluster...")
 
 	// Run the Kubernetes conformance tests
-	if err := tests.TestKubernetesConformance(ctx, log, r.opts, scenario, cluster, userClusterClient, kubeconfigFilename, cloudConfigFilename, report); err != nil {
-		log.Errorf("Conformance tests failed: %v", err)
-	}
+	// if err := tests.TestKubernetesConformance(ctx, log, r.opts, scenario, cluster, userClusterClient, kubeconfigFilename, cloudConfigFilename, report); err != nil {
+	// 	log.Errorf("Conformance tests failed: %v", err)
+	// }
 
 	// Do a simple PVC test
 	if err := util.JUnitWrapper("[KKP] [CloudProvider] Test PersistentVolumes", report, util.MeasuredRetryN(
@@ -486,62 +486,62 @@ func (r *TestRunner) testCluster(
 	}
 
 	// Do a simple LoadBalancer test
-	if err := util.JUnitWrapper("[KKP] [CloudProvider] Test LoadBalancers", report, util.MeasuredRetryN(
-		metrics.LBTestRuntimeMetric.MustCurryWith(defaultLabels),
-		metrics.LBTestAttemptsMetric.With(defaultLabels),
-		log,
-		maxTestAttempts,
-		func(attempt int) error {
-			return tests.TestLoadBalancer(ctx, log, r.opts, cluster, userClusterClient, attempt)
-		},
-	)); err != nil {
-		log.Errorf("Failed to verify that LoadBalancers work: %v", err)
-	}
+	// if err := util.JUnitWrapper("[KKP] [CloudProvider] Test LoadBalancers", report, util.MeasuredRetryN(
+	// 	metrics.LBTestRuntimeMetric.MustCurryWith(defaultLabels),
+	// 	metrics.LBTestAttemptsMetric.With(defaultLabels),
+	// 	log,
+	// 	maxTestAttempts,
+	// 	func(attempt int) error {
+	// 		return tests.TestLoadBalancer(ctx, log, r.opts, cluster, userClusterClient, attempt)
+	// 	},
+	// )); err != nil {
+	// 	log.Errorf("Failed to verify that LoadBalancers work: %v", err)
+	// }
 
-	// Do user cluster RBAC controller test
-	if err := util.JUnitWrapper("[KKP] Test user cluster RBAC controller", report, func() error {
-		return util.RetryN(maxTestAttempts, func(attempt int) error {
-			return tests.TestUserclusterControllerRBAC(ctx, log, r.opts, cluster, userClusterClient, r.opts.SeedClusterClient)
-		})
-	}); err != nil {
-		log.Errorf("Failed to verify that user cluster RBAC controller work: %v", err)
-	}
+	// // Do user cluster RBAC controller test
+	// if err := util.JUnitWrapper("[KKP] Test user cluster RBAC controller", report, func() error {
+	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
+	// 		return tests.TestUserclusterControllerRBAC(ctx, log, r.opts, cluster, userClusterClient, r.opts.SeedClusterClient)
+	// 	})
+	// }); err != nil {
+	// 	log.Errorf("Failed to verify that user cluster RBAC controller work: %v", err)
+	// }
 
-	// Do prometheus metrics available test
-	if err := util.JUnitWrapper("[KKP] Test prometheus metrics availability", report, func() error {
-		return util.RetryN(maxTestAttempts, func(attempt int) error {
-			return tests.TestUserClusterMetrics(ctx, log, r.opts, cluster, r.opts.SeedClusterClient)
-		})
-	}); err != nil {
-		log.Errorf("Failed to verify that prometheus metrics are available: %v", err)
-	}
+	// // Do prometheus metrics available test
+	// if err := util.JUnitWrapper("[KKP] Test prometheus metrics availability", report, func() error {
+	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
+	// 		return tests.TestUserClusterMetrics(ctx, log, r.opts, cluster, r.opts.SeedClusterClient)
+	// 	})
+	// }); err != nil {
+	// 	log.Errorf("Failed to verify that prometheus metrics are available: %v", err)
+	// }
 
-	// Do pod and node metrics availability test
-	if err := util.JUnitWrapper("[KKP] Test pod and node metrics availability", report, func() error {
-		return util.RetryN(maxTestAttempts, func(attempt int) error {
-			return tests.TestUserClusterPodAndNodeMetrics(ctx, log, r.opts, cluster, userClusterClient)
-		})
-	}); err != nil {
-		log.Errorf("Failed to verify that pod and node metrics are available: %v", err)
-	}
+	// // Do pod and node metrics availability test
+	// if err := util.JUnitWrapper("[KKP] Test pod and node metrics availability", report, func() error {
+	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
+	// 		return tests.TestUserClusterPodAndNodeMetrics(ctx, log, r.opts, cluster, userClusterClient)
+	// 	})
+	// }); err != nil {
+	// 	log.Errorf("Failed to verify that pod and node metrics are available: %v", err)
+	// }
 
-	// Check seccomp profiles for Pods running on user cluster
-	if err := util.JUnitWrapper("[KKP] Test pod seccomp profiles on user cluster", report, func() error {
-		return util.RetryN(maxTestAttempts, func(attempt int) error {
-			return tests.TestUserClusterSeccompProfiles(ctx, log, r.opts, cluster, userClusterClient)
-		})
-	}); err != nil {
-		log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
-	}
+	// // Check seccomp profiles for Pods running on user cluster
+	// if err := util.JUnitWrapper("[KKP] Test pod seccomp profiles on user cluster", report, func() error {
+	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
+	// 		return tests.TestUserClusterSeccompProfiles(ctx, log, r.opts, cluster, userClusterClient)
+	// 	})
+	// }); err != nil {
+	// 	log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
+	// }
 
-	// Check security context (seccomp profiles) for control plane pods running on seed cluster
-	if err := util.JUnitWrapper("[KKP] Test pod security context on seed cluster", report, func() error {
-		return util.RetryN(maxTestAttempts, func(attempt int) error {
-			return tests.TestUserClusterControlPlaneSecurityContext(ctx, log, r.opts, cluster)
-		})
-	}); err != nil {
-		log.Errorf("failed to verify security context for control plane pods: %v", err)
-	}
+	// // Check security context (seccomp profiles) for control plane pods running on seed cluster
+	// if err := util.JUnitWrapper("[KKP] Test pod security context on seed cluster", report, func() error {
+	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
+	// 		return tests.TestUserClusterControlPlaneSecurityContext(ctx, log, r.opts, cluster)
+	// 	})
+	// }); err != nil {
+	// 	log.Errorf("failed to verify security context for control plane pods: %v", err)
+	// }
 
 	log.Info("All tests completed.")
 

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -468,9 +468,9 @@ func (r *TestRunner) testCluster(
 	log.Info("Starting to test cluster...")
 
 	// Run the Kubernetes conformance tests
-	// if err := tests.TestKubernetesConformance(ctx, log, r.opts, scenario, cluster, userClusterClient, kubeconfigFilename, cloudConfigFilename, report); err != nil {
-	// 	log.Errorf("Conformance tests failed: %v", err)
-	// }
+	if err := tests.TestKubernetesConformance(ctx, log, r.opts, scenario, cluster, userClusterClient, kubeconfigFilename, cloudConfigFilename, report); err != nil {
+		log.Errorf("Conformance tests failed: %v", err)
+	}
 
 	// Do a simple PVC test
 	if err := util.JUnitWrapper("[KKP] [CloudProvider] Test PersistentVolumes", report, util.MeasuredRetryN(
@@ -486,62 +486,62 @@ func (r *TestRunner) testCluster(
 	}
 
 	// Do a simple LoadBalancer test
-	// if err := util.JUnitWrapper("[KKP] [CloudProvider] Test LoadBalancers", report, util.MeasuredRetryN(
-	// 	metrics.LBTestRuntimeMetric.MustCurryWith(defaultLabels),
-	// 	metrics.LBTestAttemptsMetric.With(defaultLabels),
-	// 	log,
-	// 	maxTestAttempts,
-	// 	func(attempt int) error {
-	// 		return tests.TestLoadBalancer(ctx, log, r.opts, cluster, userClusterClient, attempt)
-	// 	},
-	// )); err != nil {
-	// 	log.Errorf("Failed to verify that LoadBalancers work: %v", err)
-	// }
+	if err := util.JUnitWrapper("[KKP] [CloudProvider] Test LoadBalancers", report, util.MeasuredRetryN(
+		metrics.LBTestRuntimeMetric.MustCurryWith(defaultLabels),
+		metrics.LBTestAttemptsMetric.With(defaultLabels),
+		log,
+		maxTestAttempts,
+		func(attempt int) error {
+			return tests.TestLoadBalancer(ctx, log, r.opts, cluster, userClusterClient, attempt)
+		},
+	)); err != nil {
+		log.Errorf("Failed to verify that LoadBalancers work: %v", err)
+	}
 
-	// // Do user cluster RBAC controller test
-	// if err := util.JUnitWrapper("[KKP] Test user cluster RBAC controller", report, func() error {
-	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
-	// 		return tests.TestUserclusterControllerRBAC(ctx, log, r.opts, cluster, userClusterClient, r.opts.SeedClusterClient)
-	// 	})
-	// }); err != nil {
-	// 	log.Errorf("Failed to verify that user cluster RBAC controller work: %v", err)
-	// }
+	// Do user cluster RBAC controller test
+	if err := util.JUnitWrapper("[KKP] Test user cluster RBAC controller", report, func() error {
+		return util.RetryN(maxTestAttempts, func(attempt int) error {
+			return tests.TestUserclusterControllerRBAC(ctx, log, r.opts, cluster, userClusterClient, r.opts.SeedClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("Failed to verify that user cluster RBAC controller work: %v", err)
+	}
 
-	// // Do prometheus metrics available test
-	// if err := util.JUnitWrapper("[KKP] Test prometheus metrics availability", report, func() error {
-	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
-	// 		return tests.TestUserClusterMetrics(ctx, log, r.opts, cluster, r.opts.SeedClusterClient)
-	// 	})
-	// }); err != nil {
-	// 	log.Errorf("Failed to verify that prometheus metrics are available: %v", err)
-	// }
+	// Do prometheus metrics available test
+	if err := util.JUnitWrapper("[KKP] Test prometheus metrics availability", report, func() error {
+		return util.RetryN(maxTestAttempts, func(attempt int) error {
+			return tests.TestUserClusterMetrics(ctx, log, r.opts, cluster, r.opts.SeedClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("Failed to verify that prometheus metrics are available: %v", err)
+	}
 
-	// // Do pod and node metrics availability test
-	// if err := util.JUnitWrapper("[KKP] Test pod and node metrics availability", report, func() error {
-	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
-	// 		return tests.TestUserClusterPodAndNodeMetrics(ctx, log, r.opts, cluster, userClusterClient)
-	// 	})
-	// }); err != nil {
-	// 	log.Errorf("Failed to verify that pod and node metrics are available: %v", err)
-	// }
+	// Do pod and node metrics availability test
+	if err := util.JUnitWrapper("[KKP] Test pod and node metrics availability", report, func() error {
+		return util.RetryN(maxTestAttempts, func(attempt int) error {
+			return tests.TestUserClusterPodAndNodeMetrics(ctx, log, r.opts, cluster, userClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("Failed to verify that pod and node metrics are available: %v", err)
+	}
 
-	// // Check seccomp profiles for Pods running on user cluster
-	// if err := util.JUnitWrapper("[KKP] Test pod seccomp profiles on user cluster", report, func() error {
-	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
-	// 		return tests.TestUserClusterSeccompProfiles(ctx, log, r.opts, cluster, userClusterClient)
-	// 	})
-	// }); err != nil {
-	// 	log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
-	// }
+	// Check seccomp profiles for Pods running on user cluster
+	if err := util.JUnitWrapper("[KKP] Test pod seccomp profiles on user cluster", report, func() error {
+		return util.RetryN(maxTestAttempts, func(attempt int) error {
+			return tests.TestUserClusterSeccompProfiles(ctx, log, r.opts, cluster, userClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
+	}
 
-	// // Check security context (seccomp profiles) for control plane pods running on seed cluster
-	// if err := util.JUnitWrapper("[KKP] Test pod security context on seed cluster", report, func() error {
-	// 	return util.RetryN(maxTestAttempts, func(attempt int) error {
-	// 		return tests.TestUserClusterControlPlaneSecurityContext(ctx, log, r.opts, cluster)
-	// 	})
-	// }); err != nil {
-	// 	log.Errorf("failed to verify security context for control plane pods: %v", err)
-	// }
+	// Check security context (seccomp profiles) for control plane pods running on seed cluster
+	if err := util.JUnitWrapper("[KKP] Test pod security context on seed cluster", report, func() error {
+		return util.RetryN(maxTestAttempts, func(attempt int) error {
+			return tests.TestUserClusterControlPlaneSecurityContext(ctx, log, r.opts, cluster)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify security context for control plane pods: %v", err)
+	}
 
 	log.Info("All tests completed.")
 

--- a/cmd/conformance-tester/pkg/runner/waiters.go
+++ b/cmd/conformance-tester/pkg/runner/waiters.go
@@ -101,7 +101,7 @@ func podFailedKubeletAdmissionDueToNodeAffinityPredicate(p *corev1.Pod, log *zap
 }
 
 func waitUntilAllPodsAreReady(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, userClusterClient ctrlruntimeclient.Client, timeout time.Duration) error {
-	log.Debug("Waiting for all pods to be ready...")
+	log.Info("Waiting for all pods to be ready...")
 	started := time.Now()
 
 	err := wait.Poll(opts.UserClusterPollInterval, timeout, func() (done bool, err error) {

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -36,8 +36,6 @@ import (
 )
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {
-	// list does not contain AWS because since 2022-Mar-02, we were
-	// expecting problems while detaching volumes from instances
 	return cluster.Spec.Cloud.Openstack != nil ||
 		cluster.Spec.Cloud.AWS != nil ||
 		cluster.Spec.Cloud.Azure != nil ||

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -39,6 +39,7 @@ func supportsStorage(cluster *kubermaticv1.Cluster) bool {
 	// list does not contain AWS because since 2022-Mar-02, we were
 	// expecting problems while detaching volumes from instances
 	return cluster.Spec.Cloud.Openstack != nil ||
+		cluster.Spec.Cloud.AWS != nil ||
 		cluster.Spec.Cloud.Azure != nil ||
 		cluster.Spec.Cloud.VSphere != nil ||
 		cluster.Spec.Cloud.GCP != nil ||


### PR DESCRIPTION
Since #9233 we had disabled the storage tests on AWS because for unknown reasons, they simply stopped working. We tested _everything_. Clusters, credentials, APIs, we tried awscli, different Kubernetes versions, etc.pp. -- nothing worked.

Now we have updated the KKP seed that hosts our CI cluster, and then also updated the Kubernetes version in our CI cluster. And suddenly, for no apparent reason, the storage tests work again.

Neither @xmudrii nor @xrstf really know why, but we're both happy that it works again. Let's not ask any further questions.

**Release Notes:**
```release-note
NONE
```