### PR TITLE
Add dual-stack support for Azure provider resources

### DIFF
--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -27,6 +27,9 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
+	networkutil "k8c.io/kubermatic/v2/pkg/util/network"
+
+	"k8s.io/utils/net"
 )
 
 func securityGroupName(cluster *kubermaticv1.Cluster) string {
@@ -57,12 +60,24 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 		Build().
 		NodePorts()
 
+	var nodePortsIPv4CIDRs, nodePortsIPv6CIDRs []string
 	nodePortsAllowedIPRange := cluster.Spec.Cloud.Azure.NodePortsAllowedIPRange
-	if nodePortsAllowedIPRange == "" {
-		nodePortsAllowedIPRange = "0.0.0.0/0"
+	if nodePortsAllowedIPRange != "" {
+		if net.IsIPv4CIDRString(nodePortsAllowedIPRange) {
+			nodePortsIPv4CIDRs = append(nodePortsIPv4CIDRs, nodePortsAllowedIPRange)
+		} else {
+			nodePortsIPv6CIDRs = append(nodePortsIPv6CIDRs, nodePortsAllowedIPRange)
+		}
+	} else {
+		if networkutil.IsIPv4OnlyCluster(cluster) || networkutil.IsDualStackCluster(cluster) {
+			nodePortsIPv4CIDRs = append(nodePortsIPv4CIDRs, "0.0.0.0/0")
+		}
+		if networkutil.IsIPv6OnlyCluster(cluster) || networkutil.IsDualStackCluster(cluster) {
+			nodePortsIPv6CIDRs = append(nodePortsIPv6CIDRs, "::/0")
+		}
 	}
 
-	target := targetSecurityGroup(cluster.Spec.Cloud, location, cluster.Name, lowPort, highPort, nodePortsAllowedIPRange)
+	target := targetSecurityGroup(cluster.Spec.Cloud, location, cluster.Name, lowPort, highPort, nodePortsIPv4CIDRs, nodePortsIPv6CIDRs)
 
 	// check for attributes of the existing security group and return early if all values are already
 	// as expected. Since there are a lot of pointers in the network.SecurityGroup struct, we need to
@@ -83,7 +98,8 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 	})
 }
 
-func targetSecurityGroup(cloud kubermaticv1.CloudSpec, location string, clusterName string, portRangeLow int, portRangeHigh int, nodePortsAllowedRange string) *network.SecurityGroup {
+func targetSecurityGroup(cloud kubermaticv1.CloudSpec, location string, clusterName string, portRangeLow int, portRangeHigh int,
+	nodePortsIPv4CIDRs []string, nodePortsIPv6CIDRs []string) *network.SecurityGroup {
 	securityGroup := &network.SecurityGroup{
 		Name:     to.StringPtr(cloud.Azure.SecurityGroup),
 		Location: to.StringPtr(location),
@@ -138,20 +154,6 @@ func targetSecurityGroup(cloud kubermaticv1.CloudSpec, location string, clusterN
 						Priority:                 to.Int32Ptr(300),
 					},
 				},
-				{
-					// Allow access to node ports from everywhere
-					Name: to.StringPtr("node_ports_ingress"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Direction:                network.SecurityRuleDirectionInbound,
-						Protocol:                 network.SecurityRuleProtocolAsterisk,
-						SourceAddressPrefix:      to.StringPtr(nodePortsAllowedRange),
-						SourcePortRange:          to.StringPtr("*"),
-						DestinationAddressPrefix: to.StringPtr("*"),
-						DestinationPortRange:     to.StringPtr(fmt.Sprintf("%d-%d", portRangeLow, portRangeHigh)),
-						Access:                   network.SecurityRuleAccessAllow,
-						Priority:                 to.Int32Ptr(400),
-					},
-				},
 				// outbound
 				{
 					Name: to.StringPtr("outbound_allow_all"),
@@ -168,6 +170,15 @@ func targetSecurityGroup(cloud kubermaticv1.CloudSpec, location string, clusterN
 				},
 			},
 		},
+	}
+
+	if len(nodePortsIPv4CIDRs) > 0 {
+		updatedRules := append(*securityGroup.SecurityRules, nodePortsAllowedIPRangesRule("node_ports_ingress", 400, portRangeLow, portRangeHigh, nodePortsIPv4CIDRs))
+		securityGroup.SecurityRules = &updatedRules
+	}
+	if len(nodePortsIPv6CIDRs) > 0 {
+		updatedRules := append(*securityGroup.SecurityRules, nodePortsAllowedIPRangesRule("node_ports_ingress_ipv6", 401, portRangeLow, portRangeHigh, nodePortsIPv6CIDRs))
+		securityGroup.SecurityRules = &updatedRules
 	}
 
 	updatedRules := append(*securityGroup.SecurityRules, tcpDenyAllRule(), udpDenyAllRule(), icmpAllowAllRule())
@@ -205,6 +216,28 @@ func deleteSecurityGroup(ctx context.Context, clients *ClientSet, cloud kubermat
 	}
 
 	return nil
+}
+
+// nodePortsAllowedIPRangesRule returns a security rule to allow access to node ports from provided IP ranges.
+func nodePortsAllowedIPRangesRule(name string, priority int32, portRangeLow int, portRangeHigh int, nodePortsAllowedIPRanges []string) network.SecurityRule {
+	rule := network.SecurityRule{
+		Name: to.StringPtr(name),
+		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+			Direction:                network.SecurityRuleDirectionInbound,
+			Protocol:                 network.SecurityRuleProtocolAsterisk,
+			SourcePortRange:          to.StringPtr("*"),
+			DestinationAddressPrefix: to.StringPtr("*"),
+			DestinationPortRange:     to.StringPtr(fmt.Sprintf("%d-%d", portRangeLow, portRangeHigh)),
+			Access:                   network.SecurityRuleAccessAllow,
+			Priority:                 to.Int32Ptr(priority),
+		},
+	}
+	if len(nodePortsAllowedIPRanges) == 1 {
+		rule.SecurityRulePropertiesFormat.SourceAddressPrefix = to.StringPtr(nodePortsAllowedIPRanges[0])
+	} else {
+		rule.SecurityRulePropertiesFormat.SourceAddressPrefixes = &nodePortsAllowedIPRanges
+	}
+	return rule
 }
 
 func tcpDenyAllRule() network.SecurityRule {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds dual-stack support for KKP-managed Azure resources.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9424 

**Special notes for your reviewer**:
This PR already accounts for the fact that there will be multiple NodePortsAllowedIPRange CIDRs allowed as part of #9442.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add dual-stack support for Azure provider resources
```
