### PR TITLE
mark usersshkey.project as optional

### DIFF
--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -69,7 +69,9 @@ spec:
                 type: string
               project:
                 description: Project is the name of the Project object that this SSH
-                  key belongs to. This field is immutable.
+                  key belongs to. This field is immutable and required (it is marked
+                  as optional to keep the OpenAPI schema backwards compatible with
+                  KKP 2.20).
                 type: string
               publicKey:
                 description: PublicKey is the SSH public key.
@@ -79,7 +81,6 @@ spec:
             - fingerprint
             - name
             - owner
-            - project
             - publicKey
             type: object
         type: object

--- a/pkg/apis/kubermatic/v1/sshkeys.go
+++ b/pkg/apis/kubermatic/v1/sshkeys.go
@@ -53,7 +53,9 @@ type SSHKeySpec struct {
 	// This field is immutable.
 	Owner string `json:"owner"`
 	// Project is the name of the Project object that this SSH key belongs to.
-	// This field is immutable.
+	// This field is immutable and required (it is marked as optional to keep
+	// the OpenAPI schema backwards compatible with KKP 2.20).
+	// +optional
 	Project string `json:"project"`
 	// Clusters is the list of cluster names that this SSH key is assigned to.
 	Clusters []string `json:"clusters"`


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The plan in #9421 of "create a new mandatory field and then fill it during the installation" doesn't work, as Kubernetes rejects updates to invalid objects, so even if you tried to add the `spec.project` field, it won't work. So sadly we have to mark the field as optional, even though it is not. :-(

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
