### PR TITLE
disallow snapshot restore if etcd-launcher is not enabled

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -33,6 +33,7 @@ import (
 	addonmutation "k8c.io/kubermatic/v2/pkg/webhook/addon/mutation"
 	clustermutation "k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation"
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
+	"k8c.io/kubermatic/v2/pkg/webhook/etcdrestore"
 	kubermaticconfigurationvalidation "k8c.io/kubermatic/v2/pkg/webhook/kubermaticconfiguration/validation"
 	mlaadminsettingmutation "k8c.io/kubermatic/v2/pkg/webhook/mlaadminsetting/mutation"
 	oscvalidation "k8c.io/kubermatic/v2/pkg/webhook/operatingsystemmanager/operatingsystemconfig/validation"
@@ -177,7 +178,11 @@ func main() {
 	ospvalidation.NewAdmissionHandler().SetupWebhookWithManager(mgr)
 
 	// /////////////////////////////////////////
-	// Here we go!
+	// Setup EtcdRestore creation validator webhook
+	etcdRestoreValidator := etcdrestore.NewValidator(seedGetter, seedClientGetter)
+	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.EtcdRestore{}).WithValidator(etcdRestoreValidator).Complete(); err != nil {
+		log.Fatalw("Failed to setup etcdRestore validation webhook", zap.Error(err))
+	}
 
 	log.Info("Starting the webhook...")
 	if err := mgr.Start(ctrlruntime.SetupSignalHandler()); err != nil {

--- a/pkg/webhook/etcdrestore/validation.go
+++ b/pkg/webhook/etcdrestore/validation.go
@@ -83,7 +83,7 @@ func (v validator) getCluster(ctx context.Context, clusterRef v1.ObjectReference
 		return nil, fmt.Errorf("failed to get current Seed: %w", err)
 	}
 	if seed == nil {
-		return nil, fmt.Errorf("webhook not configured for a Seed cluster, cannot validate Addon resources")
+		return nil, fmt.Errorf("webhook not configured for a Seed cluster, cannot validate EtcdRestore resources")
 	}
 
 	client, err := v.seedClientGetter(seed)

--- a/pkg/webhook/etcdrestore/validation.go
+++ b/pkg/webhook/etcdrestore/validation.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcdrestore
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	client2 "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// validator for mutating Kubermatic EtcdRestore CRD.
+type validator struct {
+	seedGetter       provider.SeedGetter
+	seedClientGetter provider.SeedClientGetter
+}
+
+var _ admission.CustomValidator = &validator{}
+
+// NewValidator returns a new EtcdRestore validator.
+func NewValidator(seedGetter provider.SeedGetter,
+	seedClientGetter provider.SeedClientGetter) admission.CustomValidator {
+	return &validator{
+		seedGetter:       seedGetter,
+		seedClientGetter: seedClientGetter,
+	}
+}
+
+func (v validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	return v.validateEtcdLauncherEnabled(ctx, obj)
+}
+
+func (v validator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) error {
+	return v.validateEtcdLauncherEnabled(ctx, newObj)
+}
+
+func (v validator) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+// validateEtcdLauncherEnabled checks if cluster has etcd launcher enabled because it
+// is required for restores to work properly.
+func (v validator) validateEtcdLauncherEnabled(ctx context.Context, obj interface{}) error {
+	etcdRestore, ok := obj.(*kubermaticv1.EtcdRestore)
+	if !ok {
+		return fmt.Errorf("object is not kubermaticv1.EtcdRestore")
+	}
+
+	c, err := v.getCluster(ctx, etcdRestore.Spec.Cluster)
+	if err != nil {
+		return err
+	}
+
+	if !c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
+		return fmt.Errorf("etcd-launcher feature must be enabled for restoring clusters from etcd snapshots")
+	}
+	return nil
+}
+
+func (v validator) getCluster(ctx context.Context, clusterRef v1.ObjectReference) (*kubermaticv1.Cluster, error) {
+	seed, err := v.seedGetter()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current Seed: %w", err)
+	}
+	if seed == nil {
+		return nil, fmt.Errorf("webhook not configured for a Seed cluster, cannot validate Addon resources")
+	}
+
+	client, err := v.seedClientGetter(seed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Seed client: %w", err)
+	}
+
+	c := new(kubermaticv1.Cluster)
+	err = client.Get(ctx, client2.ObjectKey{Namespace: clusterRef.Namespace, Name: clusterRef.Name}, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster object: %w", err)
+	}
+
+	return c, nil
+}

--- a/pkg/webhook/etcdrestore/validation_test.go
+++ b/pkg/webhook/etcdrestore/validation_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package etcdrestore
 
 import (

--- a/pkg/webhook/etcdrestore/validation_test.go
+++ b/pkg/webhook/etcdrestore/validation_test.go
@@ -1,0 +1,102 @@
+package etcdrestore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	handlertest "k8c.io/kubermatic/v2/pkg/handler/test"
+	helpertest "k8c.io/kubermatic/v2/pkg/test"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = kubermaticv1.AddToScheme(testScheme)
+}
+
+func TestEtcdLauncherFeatureGate(t *testing.T) {
+	seed := kubermaticv1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubermatic",
+			Namespace: "kubermatic",
+		},
+		Spec: kubermaticv1.SeedSpec{
+			Datacenters: map[string]kubermaticv1.Datacenter{
+				"datacenterName": {
+					Spec: kubermaticv1.DatacenterSpec{
+						Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{},
+					},
+				},
+			},
+		},
+	}
+
+	seedGetter := helpertest.NewSeedGetter(&seed)
+
+	makeCluster := func(enableEtcdLauncher bool) *kubermaticv1.Cluster {
+		c := handlertest.GenDefaultCluster()
+		c.Name = fmt.Sprintf("%s-%t", c.Name, enableEtcdLauncher)
+		if c.Spec.Features == nil {
+			c.Spec.Features = make(map[string]bool)
+		}
+		c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] = enableEtcdLauncher
+		return c
+	}
+
+	seedClientGetter := func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
+		return ctrlruntimefakeclient.
+			NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(seed, makeCluster(true), makeCluster(false)).
+			Build(), nil
+	}
+
+	makeEtcdRestore := func(c *kubermaticv1.Cluster) *kubermaticv1.EtcdRestore {
+		return &kubermaticv1.EtcdRestore{
+			Spec: kubermaticv1.EtcdRestoreSpec{
+				Cluster: v1.ObjectReference{
+					Namespace: c.Namespace,
+					Name:      c.Name,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		etcdLauncherEnabled bool
+		expectError         bool
+	}{
+		{
+			"create with etcdlauncher enabled",
+			true,
+			false,
+		},
+		{
+			"create with etcdlauncher disabled",
+			false,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := makeEtcdRestore(makeCluster(test.etcdLauncherEnabled))
+			v := NewValidator(seedGetter, seedClientGetter)
+			err := v.ValidateCreate(context.Background(), e)
+			if test.expectError != (err != nil) {
+				t.Fatalf("expectedError: %t, got: %s", test.expectError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Etcd launcher is required for proper working of snapshot restore. This PR checks if it enabled before restore is created. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9453 




**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
