### PR TITLE
shutdown usersshkey webhook before attempting a migration

### DIFF
--- a/pkg/install/stack/kubermatic-master/migrations.go
+++ b/pkg/install/stack/kubermatic-master/migrations.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/install/stack/kubermatic-master/migrations.go
+++ b/pkg/install/stack/kubermatic-master/migrations.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubermaticmaster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/install/stack"
+	"k8c.io/kubermatic/v2/pkg/install/util"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// migrateUserSSHKeyProjects takes care of setting spec.project (see #9421) on all existing SSH keys
+// based on their owner references. This must happen before the new webhooks are installed.
+// The keys are updated on the master cluster and are then synced downstream by the project
+// controller. This syncing will fail as long as the seed clusters are not also updated (at least
+// the CRDs), so in this sense it's safe to do it on the master.
+// This function can be removed in KKP 2.22.
+func (*MasterStack) migrateUserSSHKeyProjects(ctx context.Context, client ctrlruntimeclient.Client, logger logrus.FieldLogger, opt stack.DeployOptions) error {
+	keys := &kubermaticv1.UserSSHKeyList{}
+	if err := client.List(ctx, keys); err != nil {
+		return fmt.Errorf("failed to list UserSSHKeys: %w", err)
+	}
+
+	apiVersion := kubermaticv1.SchemeGroupVersion.String()
+	kind := kubermaticv1.ProjectKindName
+
+	// determine if there are keys that need to be migrated
+	needMigration := false
+	for _, key := range keys.Items {
+		if key.Spec.Project == "" {
+			needMigration = true
+			break
+		}
+	}
+
+	// An old webhook could reject any changes to fields that it doesn't understand,
+	// so we must remove the problematic webhooks prior to the migration; to ensure
+	// the KKP operator doesn't bring them back, we have to scale it down first.
+	// Once the migration is over and the regular installation/upgrade has finished,
+	// the new operator will deploy a new webhook for us.
+	if needMigration {
+		logger.Info("Temporarily removing UserSSHKey webhook…")
+
+		if err := util.ShutdownDeployment(ctx, logger, client, KubermaticOperatorNamespace, KubermaticOperatorDeploymentName); err != nil {
+			return fmt.Errorf("failed to temporarily shut down the KKP operator: %w", err)
+		}
+
+		if err := util.WaitForAllPodsToBeGone(ctx, logger, client, KubermaticOperatorNamespace, KubermaticOperatorDeploymentName, 3*time.Minute); err != nil {
+			return fmt.Errorf("failed to wait for KKP operator to shut down: %w", err)
+		}
+
+		if err := util.RemoveMutatingWebhook(ctx, logger, client, common.UserSSHKeyAdmissionWebhookName); err != nil {
+			return fmt.Errorf("failed to remove the mutating webhook for UserSSHKeys: %w", err)
+		}
+	}
+
+	// Now that nobody should be blocking update operations on SSH keys, we can continue
+	// with the migration.
+	for _, key := range keys.Items {
+		if key.Spec.Project != "" {
+			continue
+		}
+
+		projectID := ""
+		for _, ref := range key.OwnerReferences {
+			if ref.APIVersion == apiVersion && ref.Kind == kind {
+				if projectID != "" {
+					return fmt.Errorf("key %s has multiple owner references to Projects, this should not be possible; reduce the owner refs to a single Project reference", key.Name)
+				}
+
+				projectID = ref.Name
+			}
+		}
+
+		if projectID == "" {
+			return fmt.Errorf("key %s no project owner reference, cannot determine project association", key.Name)
+		}
+
+		oldKey := key.DeepCopy()
+		key.Spec.Project = projectID
+
+		if err := client.Patch(ctx, &key, ctrlruntimeclient.MergeFrom(oldKey)); err != nil {
+			return fmt.Errorf("failed to update key %s: %w", key.Name, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/install/util/migrations.go
+++ b/pkg/install/util/migrations.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/install/util/migrations.go
+++ b/pkg/install/util/migrations.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/install/util/migrations.go
+++ b/pkg/install/util/migrations.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ShutdownDeployment takes the name and namespace of a deployment and will scale that
+// Deployment to 0 replicas.
+func ShutdownDeployment(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, namespace string, name string) error {
+	depLogger := logger.WithField("deployment", name).WithField("namespace", namespace)
+
+	deployment := appsv1.Deployment{}
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+
+	if err := client.Get(ctx, key, &deployment); err != nil {
+		if kerrors.IsNotFound(err) {
+			depLogger.Debug("Deployment not found.")
+			return nil
+		}
+
+		return fmt.Errorf("failed to get Deployment %s: %w", name, err)
+	}
+
+	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas > 0 {
+		depLogger.Debug("Scaling down…")
+
+		oldDeployment := deployment.DeepCopy()
+		deployment.Spec.Replicas = pointer.Int32(0)
+
+		if err := client.Patch(ctx, &deployment, ctrlruntimeclient.MergeFrom(oldDeployment)); err != nil {
+			return fmt.Errorf("failed to scale down Deployment %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// WaitForAllPodsToBeGone takes the name of a Deployment and will wait until all Pods for that
+// Deployment have been shut down.
+func WaitForAllPodsToBeGone(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, namespace string, name string, timeout time.Duration) error {
+	depLogger := logger.WithField("deployment", name).WithField("namespace", namespace)
+	depLogger.Debug("Waiting for Pods to be gone…")
+
+	// waiting for shutdown, as even a Terminating pod can still run and do dangerous things;
+	// sadly Kubernetes does not provide any status information on the Deployment when it's
+	// scaled down to 0 replicas, so we must check for existing pods
+	podNamePrefix := name + "-"
+
+	err := wait.Poll(500*time.Millisecond, timeout, func() (done bool, err error) {
+		pods := &corev1.PodList{}
+		opt := ctrlruntimeclient.ListOptions{
+			Namespace: namespace,
+		}
+
+		if err := client.List(ctx, pods, &opt); err != nil {
+			return false, fmt.Errorf("failed to list pods in %s: %w", namespace, err)
+		}
+
+		// Kubernetes does not provide real status information for pods that are terminating,
+		// so all we have to go on is pod existence, which in itself can be problematic on
+		// some providers like GKE which like to keep Terminated pods around forever.
+		for _, pod := range pods.Items {
+			// we found a pod
+			if strings.HasPrefix(pod.Name, podNamePrefix) {
+				return false, nil
+			}
+		}
+
+		// no more pods left
+		return true, nil
+	})
+
+	if errors.Is(err, wait.ErrWaitTimeout) {
+		return errors.New("there are still Pods running, please wait and let them shut down")
+	}
+
+	return err
+}
+
+func RemoveValidatingWebhook(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, webhookName string) error {
+	webhook := admissionregistrationv1.ValidatingWebhookConfiguration{}
+	webhook.Name = webhookName
+
+	return removeWebhook(ctx, logger.WithField("webhook", webhookName), client, &webhook)
+}
+
+func RemoveMutatingWebhook(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, webhookName string) error {
+	webhook := admissionregistrationv1.MutatingWebhookConfiguration{}
+	webhook.Name = webhookName
+
+	return removeWebhook(ctx, logger.WithField("webhook", webhookName), client, &webhook)
+}
+
+func removeWebhook(ctx context.Context, logger logrus.FieldLogger, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) error {
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(obj), obj); err != nil {
+		// not all webhooks need to exist in all clusters / maybe we already cleaned up
+		// because the user ran the "shutdown" command twice
+		if kerrors.IsNotFound(err) {
+			logger.Debug("Webhook not found.")
+			return nil
+		}
+
+		return fmt.Errorf("failed to get webhook %s: %w", obj.GetName(), err)
+	}
+
+	logger.Debug("Removing…")
+
+	if err := client.Delete(ctx, obj); err != nil {
+		return fmt.Errorf("failed to remove webhook %s: %w", obj.GetName(), err)
+	}
+
+	return nil
+}

--- a/pkg/webhook/usersshkey/mutation/mutation.go
+++ b/pkg/webhook/usersshkey/mutation/mutation.go
@@ -131,7 +131,6 @@ func (h *AdmissionHandler) ensureProjectRelation(ctx context.Context, key *kuber
 		return errors.New("cannot change the project for an UserSSHKey object")
 	}
 
-	// this should never occur due to OpenAPI validation
 	if key.Spec.Project == "" {
 		return errors.New("project name must be configured")
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In #9421 I added some migration, which failed on dev. As it turns out, our webhook would reject the new UserSSHKeys, as it does not know the new `spec.project` field. There are 2 options we have:

1. Shut down the webhook before migrating the data. This means:
   * Install new CRDs
   * Shutdown KKP Operator
   * Remove webhook
   * Migrate data
   * Install new Helm chart, which will
   * ... scale up the KKP Operator, which will
   * ... re-create the webhook
   The downside here is that we need slightly more code to deal with the shutdown, but this could be (and was in this PR) copied  from the 2.20 migration code, which did the exact same thing.
2. Install first, migrate later:
   * Install new CRDs
   * Install new KKP Operator, which installs the new webhook
   * Migrate data
   The downside to this is that we risk that new controllers will start up, see invalid/incomplete data and go crazy.

Because of the possibility that controllers might choke on old, incomplete data, I chose to implement option 1 in this PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
