### PR TITLE
Create nodeport-proxy resources (for LoadBalancer strategy) while reconciling other cluster resources

### DIFF
--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -17,7 +17,6 @@ limitations under the License.
 package nodeportproxy
 
 import (
-	"context"
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -32,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -153,96 +151,49 @@ type nodePortProxyData interface {
 	SupportsFailureDomainZoneAntiAffinity() bool
 }
 
-func EnsureResources(ctx context.Context, client ctrlruntimeclient.Client, data nodePortProxyData) error {
-	image := data.ImageRegistry(resources.RegistryQuay) + "/" + imageName + ":" + data.NodePortProxyTag()
-	namespace := data.Cluster().Status.NamespaceName
-	if namespace == "" {
-		return fmt.Errorf(".Status.NamespaceName is empty for cluster %q", data.Cluster().Name)
+func ServiceAccountCreator() (string, reconciling.ServiceAccountCreator) {
+	return name, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+		return sa, nil
 	}
-
-	err := reconciling.ReconcileServiceAccounts(
-		ctx, []reconciling.NamedServiceAccountCreatorGetter{serviceAccount()}, namespace, client)
-	if err != nil {
-		return fmt.Errorf("failed to ensure ServiceAccount: %w", err)
-	}
-
-	err = reconciling.ReconcileRoles(
-		ctx, []reconciling.NamedRoleCreatorGetter{role()}, namespace, client)
-	if err != nil {
-		return fmt.Errorf("failed to ensure Role: %w", err)
-	}
-
-	err = reconciling.ReconcileRoleBindings(
-		ctx, []reconciling.NamedRoleBindingCreatorGetter{roleBinding(namespace)}, namespace, client)
-	if err != nil {
-		return fmt.Errorf("failed to ensure RoleBinding: %w", err)
-	}
-
-	deployments := []reconciling.NamedDeploymentCreatorGetter{deploymentEnvoy(image, data),
-		deploymentLBUpdater(image)}
-	err = reconciling.ReconcileDeployments(ctx, deployments, namespace, client)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile Deployments: %w", err)
-	}
-
-	err = reconciling.ReconcilePodDisruptionBudgets(
-		ctx, []reconciling.NamedPodDisruptionBudgetCreatorGetter{podDisruptionBudget()}, namespace, client)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile PodDisruptionBudget: %w", err)
-	}
-	return nil
 }
 
-func serviceAccount() reconciling.NamedServiceAccountCreatorGetter {
-	return func() (string, reconciling.ServiceAccountCreator) {
-		return name, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			return sa, nil
+func RoleCreator() (string, reconciling.RoleCreator) {
+	return name, func(r *rbacv1.Role) (*rbacv1.Role, error) {
+		r.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"endpoints", "services"},
+				Verbs:     []string{"list", "get", "watch"},
+			},
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"services"},
+				ResourceNames: []string{resources.FrontLoadBalancerServiceName},
+				Verbs:         []string{"update"},
+			},
 		}
+		return r, nil
 	}
 }
 
-func role() reconciling.NamedRoleCreatorGetter {
-	return func() (string, reconciling.RoleCreator) {
-		return name, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Rules = []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"endpoints", "services"},
-					Verbs:     []string{"list", "get", "watch"},
-				},
-				{
-					APIGroups:     []string{""},
-					Resources:     []string{"services"},
-					ResourceNames: []string{resources.FrontLoadBalancerServiceName},
-					Verbs:         []string{"update"},
-				},
-			}
-			return r, nil
+func RoleBindingCreator() (string, reconciling.RoleBindingCreator) {
+	return name, func(r *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+		r.Subjects = []rbacv1.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: name,
+			},
 		}
-	}
-}
-
-func roleBinding(ns string) reconciling.NamedRoleBindingCreatorGetter {
-	return func() (string, reconciling.RoleBindingCreator) {
-		return name, func(r *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			r.Subjects = []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      name,
-					Namespace: ns,
-				},
-			}
-			r.RoleRef = rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     name,
-			}
-			return r, nil
+		r.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     name,
 		}
+		return r, nil
 	}
 }
 
-func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentEnvoyCreator(data nodePortProxyData) reconciling.NamedDeploymentCreatorGetter {
 	volumeMountNameEnvoyConfig := "envoy-config"
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
@@ -258,7 +209,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 			d.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:  "copy-envoy-config",
-					Image: image,
+					Image: fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryQuay), imageName, data.NodePortProxyTag()),
 					Command: []string{
 						"/bin/cp",
 						"/envoy.yaml",
@@ -273,7 +224,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "envoy-manager",
-				Image: image,
+				Image: fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryQuay), imageName, data.NodePortProxyTag()),
 				Command: []string{"/envoy-manager",
 					"-listen-address=:8001",
 					"-envoy-node-name=$(PODNAME)",
@@ -368,7 +319,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 	}
 }
 
-func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentLBUpdaterCreator(data nodePortProxyData) reconciling.NamedDeploymentCreatorGetter {
 	name := name + "-lb-updater"
 	return func() (string, reconciling.DeploymentCreator) {
 		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
@@ -390,7 +341,7 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 					"-expose-annotation-key=" + NodePortProxyExposeNamespacedAnnotationKey,
 					"-namespaced=true",
 				},
-				Image: image,
+				Image: fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryQuay), imageName, data.NodePortProxyTag()),
 				Env: []corev1.EnvVar{{
 					Name: "MY_NAMESPACE",
 					ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
@@ -409,7 +360,7 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 	}
 }
 
-func podDisruptionBudget() reconciling.NamedPodDisruptionBudgetCreatorGetter {
+func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGetter {
 	maxUnavailable := intstr.FromInt(1)
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return name + "-envoy", func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -197,6 +197,7 @@ func DeploymentEnvoyCreator(data nodePortProxyData) reconciling.NamedDeploymentC
 	volumeMountNameEnvoyConfig := "envoy-config"
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+			d.Name = resources.NodePortProxyEnvoyDeploymentName
 			d.Labels = resources.BaseAppLabels(envoyAppLabelValue, nil)
 			d.Spec.Replicas = resources.Int32(2)
 			d.Spec.Selector = &metav1.LabelSelector{
@@ -320,14 +321,15 @@ func DeploymentEnvoyCreator(data nodePortProxyData) reconciling.NamedDeploymentC
 }
 
 func DeploymentLBUpdaterCreator(data nodePortProxyData) reconciling.NamedDeploymentCreatorGetter {
-	name := name + "-lb-updater"
+	deploymentName := fmt.Sprintf("%s-lb-updater", name)
 	return func() (string, reconciling.DeploymentCreator) {
-		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Labels = resources.BaseAppLabels(name, nil)
+		return deploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+			d.Name = deploymentName
+			d.Labels = resources.BaseAppLabels(deploymentName, nil)
 			d.Spec.Replicas = resources.Int32(1)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(name, nil)}
-			d.Spec.Template.Labels = resources.BaseAppLabels(name, nil)
+				MatchLabels: resources.BaseAppLabels(deploymentName, nil)}
+			d.Spec.Template.Labels = resources.BaseAppLabels(deploymentName, nil)
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,121 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-envoy
+  name: nodeport-proxy-envoy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-envoy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /envoy-manager
+        - -listen-address=:8001
+        - -envoy-node-name=$(PODNAME)
+        - -envoy-admin-port=9001
+        - -envoy-stats-port=8002
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespace=$(PODNAMESPACE)
+        env:
+        - name: PODNAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: envoy-manager
+        resources:
+          limits:
+            cpu: 50m
+            memory: 48Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      - command:
+        - /usr/local/bin/envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-cluster
+        - kube-cluster
+        - --service-node
+        - $(PODNAME)
+        env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - wget
+              - -q0
+              - http://127.0.0.1:9001/healthcheck/fail
+        name: envoy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8002
+            scheme: HTTP
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /envoy.yaml
+        - /etc/envoy/envoy.yaml
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: copy-envoy-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      serviceAccountName: nodeport-proxy
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -1,0 +1,44 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nodeport-proxy-lb-updater
+  name: nodeport-proxy-lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-lb-updater
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nodeport-proxy-lb-updater
+    spec:
+      containers:
+      - command:
+        - /lb-updater
+        - -lb-namespace=$(MY_NAMESPACE)
+        - -lb-name=front-loadbalancer
+        - -expose-annotation-key=nodeport-proxy.k8s.io/expose-namespaced
+        - -namespaced=true
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/nodeport-proxy:v0.0.0-test
+        name: lb-updater
+        resources:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: nodeport-proxy
+status: {}

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.21.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.21.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.21.0-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy-envoy
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The resources created for the `LoadBalancer` expose strategy lived in their own little world that no other part of the code was aware of beyond calling `nodeportproxy.EnsureResources`. I broke `nodeport-proxy` a while back because of weird variable shadowing and no fixtures that warned of the unintended chage.

This PR cleans up the last traces of shadowing the `name` variable in the `nodeportproxy` package and reworks the whole package to be included in the `seed-controller-manager`'s resource reconcile logic. That adds fixtures for them as well. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9083

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
