### PR TITLE
hack: configure seed-name and external-url via env variables

### DIFF
--- a/hack/run-seed-controller-manager.sh
+++ b/hack/run-seed-controller-manager.sh
@@ -22,6 +22,8 @@ source hack/lib.sh
 KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
+KUBERMATIC_SEED=${KUBERMATIC_SEED:-europe-west3-c}
+KUBERMATIC_EXTERNAL_URL=${KUBERMATIC_EXTERNAL_URL:-dev.kubermatic.io}
 PPROF_PORT=${PPROF_PORT:-6600}
 
 # Deploy a user-cluster/ipam-controller for which we actuallly
@@ -63,13 +65,13 @@ set -x
 ./_build/seed-controller-manager $CTRL_EXTRA_ARGS \
   -namespace=kubermatic \
   -enable-leader-election=false \
-  -seed-name=europe-west3-c \
+  -seed-name=$KUBERMATIC_SEED \
   -kubeconfig=$KUBECONFIG \
   -ca-bundle=$CA_BUNDLE \
   -addons-path=addons \
   -feature-gates=OpenIDAuthPlugin=true,KonnectivityService=true \
   -worker-name="$(worker_name)" \
-  -external-url=dev.kubermatic.io \
+  -external-url=$KUBERMATIC_EXTERNAL_URL \
   -docker-pull-config-json-file=$DOCKERCONFIGJSON \
   -oidc-issuer-url=$OIDC_ISSUER_URL \
   -oidc-issuer-client-id=$OIDC_ISSUER_CLIENT_ID \


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Minor nit I had with the `hack/run-seed-controller-manager.sh` script: Most of it was parameterised via environment variables, but `seed-name` and `external-url` were hardcoded to values only sensible for the dev environment.

This PR allows setting `KUBERMATIC_SEED` and `KUBERMATIC_EXTERNAL_URL` to pass different values to the local `seed-controller-manager` instance.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>