### PR TITLE
Machine controller health check extended

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -116,7 +116,6 @@ func (r *Reconciler) syncHealth(ctx context.Context, cluster *kubermaticv1.Clust
 }
 
 func (r *Reconciler) machineControllerHealthCheck(ctx context.Context, namespace string, userClient ctrlruntimeclient.Client) (kubermaticv1.HealthStatus, error) {
-
 	// check the existence of the mutatingWebhookConfiguration in the user cluster
 	key := types.NamespacedName{Name: resources.MachineControllerMutatingWebhookConfigurationName}
 	webhookMutatingConf := &admissionregistrationv1.MutatingWebhookConfiguration{}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The health check for the machine-controller has been extended so that:
* the `machineController` deployment must be healthy
* the `machineControllerWebhook` deployment must be healthy
* the `mutatingWebhookConfiguration` in the user cluster must exist

When the above conditions are met, the machineController health is set to up, otherwise, it is set to down.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8837 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
