### PR TITLE
Fix context handling

### DIFF
--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -232,7 +232,7 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, config *kubermaticv1.
 
 	creators := []reconciling.NamedSecretCreatorGetter{
 		common.WebhookServingCASecretCreator(config),
-		common.WebhookServingCertSecretCreator(config, r.Client),
+		common.WebhookServingCertSecretCreator(ctx, config, r.Client),
 	}
 
 	if config.Spec.ImagePullSecret != "" {
@@ -400,10 +400,10 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 	logger.Debug("Reconciling Validating Webhooks")
 
 	creators := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
-		common.SeedAdmissionWebhookCreator(config, r.Client),
-		common.KubermaticConfigurationAdmissionWebhookCreator(config, r.Client),
-		kubermatic.UserValidatingWebhookConfigurationCreator(config, r.Client),
-		kubermatic.UserSSHKeyValidatingWebhookConfigurationCreator(config, r.Client),
+		common.SeedAdmissionWebhookCreator(ctx, config, r.Client),
+		common.KubermaticConfigurationAdmissionWebhookCreator(ctx, config, r.Client),
+		kubermatic.UserValidatingWebhookConfigurationCreator(ctx, config, r.Client),
+		kubermatic.UserSSHKeyValidatingWebhookConfigurationCreator(ctx, config, r.Client),
 	}
 
 	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {
@@ -417,7 +417,7 @@ func (r *Reconciler) reconcileMutatingWebhooks(ctx context.Context, config *kube
 	logger.Debug("Reconciling Mutating Webhooks")
 
 	creators := []reconciling.NamedMutatingWebhookConfigurationCreatorGetter{
-		kubermatic.UserSSHKeyMutatingWebhookConfigurationCreator(config, r.Client),
+		kubermatic.UserSSHKeyMutatingWebhookConfigurationCreator(ctx, config, r.Client),
 	}
 
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {

--- a/pkg/controller/operator/master/resources/kubermatic/webhooks.go
+++ b/pkg/controller/operator/master/resources/kubermatic/webhooks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubermatic
 
 import (
+	"context"
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -30,7 +31,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func UserSSHKeyMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+func UserSSHKeyMutatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
 		return common.UserSSHKeyAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -39,7 +40,7 @@ func UserSSHKeyMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticC
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.ClusterScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -86,7 +87,7 @@ func UserSSHKeyMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticC
 	}
 }
 
-func UserSSHKeyValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
+func UserSSHKeyValidatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return common.UserSSHKeyAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -94,7 +95,7 @@ func UserSSHKeyValidatingWebhookConfigurationCreator(cfg *kubermaticv1.Kubermati
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.ClusterScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -140,7 +141,7 @@ func UserSSHKeyValidatingWebhookConfigurationCreator(cfg *kubermaticv1.Kubermati
 	}
 }
 
-func UserValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
+func UserValidatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return common.UserAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -148,7 +149,7 @@ func UserValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfi
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.ClusterScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -472,7 +472,7 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, cfg *kubermaticv1.Kub
 
 	creators := []reconciling.NamedSecretCreatorGetter{
 		common.WebhookServingCASecretCreator(cfg),
-		common.WebhookServingCertSecretCreator(cfg, client),
+		common.WebhookServingCertSecretCreator(ctx, cfg, client),
 	}
 
 	if cfg.Spec.ImagePullSecret != "" {
@@ -609,16 +609,16 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 	log.Debug("reconciling Admission Webhooks")
 
 	validatingWebhookCreators := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
-		common.SeedAdmissionWebhookCreator(cfg, client),
-		common.KubermaticConfigurationAdmissionWebhookCreator(cfg, client),
-		kubermaticseed.ClusterValidatingWebhookConfigurationCreator(cfg, client),
+		common.SeedAdmissionWebhookCreator(ctx, cfg, client),
+		common.KubermaticConfigurationAdmissionWebhookCreator(ctx, cfg, client),
+		kubermaticseed.ClusterValidatingWebhookConfigurationCreator(ctx, cfg, client),
 	}
 
 	if cfg.Spec.FeatureGates[features.OperatingSystemManager] {
 		validatingWebhookCreators = append(
 			validatingWebhookCreators,
-			kubermaticseed.OperatingSystemProfileValidatingWebhookConfigurationCreator(cfg, client),
-			kubermaticseed.OperatingSystemConfigValidatingWebhookConfigurationCreator(cfg, client),
+			kubermaticseed.OperatingSystemProfileValidatingWebhookConfigurationCreator(ctx, cfg, client),
+			kubermaticseed.OperatingSystemConfigValidatingWebhookConfigurationCreator(ctx, cfg, client),
 		)
 	}
 
@@ -627,9 +627,9 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 	}
 
 	mutatingWebhookCreators := []reconciling.NamedMutatingWebhookConfigurationCreatorGetter{
-		kubermaticseed.ClusterMutatingWebhookConfigurationCreator(cfg, client),
-		kubermaticseed.AddonMutatingWebhookConfigurationCreator(cfg, client),
-		kubermaticseed.MLAAdminSettingMutatingWebhookConfigurationCreator(cfg, client),
+		kubermaticseed.ClusterMutatingWebhookConfigurationCreator(ctx, cfg, client),
+		kubermaticseed.AddonMutatingWebhookConfigurationCreator(ctx, cfg, client),
+		kubermaticseed.MLAAdminSettingMutatingWebhookConfigurationCreator(ctx, cfg, client),
 	}
 
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, mutatingWebhookCreators, "", client); err != nil {

--- a/pkg/controller/operator/seed/resources/kubermatic/webhooks.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/webhooks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubermatic
 
 import (
+	"context"
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -39,7 +40,7 @@ const (
 	OSPAdmissionWebhookName             = "kubermatic-operating-system-profiles"
 )
 
-func ClusterValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
+func ClusterValidatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return ClusterAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -47,7 +48,7 @@ func ClusterValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticCo
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.ClusterScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -93,7 +94,7 @@ func ClusterValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticCo
 	}
 }
 
-func ClusterMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+func ClusterMutatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
 		return ClusterAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -102,7 +103,7 @@ func ClusterMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConf
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.ClusterScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -149,7 +150,7 @@ func ClusterMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConf
 	}
 }
 
-func AddonMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+func AddonMutatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
 		return AddonAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -158,7 +159,7 @@ func AddonMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfig
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.NamespacedScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -205,7 +206,7 @@ func AddonMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfig
 	}
 }
 
-func MLAAdminSettingMutatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+func MLAAdminSettingMutatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
 		return MLAAdminSettingAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -214,7 +215,7 @@ func MLAAdminSettingMutatingWebhookConfigurationCreator(cfg *kubermaticv1.Kuberm
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.NamespacedScope
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -261,7 +262,7 @@ func MLAAdminSettingMutatingWebhookConfigurationCreator(cfg *kubermaticv1.Kuberm
 	}
 }
 
-func OperatingSystemConfigValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
+func OperatingSystemConfigValidatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return OSCAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -269,7 +270,7 @@ func OperatingSystemConfigValidatingWebhookConfigurationCreator(cfg *kubermaticv
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.AllScopes
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}
@@ -314,7 +315,7 @@ func OperatingSystemConfigValidatingWebhookConfigurationCreator(cfg *kubermaticv
 	}
 }
 
-func OperatingSystemProfileValidatingWebhookConfigurationCreator(cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
+func OperatingSystemProfileValidatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return OSPAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
@@ -322,7 +323,7 @@ func OperatingSystemProfileValidatingWebhookConfigurationCreator(cfg *kubermatic
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.AllScopes
 
-			ca, err := common.WebhookCABundle(cfg, client)
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
 				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR fixes one case where we stored a context in a struct (which is a code smell) and improves the operator to not use so many background contexts.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
