### PR TITLE
skip kubeone-namespace in rbac generation

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -46,8 +46,8 @@ const (
 )
 
 const (
-	saSecretsNamespaceName = "kubermatic"
-
+	saSecretsNamespaceName              = "kubermatic"
+	kubeOneNamespacePrefix              = "kubeone"
 	alertmanagerName                    = "alertmanager"
 	defaultAlertmanagerConfigSecretName = "alertmanager"
 
@@ -603,7 +603,7 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 func generateVerbsForNamespacedResource(groupName, resourceKind, namespace string) ([]string, error) {
 	// special case - only the owners of a project and project managers can create secrets in "saSecretsNamespaceName" namespace
 	//
-	if namespace == saSecretsNamespaceName {
+	if namespace == saSecretsNamespaceName || strings.Contains(namespace, kubeOneNamespacePrefix) {
 		switch {
 		case strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind:
 			return []string{"create"}, nil
@@ -623,7 +623,7 @@ func generateVerbsForNamespacedResource(groupName, resourceKind, namespace strin
 func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace string) ([]string, error) {
 	// special case - only the owners of a project can manipulate secrets in "ssaSecretsNamespaceNam" namespace
 	//
-	if namespace == saSecretsNamespaceName {
+	if namespace == saSecretsNamespaceName || strings.Contains(namespace, kubeOneNamespacePrefix) {
 		switch {
 		case strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind:
 			return []string{"get", "update", "delete"}, nil

--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -46,8 +46,9 @@ const (
 )
 
 const (
-	saSecretsNamespaceName              = "kubermatic"
-	kubeOneNamespacePrefix              = "kubeone"
+	saSecretsNamespaceName = "kubermatic"
+	// KubeOneNamespacePrefix is the kubeone namespace prefix.
+	KubeOneNamespacePrefix              = "kubeone"
 	alertmanagerName                    = "alertmanager"
 	defaultAlertmanagerConfigSecretName = "alertmanager"
 
@@ -603,7 +604,7 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 func generateVerbsForNamespacedResource(groupName, resourceKind, namespace string) ([]string, error) {
 	// special case - only the owners of a project and project managers can create secrets in "saSecretsNamespaceName" namespace
 	//
-	if namespace == saSecretsNamespaceName || strings.Contains(namespace, kubeOneNamespacePrefix) {
+	if namespace == saSecretsNamespaceName || strings.HasPrefix(namespace, KubeOneNamespacePrefix) {
 		switch {
 		case strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind:
 			return []string{"create"}, nil
@@ -623,7 +624,7 @@ func generateVerbsForNamespacedResource(groupName, resourceKind, namespace strin
 func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace string) ([]string, error) {
 	// special case - only the owners of a project can manipulate secrets in "ssaSecretsNamespaceNam" namespace
 	//
-	if namespace == saSecretsNamespaceName || strings.Contains(namespace, kubeOneNamespacePrefix) {
+	if namespace == saSecretsNamespaceName || strings.HasPrefix(namespace, KubeOneNamespacePrefix) {
 		switch {
 		case strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind:
 			return []string{"get", "update", "delete"}, nil

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -544,6 +544,8 @@ const (
 )
 
 const (
+	// KubeOneNamespacePrefix is the main kubeone namespace prefix.
+	KubeOneNamespacePrefix = "kubeone"
 	// KubeOne secret names.
 	KubeOneSSHSecretName        = "ssh"
 	KubeOneManifestSecretName   = "manifest"


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**: skip kubeone-namespace in rbac generation

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
