### PR TITLE
[release/v2.19] Enable etcd corruption checks for etcd 3.5 and increase to 4h cycle

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -456,7 +456,7 @@ func etcdCmd(config *etcdCluster) []string {
 	if config.enableCorruptionCheck {
 		cmd = append(cmd, []string{
 			"--experimental-initial-corrupt-check=true",
-			"--experimental-corrupt-check-time=10m",
+			"--experimental-corrupt-check-time=240m",
 		}...)
 	}
 	return cmd

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"text/template"
 
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/Masterminds/sprig/v3"
 
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
@@ -74,6 +75,25 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 		return resources.EtcdStatefulSetName, func(set *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 
 			replicas := computeReplicas(data, set)
+			imageTag := ImageTag(data.Cluster())
+
+			imageTagVersion, err := semverlib.NewVersion(imageTag)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse etcd image tag: %w", err)
+			}
+
+			etcdConstraint, err := semverlib.NewConstraint(">= 3.5.0, < 3.6.0")
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse etcd constraint: %w", err)
+			}
+
+			// enable initial and periodic etcd data corruption checks by default if running etcd 3.5.
+			// The etcd team has recommended to enable this feature for etcd 3.5 due to data consistency issues.
+			// Reference: https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ
+			if ok := etcdConstraint.Check(imageTagVersion); ok {
+				enableDataCorruptionChecks = true
+			}
+
 			set.Name = resources.EtcdStatefulSetName
 			set.Spec.Replicas = resources.Int32(replicas)
 			set.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
@@ -205,7 +225,7 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 				{
 					Name: resources.EtcdStatefulSetName,
 
-					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag(data.Cluster()),
+					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + imageTag,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         etcdStartCmd,
 					Env:             etcdEnv,
@@ -483,7 +503,7 @@ exec /usr/local/bin/etcd \
     --key-file /etc/etcd/pki/tls/etcd-tls.key \
 {{- if .EnableCorruptionCheck }}
     --experimental-initial-corrupt-check=true \
-    --experimental-corrupt-check-time=10m \
+    --experimental-corrupt-check-time=240m \
 {{- end }}
     --auto-compaction-retention=8
 `

--- a/pkg/resources/etcd/testdata/etcd-command-with-corruption-flags.golden.sh
+++ b/pkg/resources/etcd/testdata/etcd-command-with-corruption-flags.golden.sh
@@ -22,5 +22,5 @@ exec /usr/local/bin/etcd \
     --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
     --key-file /etc/etcd/pki/tls/etcd-tls.key \
     --experimental-initial-corrupt-check=true \
-    --experimental-corrupt-check-time=10m \
+    --experimental-corrupt-check-time=240m \
     --auto-compaction-retention=8

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
@@ -66,6 +66,8 @@ spec:
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
               --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --experimental-initial-corrupt-check=true \
+              --experimental-corrupt-check-time=240m \
               --auto-compaction-retention=8
         env:
         - name: POD_NAME
@@ -86,7 +88,7 @@ spec:
         - name: TOKEN
           value: de-test-01
         - name: ENABLE_CORRUPTION_CHECK
-          value: "false"
+          value: "true"
         - name: ETCDCTL_API
           value: "3"
         - name: ETCDCTL_CACERT


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Cherry-pick of #9477 to `release/v2.19`. Please check original PR for details and background.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
For user clusters that use etcd 3.5 (Kubernetes 1.22 clusters), etcd corruption checks are turned on to detect [etcd data consistency issues](https://github.com/etcd-io/etcd/issues/13766). Checks run at etcd startup and every 4 hours
```
