### PR TITLE
add sig-app-mgmt ownership for apps.kubermatic

### DIFF
--- a/pkg/apis/apps.kubermatic/OWNERS
+++ b/pkg/apis/apps.kubermatic/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig/app-management
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
Signed-off-by: Simon Bein <simontheleg@gmail.com>

**What does this PR do / Why do we need it**:

`apps.kubermatic` subfolder should be owned by sig-app-management.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
