### PR TITLE
Addition of missing images to image-loader

### DIFF
--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -585,7 +585,7 @@ func getCloudSpecs() []kubermaticv1.CloudSpec {
 			ProviderName: string(kubermaticv1.KubevirtCloudProvider),
 			Kubevirt: &kubermaticv1.KubevirtCloudSpec{
 				Kubeconfig:    "fakeKubeconfig",
-				CSIKubeConfig: "fakeKubeconfig",
+				CSIKubeconfig: "fakeKubeconfig",
 			},
 		},
 	}

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -449,6 +449,8 @@ func getTemplateData(clusterVersion *kubermaticversion.Version, cloudSpec kuberm
 		Spec: kubermaticv1.DatacenterSpec{
 			VSphere:   &kubermaticv1.DatacenterSpecVSphere{},
 			Openstack: &kubermaticv1.DatacenterSpecOpenstack{},
+			Hetzner:   &kubermaticv1.DatacenterSpecHetzner{},
+			Anexia:    &kubermaticv1.DatacenterSpecAnexia{},
 		},
 	}
 	objects := []runtime.Object{configMapList, secretList, serviceList}
@@ -574,6 +576,13 @@ func getCloudSpecs() []kubermaticv1.CloudSpec {
 			ProviderName: string(kubermaticv1.AnexiaCloudProvider),
 			Anexia: &kubermaticv1.AnexiaCloudSpec{
 				Token: "fakeToken",
+			},
+		},
+		{
+			ProviderName: string(kubermaticv1.KubevirtCloudProvider),
+			Kubevirt: &kubermaticv1.KubevirtCloudSpec{
+				Kubeconfig:    "fakeKubeconfig",
+				CSIKubeConfig: "fakeKubeconfig",
 			},
 		},
 	}

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -177,7 +177,7 @@ func main() {
 					zap.String("version", clusterVersion.Version.String()),
 					zap.String("provider", cloudSpec.ProviderName),
 					zap.String("CNI plugin", string(cniPlugin.Type)),
-					zap.String("CNI version", string(cniPlugin.Version)),
+					zap.String("CNI version", cniPlugin.Version),
 				)
 
 				versionLog.Info("Collecting images...")
@@ -455,6 +455,7 @@ func getTemplateData(clusterVersion *kubermaticversion.Version, cloudSpec kuberm
 			Openstack: &kubermaticv1.DatacenterSpecOpenstack{},
 			Hetzner:   &kubermaticv1.DatacenterSpecHetzner{},
 			Anexia:    &kubermaticv1.DatacenterSpecAnexia{},
+			Kubevirt:  &kubermaticv1.DatacenterSpecKubevirt{},
 		},
 	}
 	objects := []runtime.Object{configMapList, secretList, serviceList}
@@ -552,7 +553,7 @@ func getVersions(log *zap.SugaredLogger, config *kubermaticv1.KubermaticConfigur
 	return filteredVersions, nil
 }
 
-// list all the cloudSpecs for all the Cloud providers for which we are currently using the external CCM/CSI
+// list all the cloudSpecs for all the Cloud providers for which we are currently using the external CCM/CSI.
 func getCloudSpecs() []kubermaticv1.CloudSpec {
 	return []kubermaticv1.CloudSpec{
 		{
@@ -590,7 +591,7 @@ func getCloudSpecs() []kubermaticv1.CloudSpec {
 	}
 }
 
-// list all the supported CNI plugins along with their supported versions
+// list all the supported CNI plugins along with their supported versions.
 func getCNIPlugins() []*kubermaticv1.CNIPluginSettings {
 	cniPluginSettings := []*kubermaticv1.CNIPluginSettings{}
 	supportedCNIPlugins := cni.GetSupportedCNIPlugins()

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -49,11 +49,13 @@ func TestRetagImageForAllVersions(t *testing.T) {
 	imageSet := sets.NewString()
 	for _, clusterVersion := range clusterVersions {
 		for _, cloudSpec := range getCloudSpecs() {
-			images, err := getImagesForVersion(log, clusterVersion, cloudSpec, config, addonPath, kubermaticVersions, caBundle)
-			if err != nil {
-				t.Errorf("Error calling getImagesForVersion: %v", err)
+			for _, cniPlugin := range getCNIPlugins() {
+				images, err := getImagesForVersion(log, clusterVersion, cloudSpec, cniPlugin, config, addonPath, kubermaticVersions, caBundle)
+				if err != nil {
+					t.Errorf("Error calling getImagesForVersion: %v", err)
+				}
+				imageSet.Insert(images...)
 			}
-			imageSet.Insert(images...)
 		}
 	}
 

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -48,11 +48,13 @@ func TestRetagImageForAllVersions(t *testing.T) {
 
 	imageSet := sets.NewString()
 	for _, clusterVersion := range clusterVersions {
-		images, err := getImagesForVersion(log, clusterVersion, config, addonPath, kubermaticVersions, caBundle)
-		if err != nil {
-			t.Errorf("Error calling getImagesForVersion: %v", err)
+		for _, cloudSpec := range getCloudSpecs() {
+			images, err := getImagesForVersion(log, clusterVersion, cloudSpec, config, addonPath, kubermaticVersions, caBundle)
+			if err != nil {
+				t.Errorf("Error calling getImagesForVersion: %v", err)
+			}
+			imageSet.Insert(images...)
 		}
-		imageSet.Insert(images...)
 	}
 
 	if err := processImages(context.Background(), log, true, imageSet.List(), "test-registry:5000"); err != nil {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -24826,6 +24826,10 @@
         "credentialsReference": {
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },
+        "csiKubeconfig": {
+          "type": "string",
+          "x-go-name": "CSIKubeConfig"
+        },
         "kubeconfig": {
           "type": "string",
           "x-go-name": "Kubeconfig"

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -24828,7 +24828,7 @@
         },
         "csiKubeconfig": {
           "type": "string",
-          "x-go-name": "CSIKubeConfig"
+          "x-go-name": "CSIKubeconfig"
         },
         "kubeconfig": {
           "type": "string",

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -894,7 +894,7 @@ type KubevirtCloudSpec struct {
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 
 	Kubeconfig    string `json:"kubeconfig,omitempty"`
-	CSIKubeConfig string `json:"csiKubeconfig,omitempty"`
+	CSIKubeconfig string `json:"csiKubeconfig,omitempty"`
 }
 
 // AlibabaCloudSpec specifies the access data to Alibaba.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -893,7 +893,8 @@ type GCPCloudSpec struct {
 type KubevirtCloudSpec struct {
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 
-	Kubeconfig string `json:"kubeconfig,omitempty"`
+	Kubeconfig    string `json:"kubeconfig,omitempty"`
+	CSIKubeConfig string `json:"csiKubeconfig,omitempty"`
 }
 
 // AlibabaCloudSpec specifies the access data to Alibaba.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -123,7 +123,7 @@ func SecretKeySelectorValueFuncFactory(ctx context.Context, client ctrlruntimecl
 			return "", errors.New("configVar.Name is empty")
 		}
 		if configVar.Namespace == "" {
-			return "", errors.New("configVar.Namspace is empty")
+			return "", errors.New("configVar.Namespace is empty")
 		}
 		if key == "" {
 			return "", errors.New("key is empty")

--- a/pkg/provider/types_test.go
+++ b/pkg/provider/types_test.go
@@ -59,7 +59,7 @@ func TestSecretKeySelectorValueFuncFactory(t *testing.T) {
 				},
 			},
 			key:           "bar",
-			expectedError: "configVar.Namspace is empty",
+			expectedError: "configVar.Namespace is empty",
 		},
 		{
 			name: "error on empty key",

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -572,8 +572,8 @@ func GetKubevirtCredentials(data CredentialsData) (KubevirtCredentials, error) {
 		return KubevirtCredentials{}, err
 	}
 
-	if spec.CSIKubeConfig != "" {
-		kubevirtCredentials.CSIKubeConfig = spec.CSIKubeConfig
+	if spec.CSIKubeconfig != "" {
+		kubevirtCredentials.CSIKubeConfig = spec.CSIKubeconfig
 	} else if kubevirtCredentials.CSIKubeConfig, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, KubevirtCSIKubeConfig); err != nil {
 		return KubevirtCredentials{}, err
 	}

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -572,7 +572,9 @@ func GetKubevirtCredentials(data CredentialsData) (KubevirtCredentials, error) {
 		return KubevirtCredentials{}, err
 	}
 
-	if kubevirtCredentials.CSIKubeConfig, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, KubevirtCSIKubeConfig); err != nil {
+	if spec.CSIKubeConfig != "" {
+		kubevirtCredentials.CSIKubeConfig = spec.CSIKubeConfig
+	} else if kubevirtCredentials.CSIKubeConfig, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, KubevirtCSIKubeConfig); err != nil {
 		return KubevirtCredentials{}, err
 	}
 

--- a/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
@@ -18,8 +18,8 @@ import (
 // swagger:model KubevirtCloudSpec
 type KubevirtCloudSpec struct {
 
-	// c s i kube config
-	CSIKubeConfig string `json:"csiKubeconfig,omitempty"`
+	// c s i kubeconfig
+	CSIKubeconfig string `json:"csiKubeconfig,omitempty"`
 
 	// kubeconfig
 	Kubeconfig string `json:"kubeconfig,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
@@ -18,6 +18,9 @@ import (
 // swagger:model KubevirtCloudSpec
 type KubevirtCloudSpec struct {
 
+	// c s i kube config
+	CSIKubeConfig string `json:"csiKubeconfig,omitempty"`
+
 	// kubeconfig
 	Kubeconfig string `json:"kubeconfig,omitempty"`
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -641,12 +641,6 @@ func validateKubevirtCloudSpec(spec *kubermaticv1.KubevirtCloudSpec) error {
 		}
 	}
 
-	if spec.CSIKubeConfig == "" {
-		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.KubevirtCSIKubeConfig); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -641,6 +641,12 @@ func validateKubevirtCloudSpec(spec *kubermaticv1.KubevirtCloudSpec) error {
 		}
 	}
 
+	if spec.CSIKubeConfig == "" {
+		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.KubevirtCSIKubeConfig); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -582,6 +582,8 @@ spec:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                             type: string
                         type: object
+                      csiKubeconfig:
+                        type: string
                       kubeconfig:
                         type: string
                     type: object

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -544,6 +544,8 @@ spec:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                             type: string
                         type: object
+                      csiKubeconfig:
+                        type: string
                       kubeconfig:
                         type: string
                     type: object


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR improves the image-loader by loading some new images related to:
* CCM/CSI
* Canal
* Cilium

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9166 

**Special notes for your reviewer**:
This is the new output of 
```sh
./_build/image-loader -addons-path ./addons -charts-path ~/Workspace/deployments/kkp-2.19/charts/ -configuration-file ~/Workspace/deployments/kkp-2.19/kubermatic.yaml -helm-values-file ~/Workspace/deployments/kkp-2.19/values.yaml -registry registry.xxx.test -dry-run 2>&1 | grep 'Tagging image' | cut -d '"' -f4
```

```
anx-cr.io/anexia/anx-cloud-controller-manager:0.1.0
docker.io/calico/cni:v3.19.1
docker.io/calico/cni:v3.20.2
docker.io/calico/cni:v3.21.2
docker.io/calico/cni:v3.22.1
docker.io/calico/cni:v3.8.0
docker.io/calico/kube-controllers:v3.19.1
docker.io/calico/kube-controllers:v3.20.2
docker.io/calico/kube-controllers:v3.21.2
docker.io/calico/kube-controllers:v3.22.1
docker.io/calico/node:v3.19.1
docker.io/calico/node:v3.20.2
docker.io/calico/node:v3.21.2
docker.io/calico/node:v3.22.1
docker.io/calico/node:v3.8.0
docker.io/dexidp/dex:v2.30.0
docker.io/envoyproxy/envoy-alpine:v1.17.1
docker.io/envoyproxy/envoy:v1.18.4@sha256:e5c2bb2870d0e59ce917a5100311813b4ede96ce4eb0c6bfa879e3fbe3e83935
docker.io/grafana/grafana:8.1.2
docker.io/grafana/loki:2.4.2
docker.io/grafana/promtail:2.4.2
docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.12.1
docker.io/jimmidyson/configmap-reload:v0.3.0
docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0
docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0
docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.1
docker.io/kubermatic/machine-controller:v1.42.0
docker.io/kubernetesui/dashboard:v2.4.0
docker.io/kubernetesui/dashboard:v2.5.0
docker.io/kumina/openvpn-exporter:v0.2.2
docker.io/library/busybox:1.33
docker.io/lmierzwa/karma:v0.89
docker.io/minio/minio:RELEASE.2022-02-16T00-35-27Z
docker.io/nginxinc/nginx-unprivileged:1.20.1-alpine
docker.io/prom/blackbox-exporter:v0.18.0
docker.io/sstarcher/helm-exporter:0.4.3
docker.io/velero/velero:v1.6.3
gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.21.1
gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.4
gcr.io/etcd-development/etcd:v3.4.3
gcr.io/etcd-development/etcd:v3.5.1
gcr.io/google_containers/heapster-amd64:v1.5.2
ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8.1
k8s.gcr.io/autoscaling/addon-resizer:1.8.14
k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0
k8s.gcr.io/autoscaling/vpa-admission-controller:0.9.2
k8s.gcr.io/autoscaling/vpa-recommender:0.9.2
k8s.gcr.io/autoscaling/vpa-updater:0.9.2
k8s.gcr.io/coredns/coredns:v1.8.0
k8s.gcr.io/coredns/coredns:v1.8.4
k8s.gcr.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d
k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
k8s.gcr.io/kube-apiserver:v1.21.10
k8s.gcr.io/kube-apiserver:v1.21.8
k8s.gcr.io/kube-apiserver:v1.22.5
k8s.gcr.io/kube-apiserver:v1.22.7
k8s.gcr.io/kube-apiserver:v1.23.5
k8s.gcr.io/kube-controller-manager:v1.21.10
k8s.gcr.io/kube-controller-manager:v1.21.8
k8s.gcr.io/kube-controller-manager:v1.22.5
k8s.gcr.io/kube-controller-manager:v1.22.7
k8s.gcr.io/kube-controller-manager:v1.23.5
k8s.gcr.io/kube-proxy:v1.21.10
k8s.gcr.io/kube-proxy:v1.21.8
k8s.gcr.io/kube-proxy:v1.22.5
k8s.gcr.io/kube-proxy:v1.22.7
k8s.gcr.io/kube-proxy:v1.23.5
k8s.gcr.io/kube-scheduler:v1.21.10
k8s.gcr.io/kube-scheduler:v1.21.8
k8s.gcr.io/kube-scheduler:v1.22.5
k8s.gcr.io/kube-scheduler:v1.22.7
k8s.gcr.io/kube-scheduler:v1.23.5
k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.1
k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
k8s.gcr.io/metrics-server-amd64:v0.2.1
k8s.gcr.io/metrics-server/metrics-server:v0.5.0
quay.io/brancz/kube-rbac-proxy:v0.11.0
quay.io/cilium/certgen:v0.1.5
quay.io/cilium/cilium:v1.11.0@sha256:ea677508010800214b0b5497055f38ed3bff57963fa2399bcb1c69cf9476453a
quay.io/cilium/hubble-relay:v1.11.0@sha256:306ce38354a0a892b0c175ae7013cf178a46b79f51c52adb5465d87f14df0838
quay.io/cilium/hubble-ui-backend:v0.8.3@sha256:13a16ed3ae9749682c817d3b834b2f2de901da6fb41de7753d7dce16650982b3
quay.io/cilium/hubble-ui:v0.8.3@sha256:018ed122968de658d8874e2982fa6b3a8ae64b43d2356c05f977004176a89310
quay.io/cilium/operator-generic:v1.11.0@sha256:b522279577d0d5f1ad7cadaacb7321d1b172d8ae8c8bc816e503c897b420cfe3
quay.io/coreos/flannel:v0.11.0
quay.io/coreos/flannel:v0.15.1
quay.io/jetstack/cert-manager-cainjector:v1.5.2
quay.io/jetstack/cert-manager-controller:v1.5.2
quay.io/jetstack/cert-manager-webhook:v1.5.2
quay.io/kubermatic/addons:9f655f5b761c2420457aee29d4091dc67591a603
quay.io/kubermatic/dashboard:NA
quay.io/kubermatic/grafana-plugins:1.3.1
quay.io/kubermatic/http-prober:v0.3.3
quay.io/kubermatic/kubeletdnat-controller:9f655f5b761c2420457aee29d4091dc67591a603
quay.io/kubermatic/kubermatic:9f655f5b761c2420457aee29d4091dc67591a603
quay.io/kubermatic/kubermatic:v9.9.9-dev
quay.io/kubermatic/kubevirt-cloud-controller-manager:v0.1.0
quay.io/kubermatic/kubevirt-csi-driver-operator:v0.1.0
quay.io/kubermatic/nodeport-proxy:9f655f5b761c2420457aee29d4091dc67591a603
quay.io/kubermatic/openvpn:v2.5.2-r0
quay.io/kubermatic/s3-exporter:v0.5
quay.io/kubermatic/telemetry-kubermatic-agent:v0.1.0
quay.io/kubermatic/telemetry-kubernetes-agent:v0.1.0
quay.io/kubermatic/telemetry-reporter:v0.1.0
quay.io/kubermatic/util:2.0.0
quay.io/prometheus/alertmanager:v0.22.2
quay.io/prometheus/node-exporter:v1.2.2
quay.io/prometheus/prometheus:v2.29.1
quay.io/prometheus/prometheus:v2.33.3
```

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Image-loader utility now includes all the images used by KKP, considering also the provider-specific ones (e.g., CCM, CSI).
```
