### PR TITLE
Dual Stack support for OpenStack

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -26904,6 +26904,16 @@
           "type": "string",
           "x-go-name": "FloatingIPPool"
         },
+        "ipv6SubnetID": {
+          "description": "IPv6SubnetID holds the ID of the subnet used for IPv6 networking.\nIf not provided, a new subnet will be created if IPv6 is enabled.\n+optional",
+          "type": "string",
+          "x-go-name": "IPv6SubnetID"
+        },
+        "ipv6SubnetPool": {
+          "description": "IPv6SubnetPool holds the name of the subnet pool used for creating new IPv6 subnets.\nIf not provided, the default IPv6 subnet pool will be used.\n+optional",
+          "type": "string",
+          "x-go-name": "IPv6SubnetPool"
+        },
         "network": {
           "description": "Network holds the name of the internal network\nWhen specified, all worker nodes will be attached to this network. If not specified, a network, subnet \u0026 router will be created\n\nNote that the network is internal if the \"External\" field is set to false",
           "type": "string",

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -859,6 +859,14 @@ type OpenstackCloudSpec struct {
 	FloatingIPPool string `json:"floatingIPPool"`
 	RouterID       string `json:"routerID"`
 	SubnetID       string `json:"subnetID"`
+	// IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
+	// If not provided, a new subnet will be created if IPv6 is enabled.
+	// +optional
+	IPv6SubnetID string `json:"ipv6SubnetID"`
+	// IPv6SubnetPool holds the name of the subnet pool used for creating new IPv6 subnets.
+	// If not provided, the default IPv6 subnet pool will be used.
+	// +optional
+	IPv6SubnetPool string `json:"ipv6SubnetPool"`
 	// Whether or not to use Octavia for LoadBalancer type of Service
 	// implementation instead of using Neutron-LBaaS.
 	// Attention:Openstack CCM use Octavia as default load balancer

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"strings"
 
+	"k8s.io/utils/net"
+	"k8s.io/utils/pointer"
+
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	osavailabilityzones "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
@@ -33,6 +36,7 @@ import (
 	osrouters "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	ossecuritygroups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	ossecuritygrouprules "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 	osnetworks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	osports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	ossubnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -45,6 +49,8 @@ const (
 	subnetCIDR         = "192.168.1.0/24"
 	subnetFirstAddress = "192.168.1.2"
 	subnetLastAddress  = "192.168.1.254"
+
+	defaultIPv6SubnetCIDR = "fd00::/64"
 
 	resourceNamePrefix = "kubernetes-"
 )
@@ -152,10 +158,12 @@ func deleteSecurityGroup(netClient *gophercloud.ServiceClient, sgName string) er
 }
 
 type createKubermaticSecurityGroupRequest struct {
-	clusterName             string
-	lowPort                 int
-	highPort                int
-	nodePortsAllowedIPRange string
+	clusterName    string
+	ipv4Rules      bool
+	ipv6Rules      bool
+	nodePortsCIDRs []string
+	lowPort        int
+	highPort       int
 }
 
 func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req createKubermaticSecurityGroupRequest) (string, error) {
@@ -187,64 +195,91 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req cre
 			len(secGroups), secGroupName)
 	}
 
-	rules := []ossecuritygrouprules.CreateOpts{
-		{
-			// Allows ipv4 traffic within this group
-			Direction:     ossecuritygrouprules.DirIngress,
-			EtherType:     ossecuritygrouprules.EtherType4,
-			SecGroupID:    securityGroupID,
-			RemoteGroupID: securityGroupID,
-		},
-		{
-			// Allows ipv6 traffic within this group
-			Direction:     ossecuritygrouprules.DirIngress,
-			EtherType:     ossecuritygrouprules.EtherType6,
-			SecGroupID:    securityGroupID,
-			RemoteGroupID: securityGroupID,
-		},
-		{
-			// Allows ssh from external
-			Direction:    ossecuritygrouprules.DirIngress,
-			EtherType:    ossecuritygrouprules.EtherType4,
-			SecGroupID:   securityGroupID,
-			PortRangeMin: provider.DefaultSSHPort,
-			PortRangeMax: provider.DefaultSSHPort,
-			Protocol:     ossecuritygrouprules.ProtocolTCP,
-		},
-		{
+	var rules []ossecuritygrouprules.CreateOpts
+
+	if req.ipv4Rules {
+		rules = append(rules, []ossecuritygrouprules.CreateOpts{
+			{
+				// Allows ipv4 traffic within this group
+				Direction:     ossecuritygrouprules.DirIngress,
+				EtherType:     ossecuritygrouprules.EtherType4,
+				SecGroupID:    securityGroupID,
+				RemoteGroupID: securityGroupID,
+			},
+			{
+				// Allows ssh from external
+				Direction:    ossecuritygrouprules.DirIngress,
+				EtherType:    ossecuritygrouprules.EtherType4,
+				SecGroupID:   securityGroupID,
+				PortRangeMin: provider.DefaultSSHPort,
+				PortRangeMax: provider.DefaultSSHPort,
+				Protocol:     ossecuritygrouprules.ProtocolTCP,
+			},
+			{
+				// Allows ICMP traffic
+				Direction:  ossecuritygrouprules.DirIngress,
+				EtherType:  ossecuritygrouprules.EtherType4,
+				SecGroupID: securityGroupID,
+				Protocol:   ossecuritygrouprules.ProtocolICMP,
+			},
+		}...)
+	}
+
+	if req.ipv6Rules {
+		rules = append(rules, []ossecuritygrouprules.CreateOpts{
+			{
+				// Allows ipv6 traffic within this group
+				Direction:     ossecuritygrouprules.DirIngress,
+				EtherType:     ossecuritygrouprules.EtherType6,
+				SecGroupID:    securityGroupID,
+				RemoteGroupID: securityGroupID,
+			},
+			{
+				// Allows ssh from external
+				Direction:    ossecuritygrouprules.DirIngress,
+				EtherType:    ossecuritygrouprules.EtherType6,
+				SecGroupID:   securityGroupID,
+				PortRangeMin: provider.DefaultSSHPort,
+				PortRangeMax: provider.DefaultSSHPort,
+				Protocol:     ossecuritygrouprules.ProtocolTCP,
+			},
+			{
+				// Allows ICMPv6 traffic
+				Direction:  ossecuritygrouprules.DirIngress,
+				EtherType:  ossecuritygrouprules.EtherType6,
+				SecGroupID: securityGroupID,
+				Protocol:   ossecuritygrouprules.ProtocolIPv6ICMP,
+			},
+		}...)
+	}
+
+	for _, cidr := range req.nodePortsCIDRs {
+		tcp := ossecuritygrouprules.CreateOpts{
 			// Allows TCP traffic to nodePorts from external
 			Direction:      ossecuritygrouprules.DirIngress,
-			EtherType:      ossecuritygrouprules.EtherType4,
 			SecGroupID:     securityGroupID,
 			PortRangeMin:   req.lowPort,
 			PortRangeMax:   req.highPort,
 			Protocol:       ossecuritygrouprules.ProtocolTCP,
-			RemoteIPPrefix: req.nodePortsAllowedIPRange,
-		},
-		{
+			RemoteIPPrefix: cidr,
+		}
+		udp := ossecuritygrouprules.CreateOpts{
 			// Allows UDP traffic to nodePorts from external
 			Direction:      ossecuritygrouprules.DirIngress,
-			EtherType:      ossecuritygrouprules.EtherType4,
 			SecGroupID:     securityGroupID,
 			PortRangeMin:   req.lowPort,
 			PortRangeMax:   req.highPort,
 			Protocol:       ossecuritygrouprules.ProtocolUDP,
-			RemoteIPPrefix: req.nodePortsAllowedIPRange,
-		},
-		{
-			// Allows ICMP traffic
-			Direction:  ossecuritygrouprules.DirIngress,
-			EtherType:  ossecuritygrouprules.EtherType4,
-			SecGroupID: securityGroupID,
-			Protocol:   ossecuritygrouprules.ProtocolICMP,
-		},
-		{
-			// Allows ICMPv6 traffic
-			Direction:  ossecuritygrouprules.DirIngress,
-			EtherType:  ossecuritygrouprules.EtherType6,
-			SecGroupID: securityGroupID,
-			Protocol:   ossecuritygrouprules.ProtocolIPv6ICMP,
-		},
+			RemoteIPPrefix: cidr,
+		}
+		if net.IsIPv4CIDRString(cidr) {
+			tcp.EtherType = ossecuritygrouprules.EtherType4
+			udp.EtherType = ossecuritygrouprules.EtherType4
+		} else {
+			tcp.EtherType = ossecuritygrouprules.EtherType6
+			udp.EtherType = ossecuritygrouprules.EtherType6
+		}
+		rules = append(rules, tcp, udp)
 	}
 
 	for _, opts := range rules {
@@ -318,7 +353,7 @@ func deleteRouter(netClient *gophercloud.ServiceClient, routerID string) error {
 
 func createKubermaticSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID string, dnsServers []string) (*ossubnets.Subnet, error) {
 	iTrue := true
-	res := ossubnets.Create(netClient, ossubnets.CreateOpts{
+	subnetOpts := ossubnets.CreateOpts{
 		Name:       resourceNamePrefix + clusterName,
 		NetworkID:  networkID,
 		IPVersion:  gophercloud.IPv4,
@@ -331,12 +366,98 @@ func createKubermaticSubnet(netClient *gophercloud.ServiceClient, clusterName, n
 				End:   subnetLastAddress,
 			},
 		},
-		DNSNameservers: dnsServers,
-	})
+	}
+
+	for _, s := range dnsServers {
+		if net.IsIPv4String(s) {
+			subnetOpts.DNSNameservers = append(subnetOpts.DNSNameservers, s)
+		}
+	}
+
+	res := ossubnets.Create(netClient, subnetOpts)
 	if res.Err != nil {
 		return nil, res.Err
 	}
 	return res.Extract()
+}
+
+func createKubermaticIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, networkID, subnetPoolName string, dnsServers []string) (*ossubnets.Subnet, error) {
+	subnetOpts := ossubnets.CreateOpts{
+		Name:            resourceNamePrefix + clusterName + "-ipv6",
+		NetworkID:       networkID,
+		IPVersion:       gophercloud.IPv6,
+		GatewayIP:       nil,
+		EnableDHCP:      pointer.BoolPtr(true),
+		IPv6AddressMode: "dhcpv6-stateless",
+		IPv6RAMode:      "dhcpv6-stateless",
+	}
+	subnetPoolID := ""
+
+	// if IPv6 subnet pool name is provided - resolve to ID
+	if subnetPoolName != "" {
+		subnetPool, err := getSubnetPoolByName(netClient, subnetPoolName)
+		if err != nil {
+			return nil, err
+		}
+		subnetPoolID = subnetPool.ID
+	}
+
+	// if IPv6 subnet pool name is not provided - look for the default IPv6 subnet pool
+	if subnetPoolID == "" {
+		pools, err := getAllSubnetPools(netClient, subnetpools.ListOpts{IPVersion: 6, IsDefault: pointer.BoolPtr(true)})
+		if err != nil {
+			return nil, err
+		}
+		if len(pools) > 0 {
+			subnetPoolID = pools[0].ID
+		}
+	}
+
+	if subnetPoolID != "" {
+		subnetOpts.SubnetPoolID = subnetPoolID
+	} else {
+		// if no IPv6 subnet pool was provided / found, use the default IPv6 subnet CIDR
+		subnetOpts.CIDR = defaultIPv6SubnetCIDR
+	}
+
+	for _, s := range dnsServers {
+		if net.IsIPv6String(s) {
+			subnetOpts.DNSNameservers = append(subnetOpts.DNSNameservers, s)
+		}
+	}
+
+	res := ossubnets.Create(netClient, subnetOpts)
+	if res.Err != nil {
+		return nil, res.Err
+	}
+	return res.Extract()
+}
+
+func getSubnetPoolByName(netClient *gophercloud.ServiceClient, name string) (*subnetpools.SubnetPool, error) {
+	pools, err := getAllSubnetPools(netClient, subnetpools.ListOpts{Name: name})
+	if err != nil {
+		return nil, err
+	}
+	switch len(pools) {
+	case 1:
+		return &pools[0], nil
+	case 0:
+		return nil, fmt.Errorf("subnet pool named '%s' not found", name)
+	default:
+		return nil, fmt.Errorf("found %d subnet pools for name '%s', expected exactly one", len(pools), name)
+	}
+}
+
+func getAllSubnetPools(netClient *gophercloud.ServiceClient, listOpts subnetpools.ListOpts) ([]subnetpools.SubnetPool, error) {
+	allPages, err := subnetpools.List(netClient, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	allSubnetPools, err := subnetpools.ExtractSubnetPools(allPages)
+	if err != nil {
+		return nil, err
+	}
+	return allSubnetPools, nil
 }
 
 func createKubermaticRouter(netClient *gophercloud.ServiceClient, clusterName, extNetworkName string) (*osrouters.Router, error) {

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -22,9 +22,6 @@ import (
 	"net/http"
 	"strings"
 
-	"k8s.io/utils/net"
-	"k8s.io/utils/pointer"
-
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	osavailabilityzones "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
@@ -43,6 +40,9 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 
 	"k8c.io/kubermatic/v2/pkg/provider"
+
+	"k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 )
 
 const (

--- a/pkg/provider/cloud/openstack/internal/testing/fixtures.go
+++ b/pkg/provider/cloud/openstack/internal/testing/fixtures.go
@@ -28,6 +28,7 @@ import (
 const (
 	NetworkID       = "8bb661f5-76b9-45f1-9ef9-eeffcd025fe4"
 	SubnetID        = "bec43a98-2d0a-4b1d-9df0-0f21e8f89d8a"
+	SubnetPoolID    = "bed43a98-2d0a-4b1d-9df0-0f21e8f89d8a"
 	RouterID        = "b8a25073-b35f-4b64-b205-6d21c8221d98"
 	PortID          = "6f5c4730-aa3f-4677-bca2-3b1ead8545d9"
 	InterfaceInfoID = "6f5c4730-aa3f-4677-bca2-3b1ead8545d9"
@@ -41,6 +42,7 @@ const (
 	NetworksEndpoint       = "/networks"
 	SubnetsEndpoint        = "/subnets"
 	RoutersEndpoint        = "/routers"
+	SubnetPoolsEndpoint    = "/subnetpools"
 )
 
 func AddRouterInterfaceEndpoint(routerID string) string {

--- a/pkg/provider/cloud/openstack/internal/testing/simulator.go
+++ b/pkg/provider/cloud/openstack/internal/testing/simulator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -252,6 +253,51 @@ func (s *Subnet) SubResources() []ResourceBuilder {
 	return nil
 }
 
+type SubnetPool subnetpools.SubnetPool
+
+func (s SubnetPool) GetID() string {
+	return s.ID
+}
+
+func (s SubnetPool) GetName() string {
+	return s.Name
+}
+
+func (s SubnetPool) GetType() string {
+	return "subnetpools"
+}
+
+func (s SubnetPool) GetPath() string {
+	return "/subnetpools"
+}
+
+func (s *SubnetPool) FromCreateRequest(c []byte) (Resource, error) {
+	createOpts := struct {
+		subnetpools.CreateOpts `json:"subnetPool"`
+	}{}
+	err := json.Unmarshal(c, &createOpts)
+	if err != nil {
+		return nil, err
+	}
+	s.ID = SubnetPoolID
+	s.Description = createOpts.Description
+	s.ProjectID = createOpts.ProjectID
+	return s, nil
+}
+
+func (s *SubnetPool) CreateResponse() ([]byte, error) {
+	res := struct {
+		SubnetPool *SubnetPool `json:"subnetPool"`
+	}{
+		SubnetPool: s,
+	}
+	return json.Marshal(res)
+}
+
+func (s *SubnetPool) SubResources() []ResourceBuilder {
+	return nil
+}
+
 type Port ports.Port
 
 func (p Port) GetID() string {
@@ -426,6 +472,7 @@ func NewSimulator(t *testing.T) *Simulator {
 	}).
 		Register(func() Resource { return &Network{} }).
 		Register(func() Resource { return &Subnet{} }).
+		Register(func() Resource { return &SubnetPool{} }).
 		Register(func() Resource { return &SecGroup{} }).
 		Register(func() Resource { return &SecGroupRule{} }).
 		Register(func() Resource { return &Router{} }).

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -303,10 +303,10 @@ func (os *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberm
 		if nodePortsAllowedIPRange != "" {
 			req.nodePortsCIDRs = append(req.nodePortsCIDRs, nodePortsAllowedIPRange)
 		} else {
-			if network.IsIPv4OnlyCluster(cluster) || network.IsDualStackCluster(cluster) {
+			if ipv4Network {
 				req.nodePortsCIDRs = append(req.nodePortsCIDRs, "0.0.0.0/0")
 			}
-			if network.IsIPv6OnlyCluster(cluster) || network.IsDualStackCluster(cluster) {
+			if ipv6Network {
 				req.nodePortsCIDRs = append(req.nodePortsCIDRs, "::/0")
 			}
 		}

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -43,6 +43,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/util/network"
 )
 
 const (
@@ -54,12 +55,16 @@ const (
 
 	// NetworkCleanupFinalizer will instruct the deletion of the network.
 	NetworkCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-network-v2"
-	// SubnetCleanupFinalizer will instruct the deletion of the subnet.
+	// SubnetCleanupFinalizer will instruct the deletion of the IPv4 subnet.
 	SubnetCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-subnet-v2"
+	// IPv6SubnetCleanupFinalizer will instruct the deletion of the IPv6 subnet.
+	IPv6SubnetCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-subnet-ipv6"
 	// RouterCleanupFinalizer will instruct the deletion of the router.
 	RouterCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-router-v2"
-	// RouterSubnetLinkCleanupFinalizer will instruct the deletion of the link between the router and the subnet.
+	// RouterSubnetLinkCleanupFinalizer will instruct the deletion of the link between the router and the IPv4 subnet.
 	RouterSubnetLinkCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-router-subnet-link-v2"
+	// RouterIPv6SubnetLinkCleanupFinalizer will instruct the deletion of the link between the router and the IPv6 subnet.
+	RouterIPv6SubnetLinkCleanupFinalizer = "kubermatic.k8c.io/cleanup-openstack-router-subnet-link-ipv6"
 )
 
 type getClientFunc func(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error)
@@ -131,6 +136,16 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 		}
 	}
 
+	if spec.Openstack.IPv6SubnetPool != "" {
+		subnetPool, err := getSubnetPoolByName(netClient, spec.Openstack.IPv6SubnetPool)
+		if err != nil {
+			return fmt.Errorf("failed to get subnet pool %q: %w", spec.Openstack.IPv6SubnetPool, err)
+		}
+		if subnetPool.IPversion != 6 {
+			return fmt.Errorf("provided IPv6 subnet pool %q has incorect IP version: %d", spec.Openstack.IPv6SubnetPool, subnetPool.IPversion)
+		}
+	}
+
 	return nil
 }
 
@@ -196,6 +211,10 @@ func (os *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberm
 
 	var routerID string
 	var finalizers []string
+
+	ipv4Network := network.IsIPv4OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
+	ipv6Network := network.IsIPv6OnlyCluster(cluster) || network.IsDualStackCluster(cluster)
+
 	// if security group has to be created add the corresponding finalizer.
 	if cluster.Spec.Cloud.Openstack.SecurityGroups == "" {
 		finalizers = append(finalizers, SecurityGroupCleanupFinalizer)
@@ -204,19 +223,45 @@ func (os *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberm
 	if cluster.Spec.Cloud.Openstack.Network == "" {
 		finalizers = append(finalizers, NetworkCleanupFinalizer)
 	}
-	// If subnet has to be created, router and router port should be
-	// created too thus we add the finalizers.
-	if cluster.Spec.Cloud.Openstack.SubnetID == "" {
-		finalizers = append(finalizers, SubnetCleanupFinalizer, RouterCleanupFinalizer, RouterSubnetLinkCleanupFinalizer)
-	} else if cluster.Spec.Cloud.Openstack.RouterID == "" {
+
+	// if SubnetID is provided but RouterID not, try to retrieve RouterID
+	if cluster.Spec.Cloud.Openstack.SubnetID != "" && cluster.Spec.Cloud.Openstack.RouterID == "" {
 		var err error
 		routerID, err = getRouterIDForSubnet(netClient, cluster.Spec.Cloud.Openstack.SubnetID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify that the subnet '%s' has a router attached: %w", cluster.Spec.Cloud.Openstack.SubnetID, err)
 		}
-		// Subnet exists but we need to create the router
-		if routerID == "" {
-			finalizers = append(finalizers, RouterCleanupFinalizer, RouterSubnetLinkCleanupFinalizer)
+	}
+	if cluster.Spec.Cloud.Openstack.IPv6SubnetID != "" && cluster.Spec.Cloud.Openstack.RouterID == "" && routerID == "" {
+		var err error
+		routerID, err = getRouterIDForSubnet(netClient, cluster.Spec.Cloud.Openstack.IPv6SubnetID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify that the subnet '%s' has a router attached: %w", cluster.Spec.Cloud.Openstack.IPv6SubnetID, err)
+		}
+	}
+	// If router has to be created, add associated finalizer.
+	if cluster.Spec.Cloud.Openstack.RouterID == "" && routerID == "" {
+		finalizers = append(finalizers, RouterCleanupFinalizer)
+	}
+
+	if ipv4Network {
+		// If subnet has to be created, add associated finalizer.
+		if cluster.Spec.Cloud.Openstack.SubnetID == "" {
+			finalizers = append(finalizers, SubnetCleanupFinalizer)
+		}
+		// If subnet or router has to be created, subnet needs to be attached to the router.
+		if cluster.Spec.Cloud.Openstack.SubnetID == "" || (cluster.Spec.Cloud.Openstack.RouterID == "" && routerID == "") {
+			finalizers = append(finalizers, RouterSubnetLinkCleanupFinalizer)
+		}
+	}
+	if ipv6Network {
+		// If subnet has to be created, add associated finalizer.
+		if cluster.Spec.Cloud.Openstack.IPv6SubnetID == "" {
+			finalizers = append(finalizers, IPv6SubnetCleanupFinalizer)
+		}
+		// If subnet or router has to be created, subnet needs to be attached to the router.
+		if cluster.Spec.Cloud.Openstack.IPv6SubnetID == "" || (cluster.Spec.Cloud.Openstack.RouterID == "" && routerID == "") {
+			finalizers = append(finalizers, RouterIPv6SubnetLinkCleanupFinalizer)
 		}
 	}
 
@@ -246,16 +291,24 @@ func (os *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberm
 			Build().
 			NodePorts()
 
-		nodePortsAllowedIPRange := cluster.Spec.Cloud.Openstack.NodePortsAllowedIPRange
-		if nodePortsAllowedIPRange == "" {
-			nodePortsAllowedIPRange = "0.0.0.0/0"
+		req := createKubermaticSecurityGroupRequest{
+			clusterName: cluster.Name,
+			ipv4Rules:   ipv4Network,
+			ipv6Rules:   ipv6Network,
+			lowPort:     lowPort,
+			highPort:    highPort,
 		}
 
-		req := createKubermaticSecurityGroupRequest{
-			clusterName:             cluster.Name,
-			lowPort:                 lowPort,
-			highPort:                highPort,
-			nodePortsAllowedIPRange: nodePortsAllowedIPRange,
+		nodePortsAllowedIPRange := cluster.Spec.Cloud.Openstack.NodePortsAllowedIPRange
+		if nodePortsAllowedIPRange != "" {
+			req.nodePortsCIDRs = append(req.nodePortsCIDRs, nodePortsAllowedIPRange)
+		} else {
+			if network.IsIPv4OnlyCluster(cluster) || network.IsDualStackCluster(cluster) {
+				req.nodePortsCIDRs = append(req.nodePortsCIDRs, "0.0.0.0/0")
+			}
+			if network.IsIPv6OnlyCluster(cluster) || network.IsDualStackCluster(cluster) {
+				req.nodePortsCIDRs = append(req.nodePortsCIDRs, "::/0")
+			}
 		}
 
 		secGroupName, err := createKubermaticSecurityGroup(netClient, req)
@@ -288,17 +341,29 @@ func (os *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberm
 		return nil, fmt.Errorf("failed to get network '%s': %w", cluster.Spec.Cloud.Openstack.Network, err)
 	}
 
-	if cluster.Spec.Cloud.Openstack.SubnetID == "" {
+	if ipv4Network && cluster.Spec.Cloud.Openstack.SubnetID == "" {
 		subnet, err := createKubermaticSubnet(netClient, cluster.Name, network.ID, os.dc.DNSServers)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create the kubermatic subnet: %w", err)
 		}
-
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Openstack.SubnetID = subnet.ID
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to add subnet cleanup finalizer: %w", err)
+		}
+	}
+
+	if ipv6Network && cluster.Spec.Cloud.Openstack.IPv6SubnetID == "" {
+		subnet, err := createKubermaticIPv6Subnet(netClient, cluster.Name, network.ID, cluster.Spec.Cloud.Openstack.IPv6SubnetPool, os.dc.DNSServers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the v6 subnet: %w", err)
+		}
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+			cluster.Spec.Cloud.Openstack.IPv6SubnetID = subnet.ID
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to update v6 subnet ID: %w", err)
 		}
 	}
 
@@ -331,10 +396,16 @@ func (os *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberm
 	// reconciliations so far. This is to avoid hitting OpenStack API at each
 	// iteration.
 	// TODO: this is terrible, find a better way.
-	if cluster.Status.ExtendedHealth.CloudProviderInfrastructure != kubermaticv1.HealthStatusUp &&
-		kubernetes.HasFinalizer(cluster, RouterSubnetLinkCleanupFinalizer) {
-		if _, err = attachSubnetToRouter(netClient, cluster.Spec.Cloud.Openstack.SubnetID, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
-			return nil, fmt.Errorf("failed to attach subnet to router: %w", err)
+	if cluster.Status.ExtendedHealth.CloudProviderInfrastructure != kubermaticv1.HealthStatusUp {
+		if kubernetes.HasFinalizer(cluster, RouterSubnetLinkCleanupFinalizer) {
+			if _, err = attachSubnetToRouter(netClient, cluster.Spec.Cloud.Openstack.SubnetID, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
+				return nil, fmt.Errorf("failed to attach subnet to router: %w", err)
+			}
+		}
+		if kubernetes.HasFinalizer(cluster, RouterIPv6SubnetLinkCleanupFinalizer) {
+			if _, err = attachSubnetToRouter(netClient, cluster.Spec.Cloud.Openstack.IPv6SubnetID, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
+				return nil, fmt.Errorf("failed to attach subnet to router: %w", err)
+			}
 		}
 	}
 
@@ -372,10 +443,26 @@ func (os *Provider) CleanUpCloudProvider(ctx context.Context, cluster *kubermati
 		}
 	}
 
+	if kubernetes.HasFinalizer(cluster, RouterIPv6SubnetLinkCleanupFinalizer) {
+		if _, err = detachSubnetFromRouter(netClient, cluster.Spec.Cloud.Openstack.IPv6SubnetID, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
+			if !isNotFoundErr(err) {
+				return nil, fmt.Errorf("failed to detach subnet from router: %w", err)
+			}
+		}
+	}
+
 	if kubernetes.HasFinalizer(cluster, SubnetCleanupFinalizer) || kubernetes.HasFinalizer(cluster, OldNetworkCleanupFinalizer) {
 		if err := deleteSubnet(netClient, cluster.Spec.Cloud.Openstack.SubnetID); err != nil {
 			if !isNotFoundErr(err) {
 				return nil, fmt.Errorf("failed to delete subnet '%s': %w", cluster.Spec.Cloud.Openstack.SubnetID, err)
+			}
+		}
+	}
+
+	if kubernetes.HasFinalizer(cluster, IPv6SubnetCleanupFinalizer) {
+		if err := deleteSubnet(netClient, cluster.Spec.Cloud.Openstack.IPv6SubnetID); err != nil {
+			if !isNotFoundErr(err) {
+				return nil, fmt.Errorf("failed to delete subnet '%s': %w", cluster.Spec.Cloud.Openstack.IPv6SubnetID, err)
 			}
 		}
 	}
@@ -403,7 +490,9 @@ func (os *Provider) CleanUpCloudProvider(ctx context.Context, cluster *kubermati
 			cluster,
 			SecurityGroupCleanupFinalizer,
 			RouterSubnetLinkCleanupFinalizer,
+			RouterIPv6SubnetLinkCleanupFinalizer,
 			SubnetCleanupFinalizer,
+			IPv6SubnetCleanupFinalizer,
 			NetworkCleanupFinalizer,
 			RouterCleanupFinalizer,
 			OldNetworkCleanupFinalizer,

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -142,7 +142,7 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 			return fmt.Errorf("failed to get subnet pool %q: %w", spec.Openstack.IPv6SubnetPool, err)
 		}
 		if subnetPool.IPversion != 6 {
-			return fmt.Errorf("provided IPv6 subnet pool %q has incorect IP version: %d", spec.Openstack.IPv6SubnetPool, subnetPool.IPversion)
+			return fmt.Errorf("provided IPv6 subnet pool %q has incorrect IP version: %d", spec.Openstack.IPv6SubnetPool, subnetPool.IPversion)
 		}
 	}
 

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -92,6 +92,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					Name: "cluster-xyz",
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{},
 					},
@@ -110,6 +113,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							SecurityGroups: "kubernetes-cluster-xyz",
@@ -131,6 +137,62 @@ func TestInitializeCloudProvider(t *testing.T) {
 			},
 		},
 		{
+			name: "Create all - dual stack",
+			dc:   &kubermaticv1.DatacenterSpecOpenstack{},
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-xyz",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16", "fd00::/64"}},
+					},
+					Cloud: kubermaticv1.CloudSpec{
+						Openstack: &kubermaticv1.OpenstackCloudSpec{},
+					},
+				},
+			},
+			resources: []ostesting.Resource{&ostesting.ExternalNetwork},
+			wantCluster: kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-xyz",
+					Finalizers: []string{
+						SecurityGroupCleanupFinalizer,
+						NetworkCleanupFinalizer,
+						SubnetCleanupFinalizer,
+						IPv6SubnetCleanupFinalizer,
+						RouterCleanupFinalizer,
+						RouterSubnetLinkCleanupFinalizer,
+						RouterIPv6SubnetLinkCleanupFinalizer,
+					},
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16", "fd00::/64"}},
+					},
+					Cloud: kubermaticv1.CloudSpec{
+						Openstack: &kubermaticv1.OpenstackCloudSpec{
+							SecurityGroups: "kubernetes-cluster-xyz",
+							FloatingIPPool: "external-network",
+							Network:        "kubernetes-cluster-xyz",
+							SubnetID:       ostesting.SubnetID,
+							IPv6SubnetID:   ostesting.SubnetID,
+							RouterID:       ostesting.RouterID,
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRequests: map[ostesting.Request]int{
+				{Method: http.MethodPost, Path: ostesting.SecurityGroupsEndpoint}:                        1,
+				{Method: http.MethodPost, Path: ostesting.NetworksEndpoint}:                              1,
+				{Method: http.MethodPost, Path: ostesting.SubnetsEndpoint}:                               2,
+				{Method: http.MethodGet, Path: ostesting.SubnetPoolsEndpoint}:                            1,
+				{Method: http.MethodPost, Path: ostesting.RoutersEndpoint}:                               1,
+				{Method: http.MethodPut, Path: ostesting.AddRouterInterfaceEndpoint(ostesting.RouterID)}: 2,
+			},
+		},
+		{
 			name: "Create nothing",
 			dc:   &kubermaticv1.DatacenterSpecOpenstack{},
 			cluster: &kubermaticv1.Cluster{
@@ -138,6 +200,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					Name: "cluster-xyz",
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							SecurityGroups: "kubernetes-cluster-xyz",
@@ -166,6 +231,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					Name: "cluster-xyz",
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							SecurityGroups: "kubernetes-cluster-xyz",
@@ -199,6 +267,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					Name: "cluster-xyz",
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							Network: "kubernetes-cluster-xyz",
@@ -221,6 +292,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							SecurityGroups: "kubernetes-cluster-xyz",
@@ -249,6 +323,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					Name: "cluster-xyz",
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							Network:  "kubernetes-cluster-xyz",
@@ -271,6 +348,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							SecurityGroups: "kubernetes-cluster-xyz",
@@ -299,6 +379,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					Name: "cluster-xyz",
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							Network:  "kubernetes-cluster-xyz",
@@ -320,6 +403,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+						Pods: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/16"}},
+					},
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							SecurityGroups: "kubernetes-cluster-xyz",

--- a/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
@@ -36,6 +36,16 @@ type OpenstackCloudSpec struct {
 	// Note that the network is external if the "External" field is set to true
 	FloatingIPPool string `json:"floatingIPPool,omitempty"`
 
+	// IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
+	// If not provided, a new subnet will be created if IPv6 is enabled.
+	// +optional
+	IPV6SubnetID string `json:"ipv6SubnetID,omitempty"`
+
+	// IPv6SubnetPool holds the name of the subnet pool used for creating new IPv6 subnets.
+	// If not provided, the default IPv6 subnet pool will be used.
+	// +optional
+	IPV6SubnetPool string `json:"ipv6SubnetPool,omitempty"`
+
 	// Network holds the name of the internal network
 	// When specified, all worker nodes will be attached to this network. If not specified, a network, subnet & router will be created
 	//

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -734,6 +734,16 @@ spec:
                           public ip from this floating ip pool \n Note that the network
                           is external if the \"External\" field is set to true"
                         type: string
+                      ipv6SubnetID:
+                        description: IPv6SubnetID holds the ID of the subnet used
+                          for IPv6 networking. If not provided, a new subnet will
+                          be created if IPv6 is enabled.
+                        type: string
+                      ipv6SubnetPool:
+                        description: IPv6SubnetPool holds the name of the subnet pool
+                          used for creating new IPv6 subnets. If not provided, the
+                          default IPv6 subnet pool will be used.
+                        type: string
                       network:
                         description: "Network holds the name of the internal network
                           When specified, all worker nodes will be attached to this

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -696,6 +696,16 @@ spec:
                           public ip from this floating ip pool \n Note that the network
                           is external if the \"External\" field is set to true"
                         type: string
+                      ipv6SubnetID:
+                        description: IPv6SubnetID holds the ID of the subnet used
+                          for IPv6 networking. If not provided, a new subnet will
+                          be created if IPv6 is enabled.
+                        type: string
+                      ipv6SubnetPool:
+                        description: IPv6SubnetPool holds the name of the subnet pool
+                          used for creating new IPv6 subnets. If not provided, the
+                          default IPv6 subnet pool will be used.
+                        type: string
                       network:
                         description: "Network holds the name of the internal network
                           When specified, all worker nodes will be attached to this


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds dual-stack support for OpenStack provider.

Dual-stack on OpenStack can be deployed in 3 ways:
 - (preferred) by referencing an IPv6 [subnet pool](https://docs.openstack.org/neutron/rocky/admin/config-subnet-pools.html) used to allocate IPv6 subnet, or using the default IPv6 subnet pool (if it exists),
 - by referencing an existing IPv6 subnet,
 - if no IPv6 subnet pool is used, and existing subnet is not specified either, an IPv6 subnet will be created with a pre-defined private CIDR.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9451 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add dual-stack support for OpenStack provider.
```
