### PR TITLE
Add metering report config name validation

### DIFF
--- a/pkg/ee/metering/report_config_handler.go
+++ b/pkg/ee/metering/report_config_handler.go
@@ -71,8 +71,8 @@ type createReportConfigurationReq struct {
 }
 
 func (m createReportConfigurationReq) Validate() error {
-	if m.Name == "" {
-		return k8cerrors.NewBadRequest("name cannot be empty.")
+	if !validation.MeteringReportNameValidator.MatchString(m.Name) {
+		return k8cerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
 	}
 
 	cronExpressionParser := validation.GetCronExpressionParser()
@@ -101,8 +101,8 @@ type updateReportConfigurationReq struct {
 }
 
 func (m updateReportConfigurationReq) Validate() error {
-	if m.Name == "" {
-		return k8cerrors.NewBadRequest("name cannot be empty.")
+	if !validation.MeteringReportNameValidator.MatchString(m.Name) {
+		return k8cerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
 	}
 
 	if m.Body.Schedule != "" {
@@ -132,6 +132,10 @@ func DecodeCreateMeteringReportConfigurationReq(r *http.Request) (interface{}, e
 
 	req.Name = mux.Vars(r)["name"]
 
+	if req.Name == "" {
+		return nil, k8cerrors.NewBadRequest("`name` cannot be empty")
+	}
+
 	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
 		return nil, err
 	}
@@ -143,6 +147,10 @@ func DecodeUpdateMeteringReportConfigurationReq(r *http.Request) (interface{}, e
 	var req updateReportConfigurationReq
 
 	req.Name = mux.Vars(r)["name"]
+
+	if req.Name == "" {
+		return nil, k8cerrors.NewBadRequest("`name` cannot be empty")
+	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
 		return nil, err

--- a/pkg/ee/metering/report_config_handler_test.go
+++ b/pkg/ee/metering/report_config_handler_test.go
@@ -213,6 +213,19 @@ func TestCreateMeteringReportConfigEndpoint(t *testing.T) {
 			httpStatus:             http.StatusConflict,
 			expectedResponse:       `{"error":{"code":409,"message":"report configuration \"weekly\" already exists"}}`,
 		},
+		// scenario 6
+		{
+			name:       "Create new metering report configuration. Invalid name.",
+			reportName: "invalid_name_",
+			body: `{
+				"interval": 30,
+				"schedule": "1 1 1 * *"
+			}`,
+			existingKubermaticObjs: []ctrlruntimeclient.Object{testSeed},
+			existingAPIUser:        test.GenDefaultAdminAPIUser(),
+			httpStatus:             http.StatusBadRequest,
+			expectedResponse:       `{"error":{"code":400,"message":"metering report configuration name can contain only alphanumeric characters or '-'"}}`,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -275,6 +288,19 @@ func TestUpdateMeteringReportConfigEndpoint(t *testing.T) {
 			expectedResponse:       `{"error":{"code":400,"message":"invalid cron expression format: X 1 1 * *"}}`,
 		},
 		// scenario 3
+		{
+			name:       "Update existing metering report configuration.",
+			reportName: "invalid_name_",
+			body: `{
+				"interval": 30,
+				"schedule": "1 1 1 * *"
+			}`,
+			existingKubermaticObjs: []ctrlruntimeclient.Object{testSeed},
+			existingAPIUser:        test.GenDefaultAdminAPIUser(),
+			httpStatus:             http.StatusBadRequest,
+			expectedResponse:       `{"error":{"code":400,"message":"metering report configuration name can contain only alphanumeric characters or '-'"}}`,
+		},
+		// scenario 4
 		{
 			name:       "Update non-existing metering report configuration.",
 			reportName: "monthly",

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -138,7 +138,7 @@ func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 		}
 
 		if err := updateMeteringReportConfiguration(ctx, req, masterClient); err != nil {
-			return nil, fmt.Errorf("failed to create metering report configuration: %w", err)
+			return nil, fmt.Errorf("failed to update metering report configuration: %w", err)
 		}
 
 		return nil, nil
@@ -157,7 +157,7 @@ func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 		}
 
 		if err := deleteMeteringReportConfiguration(ctx, req, masterClient); err != nil {
-			return nil, fmt.Errorf("failed to create metering report configuration: %w", err)
+			return nil, fmt.Errorf("failed to delete metering report configuration: %w", err)
 		}
 
 		return nil, nil

--- a/pkg/validation/metering.go
+++ b/pkg/validation/metering.go
@@ -18,11 +18,14 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/robfig/cron/v3"
 
 	v1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
+
+var MeteringReportNameValidator = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
 
 func GetCronExpressionParser() cron.Parser {
 	return cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
@@ -31,7 +34,10 @@ func GetCronExpressionParser() cron.Parser {
 func ValidateMeteringConfiguration(configuration *v1.MeteringConfiguration) error {
 	if configuration != nil && len(configuration.ReportConfigurations) > 0 {
 		parser := GetCronExpressionParser()
-		for _, reportConfig := range configuration.ReportConfigurations {
+		for reportName, reportConfig := range configuration.ReportConfigurations {
+			if !MeteringReportNameValidator.MatchString(reportName) {
+				return fmt.Errorf("metering report configuration name can contain only alphanumeric characters or '-', got: %s", reportName)
+			}
 			if _, err := parser.Parse(reportConfig.Schedule); err != nil {
 				return fmt.Errorf("invalid cron expression format: %s", reportConfig.Schedule)
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Add additional metering report config name validation and fix some error messages in metering report config api. We need this additional name checking as it will be used as part of each report name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
