### PR TITLE
improve CRDs, mark more fields as optional and improve documentation

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -143,6 +143,7 @@ type ClusterSpec struct {
 
 	// Pause tells that this cluster is currently not managed by the controller.
 	// It indicates that the user needs to do some action to resolve the pause.
+	// +kubebuilder:default=false
 	Pause bool `json:"pause"`
 	// PauseReason is the reason why the cluster is no being managed.
 	PauseReason string `json:"pauseReason,omitempty"`

--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -74,6 +74,9 @@ type ClusterTemplateList struct {
 
 // ClusterTemplateSSHKey is the object for holding SSH key.
 type ClusterTemplateSSHKey struct {
+	// ID is the name of the UserSSHKey object that is supposed to be assigned
+	// to any ClusterTemplateInstance created based on this template.
+	ID string `json:"id"`
+	// Name is the human readable SSH key name.
 	Name string `json:"name"`
-	ID   string `json:"id"`
 }

--- a/pkg/apis/kubermatic/v1/sshkeys.go
+++ b/pkg/apis/kubermatic/v1/sshkeys.go
@@ -50,8 +50,9 @@ type SSHKeySpec struct {
 	// Name is the human readable name for this SSH key.
 	Name string `json:"name"`
 	// Owner is the name of the User object that owns this SSH key.
-	// This field is immutable.
-	Owner string `json:"owner"`
+	// Deprecated: This field is not used anymore.
+	// +optional
+	Owner string `json:"owner,omitempty"`
 	// Project is the name of the Project object that this SSH key belongs to.
 	// This field is immutable.
 	Project string `json:"project"`
@@ -59,6 +60,7 @@ type SSHKeySpec struct {
 	Clusters []string `json:"clusters"`
 	// Fingerprint is calculated on the server-side and doesn't need to be set
 	// by clients.
+	// +optional
 	Fingerprint string `json:"fingerprint"`
 	// PublicKey is the SSH public key.
 	PublicKey string `json:"publicKey"`

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -57,10 +57,18 @@ type UserStatus struct {
 
 // UserSpec specifies a user.
 type UserSpec struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Email   string `json:"email"`
-	IsAdmin bool   `json:"admin"`
+	// ID is an unnused legacy field.
+	// Deprecated: do not set this field anymore.
+	ID string `json:"id,omitempty"`
+	// Name is the full name of this user.
+	Name string `json:"name"`
+	// Email is the email address of this user. Emails must be globally unique across
+	// all KKP users.
+	Email string `json:"email"`
+	// IsAdmin defines whether this user is an administrator with additional permissions.
+	// Admins can for example see all projects and clusters in the KKP dashboard.
+	// +kubebuilder:default=false
+	IsAdmin bool `json:"admin"`
 
 	// Project is the name of the project that this service account user is tied to. This
 	// field is only applicable to service accounts and regular users must not set this field.

--- a/pkg/apis/kubermatic/v1/user_project_binding.go
+++ b/pkg/apis/kubermatic/v1/user_project_binding.go
@@ -48,9 +48,12 @@ type UserProjectBinding struct {
 
 // UserProjectBindingSpec specifies a user.
 type UserProjectBindingSpec struct {
+	// UserEmail is the email of the user that is bound to the given project.
 	UserEmail string `json:"userEmail"`
+	// ProjectID is the name of the target project.
 	ProjectID string `json:"projectID"`
-	Group     string `json:"group"`
+	// Group is the user's group, determining their permissions within the project.
+	Group string `json:"group"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -619,7 +619,6 @@ func TestEnsureProjectCleanup(t *testing.T) {
 
 			name:          "Scenario 1: When a project is removed corresponding Subject from the Cluster RBAC Binding are removed",
 			projectToSync: test.CreateProject("plan9"),
-			// projectToSync: test.CreateProject("plan9", test.CreateUser("James Bond")),
 			projectResourcesToSync: []projectResource{
 				{
 					object: &kubermaticv1.Cluster{
@@ -1933,7 +1932,6 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 
 			name:          "Scenario 1: When a project is removed corresponding Subject from the RBAC Binding are removed",
 			projectToSync: test.CreateProject("plan9"),
-			// projectToSync: test.CreateProject("plan9", test.CreateUser("James Bond")),
 			projectResourcesToSync: []projectResource{
 
 				{

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1756,6 +1756,7 @@ spec:
                     type: integer
                 type: object
               pause:
+                default: false
                 description: Pause tells that this cluster is currently not managed
                   by the controller. It indicates that the user needs to do some action
                   to resolve the pause.

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1718,6 +1718,7 @@ spec:
                     type: integer
                 type: object
               pause:
+                default: false
                 description: Pause tells that this cluster is currently not managed
                   by the controller. It indicates that the user needs to do some action
                   to resolve the pause.
@@ -1785,8 +1786,12 @@ spec:
               description: ClusterTemplateSSHKey is the object for holding SSH key.
               properties:
                 id:
+                  description: ID is the name of the UserSSHKey object that is supposed
+                    to be assigned to any ClusterTemplateInstance created based on
+                    this template.
                   type: string
                 name:
+                  description: Name is the human readable SSH key name.
                   type: string
               required:
               - id

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
@@ -51,10 +51,15 @@ spec:
             description: UserProjectBindingSpec specifies a user.
             properties:
               group:
+                description: Group is the user's group, determining their permissions
+                  within the project.
                 type: string
               projectID:
+                description: ProjectID is the name of the target project.
                 type: string
               userEmail:
+                description: UserEmail is the email of the user that is bound to the
+                  given project.
                 type: string
             required:
             - group

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -46,10 +46,18 @@ spec:
             description: UserSpec specifies a user.
             properties:
               admin:
+                default: false
+                description: IsAdmin defines whether this user is an administrator
+                  with additional permissions. Admins can for example see all projects
+                  and clusters in the KKP dashboard.
                 type: boolean
               email:
+                description: Email is the email address of this user. Emails must
+                  be globally unique across all KKP users.
                 type: string
               id:
+                description: 'ID is an unnused legacy field. Deprecated: do not set
+                  this field anymore.'
                 type: string
               invalidTokensReference:
                 description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector
@@ -91,6 +99,7 @@ spec:
                     type: string
                 type: object
               name:
+                description: Name is the full name of this user.
                 type: string
               project:
                 description: Project is the name of the project that this service
@@ -118,7 +127,6 @@ spec:
             required:
             - admin
             - email
-            - id
             - name
             type: object
           status:

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -64,8 +64,8 @@ spec:
                 description: Name is the human readable name for this SSH key.
                 type: string
               owner:
-                description: Owner is the name of the User object that owns this SSH
-                  key. This field is immutable.
+                description: 'Owner is the name of the User object that owns this
+                  SSH key. Deprecated: This field is not used anymore.'
                 type: string
               project:
                 description: Project is the name of the Project object that this SSH
@@ -76,9 +76,7 @@ spec:
                 type: string
             required:
             - clusters
-            - fingerprint
             - name
-            - owner
             - project
             - publicKey
             type: object


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
One more step on our path to GitOps glory:

* `Cluster.Spec.Pause` now defaults to `false`
* `User.Spec.ID` is marked as deprecated/optional, as this field is not used anymore
* `User.Spec.IsAdmin` now defaults to `false`
* `UserSSHKey.Spec.Owner` is marked as deprecated/optional, as this field is not used anymore
* `UserSSHKey.Spec.Fingerprint` is marked as optional because the KKP webhook automatically (re)calculates the fingerprint

**Does this PR introduce a user-facing change?**:
```release-note
improve usability of a couple of KKP resources: `Cluster.Spec.Pause` now defaults to `false`; `UserSSHKey.Spec.Owner` is marked as deprecated/optional, as this field is not used anymore; `UserSSHKey.Spec.Fingerprint` is marked as optional because the KKP webhook automatically (re)calculates the fingerprint; `User.Spec.IsAdmin` now defaults to `false`; `User.Spec.ID` is marked as deprecated/optional, as this field is not used anymore
```
