### PR TITLE
Add HeadlessInstallation feature gate to disable API/UI/Ingress

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -36,7 +36,8 @@ spec:
       requests:
         cpu: 100m
         memory: 150Mi
-  # Auth defines keys and URLs for Dex.
+  # Auth defines keys and URLs for Dex. These must be defined unless the HeadlessInstallation
+  # feature gate is set, which will disable the UI/API and its need for an OIDC provider entirely.
   auth:
     clientID: kubermatic
     issuerClientID: kubermaticIssuer

--- a/hack/ci/testdata/kubermatic.yaml
+++ b/hack/ci/testdata/kubermatic.yaml
@@ -18,8 +18,23 @@ metadata:
   name: e2e
   namespace: kubermatic
 spec:
+  ingress:
+    domain: '__KUBERMATIC_DOMAIN__'
+    disable: true
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   userCluster:
     apiserverReplicas: 1
+  api:
+    replicas: 1
+    debugLog: true
   featureGates:
-    HeadlessInstallation: true
+    # VPA won't do anything useful due to missing Prometheus, but we can
+    # at least ensure we deploy a working set of Deployments.
+    VerticalPodAutoscaler: true
+  ui:
+    replicas: 0
+  # Dex integration
+  auth:
+    tokenIssuer: "http://dex.oauth:5556/dex"
+    issuerRedirectURL: "http://localhost:8000"
+    serviceAccountKey: "__SERVICE_ACCOUNT_KEY__"

--- a/hack/ci/testdata/kubermatic.yaml
+++ b/hack/ci/testdata/kubermatic.yaml
@@ -18,23 +18,8 @@ metadata:
   name: e2e
   namespace: kubermatic
 spec:
-  ingress:
-    domain: '__KUBERMATIC_DOMAIN__'
-    disable: true
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   userCluster:
     apiserverReplicas: 1
-  api:
-    replicas: 1
-    debugLog: true
   featureGates:
-    # VPA won't do anything useful due to missing Prometheus, but we can
-    # at least ensure we deploy a working set of Deployments.
-    VerticalPodAutoscaler: true
-  ui:
-    replicas: 0
-  # Dex integration
-  auth:
-    tokenIssuer: "http://dex.oauth:5556/dex"
-    issuerRedirectURL: "http://localhost:8000"
-    serviceAccountKey: "__SERVICE_ACCOUNT_KEY__"
+    HeadlessInstallation: true

--- a/hack/ci/testdata/kubermatic_headless.yaml
+++ b/hack/ci/testdata/kubermatic_headless.yaml
@@ -19,17 +19,13 @@ metadata:
   namespace: kubermatic
 spec:
   ingress:
+    # Even though no ingress will be created (due to the HeadlessInstallation
+    # feature gate), we still need the base domain to construct the URLs to
+    # the usercluster kube-apiserver. This traffic however is never routed
+    # through nginx.
     domain: '__KUBERMATIC_DOMAIN__'
-    disable: true
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   userCluster:
     apiserverReplicas: 1
-  api:
-    replicas: 0
-  ui:
-    replicas: 0
-  # Dex integration
-  auth:
-    tokenIssuer: "http://dex.oauth:5556/dex"
-    issuerRedirectURL: "http://localhost:8000"
-    serviceAccountKey: "__SERVICE_ACCOUNT_KEY__"
+  featureGates:
+    HeadlessInstallation: true

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -73,7 +73,9 @@ type KubermaticConfigurationSpec struct {
 	CABundle corev1.TypedLocalObjectReference `json:"caBundle,omitempty"`
 	// ImagePullSecret is used to authenticate against Docker registries.
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
-	// Auth defines keys and URLs for Dex.
+	// Auth defines keys and URLs for Dex. These must be defined unless the HeadlessInstallation
+	// feature gate is set, which will disable the UI/API and its need for an OIDC provider entirely.
+	// +optional
 	Auth KubermaticAuthConfiguration `json:"auth"`
 	// FeatureGates are used to optionally enable certain features.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/master/resources/kubermatic"
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -216,8 +217,9 @@ func (r *Reconciler) reconcileNamespaces(ctx context.Context, config *kubermatic
 func (r *Reconciler) reconcileConfigMaps(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
 	logger.Debug("Reconciling ConfigMaps")
 
-	creators := []reconciling.NamedConfigMapCreatorGetter{
-		kubermatic.UIConfigConfigMapCreator(config),
+	creators := []reconciling.NamedConfigMapCreatorGetter{}
+	if !config.Spec.FeatureGates[features.HeadlessInstallation] {
+		creators = append(creators, kubermatic.UIConfigConfigMapCreator(config))
 	}
 
 	if err := reconciling.ReconcileConfigMaps(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
@@ -322,10 +324,15 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, config *kubermati
 	logger.Debug("Reconciling Deployments")
 
 	creators := []reconciling.NamedDeploymentCreatorGetter{
-		kubermatic.APIDeploymentCreator(config, r.workerName, r.versions),
-		kubermatic.UIDeploymentCreator(config, r.versions),
 		kubermatic.MasterControllerManagerDeploymentCreator(config, r.workerName, r.versions),
 		common.WebhookDeploymentCreator(config, r.versions, nil, false),
+	}
+
+	if !config.Spec.FeatureGates[features.HeadlessInstallation] {
+		creators = append(creators,
+			kubermatic.APIDeploymentCreator(config, r.workerName, r.versions),
+			kubermatic.UIDeploymentCreator(config, r.versions),
+		)
 	}
 
 	modifiers := []reconciling.ObjectModifier{
@@ -349,9 +356,14 @@ func (r *Reconciler) reconcilePodDisruptionBudgets(ctx context.Context, config *
 	logger.Debug("Reconciling PodDisruptionBudgets")
 
 	creators := []reconciling.NamedPodDisruptionBudgetCreatorGetter{
-		kubermatic.APIPDBCreator(config),
-		kubermatic.UIPDBCreator(config),
 		kubermatic.MasterControllerManagerPDBCreator(config),
+	}
+
+	if !config.Spec.FeatureGates[features.HeadlessInstallation] {
+		creators = append(creators,
+			kubermatic.APIPDBCreator(config),
+			kubermatic.UIPDBCreator(config),
+		)
 	}
 
 	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
@@ -365,9 +377,14 @@ func (r *Reconciler) reconcileServices(ctx context.Context, config *kubermaticv1
 	logger.Debug("Reconciling Services")
 
 	creators := []reconciling.NamedServiceCreatorGetter{
-		kubermatic.APIServiceCreator(config),
-		kubermatic.UIServiceCreator(config),
 		common.WebhookServiceCreator(config, r.Client),
+	}
+
+	if !config.Spec.FeatureGates[features.HeadlessInstallation] {
+		creators = append(creators,
+			kubermatic.APIServiceCreator(config),
+			kubermatic.UIServiceCreator(config),
+		)
 	}
 
 	if err := reconciling.ReconcileServices(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
@@ -380,6 +397,11 @@ func (r *Reconciler) reconcileServices(ctx context.Context, config *kubermaticv1
 func (r *Reconciler) reconcileIngresses(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
 	if config.Spec.Ingress.Disable {
 		logger.Debug("Skipping Ingress creation because it was explicitly disabled")
+		return nil
+	}
+
+	if config.Spec.FeatureGates[features.HeadlessInstallation] {
+		logger.Debug("Headless installation requested, skipping.")
 		return nil
 	}
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -64,6 +64,12 @@ const (
 	// enable OSM to be used as a provisioning tool, is via the enabling of the EnableOperatingSystemManager field in
 	// user cluster.
 	OperatingSystemManager = "OperatingSystemManager"
+
+	// HeadlessInstallation feature makes the KKP installer not install nginx and Dex. This is useful to create
+	// a KKP system without UI/API deployments, that will only be interacted with using kubectl or similar means.
+	// Setting this feature flag will make KKP ignore any UI/API/Ingress configuration.
+	// This feature is in preview and not yet ready for production.
+	HeadlessInstallation = "HeadlessInstallation"
 )
 
 // FeatureGate is map of key=value pairs that enables/disables various features.

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -29,6 +29,7 @@ import (
 	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/sirupsen/logrus"
 
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
@@ -50,6 +51,11 @@ import (
 func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
 	logger.Info("📦 Deploying cert-manager…")
 	sublogger := log.Prefix(logger, "   ")
+
+	if opt.KubermaticConfiguration.Spec.FeatureGates[features.HeadlessInstallation] {
+		sublogger.Info("Headless installation requested, skipping.")
+		return nil
+	}
 
 	if opt.KubermaticConfiguration.Spec.Ingress.CertificateIssuer.Name == "" {
 		sublogger.Info("No CertificateIssuer configured in KubermaticConfiguration, skipping.")

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
@@ -44,6 +45,11 @@ import (
 func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
 	logger.Info("📦 Deploying nginx-ingress-controller…")
 	sublogger := log.Prefix(logger, "   ")
+
+	if opt.KubermaticConfiguration.Spec.FeatureGates[features.HeadlessInstallation] {
+		sublogger.Info("Headless installation requested, skipping.")
+		return nil
+	}
 
 	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "nginx-ingress-controller"))
 	if err != nil {

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/stack/common"
@@ -201,6 +202,11 @@ func deployDex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntime
 	logger.Info("📦 Deploying Dex…")
 	sublogger := log.Prefix(logger, "   ")
 
+	if opt.KubermaticConfiguration.Spec.FeatureGates[features.HeadlessInstallation] {
+		sublogger.Info("Headless installation requested, skipping.")
+		return nil
+	}
+
 	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "oauth"))
 	if err != nil {
 		return fmt.Errorf("failed to load Helm chart: %w", err)
@@ -322,6 +328,11 @@ func applyKubermaticConfiguration(ctx context.Context, logger *logrus.Entry, kub
 func showDNSSettings(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, opt stack.DeployOptions) {
 	logger.Info("📡 Determining DNS settings…")
 	sublogger := log.Prefix(logger, "   ")
+
+	if opt.KubermaticConfiguration.Spec.FeatureGates[features.HeadlessInstallation] {
+		sublogger.Info("Headless installation requested, skipping.")
+		return
+	}
 
 	if opt.KubermaticConfiguration.Spec.Ingress.Disable {
 		sublogger.Info("Ingress creation has been disabled in the KubermaticConfiguration, skipping.")

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -167,14 +167,12 @@ func validateKubermaticConfiguration(config *kubermaticv1.KubermaticConfiguratio
 		failures = append(failures, errors.New("the namespace must be \"kubermatic\""))
 	}
 
+	if config.Spec.Ingress.Domain == "" {
+		failures = append(failures, errors.New("spec.ingress.domain cannot be left empty"))
+	}
+
 	// only validate auth-related keys if we are not setting up a headless system
 	if !config.Spec.FeatureGates[features.HeadlessInstallation] {
-		if !config.Spec.Ingress.Disable {
-			if config.Spec.Ingress.Domain == "" {
-				failures = append(failures, errors.New("spec.ingress.domain cannot be left empty"))
-			}
-		}
-
 		failures = validateRandomSecret(config, config.Spec.Auth.ServiceAccountKey, "spec.auth.serviceAccountKey", failures)
 
 		if err := serviceaccount.ValidateKey([]byte(config.Spec.Auth.ServiceAccountKey)); err != nil {

--- a/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/validation/openapi/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -96,7 +96,9 @@ spec:
                     type: object
                 type: object
               auth:
-                description: Auth defines keys and URLs for Dex.
+                description: Auth defines keys and URLs for Dex. These must be defined
+                  unless the HeadlessInstallation feature gate is set, which will
+                  disable the UI/API and its need for an OIDC provider entirely.
                 properties:
                   clientID:
                     type: string
@@ -771,8 +773,6 @@ spec:
                         type: object
                     type: object
                 type: object
-            required:
-            - auth
             type: object
         type: object
     served: true


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Now that most of the bare minimum resources work just fine with GitOps and we have a dedicated gitops e2e test, it's now time to strip down the gitops environment even more and allow to disable nginx/dex/cert-manager entirely.

To achieve this, I chose to add a feature gate to KKP. Determining the headless state just based on "are ui.replicas=0 and api.replicas=0?" seems brittle and could lead to unintended consequences. With a dedicated feature gate, the admins can make their intentions absolutely clear and the operator can take the appropriate actions.

Note that this leaves behind a KKP system that has **no user contexts**. Meaning that only cluster-admins with access to master/seed clusters can make use of KKP. User authentication is still a giant TBD epic.

**Does this PR introduce a user-facing change?**:
```release-note
A new `HeadlessInstallation` (preview, not yet ready for production) feature flag can be used to disable the KKP UI, API and Ingress, which will also skip installing nginx/Dex/cert-manager. Use this if you intend to only access the master/seed clusters directly and need no user separation.
```
