### PR TITLE
add preset controller

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -37,6 +37,7 @@ import (
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
+	presetcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/preset-controller"
 	projectcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/project"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/pvwatcher"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition"
@@ -67,6 +68,7 @@ var AllControllers = map[string]controllerCreator{
 	clustertemplatecontroller.ControllerName:      createClusterTemplateController,
 	projectcontroller.ControllerName:              createProjectController,
 	clusterphasecontroller.ControllerName:         createClusterPhaseController,
+	presetcontroller.ControllerName:               createPresetController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -362,6 +364,15 @@ func createClusterTemplateController(ctrlCtx *controllerContext) error {
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.runOptions.namespace,
+		ctrlCtx.runOptions.workerCount,
+	)
+}
+
+func createPresetController(ctrlCtx *controllerContext) error {
+	return presetcontroller.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
 		ctrlCtx.runOptions.workerCount,
 	)
 }

--- a/pkg/controller/seed-controller-manager/preset-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package presetcontroller
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kkp_preset_controller"
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	workerName              string
+	recorder                record.EventRecorder
+	seedClient              ctrlruntimeclient.Client
+}
+
+func Add(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	numWorkers int,
+) error {
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		workerName:              workerName,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		seedClient:              mgr.GetClient(),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Preset{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch for seed preset instance: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile reconciles the kubermatic cluster template instance in the seed cluster.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+	log.Debug("Reconciling")
+
+	preset := &kubermaticv1.Preset{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, preset); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, fmt.Errorf("failed to get preset %s: %w", request.NamespacedName, err)
+	}
+
+	err := r.reconcile(ctx, preset, log)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Eventf(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, preset *kubermaticv1.Preset, log *zap.SugaredLogger) error {
+	// handle deletion to change all cluster annotation
+	if !preset.DeletionTimestamp.IsZero() {
+		log.Debugf("The preset %s was deleted", preset.Name)
+		workerNameLabelSelectorRequirements, _ := r.workerNameLabelSelector.Requirements()
+		presetLabelRequirement, err := labels.NewRequirement(kubermaticv1.IsCredentialPresetLabelKey, selection.Equals, []string{"true"})
+		if err != nil {
+			return fmt.Errorf("failed to construct label requirement for credential preset: %w", err)
+		}
+
+		listOpts := &ctrlruntimeclient.ListOptions{
+			LabelSelector: labels.NewSelector().Add(append(workerNameLabelSelectorRequirements, *presetLabelRequirement)...),
+		}
+
+		clusters := &kubermaticv1.ClusterList{}
+		if err := r.seedClient.List(ctx, clusters, listOpts); err != nil {
+			log.Errorw("Failed to get clusters", zap.Error(err))
+			return fmt.Errorf("failed to get clusters %w", err)
+		}
+		log.Debugf("Update clusters after preset deletion")
+		for _, cluster := range clusters.Items {
+			if cluster.Annotations != nil && cluster.Annotations[kubermaticv1.PresetNameAnnotation] == preset.Name {
+				log.Debugf("Update cluster %s", cluster.Name)
+				copyCluster := cluster.DeepCopy()
+				copyCluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation] = string(kubermaticv1.PresetDeleted)
+				if err := r.seedClient.Update(ctx, copyCluster); err != nil {
+					log.Errorw("Failed to update cluster", zap.Error(err))
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package presetcontroller
+
+import (
+	"context"
+	"testing"
+
+	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var now = metav1.Now()
+
+func TestReconcile(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	testCases := []struct {
+		name                 string
+		namespacedName       types.NamespacedName
+		expectedClusters     []string
+		expectedGetErrStatus metav1.StatusReason
+		seedClient           ctrlruntimeclient.Client
+	}{
+		{
+			name: "scenario 1: reconcile only deleted preset",
+			namespacedName: types.NamespacedName{
+				Name: test.TestFakeCredential,
+			},
+			expectedClusters: nil,
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(
+					getPreset(nil),
+					genCluster("ct2-0", "bob@acme.com", test.TestFakeCredential),
+					genCluster("ct2-1", "bob@acme.com", "test"),
+					genCluster("ct2-2", "bob@acme.com", test.TestFakeCredential),
+				).
+				Build(),
+		},
+		{
+			name: "scenario 2: reconcile deleted preset",
+			namespacedName: types.NamespacedName{
+				Name: test.TestFakeCredential,
+			},
+			expectedClusters: []string{"ct2-0", "ct2-2"},
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(
+					getPreset(&now),
+					genCluster("ct2-0", "bob@acme.com", test.TestFakeCredential),
+					genCluster("ct2-1", "bob@acme.com", "test"),
+					genCluster("ct2-2", "bob@acme.com", test.TestFakeCredential),
+				).
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				seedClient:              tc.seedClient,
+			}
+
+			request := reconcile.Request{NamespacedName: tc.namespacedName}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+			if tc.expectedGetErrStatus != "" {
+				if err == nil {
+					t.Fatalf("expected error status %v", tc.expectedGetErrStatus)
+				}
+				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				}
+				return
+			}
+
+			for _, clusterName := range tc.expectedClusters {
+				cluster := &kubermaticv1.Cluster{}
+				if err := tc.seedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: clusterName}, cluster); err != nil {
+					t.Fatalf("can't get expected cluster %s", clusterName)
+				}
+				if cluster.Annotations == nil {
+					t.Fatalf("expected annotations for the cluster")
+				}
+				if cluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation] != string(kubermaticv1.PresetDeleted) {
+					t.Fatalf("expected annotation %s with value %s", kubermaticv1.PresetInvalidatedAnnotation, kubermaticv1.PresetDeleted)
+				}
+			}
+		})
+	}
+}
+
+func genCluster(name, userEmail, preset string) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Labels:          map[string]string{kubermaticv1.IsCredentialPresetLabelKey: "true"},
+			ResourceVersion: "1",
+			Finalizers:      []string{kubermaticapiv1.CredentialsSecretsCleanupFinalizer},
+			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail, kubermaticv1.PresetNameAnnotation: preset},
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			HumanReadableName: name,
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: "fake-dc",
+				Fake:           &kubermaticv1.FakeCloudSpec{},
+			},
+		},
+		Status: kubermaticv1.ClusterStatus{
+			UserEmail: userEmail,
+		},
+	}
+}
+
+func getPreset(deletionTimestamp *metav1.Time) *kubermaticv1.Preset {
+	preset := test.GenDefaultPreset()
+	preset.DeletionTimestamp = deletionTimestamp
+	return preset
+}

--- a/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
@@ -115,7 +115,7 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("can't get expected cluster %s", clusterName)
 				}
 				if cluster.Annotations == nil {
-					t.Fatalf("expected annotations for the cluster")
+					t.Fatal("expected annotations for the cluster")
 				}
 				if cluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation] != string(kubermaticv1.PresetDeleted) {
 					t.Fatalf("expected annotation %s with value %s", kubermaticv1.PresetInvalidatedAnnotation, kubermaticv1.PresetDeleted)

--- a/pkg/controller/seed-controller-manager/preset-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/doc.go
@@ -16,5 +16,7 @@ limitations under the License.
 
 /*
 Package presetcontroller contains a controller that is responsible for managing presets.
+Preset deletion can affect all the clusters which were created with this preset. Setting `presetInvalidated`
+annotation for all those clusters will indicate a need to evaluate the credentials.
 */
 package presetcontroller

--- a/pkg/controller/seed-controller-manager/preset-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package presetcontroller contains a controller that is responsible for managing presets.
+*/
+package presetcontroller


### PR DESCRIPTION
**What does this PR do / Why do we need it**: add a preset controller. Checks if preset was deleted and changes all affected clusters (set credential preset annotation)

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9464


```release-note
Add a controller to monitor preset deletion. All affected clusters will be annotated. The end-user can make the decision to migrate the cluster credentials.
```
