### PR TITLE
Call BuildChartDependencies for each chart in image-loader

### DIFF
--- a/cmd/image-loader/helm.go
+++ b/cmd/image-loader/helm.go
@@ -67,6 +67,11 @@ func getImagesForHelmCharts(ctx context.Context, log *zap.SugaredLogger, config 
 			continue
 		}
 
+		chartLog.Info("Fetching chart dependencies")
+		if err := helmClient.BuildChartDependencies(chartPath, nil); err != nil {
+			return nil, fmt.Errorf("failed to download chart dependencies: %w", err)
+		}
+
 		chartLog.Info("Rendering chart")
 
 		rendered, err := helmClient.RenderChart(mockNamespaceName, chartName, chartPath, valuesFile, nil)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

`image-loader` did not fetch chart dependencies and failed if chart dependencies hadn't been downloaded before. This PR reuses the `BuildChartDependencies` call introduced in #8202 to mimic the installer's behaviour.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9004

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `image-loader` utility downloads chart dependencies (as `kubermatic-installer` already does) when generating the list of images to load
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>