### PR TITLE
Skip ipv6 in DNAT controller

### DIFF
--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -94,8 +94,11 @@ spec:
                 | jq -r '.items[]|  (.metadata|.name+" "+.uid) + " " + (.status.addresses[]|select(.type=="InternalIP")|.address)' \
                 | while read name uid ip; do
                     left=$( echo $virtualnodenet | cut -d. -f1-2 )
-                    right=$( echo $ip | cut -d. -f3-4 )
-                    iptables -t nat -A host_dnat_inactive -d $left.$right -j DNAT --to $ip
+                    right=$( echo $ip | cut -d. -s -f3-4 )
+                     if [[ -n "$right" ]]
+                     then
+                        iptables -t nat -A host_dnat_inactive -d $left.$right -j DNAT --to $ip
+                     fi
                 done
                 # swap the chains (inactive / active):
                 iptables -t nat -I PREROUTING -j host_dnat_inactive

--- a/pkg/controller/kubeletdnat-controller/controller.go
+++ b/pkg/controller/kubeletdnat-controller/controller.go
@@ -190,11 +190,16 @@ func getNodeAddresses(node corev1.Node) []string {
 
 func getInternalNodeAddress(node corev1.Node) (string, error) {
 	for _, address := range node.Status.Addresses {
-		if address.Type == corev1.NodeInternalIP {
+		if address.Type == corev1.NodeInternalIP && isIPv4(address.Address) {
 			return address.Address, nil
 		}
 	}
 	return "", fmt.Errorf("no internal address found; known addresses: %v", node.Status.Addresses)
+}
+
+func isIPv4(address string) bool {
+	ip := net.ParseIP(address)
+	return ip != nil && ip.To4() != nil
 }
 
 // getRulesForNode determines the used kubelet address of a node


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
Remove ipv6 from the dnat-controller of openvpn-client.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove ipv6 from the dnat-controller of openvpn-client.
```
