### PR TITLE
Fix potential race in cleanup of Azure resources

### DIFF
--- a/pkg/provider/cloud/azure/availability_set.go
+++ b/pkg/provider/cloud/azure/availability_set.go
@@ -118,10 +118,10 @@ func deleteAvailabilitySet(ctx context.Context, clients *ClientSet, cloud kuberm
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	res, err := clients.AvailabilitySets.Get(ctx, cloud.Azure.ResourceGroup, cloud.Azure.AvailabilitySet)
 	if err != nil {
+		if isNotFound(res.Response) {
+			return nil
+		}
 		return err
-	}
-	if isNotFound(res.Response) {
-		return nil
 	}
 
 	_, err = clients.AvailabilitySets.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.AvailabilitySet)

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -87,7 +87,7 @@ func ensureResourceGroup(ctx context.Context, groupsClient resourcesapi.GroupsCl
 }
 
 func deleteResourceGroup(ctx context.Context, clients *ClientSet, cloud kubermaticv1.CloudSpec) error {
-	// We're doing a Get to see if its already gone or not.
+	// We first check existence of the resource group to see if its already gone or not.
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	// Doing a get is simpler.
 	resp, err := clients.Groups.CheckExistence(ctx, cloud.Azure.ResourceGroup)

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -89,7 +89,6 @@ func ensureResourceGroup(ctx context.Context, groupsClient resourcesapi.GroupsCl
 func deleteResourceGroup(ctx context.Context, clients *ClientSet, cloud kubermaticv1.CloudSpec) error {
 	// We first check existence of the resource group to see if its already gone or not.
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
-	// Doing a get is simpler.
 	resp, err := clients.Groups.CheckExistence(ctx, cloud.Azure.ResourceGroup)
 	if err != nil {
 		return err

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -90,8 +90,12 @@ func deleteResourceGroup(ctx context.Context, clients *ClientSet, cloud kubermat
 	// We're doing a Get to see if its already gone or not.
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	// Doing a get is simpler.
-	if _, err := clients.Groups.Get(ctx, cloud.Azure.ResourceGroup); err != nil {
+	resp, err := clients.Groups.CheckExistence(ctx, cloud.Azure.ResourceGroup)
+	if err != nil {
 		return err
+	}
+	if isNotFound(resp) {
+		return nil
 	}
 
 	future, err := clients.Groups.Delete(ctx, cloud.Azure.ResourceGroup)

--- a/pkg/provider/cloud/azure/route_table.go
+++ b/pkg/provider/cloud/azure/route_table.go
@@ -108,10 +108,10 @@ func deleteRouteTable(ctx context.Context, clients *ClientSet, cloud kubermaticv
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	res, err := clients.RouteTables.Get(ctx, cloud.Azure.ResourceGroup, cloud.Azure.RouteTableName, "")
 	if err != nil {
+		if isNotFound(res.Response) {
+			return nil
+		}
 		return err
-	}
-	if isNotFound(res.Response) {
-		return nil
 	}
 
 	future, err := clients.RouteTables.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.RouteTableName)

--- a/pkg/provider/cloud/azure/route_table.go
+++ b/pkg/provider/cloud/azure/route_table.go
@@ -104,6 +104,16 @@ func ensureRouteTable(ctx context.Context, clients *ClientSet, cloud kubermaticv
 }
 
 func deleteRouteTable(ctx context.Context, clients *ClientSet, cloud kubermaticv1.CloudSpec) error {
+	// We first do Get to check existence of the route table to see if its already gone or not.
+	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
+	res, err := clients.RouteTables.Get(ctx, cloud.Azure.ResourceGroup, cloud.Azure.RouteTableName, "")
+	if err != nil {
+		return err
+	}
+	if isNotFound(res.Response) {
+		return nil
+	}
+
 	future, err := clients.RouteTables.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.RouteTableName)
 	if err != nil {
 		return err

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -206,6 +206,16 @@ func ensureSecurityGroup(ctx context.Context, clients *ClientSet, cloud kubermat
 }
 
 func deleteSecurityGroup(ctx context.Context, clients *ClientSet, cloud kubermaticv1.CloudSpec) error {
+	// We first do Get to check existence of the security group to see if its already gone or not.
+	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
+	res, err := clients.SecurityGroups.Get(ctx, cloud.Azure.ResourceGroup, cloud.Azure.SecurityGroup, "")
+	if err != nil {
+		return err
+	}
+	if isNotFound(res.Response) {
+		return nil
+	}
+
 	future, err := clients.SecurityGroups.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.SecurityGroup)
 	if err != nil {
 		return err

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -210,10 +210,10 @@ func deleteSecurityGroup(ctx context.Context, clients *ClientSet, cloud kubermat
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	res, err := clients.SecurityGroups.Get(ctx, cloud.Azure.ResourceGroup, cloud.Azure.SecurityGroup, "")
 	if err != nil {
+		if isNotFound(res.Response) {
+			return nil
+		}
 		return err
-	}
-	if isNotFound(res.Response) {
-		return nil
 	}
 
 	future, err := clients.SecurityGroups.Delete(ctx, cloud.Azure.ResourceGroup, cloud.Azure.SecurityGroup)

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -138,6 +138,17 @@ func deleteSubnet(ctx context.Context, clients *ClientSet, cloud kubermaticv1.Cl
 	if cloud.Azure.VNetResourceGroup != "" {
 		resourceGroup = cloud.Azure.VNetResourceGroup
 	}
+
+	// We first do Get to check existence of the subnet to see if its already gone or not.
+	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
+	res, err := clients.Subnets.Get(ctx, resourceGroup, cloud.Azure.VNetName, cloud.Azure.SubnetName, "")
+	if err != nil {
+		return err
+	}
+	if isNotFound(res.Response) {
+		return nil
+	}
+
 	deleteSubnetFuture, err := clients.Subnets.Delete(ctx, resourceGroup, cloud.Azure.VNetName, cloud.Azure.SubnetName)
 	if err != nil {
 		return err

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -143,10 +143,10 @@ func deleteSubnet(ctx context.Context, clients *ClientSet, cloud kubermaticv1.Cl
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	res, err := clients.Subnets.Get(ctx, resourceGroup, cloud.Azure.VNetName, cloud.Azure.SubnetName, "")
 	if err != nil {
+		if isNotFound(res.Response) {
+			return nil
+		}
 		return err
-	}
-	if isNotFound(res.Response) {
-		return nil
 	}
 
 	deleteSubnetFuture, err := clients.Subnets.Delete(ctx, resourceGroup, cloud.Azure.VNetName, cloud.Azure.SubnetName)

--- a/pkg/provider/cloud/azure/vnet.go
+++ b/pkg/provider/cloud/azure/vnet.go
@@ -135,10 +135,10 @@ func deleteVNet(ctx context.Context, clients *ClientSet, cloud kubermaticv1.Clou
 	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
 	res, err := clients.Networks.Get(ctx, resourceGroup, cloud.Azure.VNetName, "")
 	if err != nil {
+		if isNotFound(res.Response) {
+			return nil
+		}
 		return err
-	}
-	if isNotFound(res.Response) {
-		return nil
 	}
 
 	deleteVNetFuture, err := clients.Networks.Delete(ctx, resourceGroup, cloud.Azure.VNetName)

--- a/pkg/provider/cloud/azure/vnet.go
+++ b/pkg/provider/cloud/azure/vnet.go
@@ -130,6 +130,17 @@ func deleteVNet(ctx context.Context, clients *ClientSet, cloud kubermaticv1.Clou
 	if cloud.Azure.VNetResourceGroup != "" {
 		resourceGroup = cloud.Azure.VNetResourceGroup
 	}
+
+	// We first do Get to check existence of the VNet to see if its already gone or not.
+	// We could also directly call delete but the error response would need to be unpacked twice to get the correct error message.
+	res, err := clients.Networks.Get(ctx, resourceGroup, cloud.Azure.VNetName, "")
+	if err != nil {
+		return err
+	}
+	if isNotFound(res.Response) {
+		return nil
+	}
+
 	deleteVNetFuture, err := clients.Networks.Delete(ctx, resourceGroup, cloud.Azure.VNetName)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fixes occasional issue by deletion of Azure resources that would manifest with the following error message and cluster stuck in deletion:

```
failed cloud provider cleanup: failed to delete resource group "kubernetes-9hv4krpggv": resources.GroupsClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'kubernetes-9hv4krpggv' could not be found."
```

Apart from that it also unifies the deletion logic across all Azure resources.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed potential race in cleanup of Azure resources.
```
