### PR TITLE
[release/v2.18] Implement vsphereCSIClusterID feature flag (#9202)

### DIFF
--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -212,6 +212,15 @@ const (
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.
 	ClusterFeatureRancherIntegration = "rancherIntegration"
 
+	// ClusterFeatureVsphereCSIClusterID sets the cluster-id in the vSphere CSI config to
+	// the name of the user cluster. Originally, we have been setting cluster-id to the
+	// vSphere Compute Cluster name (provided via the Datacenter object), however,
+	// this is supposed to identify the Kubernetes cluster, therefore it must be unique.
+	// This feature flag is enabled by default for new vSphere clusters, while existing
+	// vSphere clusters must be migrated manually (preferably by following advice here:
+	// https://kb.vmware.com/s/article/84446).
+	ClusterFeatureVsphereCSIClusterID = "vsphereCSIClusterID"
+
 	// ClusterFeatureEtcdLauncher enables features related to the experimental etcd-launcher. This includes user-cluster
 	// etcd scaling, automatic volume recovery and new backup/restore contorllers.
 	ClusterFeatureEtcdLauncher = "etcdLauncher"

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -244,6 +244,9 @@ func GenerateCluster(ctx context.Context, projectID string, body apiv1.CreateClu
 		if cloudcontroller.ExternalCloudControllerClusterName(partialCluster) {
 			partialCluster.Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] = true
 		}
+		if partialCluster.Spec.Cloud.VSphere != nil {
+			partialCluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID] = true
+		}
 	}
 	return partialCluster, nil
 }

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -294,6 +294,18 @@ func getVsphereCloudConfig(
 	if cluster.Spec.Cloud.VSphere.Datastore != "" {
 		datastore = cluster.Spec.Cloud.VSphere.Datastore
 	}
+
+	// Originally, we have been setting cluster-id to the vSphere Compute Cluster name
+	// (provided via the Datacenter object), however, this is supposed to identify the
+	// Kubernetes cluster, therefore it must be unique. This feature flag is enabled by
+	// default for new vSphere clusters, while existing vSphere clusters must be
+	// migrated manually (preferably by following advice here:
+	// https://kb.vmware.com/s/article/84446).
+	clusterID := dc.Spec.VSphere.Cluster
+	if cluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID] {
+		clusterID = cluster.Name
+	}
+
 	return &vsphere.CloudConfig{
 		Global: vsphere.GlobalOpts{
 			User:             credentials.VSphere.Username,
@@ -304,7 +316,7 @@ func getVsphereCloudConfig(
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			DefaultDatastore: datastore,
 			WorkingDir:       cluster.Name,
-			ClusterID:        cluster.Name,
+			ClusterID:        clusterID,
 		},
 		Workspace: vsphere.WorkspaceOpts{
 			// This is redundant with what the Vsphere cloud provider itself does:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.19.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.19.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.19.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.19.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi-externalCloudProvider.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-cloud-config-csi.yaml
@@ -11,7 +11,7 @@ data:
     datacenter        = "vs-datacenter"
     datastore         = "vs-datastore"
     server            = "vs-endpoint.io"
-    cluster-id        = "de-test-01"
+    cluster-id        = "vs-cluster"
 
     [Disk]
     scsicontrollertype = "pvscsi"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a manual cherry pick of [#9202](https://github.com/kubermatic/kubermatic/pull/9202)
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will 
close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `vsphereCSIClusterID` feature flag for the cluster object. This feature flag changes the cluster-id in the vSphere CSI config to the cluster name instead of the vSphere Compute Cluster name provided via Datacenter config. Migrating the cluster-id requires manual steps (docs link to be added).
```