### PR TITLE
Enable the vsphereCSIClusterID feature flag when running the CCM/CSI migration

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -686,6 +686,9 @@ func MigrateEndpointToExternalCCM(ctx context.Context, userInfoGetter provider.U
 		newCluster.Spec.Features = make(map[string]bool)
 	}
 	newCluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] = true
+	if oldCluster.Spec.Cloud.VSphere != nil {
+		newCluster.Spec.Features[kubermaticv1.ClusterFeatureVsphereCSIClusterID] = true
+	}
 
 	seedAdminClient := privilegedClusterProvider.GetSeedClusterAdminRuntimeClient()
 	if err := seedAdminClient.Patch(ctx, newCluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

We implemented the `vsphereCSIClusterID` feature flag in #9202 to solve the problem with `cluster-id` being non-unique. This flag is enabled by default for new clusters and can be enabled manually for existing clusters. However, we don't enable this feature flag by default when migrating clusters to the external CCM/CSI, so users need to enable this feature gate manually and follow the migration guidelines.

This is now solved with this PR, so we automatically enable this feature flag when running the CCM/CSI migration, meaning that there's no action required from the user.

**Special notes for your reviewer**:

This should be cherry-picked to all branches supporting the CCM/CSI migration for vSphere.

**Does this PR introduce a user-facing change?**:
```release-note
Enable the "vsphereCSIClusterID" feature flag when running the CCM/CSI migration
```

/assign @moadqassem @maciaszczykm 