### PR TITLE
Upgrade to klog/v2

### DIFF
--- a/cmd/kubeletdnat-controller/main.go
+++ b/cmd/kubeletdnat-controller/main.go
@@ -32,7 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"

--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -84,7 +84,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/cmd/kubermatic-operator/main.go
+++ b/cmd/kubermatic-operator/main.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/cmd/kubermatic-webhook/options.go
+++ b/cmd/kubermatic-webhook/options.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/webhook"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -39,7 +39,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	ctrlruntimezaplog "sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -55,7 +55,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	k8s.io/cli-runtime v0.23.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/code-generator v0.23.4
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.30.0
 	k8s.io/kube-aggregator v0.23.4
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
 	k8s.io/kubectl v0.23.4
@@ -279,7 +279,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/component-base v0.23.4 // indirect
 	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c // indirect
-	k8s.io/klog/v2 v2.30.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kubelet v0.22.2 // indirect
 	kubevirt.io/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk v0.2.1 // indirect

--- a/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
@@ -72,7 +73,7 @@ type projectResource struct {
 }
 
 // New creates a new controller aggregator for managing RBAC for resources.
-func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manager.Manager, labelSelectorFunc func(*metav1.ListOptions), workerPredicate predicate.Predicate, workerCount int) (*ControllerAggregator, error) {
+func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manager.Manager, log *zap.SugaredLogger, labelSelectorFunc func(*metav1.ListOptions), workerPredicate predicate.Predicate, workerCount int) (*ControllerAggregator, error) {
 	projectResources := []projectResource{
 		{
 			object: &kubermaticv1.Cluster{
@@ -147,11 +148,11 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 		},
 	}
 
-	if err := newProjectRBACController(ctx, metrics, mgr, seedManagerMap, projectResources, workerPredicate); err != nil {
+	if err := newProjectRBACController(ctx, metrics, mgr, seedManagerMap, log, projectResources, workerPredicate); err != nil {
 		return nil, err
 	}
 
-	resourcesRBACCtrl, err := newResourcesControllers(ctx, metrics, mgr, seedManagerMap, projectResources)
+	resourcesRBACCtrl, err := newResourcesControllers(ctx, metrics, mgr, log, seedManagerMap, projectResources)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/master-controller-manager/rbac/rbac_project_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_project_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/controller/master-controller-manager/rbac/rbac_project_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_project_controller.go
@@ -19,6 +19,7 @@ package rbac
 import (
 	"context"
 
+	"go.uber.org/zap"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -41,6 +42,7 @@ type projectController struct {
 	projectQueue workqueue.RateLimitingInterface
 	metrics      *Metrics
 
+	log              *zap.SugaredLogger
 	projectResources []projectResource
 	client           ctrlruntimeclient.Client
 	restMapper       meta.RESTMapper
@@ -52,7 +54,7 @@ type projectController struct {
 
 // The controller will also set proper ownership chain through OwnerReferences
 // so that whenever a project is deleted dependent object will be garbage collected.
-func newProjectRBACController(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manager.Manager, resources []projectResource, workerPredicate predicate.Predicate) error {
+func newProjectRBACController(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manager.Manager, log *zap.SugaredLogger, resources []projectResource, workerPredicate predicate.Predicate) error {
 	seedClientMap := make(map[string]ctrlruntimeclient.Client)
 	for k, v := range seedManagerMap {
 		seedClientMap[k] = v.GetClient()
@@ -60,6 +62,7 @@ func newProjectRBACController(ctx context.Context, metrics *Metrics, mgr manager
 
 	c := &projectController{
 		projectQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_for_project"),
+		log:              log,
 		metrics:          metrics,
 		projectResources: resources,
 		client:           mgr.GetClient(),

--- a/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -36,6 +36,7 @@ import (
 
 type resourcesController struct {
 	projectResourcesQueue workqueue.RateLimitingInterface
+	log                   *zap.SugaredLogger
 	metrics               *Metrics
 	projectResources      []projectResource
 	client                ctrlruntimeclient.Client
@@ -45,13 +46,15 @@ type resourcesController struct {
 }
 
 // newResourcesController creates a new controller for managing RBAC for named resources that belong to project.
-func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manager.Manager, resources []projectResource) ([]*resourcesController, error) {
-	klog.V(4).Infof("considering master cluster provider for resources")
+func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.Manager, log *zap.SugaredLogger, seedManagerMap map[string]manager.Manager, resources []projectResource) ([]*resourcesController, error) {
+	log.Debug("considering master cluster provider for resources")
+
 	for _, resource := range resources {
 		clonedObject := resource.object.DeepCopyObject()
 
 		mc := &resourcesController{
 			projectResourcesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_resources"),
+			log:                   log.With("kind", clonedObject.GetObjectKind().GroupVersionKind().Kind),
 			metrics:               metrics,
 			projectResources:      resources,
 			client:                mgr.GetClient(),
@@ -67,7 +70,7 @@ func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.
 		}
 
 		if resource.destination == destinationSeed {
-			klog.V(4).Infof("skipping adding a shared informer and indexer for a project's resource %q for master provider, as it is meant only for the seed cluster provider", resource.object.GetObjectKind().GroupVersionKind().String())
+			mc.log.Debug("skipping adding a shared informer and indexer for master provider, as it is meant only for the seed cluster provider")
 			continue
 		}
 
@@ -77,12 +80,15 @@ func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.
 	}
 
 	for seedName, seedManager := range seedManagerMap {
-		klog.V(4).Infof("considering %s provider for resources", seedName)
+		seedLog := log.With("seed", seedName)
+		seedLog.Debug("building controllers for seed", seedName)
+
 		for _, resource := range resources {
 			clonedObject := resource.object.DeepCopyObject()
 
 			c := &resourcesController{
 				projectResourcesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fmt.Sprintf("rbac_generator_resources_%s", seedName)),
+				log:                   seedLog.With("kind", clonedObject.GetObjectKind().GroupVersionKind().Kind),
 				metrics:               metrics,
 				projectResources:      resources,
 				client:                seedManager.GetClient(),
@@ -98,7 +104,7 @@ func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.
 			}
 
 			if len(resource.destination) == 0 {
-				klog.V(4).Infof("skipping adding a shared informer and indexer for a project's resource %q for provider %q, as it is meant only for the master cluster provider", resource.object.GetObjectKind().GroupVersionKind().String(), seedName)
+				c.log.Debugf("skipping adding a shared informer and indexer, as it is meant only for the master cluster provider")
 				continue
 			}
 

--- a/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/master-controller-manager/rbac/sync_project.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac/test"
@@ -94,6 +95,7 @@ func TestEnsureProjectInitialized(t *testing.T) {
 			target := projectController{
 				client:     masterClient,
 				restMapper: getFakeRestMapper(t),
+				log:        zap.NewNop().Sugar(),
 			}
 			err := target.ensureCleanupFinalizerExists(ctx, test.projectToSync)
 			assert.NoError(t, err)
@@ -540,6 +542,7 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 				restMapper:       getFakeRestMapper(t),
 				seedClientMap:    seedClientMap,
 				projectResources: test.projectResourcesToSync,
+				log:              zap.NewNop().Sugar(),
 			}
 			err := target.ensureClusterRBACRoleBindingForResources(ctx, test.projectToSync)
 			assert.NoError(t, err)
@@ -834,6 +837,7 @@ func TestEnsureProjectCleanup(t *testing.T) {
 				client:           fakeMasterClusterClient,
 				restMapper:       getFakeRestMapper(t),
 				seedClientMap:    seedClusterClientMap,
+				log:              zap.NewNop().Sugar(),
 			}
 			err := target.ensureProjectCleanup(ctx, test.projectToSync)
 			assert.NoError(t, err)
@@ -1106,6 +1110,7 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 				client:           fakeMasterClient,
 				restMapper:       getFakeRestMapper(t),
 				seedClientMap:    seedClients,
+				log:              zap.NewNop().Sugar(),
 			}
 			err := target.ensureClusterRBACRoleForResources(ctx)
 			assert.Nil(t, err)
@@ -1407,6 +1412,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 				restMapper:       getFakeRestMapper(t),
 				seedClientMap:    seedClientMap,
 				projectResources: test.projectResourcesToSync,
+				log:              zap.NewNop().Sugar(),
 			}
 			err := target.ensureRBACRoleForResources(ctx)
 			assert.Nil(t, err)
@@ -1855,6 +1861,7 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 				restMapper:       getFakeRestMapper(t),
 				seedClientMap:    seedClusterClientMap,
 				projectResources: test.projectResourcesToSync,
+				log:              zap.NewNop().Sugar(),
 			}
 			err := target.ensureRBACRoleBindingForResources(ctx, test.projectToSync)
 			assert.Nil(t, err)
@@ -2153,6 +2160,7 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 				restMapper:       getFakeRestMapper(t),
 				seedClientMap:    seedClusterClientMap,
 				projectResources: test.projectResourcesToSync,
+				log:              zap.NewNop().Sugar(),
 			}
 			err = target.ensureProjectCleanup(ctx, test.projectToSync)
 			assert.NoError(t, err)

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac/test"
@@ -865,6 +866,7 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 				client:     fakeMasterClusterClient,
 				restMapper: getFakeRestMapper(t),
 				objectType: test.dependantToSync.DeepCopyObject().(ctrlruntimeclient.Object),
+				log:        zap.NewNop().Sugar(),
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)
@@ -1091,6 +1093,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 				client:     fakeMasterClusterClient,
 				restMapper: getFakeRestMapper(t),
 				objectType: test.dependantToSync.DeepCopyObject().(ctrlruntimeclient.Object),
+				log:        zap.NewNop().Sugar(),
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)
@@ -1731,7 +1734,7 @@ func TestEnsureProjectClusterRBACRoleBindingForNamedResource(t *testing.T) {
 			fakeMasterClusterClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(objs...).Build()
 
 			// act
-			err := ensureClusterRBACRoleBindingForNamedResource(context.Background(), fakeMasterClusterClient, test.projectToSync.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, test.projectToSync.GetObjectMeta())
+			err := ensureClusterRBACRoleBindingForNamedResource(context.Background(), zap.NewNop().Sugar(), fakeMasterClusterClient, test.projectToSync.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, test.projectToSync.GetObjectMeta())
 			assert.NoError(t, err)
 
 			{
@@ -2260,7 +2263,7 @@ func TestEnsureProjectClusterRBACRoleForNamedResource(t *testing.T) {
 			fakeMasterClusterClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(objs...).Build()
 
 			// act
-			err := ensureClusterRBACRoleForNamedResource(context.Background(), fakeMasterClusterClient, test.projectToSync.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, test.projectToSync.GetObjectMeta())
+			err := ensureClusterRBACRoleForNamedResource(context.Background(), zap.NewNop().Sugar(), fakeMasterClusterClient, test.projectToSync.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, test.projectToSync.GetObjectMeta())
 			assert.NoError(t, err)
 
 			{
@@ -2541,6 +2544,7 @@ func TestSyncClusterConstraintsRBAC(t *testing.T) {
 				client:     fakeMasterClusterClient,
 				restMapper: getFakeRestMapper(t),
 				objectType: test.dependantToSync.DeepCopyObject().(ctrlruntimeclient.Object),
+				log:        zap.NewNop().Sugar(),
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)
@@ -2949,6 +2953,7 @@ func TestSyncClusterAlertmanagerRBAC(t *testing.T) {
 				client:     fakeSeedClusterClient,
 				restMapper: getFakeRestMapper(t),
 				objectType: test.dependantToSync.DeepCopyObject().(ctrlruntimeclient.Object),
+				log:        zap.NewNop().Sugar(),
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)
@@ -3256,6 +3261,7 @@ func TestSyncClusterRuleGroupsRBAC(t *testing.T) {
 				client:     fakeSeedClusterClient,
 				restMapper: getFakeRestMapper(t),
 				objectType: test.dependantToSync.DeepCopyObject().(ctrlruntimeclient.Object),
+				log:        zap.NewNop().Sugar(),
 			}
 			objmeta, err := meta.Accessor(test.dependantToSync)
 			assert.NoError(t, err)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR makes the rbac controller use our default logging stuf (i.e. zap) and upgrades klog to v2 for all the upstream components (our codebase itself doesn't use klog anymore (:partying_face:), but we still want to have `-v` available to toggle the verbosity of kubernetes upstream libraries).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
