### PR TITLE
applicationInstallationController: add logic to trigger install/ uninstall of an application

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -28,6 +28,7 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/applications/fake"
 	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	applicationinstallationcontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/application-installation-controller"
 	ccmcsimigrator "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator"
@@ -380,7 +381,7 @@ func main() {
 		log.Info("Registered constraintsyncer controller")
 	}
 
-	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker); err != nil {
+	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, fake.ApplicationInstallerLogger{}); err != nil {
 		log.Fatalw("Failed to add user Application Installation controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered Application Installation controller")

--- a/pkg/apis/apps.kubermatic/v1/types.go
+++ b/pkg/apis/apps.kubermatic/v1/types.go
@@ -21,6 +21,10 @@ import corev1 "k8s.io/api/core/v1"
 const (
 	// ApplicationDefinitionSeedCleanupFinalizer indicates that synced application definition on seed clusters need cleanup.
 	ApplicationDefinitionSeedCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-application-definition"
+
+	// ApplicationInstallationCleanupFinalizer indicates that application installed on user-cluster need cleanup
+	// ie uninstall the application, remove  namespace where application were installed ...
+	ApplicationInstallationCleanupFinalizer = "kubermatic.k8c.io/cleanup-application-installation"
 )
 
 // GlobalSecretKeySelector is needed as we can not use v1.SecretKeySelector

--- a/pkg/applications/OWNERS
+++ b/pkg/applications/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig-app-management
+
+options:
+  no_parent_owners: true

--- a/pkg/applications/doc.go
+++ b/pkg/applications/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /*
-Package applications contains locig for download the source of an application (eg download manifest from git) and
-install / uninstall the application into user-cluster.
+Package applications contains logic to download the source of an application (eg download manifest from git) and
+install / uninstall the application into the user-cluster.
 */
 package applications

--- a/pkg/applications/doc.go
+++ b/pkg/applications/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package applications contains locig for download the source of an application (eg download manifest from git) and
+install / uninstall the application into user-cluster.
+*/
+package applications

--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ApplicationInstallerRecorder is a fake ApplicationInstaller that record call to apply and delete for testing assertions.
+type ApplicationInstallerRecorder struct {
+	// ApplyEvents stores the call to apply function. Key is the name of the applicationInstallation.
+	ApplyEvents sync.Map
+
+	// DeleteEvents stores the call to delete function. Key is the name of the applicationInstallation.
+	DeleteEvents sync.Map
+}
+
+func (a *ApplicationInstallerRecorder) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+	a.ApplyEvents.Store(applicationInstallation.Name, *applicationInstallation.DeepCopy())
+	return nil
+}
+
+func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+	a.DeleteEvents.Store(applicationInstallation.Name, *applicationInstallation.DeepCopy())
+	return nil
+}
+
+// ApplicationInstallerLogger is a fake ApplicationInstaller that just log actions. it used for development of controller.
+type ApplicationInstallerLogger struct {
+}
+
+func (a ApplicationInstallerLogger) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+	log.Debugf("Install application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
+	return nil
+}
+
+func (a ApplicationInstallerLogger) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+	log.Debugf("Uninstall application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
+	return nil
+}

--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -27,7 +27,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ApplicationInstallerRecorder is a fake ApplicationInstaller that record call to apply and delete for testing assertions.
+// ApplicationInstallerRecorder is a fake ApplicationInstaller that records calls to apply and delete for testing assertions.
 type ApplicationInstallerRecorder struct {
 	// ApplyEvents stores the call to apply function. Key is the name of the applicationInstallation.
 	ApplyEvents sync.Map
@@ -46,7 +46,7 @@ func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.Suga
 	return nil
 }
 
-// ApplicationInstallerLogger is a fake ApplicationInstaller that just log actions. it used for development of controller.
+// ApplicationInstallerLogger is a fake ApplicationInstaller that just logs actions. it's used for the development of the controller.
 type ApplicationInstallerLogger struct {
 }
 

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -26,13 +26,11 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ApplicationInstaller handle the installation / uninstallation of an Application on a user cluster.
+// ApplicationInstaller handles the installation / uninstallation of an Application on the user cluster.
 type ApplicationInstaller interface {
-	// Apply function install the application on user cluster and return error if the installation failed.
-	// this function is idempotent
+	// Apply function installs the application on the user-cluster and returns an error if the installation has failed; this is idempotent.
 	Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
 
-	// Delete function uninstall the application on user cluster and return error if the installation failed.
-	// this function is idempotent
-	Delete(ctx context.Context, log *zap.SugaredLogger, seddClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
+	// Delete function uninstalls the application on the user-cluster and returns an error if the uninstallation has failed; this is idempotent.
+	Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
 }

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applications
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ApplicationInstaller handle the installation / uninstallation of an Application on a user cluster.
+type ApplicationInstaller interface {
+	// Apply function install the application on user cluster and return error if the installation failed.
+	// this function is idempotent
+	Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
+
+	// Delete function uninstall the application on user cluster and return error if the installation failed.
+	// this function is idempotent
+	Delete(ctx context.Context, log *zap.SugaredLogger, seddClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
+}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package applicationinstallationcontroller
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	timeout  = time.Second * 10
+	interval = time.Second * 1
+)
+
+var _ = Describe("application Installation controller", func() {
+	Context("when application is created", func() {
+		It("should update application.Status with applicationVersion and install application", func() {
+			appDefName := "app-def-1"
+			appInstallName := "app-1"
+
+			Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
+
+			def := &appkubermaticv1.ApplicationDefinition{}
+			Expect(userClient.Get(ctx, types.NamespacedName{Name: appDefName}, def)).To(Succeed())
+
+			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0"))).To(Succeed())
+
+			app := &appkubermaticv1.ApplicationInstallation{}
+			Eventually(func() bool {
+				if err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, app); err != nil {
+					return false
+				}
+				return app.Status.ApplicationVersion != nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("check status is updated with applicationVersion")
+			Expect(*app.Status.ApplicationVersion).To(Equal(def.Spec.Versions[0]))
+
+			expectApplicationInstalledWithVersion(app.Name, def.Spec.Versions[0])
+		})
+	})
+
+	Context("when creating an application that reference an ApplicationDefinton that not exist", func() {
+		It("nothing should happened", func() {
+			appDefName := "app-def-2"
+			appInstallName := "app-2"
+
+			Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
+			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, "app-def-not-exist", "1.0.0"))).To(Succeed())
+
+			By("wait for application to be created")
+			app := appkubermaticv1.ApplicationInstallation{}
+			Eventually(func() bool {
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, &app)
+				return err == nil
+			}, 3*time.Second, interval).Should(BeTrue())
+
+			By("ensure application is not deleted")
+			Consistently(func() bool {
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, &app)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("application has not been installed")
+			_, found := applicationInstallerRecorder.ApplyEvents.Load(appInstallName)
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	Context("when creating an application that reference an applicationVersion that not exist", func() {
+		It("nothing should happened", func() {
+			appDefName := "app-def-3"
+			appInstallName := "app-3"
+
+			Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
+			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0-not-exist"))).To(Succeed())
+
+			By("wait for application to be created")
+			app := appkubermaticv1.ApplicationInstallation{}
+			Eventually(func() bool {
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, &app)
+				return err == nil
+			}, 3*time.Second, interval).Should(BeTrue())
+
+			By("ensure application is not deleted")
+			Consistently(func() bool {
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, &app)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("application has not been installed")
+			_, found := applicationInstallerRecorder.ApplyEvents.Load(appInstallName)
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	Context("when an applicationDefinition is removed", func() {
+		It("should remove the application using this ApplicationDefintion", func() {
+			appDefName := "app-def-5"
+			appInstallName := "app-5"
+
+			Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
+			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0"))).To(Succeed())
+
+			def := &appkubermaticv1.ApplicationDefinition{}
+			Expect(userClient.Get(ctx, types.NamespacedName{Name: appDefName}, def)).To(Succeed())
+
+			By("wait for application to be created")
+			app := &appkubermaticv1.ApplicationInstallation{}
+			Eventually(func() bool {
+				if err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, app); err != nil {
+					return false
+				}
+				return app.Status.ApplicationVersion != nil
+			}, timeout, interval).Should(BeTrue())
+
+			expectApplicationInstalledWithVersion(appInstallName, def.Spec.Versions[0])
+
+			By("removing applicationDefinition")
+			Expect(userClient.Delete(ctx, def)).To(Succeed())
+
+			By("Checking application Installation CR is removed")
+			Eventually(func() bool {
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, &appkubermaticv1.ApplicationInstallation{})
+
+				return err != nil && apierrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			expectApplicationUninstalledWithVersion(appInstallName, def.Spec.Versions[0])
+		})
+	})
+
+	Context("when an applicationVersion is removed", func() {
+		It("should remove the application using this appVersion", func() {
+			appDefName := "app-def-4"
+			appInstallName := "app-4"
+
+			Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
+			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0"))).To(Succeed())
+
+			def := &appkubermaticv1.ApplicationDefinition{}
+			Expect(userClient.Get(ctx, types.NamespacedName{Name: appDefName}, def)).To(Succeed())
+
+			By("wait for application to be created")
+			app := &appkubermaticv1.ApplicationInstallation{}
+			Eventually(func() bool {
+				if err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, app); err != nil {
+					return false
+				}
+				return app.Status.ApplicationVersion != nil
+			}, timeout, interval).Should(BeTrue())
+
+			expectApplicationInstalledWithVersion(appInstallName, def.Spec.Versions[0])
+
+			previousVersion := def.Spec.Versions[0]
+
+			By("removing applicationVersion from applicationDefinition")
+			def.Spec.Versions = []appkubermaticv1.ApplicationVersion{
+				{
+					Version: "3.0.0",
+					Constraints: appkubermaticv1.ApplicationConstraints{
+						K8sVersion: "> 1.19",
+						KKPVersion: "> 2.0",
+					},
+					Template: appkubermaticv1.ApplicationTemplate{
+						Source: appkubermaticv1.ApplicationSource{
+							Helm: &appkubermaticv1.HelmSource{
+								URL:          "http://helmrepo.local",
+								ChartName:    "someChartName",
+								ChartVersion: "12",
+								Credentials:  nil,
+							},
+						},
+						Method:   "helm",
+						FormSpec: nil,
+					},
+				}}
+			Expect(userClient.Update(ctx, def)).To(Succeed())
+
+			By("Checking application Installation CR is removed")
+			Eventually(func() bool {
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName}, &appkubermaticv1.ApplicationInstallation{})
+
+				return err != nil && apierrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			expectApplicationUninstalledWithVersion(appInstallName, previousVersion)
+		})
+	})
+
+})
+
+func expectApplicationInstalledWithVersion(appName string, expectedVersion appkubermaticv1.ApplicationVersion) {
+	By("check application has been installed")
+	EventuallyWithOffset(1, func(g Gomega) {
+		result, found := applicationInstallerRecorder.ApplyEvents.Load(appName)
+		g.Expect(found).To(BeTrue(), "Application "+appName+" has not been installed")
+
+		currentVersion := result.(appkubermaticv1.ApplicationInstallation)
+		g.Expect(*currentVersion.Status.ApplicationVersion).To(Equal(expectedVersion))
+	}, timeout, interval).Should(Succeed())
+}
+
+func expectApplicationUninstalledWithVersion(appName string, expectedVersion appkubermaticv1.ApplicationVersion) {
+	By("Checking application Installation has been uninstalled")
+	EventuallyWithOffset(1, func(g Gomega) {
+		result, found := applicationInstallerRecorder.DeleteEvents.Load(appName)
+		g.Expect(found).To(BeTrue(), "Application "+appName+" has not been uninstalled")
+
+		currentVersion := result.(appkubermaticv1.ApplicationInstallation)
+		g.Expect(*currentVersion.Status.ApplicationVersion).To(Equal(expectedVersion))
+	}, timeout, interval).Should(Succeed())
+}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 var _ = Describe("application Installation controller", func() {
-	Context("when application is created", func() {
+	Context("when an application is created", func() {
 		It("should update application.Status with applicationVersion and install application", func() {
 			appDefName := "app-def-1"
 			appInstallName := "app-1"
@@ -62,8 +62,8 @@ var _ = Describe("application Installation controller", func() {
 		})
 	})
 
-	Context("when creating an application that reference an ApplicationDefinton that not exist", func() {
-		It("nothing should happened", func() {
+	Context("when creating an application that references an ApplicationDefinton that does not exist", func() {
+		It("nothing should happen", func() {
 			appDefName := "app-def-2"
 			appInstallName := "app-2"
 
@@ -89,8 +89,8 @@ var _ = Describe("application Installation controller", func() {
 		})
 	})
 
-	Context("when creating an application that reference an applicationVersion that not exist", func() {
-		It("nothing should happened", func() {
+	Context("when creating an application that references an applicationVersion that does not exist", func() {
+		It("nothing should happen", func() {
 			appDefName := "app-def-3"
 			appInstallName := "app-3"
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -61,7 +61,7 @@ func TestEnqueueApplicationInstallation(t *testing.T) {
 			},
 		},
 		{
-			name:                  "scenario 2: when no application reference ApplicationDef 'app-def-1' nothing is enqueued",
+			name:                  "scenario 2: when no application reference ApplicationDef 'app-def-1', nothing is enqueued",
 			applicationDefinition: genApplicationDefinition("app-def-1"),
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
@@ -73,7 +73,7 @@ func TestEnqueueApplicationInstallation(t *testing.T) {
 			expectedReconcileRequests: []reconcile.Request{},
 		},
 		{
-			name:                  "scenario 3: when no application in cluster nothing is enqueued",
+			name:                  "scenario 3: when no application in cluster, nothing is enqueued",
 			applicationDefinition: genApplicationDefinition("app-def-1"),
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/doc.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /*
-Package applicationinstallationcontroller contains a controller that is responsible for reconcile ApplicationInstallation
-(ie install, update or uninstall applications into user-cluster)
+Package applicationinstallationcontroller contains a controller that is responsible for reconciling ApplicationInstallation
+(ie install, update or uninstall applications into the user-cluster)
 */
 package applicationinstallationcontroller

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/suite_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/suite_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/applications/fake"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var testEnv *envtest.Environment
+var userClient ctrlruntimeclient.Client
+var ctx context.Context
+var cancel context.CancelFunc
+var applicationInstallerRecorder fake.ApplicationInstallerRecorder
+
+func TestApplicationInstallerController(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Application Intallation controller test suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{"../../../validation/openapi/crd/k8c.io"},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = kubermaticv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	userClient = mgr.GetClient()
+	applicationInstallerRecorder = fake.ApplicationInstallerRecorder{}
+
+	err = Add(ctx, kubermaticlog.Logger, mgr, mgr, func(ctx context.Context) (bool, error) {
+		return false, nil
+	}, &applicationInstallerRecorder)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = mgr.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	// stop controller
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR implements the reconcile logic that triggers the installation / uninstallation of the application. We use fake AplicationInstaller that just logs actions, domain logic will be implemented in further PR.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8384 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
