### PR TITLE
Add omitempty json tags to optional IPv6 OpenStack cloud spec options

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -875,11 +875,11 @@ type OpenstackCloudSpec struct {
 	// IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
 	// If not provided, a new subnet will be created if IPv6 is enabled.
 	// +optional
-	IPv6SubnetID string `json:"ipv6SubnetID"`
+	IPv6SubnetID string `json:"ipv6SubnetID,omitempty"`
 	// IPv6SubnetPool holds the name of the subnet pool used for creating new IPv6 subnets.
 	// If not provided, the default IPv6 subnet pool will be used.
 	// +optional
-	IPv6SubnetPool string `json:"ipv6SubnetPool"`
+	IPv6SubnetPool string `json:"ipv6SubnetPool,omitempty"`
 	// Whether or not to use Octavia for LoadBalancer type of Service
 	// implementation instead of using Neutron-LBaaS.
 	// Attention:Openstack CCM use Octavia as default load balancer


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds omitempty json tags to the new optional IPv6 OpenStack cloud spec options forgotten in https://github.com/kubermatic/kubermatic/pull/9532

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
