### PR TITLE
ensure that etcd launcher is enabled if etcd backup/restore is enabled

### DIFF
--- a/hack/ci/testdata/kubermatic_backup.yaml
+++ b/hack/ci/testdata/kubermatic_backup.yaml
@@ -33,6 +33,8 @@ spec:
     replicas: 1
   ui:
     replicas: 0
+  featureGates:
+    EtcdLauncher: true
   # Dex integration
   auth:
     tokenIssuer: "http://dex.oauth:5556/dex"

--- a/pkg/webhook/seed/validation.go
+++ b/pkg/webhook/seed/validation.go
@@ -182,6 +182,10 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object, isDelete b
 	}
 
 	if subject.Spec.EtcdBackupRestore != nil {
+		if !v.features.Enabled(features.EtcdLauncher) {
+			return errors.New("EtcdLauncher feature must be enabled for etcd backup and restore")
+		}
+
 		if len(subject.Spec.EtcdBackupRestore.Destinations) == 0 {
 			return errors.New("invalid etcd backup configuration: must define at least one backup destination")
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Etcd launcher is required for proper working of snapshot restore. While validating seed we check if it enabled before restore is enabled. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9453 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
