### PR TITLE
telemetry does not need access to pre-2.20 API groups anymore

### DIFF
--- a/charts/telemetry/templates/kubermatic-role.yaml
+++ b/charts/telemetry/templates/kubermatic-role.yaml
@@ -35,9 +35,3 @@ rules:
   - secrets
   verbs:
   - get
-- apiGroups:
-  - operator.kubermatic.io
-  resources:
-  - kubermaticconfigurations
-  verbs:
-  - list


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Just some cleanup.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
