### PR TITLE
update Dex to 2.31.1

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: oauth
 version: v9.9.9-dev
-appVersion: v2.30.0
+appVersion: v2.31.1
 description: Dex
 keywords:
   - kubermatic

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -14,8 +14,8 @@
 
 dex:
   image:
-    repository: "docker.io/dexidp/dex"
-    tag: "v2.30.0"
+    repository: "ghcr.io/dexidp/dex"
+    tag: "v2.31.1"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Yay, one more Helm chart that doesn't use docker.io anymore. :-)

**Does this PR introduce a user-facing change?**:
```release-note
Update Dex to 2.31.1
```
