### PR TITLE
Add kubeconfig validation before creating secret

### DIFF
--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -193,8 +193,8 @@ func (p *FakeExternalClusterProvider) GenerateClient(cfg *clientcmdapi.Config) (
 	return p.FakeClient, nil
 }
 
-func (p *FakeExternalClusterProvider) ValidateKubeconfig(ctx context.Context, kubeconfig []byte) error {
-	return p.Provider.ValidateKubeconfig(ctx, kubeconfig)
+func (p *FakeExternalClusterProvider) ValidateKubeconfig(_ context.Context, _ []byte) error {
+	return nil
 }
 
 func (p *FakeExternalClusterProvider) CreateOrUpdateKubeconfigSecretForCluster(ctx context.Context, cluster *kubermaticv1.ExternalCluster, kubeconfig []byte) error {

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -193,7 +193,11 @@ func (p *FakeExternalClusterProvider) GenerateClient(cfg *clientcmdapi.Config) (
 	return p.FakeClient, nil
 }
 
-func (p *FakeExternalClusterProvider) CreateOrUpdateKubeconfigSecretForCluster(ctx context.Context, cluster *kubermaticv1.ExternalCluster, kubeconfig string) error {
+func (p *FakeExternalClusterProvider) ValidateKubeconfig(ctx context.Context, kubeconfig []byte) error {
+	return p.Provider.ValidateKubeconfig(ctx, kubeconfig)
+}
+
+func (p *FakeExternalClusterProvider) CreateOrUpdateKubeconfigSecretForCluster(ctx context.Context, cluster *kubermaticv1.ExternalCluster, kubeconfig []byte) error {
 	return p.Provider.CreateOrUpdateKubeconfigSecretForCluster(ctx, cluster, kubeconfig)
 }
 

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -43,7 +43,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -179,30 +178,16 @@ func CreateEndpoint(
 
 		// connect cluster by kubeconfig
 		if cloud == nil {
+			newCluster := genExternalCluster(req.Body.Name, project.Name)
+			kuberneteshelper.AddFinalizer(newCluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
 			config, err := base64.StdEncoding.DecodeString(req.Body.Kubeconfig)
 			if err != nil {
 				return nil, errors.NewBadRequest(err.Error())
 			}
-
-			cfg, err := clientcmd.Load(config)
-			if err != nil {
-				return nil, common.KubernetesErrorToHTTPError(err)
+			if err := clusterProvider.ValidateKubeconfig(ctx, config); err != nil {
+				return nil, err
 			}
-
-			cli, err := clusterProvider.GenerateClient(cfg)
-			if err != nil {
-				return nil, errors.NewBadRequest(fmt.Sprintf("cannot connect to the kubernetes cluster: %v", err))
-			}
-			// check if kubeconfig can automatically authenticate and get resources.
-			if err := cli.List(ctx, &corev1.PodList{}); err != nil {
-				return nil, errors.NewBadRequest(fmt.Sprintf("can not retrieve data, check your kubeconfig: %v", err))
-			}
-
-			newCluster := genExternalCluster(req.Body.Name, project.Name)
-
-			kuberneteshelper.AddFinalizer(newCluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
-
-			if err := clusterProvider.CreateOrUpdateKubeconfigSecretForCluster(ctx, newCluster, req.Body.Kubeconfig); err != nil {
+			if err := clusterProvider.CreateOrUpdateKubeconfigSecretForCluster(ctx, newCluster, config); err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 
@@ -527,14 +512,10 @@ func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			if err != nil {
 				return nil, errors.NewBadRequest(err.Error())
 			}
-			cfg, err := clientcmd.Load(config)
-			if err != nil {
-				return nil, common.KubernetesErrorToHTTPError(err)
+			if err := clusterProvider.ValidateKubeconfig(ctx, config); err != nil {
+				return nil, err
 			}
-			if _, err := clusterProvider.GenerateClient(cfg); err != nil {
-				return nil, errors.NewBadRequest(fmt.Sprintf("cannot connect to the kubernetes cluster: %v", err))
-			}
-			if err := clusterProvider.CreateOrUpdateKubeconfigSecretForCluster(ctx, cluster, req.Body.Kubeconfig); err != nil {
+			if err := clusterProvider.CreateOrUpdateKubeconfigSecretForCluster(ctx, cluster, config); err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 		}

--- a/pkg/provider/kubernetes/external_cluster_test.go
+++ b/pkg/provider/kubernetes/external_cluster_test.go
@@ -129,17 +129,16 @@ func TestCreateOrUpdateKubeconfigSecretForCluster(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			if err := provider.CreateOrUpdateKubeconfigSecretForCluster(context.Background(), tc.externalCluster, tc.kubeconfig); err != nil {
+			kubeconfig, err := base64.StdEncoding.DecodeString(tc.kubeconfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := provider.CreateOrUpdateKubeconfigSecretForCluster(context.Background(), tc.externalCluster, kubeconfig); err != nil {
 				t.Fatal(err)
 			}
 
 			secret := &corev1.Secret{}
 			if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: tc.externalCluster.GetKubeconfigSecretName(), Namespace: resources.KubermaticNamespace}, secret); err != nil {
-				t.Fatal(err)
-			}
-			kubeconfig, err := base64.StdEncoding.DecodeString(tc.kubeconfig)
-			if err != nil {
 				t.Fatal(err)
 			}
 			tc.expectedSecret.Data = map[string][]byte{resources.ExternalClusterKubeconfig: kubeconfig}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -773,7 +773,9 @@ type ExternalClusterProvider interface {
 
 	GetClient(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (ctrlruntimeclient.Client, error)
 
-	CreateOrUpdateKubeconfigSecretForCluster(ctx context.Context, cluster *kubermaticv1.ExternalCluster, kubeconfig string) error
+	ValidateKubeconfig(ctx context.Context, kubeconfig []byte) error
+
+	CreateOrUpdateKubeconfigSecretForCluster(ctx context.Context, cluster *kubermaticv1.ExternalCluster, kubeconfig []byte) error
 
 	CreateOrUpdateCredentialSecretForCluster(ctx context.Context, cloud *apiv2.ExternalClusterCloudSpec, projectID, clusterID string) (*providerconfig.GlobalSecretKeySelector, error)
 


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**:  Add kubeconfig validation before creating secret

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9581

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
