### PR TITLE
allowing arbitrary name for the cluster + adding length validation

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -1048,19 +1048,19 @@ func ConvertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, dat
 
 func ValidateClusterSpec(updateManager common.UpdateManager, body apiv1.CreateClusterSpec) error {
 	if body.Cluster.Spec.Cloud.DatacenterName == "" {
-		return fmt.Errorf("cluster datacenter name is empty")
+		return errors.New("cluster datacenter name is empty")
 	}
 	if body.Cluster.ID != "" {
-		return fmt.Errorf("cluster.ID is read-only")
+		return errors.New("cluster.ID is read-only")
 	}
 	if !ClusterTypes.Has(body.Cluster.Type) {
 		return fmt.Errorf("invalid cluster type %s", body.Cluster.Type)
 	}
 	if body.Cluster.Spec.Version.Semver() == nil {
-		return fmt.Errorf("invalid cluster: invalid cloud spec \"Version\" is required but was not specified")
+		return errors.New("invalid cluster: invalid cloud spec \"Version\" is required but was not specified")
 	}
 	if len(body.Cluster.Name) > 100 {
-		return fmt.Errorf("invalid cluster name: too long (greater than 100 characters)")
+		return errors.New("invalid cluster name: too long (greater than 100 characters)")
 	}
 
 	providerName, err := provider.ClusterCloudProviderName(body.Cluster.Spec.Cloud)

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -1059,6 +1059,9 @@ func ValidateClusterSpec(updateManager common.UpdateManager, body apiv1.CreateCl
 	if body.Cluster.Spec.Version.Semver() == nil {
 		return fmt.Errorf("invalid cluster: invalid cloud spec \"Version\" is required but was not specified")
 	}
+	if len(body.Cluster.Name) > 100 {
+		return fmt.Errorf("invalid cluster name: too long (greater than 100 characters)")
+	}
 
 	providerName, err := provider.ClusterCloudProviderName(body.Cluster.Spec.Cloud)
 	if err != nil {

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -225,6 +225,9 @@ func GenerateCluster(
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
+	// Generate the name here so that it can be used below.
+	partialCluster.Name = rand.String(10)
+
 	// Serialize initial machine deployment request into annotation if it is in the body and provider different than
 	// BringYourOwn was selected. The request will be transformed into machine deployment by the controller once cluster
 	// will be ready. To make it easier to determine if a machine deployment annotation has already been applied to
@@ -237,7 +240,7 @@ func GenerateCluster(
 		}
 		if !isBYO {
 			if body.NodeDeployment.Name == "" {
-				body.NodeDeployment.Name = fmt.Sprintf("%s-worker-%s", body.Cluster.Name, rand.String(6))
+				body.NodeDeployment.Name = fmt.Sprintf("%s-worker-%s", partialCluster.Name, rand.String(6))
 			}
 
 			data, err := json.Marshal(body.NodeDeployment)
@@ -258,9 +261,6 @@ func GenerateCluster(
 	} else {
 		partialCluster.Spec.EnableUserSSHKeyAgent = body.Cluster.Spec.EnableUserSSHKeyAgent
 	}
-
-	// Generate the name here so that it can be used in the secretName below.
-	partialCluster.Name = rand.String(10)
 
 	if cloudcontroller.ExternalCloudControllerFeatureSupported(dc, partialCluster, version.NewFromConfiguration(config).GetIncompatibilities()...) {
 		partialCluster.Spec.Features = map[string]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -49,7 +49,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	} else {
 		// GenerateName can be set only if Name is empty to avoid confusing error:
 		// https://github.com/kubernetes/kubernetes/issues/32220
-		md.GenerateName = fmt.Sprintf("%s-worker-", c.Spec.HumanReadableName)
+		md.GenerateName = fmt.Sprintf("%s-worker-", c.Name)
 	}
 
 	// Add Annotations to Machine Deployment


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
- Changes the machine deployment name generation to use the cluster generated id instead of the name chosen by the user, so it won't break the machine deployment when receiving arbitrary name for the cluster.
- Limits the accepted cluster name length (max 100 characters), so it won't break any other part of the system.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #7004

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Auto generated names for the machine deployments now contain the cluster id as prefix, instead of the cluster human readable name.
```
