### PR TITLE
prow: fix label for sig/app-management in OWNERS files

### DIFF
--- a/pkg/applications/OWNERS
+++ b/pkg/applications/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true

--- a/pkg/controller/master-controller-manager/project-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/project-synchronizer/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true

--- a/pkg/controller/master-controller-manager/user-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/user-synchronizer/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/OWNERS
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-app-management
 
 labels:
-  - sig-app-management
+  - sig/app-management
 
 options:
   no_parent_owners: true


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In some OWNERS file of `sig-app-management` the label was incorrect, consequently, the PR were not labeled with `sig/app-management`

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
