### PR TITLE
fix NodeFilesystem alert rules

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: v9.9.10-dev
+version: v9.9.9-dev
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: v9.9.9-dev
+version: v9.9.10-dev
 appVersion: v2.29.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-node-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-node-exporter.yaml
@@ -179,7 +179,7 @@ groups:
           and
           node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} < 0.4
           and
-          node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
+          node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
         for: 1h
         labels:
           severity: warning
@@ -194,7 +194,7 @@ groups:
           and
           node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} < 0.2
           and
-          node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
+          node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
         for: 1h
         labels:
           severity: critical
@@ -202,26 +202,26 @@ groups:
           service: 'node-exporter'
       - alert: NodeFilesystemOutOfSpace
         annotations:
-          message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available space left.
+          message: Filesystem on node {{ $labels.node_name }} having IP {{ $labels.instance }} has only {{ $value }}% available space left on drive {{ $labels.device }}.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-nodefilesystemoutofspace
         expr: |
-          node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
+          node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 10
           and
-          node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
-        for: 1h
+          node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
+        for: 30m
         labels:
           severity: warning
           resource: '{{ $labels.instance }} {{ $labels.device }}'
           service: 'node-exporter'
       - alert: NodeFilesystemOutOfSpace
         annotations:
-          message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available space left.
+          message: Filesystem on node {{ $labels.node_name }} having IP {{ $labels.instance }} has only {{ $value }}% available space left on drive {{ $labels.device }}.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-nodefilesystemoutofspace
         expr: |
-          node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
+          node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
           and
-          node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
-        for: 1h
+          node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
+        for: 10m
         labels:
           severity: critical
           resource: '{{ $labels.instance }} {{ $labels.device }}'
@@ -271,10 +271,10 @@ groups:
           service: 'node-exporter'
       - alert: NodeFilesystemOutOfSpace
         annotations:
-          message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ $value }}% available space left.
+          message: Filesystem on node {{ $labels.node_name }} having IP {{ $labels.instance }} has only {{ $value }}% inodes available on drive {{ $labels.device }}.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-nodefilesystemoutofspace
         expr: |
-          node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
+          node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 10
           and
           node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
         for: 1h

--- a/charts/monitoring/prometheus/rules/src/general/node-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/node-exporter.yaml
@@ -205,7 +205,7 @@ groups:
       and
       node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} < 0.4
       and
-      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: warning
@@ -223,7 +223,7 @@ groups:
       and
       node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} < 0.2
       and
-      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: critical
@@ -233,14 +233,14 @@ groups:
   - alert: NodeFilesystemOutOfSpace
     annotations:
       message:
-        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
-        {{ $value }}% available space left.
+        Filesystem on node {{ $labels.node_name }} having IP {{ $labels.instance }} has only
+        {{ $value }}% available space left on drive {{ $labels.device }}.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-nodefilesystemoutofspace
     expr: |
-      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
+      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 10
       and
-      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
-    for: 1h
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
+    for: 30m
     labels:
       severity: warning
       resource: '{{ $labels.instance }} {{ $labels.device }}'
@@ -249,14 +249,14 @@ groups:
   - alert: NodeFilesystemOutOfSpace
     annotations:
       message:
-        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
-        {{ $value }}% available space left.
+        Filesystem on node {{ $labels.node_name }} having IP {{ $labels.instance }} has only
+        {{ $value }}% available space left on drive {{ $labels.device }}.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-nodefilesystemoutofspace
     expr: |
-      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
+      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
-      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
-    for: 1h
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
+    for: 10m
     labels:
       severity: critical
       resource: '{{ $labels.instance }} {{ $labels.device }}'
@@ -317,11 +317,10 @@ groups:
   - alert: NodeFilesystemOutOfSpace
     annotations:
       message:
-        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
-        {{ $value }}% available space left.
+        Filesystem on node {{ $labels.node_name }} having IP {{ $labels.instance }} has only {{ $value }}% inodes available on drive {{ $labels.device }}.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-nodefilesystemoutofspace
     expr: |
-      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 10
       and
       node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
- Prometheus rules configured specifically for NodeFilesystem are using the wrong metrics `node_filesystem_readonly_bytes` it should be `node_filesystem_readonly`.
- Tweak alert message with node name and at someplace fix the wrong message.
- Tweak alert trigger duration to lower to act it on quickly. 
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
