### PR TITLE
wait for new cluster objects to appear in cache before attempting to …

### DIFF
--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -100,7 +100,7 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 			return fmt.Errorf("failed to create %T '%s': %w", obj, namespacedName.String(), err)
 		}
 		// Wait until the object exists in the cache
-		createdObjectIsInCache := waitUntilObjectExistsInCacheConditionFunc(ctx, client, objectLogger(obj), namespacedName, obj)
+		createdObjectIsInCache := WaitUntilObjectExistsInCacheConditionFunc(ctx, client, objectLogger(obj), namespacedName, obj)
 		err = wait.PollImmediate(10*time.Millisecond, 10*time.Second, createdObjectIsInCache)
 		if err != nil {
 			return fmt.Errorf("failed waiting for the cache to contain our newly created object: %w", err)
@@ -187,7 +187,7 @@ func waitUntilUpdateIsInCacheConditionFunc(
 	}
 }
 
-func waitUntilObjectExistsInCacheConditionFunc(
+func WaitUntilObjectExistsInCacheConditionFunc(
 	ctx context.Context,
 	client ctrlruntimeclient.Client,
 	log *zap.SugaredLogger,

--- a/pkg/test/e2e/expose-strategy/cluster.go
+++ b/pkg/test/e2e/expose-strategy/cluster.go
@@ -25,6 +25,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
@@ -124,6 +125,11 @@ func (c *ClusterJig) SetUp(ctx context.Context) error {
 	}
 	if err := c.Client.Create(ctx, c.Cluster); err != nil {
 		return fmt.Errorf("failed to create cluster: %w", err)
+	}
+
+	waiter := reconciling.WaitUntilObjectExistsInCacheConditionFunc(ctx, c.Client, c.Log, ctrlruntimeclient.ObjectKeyFromObject(c.Cluster), c.Cluster)
+	if err := wait.Poll(100*time.Millisecond, 5*time.Second, waiter); err != nil {
+		return fmt.Errorf("failed waiting for the new cluster to appear in the cache: %w", err)
 	}
 
 	if err := kubermaticv1helper.UpdateClusterStatus(ctx, c.Client, c.Cluster, func(c *kubermaticv1.Cluster) {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR was triggered by #9584, before I realized that in master we already fixed the issue via #9122 and should just backport that to 2.20.

However, this PR applies the same fix to more places in our codebase, which had a very slight chance of running into a race condition as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
