### PR TITLE
Recover from PVC deletion in etcd-launcher

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -125,9 +125,11 @@ func main() {
 	}
 
 	thisMember, err := e.getMemberByName(e.podName, log)
-	if err != nil {
+
+	switch {
+	case err != nil:
 		log.Warnw("failed to check cluster membership", zap.Error(err))
-	} else if thisMember != nil {
+	case thisMember != nil:
 		log.Infof("%v is a member", thisMember.GetPeerURLs())
 
 		if _, err := os.Stat(filepath.Join(e.dataDir, "member")); errors.Is(err, fs.ErrNotExist) {
@@ -149,7 +151,7 @@ func main() {
 				log.Panicw("join cluster as fresh member", zap.Error(err))
 			}
 		}
-	} else {
+	default:
 		// if no membership information was found but we were able to list from an etcd cluster, we can attempt to join
 		if err := joinCluster(e, log); err != nil {
 			log.Panicw("failed to join cluster as fresh member", zap.Error(err))

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -127,9 +127,7 @@ func main() {
 	thisMember, err := e.getMemberByName(e.podName, log)
 	if err != nil {
 		log.Warnw("failed to check cluster membership", zap.Error(err))
-	}
-
-	if thisMember != nil {
+	} else if thisMember != nil {
 		log.Infof("%v is a member", thisMember.GetPeerURLs())
 
 		if _, err := os.Stat(filepath.Join(e.dataDir, "member")); errors.Is(err, fs.ErrNotExist) {
@@ -150,6 +148,11 @@ func main() {
 			if err := joinCluster(e, log); err != nil {
 				log.Panicw("join cluster as fresh member", zap.Error(err))
 			}
+		}
+	} else {
+		// if no membership information was found but we were able to list from an etcd cluster, we can attempt to join
+		if err := joinCluster(e, log); err != nil {
+			log.Panicw("failed to join cluster as fresh member", zap.Error(err))
 		}
 	}
 

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -613,10 +613,10 @@ func waitForEtcdRestore(ctx context.Context, t *testing.T, client ctrlruntimecli
 }
 
 func waitForClusterHealthy(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	before := time.Now()
+
 	// let's briefly sleep to give controllers a chance to kick in
 	time.Sleep(10 * time.Second)
-
-	before := time.Now()
 
 	if err := wait.PollImmediate(3*time.Second, 10*time.Minute, func() (bool, error) {
 		// refresh cluster object for updated health status


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
`etcd-launcher` was not capable of recovering from a deleted PVC when the initial Pod was terminated and a fresh PVC+Pod combination was spun up by the STS controller to replace it. This PR moves the cluster join logic earlier in the `etcd-launcher` startup process, thus making sure that the main `etcd` process doesn't crash the launcher before checking for membership and stale data. More details in the issue linked below.

The PR also moves recovery tests into their own test setup in the `etcd-launcher-e2e` tests.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9020

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
etcd-launcher now recovers from a PVC deletion when restarting with a fresh data volume
```
