### PR TITLE
fix api panic in GetKubeconfigEndpoint

### DIFF
--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -112,7 +112,7 @@ func GetKubeconfigEndpoint(ctx context.Context, cluster *kubermaticv1.ExternalCl
 
 	kubeconfig, err := base64.StdEncoding.DecodeString(rawKubeconfig)
 	if err != nil {
-		panic(fmt.Sprintf("Invalid base64 string %q", rawKubeconfig))
+		return nil, fmt.Errorf("invalid base64 string for kubeconfig: %s", kubeconfigReference)
 	}
 
 	cfg, err := clientcmd.Load(kubeconfig)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Converts panic which appears to be leftover  from debugging to error. 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
