### PR TITLE
[release/v2.18] Update to etcd 3.5.3 for Kubernetes 1.22+

### DIFF
--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -371,7 +371,7 @@ func ImageTag(c *kubermaticv1.Cluster) string {
 		return "v3.4.3"
 	}
 
-	return "v3.5.1"
+	return "v3.5.3"
 }
 
 func computeReplicas(data etcdStatefulSetCreatorData, set *appsv1.StatefulSet) int32 {

--- a/pkg/resources/test/fixtures/cronjob-aws-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger.yaml
@@ -46,7 +46,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.5.1
+            image: gcr.io/etcd-development/etcd:v3.5.3
             name: defragger
             resources: {}
             volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -341,7 +341,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -335,7 +335,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -335,7 +335,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -331,7 +331,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -335,7 +335,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
@@ -97,7 +97,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.crt
         - name: ETCDCTL_KEY
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
-        image: gcr.io/etcd-development/etcd:v3.5.1
+        image: gcr.io/etcd-development/etcd:v3.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/9604 (courtesy of fixture updates). Please see original PR for details.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
For Kubernetes 1.22 and higher, etcd is updated to v3.5.3 to fix data consistency issues as reported by upstream developers
```
