### PR TITLE
do not use DOCKER_CONFIG env var to prevent conflicts with Helm

### DIFF
--- a/hack/ci/deploy-dev-asia.sh
+++ b/hack/ci/deploy-dev-asia.sh
@@ -36,13 +36,13 @@ echodate "Getting secrets from Vault"
 retry 5 vault_ci_login
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export DOCKER_CONFIG=/tmp/dockercfg
+export IMAGE_PULL_SECRET=/tmp/dockercfg
 export KUBERMATIC_CONFIG=/tmp/kubermatic.yaml
 
 # deploy to dev-asia
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=asia-south1-c-values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}
-vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${DOCKER_CONFIG}
+vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${IMAGE_PULL_SECRET}
 vault kv get -field=kubermatic.yaml dev/seed-clusters/dev.kubermatic.io > ${KUBERMATIC_CONFIG}
 kubectl config use-context asia-south1-c
 echodate "Successfully got secrets for dev-asia from Vault"

--- a/hack/ci/deploy-dev.sh
+++ b/hack/ci/deploy-dev.sh
@@ -33,13 +33,13 @@ echodate "Getting secrets from Vault"
 retry 5 vault_ci_login
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export DOCKER_CONFIG=/tmp/dockercfg
+export IMAGE_PULL_SECRET=/tmp/dockercfg
 export KUBERMATIC_CONFIG=/tmp/kubermatic.yaml
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=europe-west3-c-values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}
-vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${DOCKER_CONFIG}
+vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${IMAGE_PULL_SECRET}
 vault kv get -field=kubermatic.yaml dev/seed-clusters/dev.kubermatic.io > ${KUBERMATIC_CONFIG}
 echodate "Successfully got secrets for dev from Vault"
 

--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -117,9 +117,8 @@ logging)
   ;;
 
 kubermatic)
-
-  if [ -n "${DOCKER_CONFIG:-}" ]; then
-    yq write --inplace charts/kubermatic-operator/values.yaml 'kubermaticOperator.imagePullSecret' "$(cat $DOCKER_CONFIG)"
+  if [ -n "${IMAGE_PULL_SECRET:-}" ]; then
+    yq write --inplace charts/kubermatic-operator/values.yaml 'kubermaticOperator.imagePullSecret' "$(cat $IMAGE_PULL_SECRET)"
   fi
 
   # Kubermatic


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Since https://github.com/helm/helm/pull/10536, Helm treats `DOCKER_CONFIG` env vars [differently], leading to conflicts with our deployment scripts: https://public-prow.loodse.com/view/gs/prow-dev-public-data/logs/post-kubermatic-deploy-dev/1514628349719220224

This PR simply changes the name of the var to prevent that clash.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
