### PR TITLE
fail etcd restore if etcdLauncher feature not enabled on cluster

### DIFF
--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -144,6 +144,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	if !cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
+		return reconcile.Result{}, fmt.Errorf("etcdLauncher not enabled on cluster: %q", cluster.Name)
+	}
+
 	if cluster.Status.NamespaceName == "" {
 		log.Debug("Cluster has no namespace name yet, skipping")
 		return reconcile.Result{}, nil

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -144,10 +144,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if !cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
-		return reconcile.Result{}, fmt.Errorf("etcdLauncher not enabled on cluster: %q", cluster.Name)
-	}
-
 	if cluster.Status.NamespaceName == "" {
 		log.Debug("Cluster has no namespace name yet, skipping")
 		return reconcile.Result{}, nil
@@ -175,6 +171,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, restore *kubermaticv1.EtcdRestore, cluster *kubermaticv1.Cluster,
 	seed *kubermaticv1.Seed) (*reconcile.Result, error) {
+	if !cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
+		return nil, fmt.Errorf("etcdLauncher not enabled on cluster: %q", cluster.Name)
+	}
+
 	if restore.Status.Phase == kubermaticv1.EtcdRestorePhaseCompleted {
 		return nil, nil
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Etcd launcher is required for proper working of snapshot restore. This PR checks if it enabled on the cluster while reconciling. If it is not enabled error is returned. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9453 




**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
