### PR TITLE
Update Alertmanager to 0.24.0

### DIFF
--- a/charts/monitoring/alertmanager/Chart.yaml
+++ b/charts/monitoring/alertmanager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: alertmanager
 version: v9.9.9-dev
-appVersion: v0.22.2
+appVersion: v0.24.0
 description: Alertmanager for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -15,11 +15,11 @@
 alertmanager:
   image:
     repository: quay.io/prometheus/alertmanager
-    tag: v0.22.2
+    tag: v0.24.0
     pullPolicy: IfNotPresent
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.3.0
+    tag: v0.7.1
     pullPolicy: IfNotPresent
   host: ""
   replicas: 3
@@ -36,8 +36,6 @@ alertmanager:
     #   port: 8080
     #   protocol: TCP
     #   targetPort: 8080
-
-
 
   config:
     global:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The changelogs do not mention any BC breaks between 0.22.2 and 0.24.0, so I hope this is a safe upgrade. Same goes for the configmap-reloader.

**Does this PR introduce a user-facing change?**:
```release-note
Update Alertmanager to 0.24.0
```
