### PR TITLE
Do not validate secretbox keys if secretbox is not configured

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -299,23 +299,23 @@ func validateEncryptionConfiguration(spec *kubermaticv1.ClusterSpec, fieldPath *
 		if spec.EncryptionConfiguration.Secretbox == nil {
 			allErrs = append(allErrs, field.Required(fieldPath.Child("secretbox"),
 				"exactly one encryption provider (secretbox, kms) needs to be configured"))
-		}
+		} else {
+			for i, key := range spec.EncryptionConfiguration.Secretbox.Keys {
+				childPath := fieldPath.Child("secretbox", "keys").Index(i)
+				if key.Name == "" {
+					allErrs = append(allErrs, field.Required(childPath.Child("name"),
+						"secretbox key name is required"))
+				}
 
-		for i, key := range spec.EncryptionConfiguration.Secretbox.Keys {
-			childPath := fieldPath.Child("secretbox", "keys").Index(i)
-			if key.Name == "" {
-				allErrs = append(allErrs, field.Required(childPath.Child("name"),
-					"secretbox key name is required"))
-			}
+				if key.Value == "" && key.SecretRef == nil {
+					allErrs = append(allErrs, field.Required(childPath,
+						"either 'value' or 'secretRef' must be set"))
+				}
 
-			if key.Value == "" && key.SecretRef == nil {
-				allErrs = append(allErrs, field.Required(childPath,
-					"either 'value' or 'secretRef' must be set"))
-			}
-
-			if key.Value != "" && key.SecretRef != nil {
-				allErrs = append(allErrs, field.Invalid(childPath, key,
-					"'value' and 'secretRef' cannot be set at the same time"))
+				if key.Value != "" && key.SecretRef != nil {
+					allErrs = append(allErrs, field.Invalid(childPath, key,
+						"'value' and 'secretRef' cannot be set at the same time"))
+				}
 			}
 		}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Noticed #9582 introduced a nil pointer exception in the validation webhook when an invalid encryptionConfiguration was passed. Woops. Good news is that the configuration is invalid anyway and shouldn't be accepted, but obviously a server error was not the intended response. This PR fixes this by not trying to iterate over secretbox keys if secretbox isn't configured (duh).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>