### PR TITLE
Update blackbox-exporter to 0.20.0

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: blackbox-exporter
 version: v9.9.9-dev
-appVersion: v0.18.0
+appVersion: v0.20.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:
   - kubermatic

--- a/charts/monitoring/blackbox-exporter/templates/deployment.yaml
+++ b/charts/monitoring/blackbox-exporter/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
         ports:
         - containerPort: 9115
           name: web
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: web
         volumeMounts:
         - name: config
           mountPath: /etc/blackbox_exporter

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -14,8 +14,8 @@
 
 blackboxExporter:
   image:
-    repository: docker.io/prom/blackbox-exporter
-    tag: v0.18.0
+    repository: quay.io/prometheus/blackbox-exporter
+    tag: v0.20.0
     pullPolicy: IfNotPresent
 
   containers:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This updates our blackbox exporter.

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Update blackbox-exporter to 0.20.0; HTTP probe: `no_follow_redirects` has been renamed to `follow_redirects`.
```
