### PR TITLE
Update node-exporter to 1.3.1

### DIFF
--- a/charts/monitoring/node-exporter/Chart.yaml
+++ b/charts/monitoring/node-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: node-exporter
 version: v9.9.9-dev
-appVersion: v1.2.2
+appVersion: v1.3.1
 description: Prometheus Node Exporter for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/node-exporter/values.yaml
+++ b/charts/monitoring/node-exporter/values.yaml
@@ -15,7 +15,7 @@
 nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
-    tag: v1.2.2
+    tag: v1.3.1
   resources:
     requests:
       cpu: 50m
@@ -27,7 +27,7 @@ nodeExporter:
   rbacProxy:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
-      tag: v0.11.0
+      tag: v0.12.0
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
release notes for node-exporter mention no important changes, same with rbac-proxy.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update node-exporter to 1.3.1
```
