### PR TITLE
Update Velero to 1.8.1

### DIFF
--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: velero
 version: v9.9.9-dev
-appVersion: v1.6.3
+appVersion: v1.8.1
 description: A Helm chart for Velero
 keywords:
   - kubermatic

--- a/charts/backup/velero/crd/backups.yaml
+++ b/charts/backup/velero/crd/backups.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: backups.velero.io
@@ -230,6 +230,13 @@ spec:
                       additionalProperties:
                         type: string
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                metadata:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
                       type: object
                   type: object
                 orderedResources:

--- a/charts/backup/velero/crd/backupstoragelocations.yaml
+++ b/charts/backup/velero/crd/backupstoragelocations.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: backupstoragelocations.velero.io

--- a/charts/backup/velero/crd/deletebackuprequests.yaml
+++ b/charts/backup/velero/crd/deletebackuprequests.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: deletebackuprequests.velero.io

--- a/charts/backup/velero/crd/downloadrequests.yaml
+++ b/charts/backup/velero/crd/downloadrequests.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: downloadrequests.velero.io
@@ -41,6 +41,7 @@ spec:
                         - BackupLog
                         - BackupContents
                         - BackupVolumeSnapshots
+                        - BackupItemSnapshots
                         - BackupResourceList
                         - RestoreLog
                         - RestoreResults

--- a/charts/backup/velero/crd/podvolumebackups.yaml
+++ b/charts/backup/velero/crd/podvolumebackups.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: podvolumebackups.velero.io

--- a/charts/backup/velero/crd/podvolumerestores.yaml
+++ b/charts/backup/velero/crd/podvolumerestores.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: podvolumerestores.velero.io

--- a/charts/backup/velero/crd/resticrepositories.yaml
+++ b/charts/backup/velero/crd/resticrepositories.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: resticrepositories.velero.io

--- a/charts/backup/velero/crd/restores.yaml
+++ b/charts/backup/velero/crd/restores.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: restores.velero.io
@@ -153,12 +153,12 @@ spec:
                                         description: A single application container that you want to run within a pod.
                                         properties:
                                           args:
-                                            description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                            description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                             items:
                                               type: string
                                             type: array
                                           command:
-                                            description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                            description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                             items:
                                               type: string
                                             type: array
@@ -171,7 +171,7 @@ spec:
                                                   description: Name of the environment variable. Must be a C_IDENTIFIER.
                                                   type: string
                                                 value:
-                                                  description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                                  description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                                   type: string
                                                 valueFrom:
                                                   description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -492,6 +492,10 @@ spec:
                                                 required:
                                                   - port
                                                 type: object
+                                              terminationGracePeriodSeconds:
+                                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
                                               timeoutSeconds:
                                                 description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                                 format: int32
@@ -520,6 +524,7 @@ spec:
                                                   description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                                   type: string
                                                 protocol:
+                                                  default: TCP
                                                   description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                                   type: string
                                               required:
@@ -611,13 +616,17 @@ spec:
                                                 required:
                                                   - port
                                                 type: object
+                                              terminationGracePeriodSeconds:
+                                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
                                               timeoutSeconds:
                                                 description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                                 format: int32
                                                 type: integer
                                             type: object
                                           resources:
-                                            description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -626,7 +635,7 @@ spec:
                                                     - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -635,11 +644,11 @@ spec:
                                                     - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                 type: object
                                             type: object
                                           securityContext:
-                                            description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                            description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                             properties:
                                               allowPrivilegeEscalation:
                                                 description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
@@ -717,13 +726,16 @@ spec:
                                                   gmsaCredentialSpecName:
                                                     description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                                     type: string
+                                                  hostProcess:
+                                                    description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                    type: boolean
                                                   runAsUserName:
                                                     description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                                     type: string
                                                 type: object
                                             type: object
                                           startupProbe:
-                                            description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: One and only one of the following should be specified. Exec specifies the action to take.
@@ -802,6 +814,10 @@ spec:
                                                 required:
                                                   - port
                                                 type: object
+                                              terminationGracePeriodSeconds:
+                                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
                                               timeoutSeconds:
                                                 description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                                 format: int32

--- a/charts/backup/velero/crd/schedules.yaml
+++ b/charts/backup/velero/crd/schedules.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: schedules.velero.io
@@ -236,6 +236,13 @@ spec:
                           additionalProperties:
                             type: string
                           description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    metadata:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
                           type: object
                       type: object
                     orderedResources:

--- a/charts/backup/velero/crd/serverstatusrequests.yaml
+++ b/charts/backup/velero/crd/serverstatusrequests.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: serverstatusrequests.velero.io

--- a/charts/backup/velero/crd/volumesnapshotlocations.yaml
+++ b/charts/backup/velero/crd/volumesnapshotlocations.yaml
@@ -1,9 +1,9 @@
-# This file has been generated with Velero v1.6.3. Do not edit.
+# This file has been generated with Velero v1.8.1. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     component: velero
   name: volumesnapshotlocations.velero.io

--- a/charts/backup/velero/templates/deployment.yaml
+++ b/charts/backup/velero/templates/deployment.yaml
@@ -49,9 +49,6 @@ spec:
         {{- range .Values.velero.serverFlags }}
         - '{{ . }}'
         {{- end }}
-        {{- with .Values.velero.defaultBackupStorageLocation }}
-        - '--default-backup-storage-location={{ . }}'
-        {{- end }}
         {{- with .Values.velero.defaultVolumeSnapshotLocations }}
         - '--default-volume-snapshot-locations={{ . | join "," }}'
         {{- end }}

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -90,10 +90,10 @@ velero:
     #restic:
     #  password: averysecurepassword
 
-  # define one of your backupStorageLocations as the default
-  #defaultBackupStorageLocation: aws
-
-  # see https://velero.io/docs/v1.1.0/api-types/backupstoragelocation/
+  # see https://velero.io/docs/v1.8/api-types/backupstoragelocation/;
+  # one of the backup storage location should be marked with "default: true"
+  # or named "default" (previously this was the --default-backup-storage-location
+  # flag)
   #backupStorageLocations:
   #  aws:
   #    provider: aws
@@ -107,7 +107,7 @@ velero:
   #defaultVolumeSnapshotLocations:
   #  - aws:aws
 
-  # see https://velero.io/docs/v1.1.0/api-types/volumesnapshotlocation/
+  # see https://velero.io/docs/v1.8/api-types/volumesnapshotlocation/
   #volumeSnapshotLocations:
   #  aws:
   #    provider: aws

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -18,7 +18,7 @@ velero:
   # that also contains the restic binary
   image:
     repository: docker.io/velero/velero
-    tag: v1.6.3
+    tag: v1.8.1
     pullPolicy: IfNotPresent
 
   # CLI flags to pass to velero server; note that the two flags
@@ -30,21 +30,21 @@ velero:
   # At least one plugin provider image is required.
   initContainers:
   # - name: velero-plugin-for-aws
-  #   image: docker.io/velero/velero-plugin-for-aws:v1.1.0
+  #   image: docker.io/velero/velero-plugin-for-aws:v1.4.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
 
   # - name: velero-plugin-for-gcp
-  #   image: docker.io/velero/velero-plugin-for-gcp:v1.1.0
+  #   image: docker.io/velero/velero-plugin-for-gcp:v1.4.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
 
   # - name: velero-plugin-for-microsoft-azure
-  #   image: docker.io/velero/velero-plugin-for-microsoft-azure:v1.1.0
+  #   image: docker.io/velero/velero-plugin-for-microsoft-azure:v1.4.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -23,7 +23,7 @@ containerize ./hack/update-velero-crds.sh
 
 velero=velero
 if ! [ -x "$(command -v $velero)" ]; then
-  version=v1.6.3
+  version=v1.8.1
   url="https://github.com/vmware-tanzu/velero/releases/download/$version/velero-$version-linux-amd64.tar.gz"
   velero=/tmp/velero
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
What it says on the tin. The upgrade notes for 1.7 and 1.8 only mention that the default storage location handling has been deprecated, which is why I removed it entirely from our Helm chart.

* https://velero.io/docs/v1.8/upgrade-to-1.8/
* https://velero.io/docs/v1.7/upgrade-to-1.7/

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Update Velero to 1.8; removed `velero.defaultBackupStorageLocation` from the Helm values, set `spec.default=true` on your BackupStorageLocation instead (see `values.yaml` for an example).
```
