### PR TITLE
Update oauth2-proxy to 7.2.1

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: v9.9.9-dev
-appVersion: v7.0.1
+appVersion: v7.2.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.0.1
+    tag: v7.2.1
     pullPolicy: IfNotPresent
 
   # secret which holds the CA certificates that should be used when connecting to the provider


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
No breaking changes for us.

**Does this PR introduce a user-facing change?**:
```release-note
Update oauth2-proxy (IAP chart) to 7.2.1
```
