### PR TITLE
Machine resource quota webhook 

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	clusterAPIGroup   = "cluster.k8s.io"
+	clusterAPIVersion = "v1alpha1"
+)
+
+// ValidatingWebhookConfigurationCreator returns the ValidatingWebhookConfiguration for the machine CRD.
+func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
+	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
+		return resources.MachineValidatingWebhookConfigurationName, func(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+			failurePolicy := admissionregistrationv1.Fail
+			sideEffects := admissionregistrationv1.SideEffectClassNone
+			mURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1-machine", resources.UserClusterWebhookServiceName, namespace)
+			reviewVersions := []string{"v1", "v1beta1"}
+
+			// This only gets set when the APIServer supports it, so carry it over
+			var scope *admissionregistrationv1.ScopeType
+			if len(validatingWebhookConfiguration.Webhooks) != 1 {
+				validatingWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{{}, {}}
+			} else if len(validatingWebhookConfiguration.Webhooks[0].Rules) > 0 {
+				scope = validatingWebhookConfiguration.Webhooks[0].Rules[0].Scope
+			}
+
+			validatingWebhookConfiguration.Webhooks[0].Name = fmt.Sprintf("%s-machines", resources.MachineValidatingWebhookConfigurationName)
+			validatingWebhookConfiguration.Webhooks[0].NamespaceSelector = &metav1.LabelSelector{}
+			validatingWebhookConfiguration.Webhooks[0].SideEffects = &sideEffects
+			validatingWebhookConfiguration.Webhooks[0].FailurePolicy = &failurePolicy
+			validatingWebhookConfiguration.Webhooks[0].AdmissionReviewVersions = reviewVersions
+			validatingWebhookConfiguration.Webhooks[0].Rules = []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{clusterAPIGroup},
+					APIVersions: []string{clusterAPIVersion},
+					Resources:   []string{"machines"},
+					Scope:       scope,
+				},
+			}}
+			validatingWebhookConfiguration.Webhooks[0].ClientConfig = admissionregistrationv1.WebhookClientConfig{
+				URL:      &mURL,
+				CABundle: triple.EncodeCertPEM(caCert),
+			}
+
+			return validatingWebhookConfiguration, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -37,7 +37,8 @@ const (
 func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return resources.MachineValidatingWebhookConfigurationName, func(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
-			failurePolicy := admissionregistrationv1.Fail
+			// TODO - change to Fail when the resource quotas are fully implemented
+			failurePolicy := admissionregistrationv1.Ignore
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			mURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1-machine", resources.UserClusterWebhookServiceName, namespace)
 			reviewVersions := []string{"v1", "v1beta1"}

--- a/pkg/ee/validation/machine/fake.go
+++ b/pkg/ee/validation/machine/fake.go
@@ -1,4 +1,4 @@
-//go:build !ee
+//go:build ee
 
 /*
                   Kubermatic Enterprise Read-Only License
@@ -53,7 +53,7 @@ func getFakeQuotaRequest(config *types.Config) (*ResourceQuota, error) {
 		return nil, fmt.Errorf("error parsing quantity: %v", err)
 	}
 
-	return NewResourceQuota(&cpu, &mem, &storage), nil
+	return NewResourceQuota(cpu, mem, storage), nil
 }
 
 type FakeProviderSpec struct {

--- a/pkg/ee/validation/machine/fake.go
+++ b/pkg/ee/validation/machine/fake.go
@@ -36,21 +36,21 @@ import (
 func getFakeQuotaRequest(config *types.Config) (*ResourceQuota, error) {
 	spec := &FakeProviderSpec{}
 	if err := json.Unmarshal(config.CloudProviderSpec.Raw, spec); err != nil {
-		return nil, fmt.Errorf("error unmarshalling fake raw config: %v", err)
+		return nil, fmt.Errorf("error unmarshalling fake raw config: %w", err)
 	}
 	cpu, err := resource.ParseQuantity(spec.Cpu)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
 	mem, err := resource.ParseQuantity(spec.Memory)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
 	storage, err := resource.ParseQuantity(spec.Storage)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
 	return NewResourceQuota(cpu, mem, storage), nil

--- a/pkg/ee/validation/machine/fake.go
+++ b/pkg/ee/validation/machine/fake.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func getFakeQuotaRequest(config *types.Config) (*ResourceQuota, error) {
+func getFakeQuotaRequest(config *types.Config) (*ResourceDetails, error) {
 	spec := &FakeProviderSpec{}
 	if err := json.Unmarshal(config.CloudProviderSpec.Raw, spec); err != nil {
 		return nil, fmt.Errorf("error unmarshalling fake raw config: %w", err)
@@ -53,7 +53,7 @@ func getFakeQuotaRequest(config *types.Config) (*ResourceQuota, error) {
 		return nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
-	return NewResourceQuota(cpu, mem, storage), nil
+	return NewResourceDetails(cpu, mem, storage), nil
 }
 
 type FakeProviderSpec struct {

--- a/pkg/ee/validation/machine/fake.go
+++ b/pkg/ee/validation/machine/fake.go
@@ -1,0 +1,63 @@
+//go:build !ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package machine
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func getFakeQuotaRequest(config *types.Config) (*ResourceQuota, error) {
+	spec := &FakeProviderSpec{}
+	if err := json.Unmarshal(config.CloudProviderSpec.Raw, spec); err != nil {
+		return nil, fmt.Errorf("error unmarshalling fake raw config: %v", err)
+	}
+	cpu, err := resource.ParseQuantity(spec.Cpu)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+
+	mem, err := resource.ParseQuantity(spec.Memory)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+
+	storage, err := resource.ParseQuantity(spec.Storage)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+
+	return NewResourceQuota(&cpu, &mem, &storage), nil
+}
+
+type FakeProviderSpec struct {
+	Cpu     string `json:"cpu"`
+	Memory  string `json:"memory"`
+	Storage string `json:"storage"`
+}

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -33,9 +33,8 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"k8s.io/apimachinery/pkg/api/resource"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -1,0 +1,159 @@
+//go:build !ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.
+func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *v1alpha1.Machine) error {
+	config, err := types.GetConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return fmt.Errorf("failed to read machine.spec.providerSpec: %v", err)
+	}
+
+	// TODO add all providers
+	var quotaReq *ResourceQuota
+	switch config.CloudProvider {
+	// add this fake for test and so further code is reachable until more providers are implemented
+	case types.CloudProviderFake:
+		quotaReq, err = getFakeQuotaRequest(config)
+		if err != nil {
+			return fmt.Errorf("error getting fake quota req: %v", err)
+		}
+	default:
+		// TODO skip for now, when all providers are added, throw error
+		log.Debugf("provider %q not supported", config.CloudProvider)
+		return nil
+	}
+
+	// TODO Get quota and usage from ResourceQuota when its implemented
+	quota, currentUsage, err := getResourceQuota()
+	if err != nil {
+		return fmt.Errorf("failed to get resouce quota: %v", err)
+	}
+
+	// add requested resources to current usage and compare
+	usageCPU := currentUsage.Cpu()
+	usageMEM := currentUsage.Memory()
+	usageSTO := currentUsage.Storage()
+
+	usageCPU.Add(*quotaReq.Cpu())
+	usageMEM.Add(*quotaReq.Memory())
+	usageSTO.Add(*quotaReq.Storage())
+
+	if quota.Cpu().Cmp(*usageCPU) < 0 {
+		log.Debugf("requested CPU %q would exceed current quota (quota/used %q/%q)",
+			quotaReq.Cpu(), quota.Cpu(), currentUsage.Cpu())
+		return fmt.Errorf("requested CPU %q would exceed current quota (quota/used %q/%q)",
+			quotaReq.Cpu(), quota.Cpu(), currentUsage.Cpu())
+	}
+
+	if quota.Memory().Cmp(*usageMEM) < 0 {
+		log.Debugf("requested Memory %q would exceed current quota (quota/used %q/%q)",
+			quotaReq.Memory(), quota.Memory(), currentUsage.Memory())
+		return fmt.Errorf("requested Memory %q would exceed current quota (quota/used %q/%q)",
+			quotaReq.Memory(), quota.Memory(), currentUsage.Memory())
+	}
+
+	if quota.Storage().Cmp(*usageSTO) < 0 {
+		log.Debugf("requested Storage %q would exceed current quota (quota/used %q/%q)",
+			quotaReq.Storage(), quota.Storage(), currentUsage.Storage())
+		return fmt.Errorf("requested Storage %q would exceed current quota (quota/used %q/%q)",
+			quotaReq.Storage(), quota.Storage(), currentUsage.Storage())
+	}
+
+	return nil
+}
+
+// TODO we should get it from the resourceQuota CRD for the project
+func getResourceQuota() (*ResourceQuota, *ResourceQuota, error) {
+	cpu, err := resource.ParseQuantity("5")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+	cpuUsed, err := resource.ParseQuantity("3")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+
+	mem, err := resource.ParseQuantity("5G")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+	memUsed, err := resource.ParseQuantity("3G")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+
+	storage, err := resource.ParseQuantity("100G")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+	storageUsed, err := resource.ParseQuantity("60G")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+	}
+
+	return NewResourceQuota(&cpu, &mem, &storage),
+		NewResourceQuota(&cpuUsed, &memUsed, &storageUsed), nil
+}
+
+type ResourceQuota struct {
+	cpu     *resource.Quantity
+	mem     *resource.Quantity
+	storage *resource.Quantity
+}
+
+func NewResourceQuota(cpu *resource.Quantity, mem *resource.Quantity, storage *resource.Quantity) *ResourceQuota {
+	return &ResourceQuota{
+		cpu:     cpu,
+		mem:     mem,
+		storage: storage,
+	}
+}
+
+func (r *ResourceQuota) Cpu() *resource.Quantity {
+	return r.cpu
+}
+
+func (r *ResourceQuota) Memory() *resource.Quantity {
+	return r.mem
+}
+
+func (r *ResourceQuota) Storage() *resource.Quantity {
+	return r.storage
+}

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -41,7 +41,7 @@ import (
 func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *v1alpha1.Machine) error {
 	config, err := types.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {
-		return fmt.Errorf("failed to read machine.spec.providerSpec: %v", err)
+		return fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)
 	}
 
 	// TODO add all providers
@@ -51,7 +51,7 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	case types.CloudProviderFake:
 		quotaReq, err = getFakeQuotaRequest(config)
 		if err != nil {
-			return fmt.Errorf("error getting fake quota req: %v", err)
+			return fmt.Errorf("error getting fake quota req: %w", err)
 		}
 	default:
 		// TODO skip for now, when all providers are added, throw error
@@ -62,7 +62,7 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	// TODO Get quota and usage from ResourceQuota when its implemented
 	quota, currentUsage, err := getResourceQuota()
 	if err != nil {
-		return fmt.Errorf("failed to get resouce quota: %v", err)
+		return fmt.Errorf("failed to get resource quota: %w", err)
 	}
 
 	// add requested resources to current usage and compare
@@ -95,33 +95,33 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	return nil
 }
 
-// TODO we should get it from the resourceQuota CRD for the project, for now just some hardcoded values for tests
+// TODO we should get it from the resourceQuota CRD for the project, for now just some hardcoded values for tests.
 func getResourceQuota() (*ResourceQuota, *ResourceQuota, error) {
 	cpu, err := resource.ParseQuantity("5")
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 	cpuUsed, err := resource.ParseQuantity("3")
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
 	mem, err := resource.ParseQuantity("5G")
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 	memUsed, err := resource.ParseQuantity("3G")
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
 	storage, err := resource.ParseQuantity("100G")
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 	storageUsed, err := resource.ParseQuantity("60G")
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing quantity: %v", err)
+		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
 	return NewResourceQuota(cpu, mem, storage),

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -45,7 +45,7 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	}
 
 	// TODO add all providers
-	var quotaReq *ResourceQuota
+	var quotaReq *ResourceDetails
 	switch config.CloudProvider {
 	// add this fake for test and so further code is reachable until more providers are implemented
 	case types.CloudProviderFake:
@@ -59,14 +59,14 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 		return nil
 	}
 
-	// TODO Get quota and usage from ResourceQuota when its implemented
+	// TODO Get quota and usage from ResourceQuota CRD when its implemented
 	quota, currentUsage, err := getResourceQuota()
 	if err != nil {
 		return fmt.Errorf("failed to get resource quota: %w", err)
 	}
 
 	// add requested resources to current usage and compare
-	combinedUsage := NewResourceQuota(currentUsage.cpu, currentUsage.mem, currentUsage.storage)
+	combinedUsage := NewResourceDetails(currentUsage.cpu, currentUsage.mem, currentUsage.storage)
 	combinedUsage.Cpu().Add(*quotaReq.Cpu())
 	combinedUsage.Memory().Add(*quotaReq.Memory())
 	combinedUsage.Storage().Add(*quotaReq.Storage())
@@ -95,8 +95,8 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	return nil
 }
 
-// TODO we should get it from the resourceQuota CRD for the project, for now just some hardcoded values for tests.
-func getResourceQuota() (*ResourceQuota, *ResourceQuota, error) {
+// TODO we should get it from the ResourceQuota CRD for the project, for now just some hardcoded values for tests.
+func getResourceQuota() (*ResourceDetails, *ResourceDetails, error) {
 	cpu, err := resource.ParseQuantity("5")
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
@@ -124,32 +124,32 @@ func getResourceQuota() (*ResourceQuota, *ResourceQuota, error) {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
-	return NewResourceQuota(cpu, mem, storage),
-		NewResourceQuota(cpuUsed, memUsed, storageUsed), nil
+	return NewResourceDetails(cpu, mem, storage),
+		NewResourceDetails(cpuUsed, memUsed, storageUsed), nil
 }
 
-type ResourceQuota struct {
+type ResourceDetails struct {
 	cpu     resource.Quantity
 	mem     resource.Quantity
 	storage resource.Quantity
 }
 
-func NewResourceQuota(cpu resource.Quantity, mem resource.Quantity, storage resource.Quantity) *ResourceQuota {
-	return &ResourceQuota{
+func NewResourceDetails(cpu resource.Quantity, mem resource.Quantity, storage resource.Quantity) *ResourceDetails {
+	return &ResourceDetails{
 		cpu:     cpu,
 		mem:     mem,
 		storage: storage,
 	}
 }
 
-func (r *ResourceQuota) Cpu() *resource.Quantity {
+func (r *ResourceDetails) Cpu() *resource.Quantity {
 	return &r.cpu
 }
 
-func (r *ResourceQuota) Memory() *resource.Quantity {
+func (r *ResourceDetails) Memory() *resource.Quantity {
 	return &r.mem
 }
 
-func (r *ResourceQuota) Storage() *resource.Quantity {
+func (r *ResourceDetails) Storage() *resource.Quantity {
 	return &r.storage
 }

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -72,23 +72,23 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	combinedUsage.Storage().Add(*quotaReq.Storage())
 
 	if quota.Cpu().Cmp(*combinedUsage.Cpu()) < 0 {
-		log.Debugf("requested CPU %q would exceed current quota (quota/used %q/%q)",
-			quotaReq.Cpu(), quota.Cpu(), currentUsage.Cpu())
+		log.Debugw("requested CPU would exceed current quota", "request",
+			quotaReq.Cpu(), "quota", quota.Cpu(), "used", currentUsage.Cpu())
 		return fmt.Errorf("requested CPU %q would exceed current quota (quota/used %q/%q)",
 			quotaReq.Cpu(), quota.Cpu(), currentUsage.Cpu())
 	}
 
 	if quota.Memory().Cmp(*combinedUsage.Memory()) < 0 {
-		log.Debugf("requested Memory %q would exceed current quota (quota/used %q/%q)",
-			quotaReq.Memory(), quota.Memory(), currentUsage.Memory())
+		log.Debugw("requested Memory would exceed current quota", "request",
+			quotaReq.Memory(), "quota", quota.Memory(), "used", currentUsage.Memory())
 		return fmt.Errorf("requested Memory %q would exceed current quota (quota/used %q/%q)",
 			quotaReq.Memory(), quota.Memory(), currentUsage.Memory())
 	}
 
 	if quota.Storage().Cmp(*combinedUsage.Storage()) < 0 {
-		log.Debugf("requested Storage %q would exceed current quota (quota/used %q/%q)",
-			quotaReq.Storage(), quota.Storage(), currentUsage.Storage())
-		return fmt.Errorf("requested Storage %q would exceed current quota (quota/used %q/%q)",
+		log.Debugw("requested disk size would exceed current quota", "request",
+			quotaReq.Storage(), "quota", quota.Storage(), "used", currentUsage.Storage())
+		return fmt.Errorf("requested disk size %q would exceed current quota (quota/used %q/%q)",
 			quotaReq.Storage(), quota.Storage(), currentUsage.Storage())
 	}
 

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-
 	"k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
 	"k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestResourceQuotaValidation(t *testing.T) {
-
 	l := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
 
 	testCases := []struct {

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -1,0 +1,90 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package machine_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
+	"k8c.io/kubermatic/v2/pkg/ee/validation/machine"
+	"k8c.io/kubermatic/v2/pkg/handler/test"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+)
+
+func TestResourceQuotaValidation(t *testing.T) {
+
+	l := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
+
+	testCases := []struct {
+		name        string
+		machine     *v1alpha1.Machine
+		expectedErr bool
+	}{
+		{
+			name:        "quota that fits should succeed",
+			machine:     genFakeMachine("2", "2G", "10G"),
+			expectedErr: false,
+		},
+		{
+			name:        "should fail with CPU quota exceeded",
+			machine:     genFakeMachine("5", "2G", "10G"),
+			expectedErr: true,
+		},
+		{
+			name:        "should fail with Memory quota exceeded",
+			machine:     genFakeMachine("2", "5G", "10G"),
+			expectedErr: true,
+		},
+		{
+			name:        "should fail with Storage quota exceeded",
+			machine:     genFakeMachine("2", "2G", "50G"),
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := machine.ValidateQuota(context.Background(), l, nil, tc.machine)
+			if err != nil {
+				if !tc.expectedErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if err == nil && tc.expectedErr {
+				t.Fatal("expected error, got none")
+			}
+		})
+	}
+}
+
+func genFakeMachine(cpu, memory, storage string) *v1alpha1.Machine {
+	return test.GenTestMachine("fake",
+		fmt.Sprintf(`{"cloudProvider":"fake", "cloudProviderSpec":{"cpu":"%s","memory":"%s","storage":"%s"}}`, cpu, memory, storage),
+		nil, nil)
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -434,7 +434,7 @@ const (
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
 
 	// MachineValidatingWebhookConfigurationName is the name for the machine validating webhook.
-	MachineValidatingWebhookConfigurationName = "machine.kubermatic.io"
+	MachineValidatingWebhookConfigurationName = "machine.kubermatic.k8c.io"
 
 	// GatekeeperValidatingWebhookConfigurationName is the name of the gatekeeper validating webhook
 	// configuration.

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -433,6 +433,9 @@ const (
 	// configuration.
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
 
+	// MachineValidatingWebhookConfigurationName is the name for the machine validating webhook.
+	MachineValidatingWebhookConfigurationName = "machine.kubermatic.io"
+
 	// GatekeeperValidatingWebhookConfigurationName is the name of the gatekeeper validating webhook
 	// configuration.
 	GatekeeperValidatingWebhookConfigurationName = "gatekeeper-validating-webhook-configuration"

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"errors"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"go.uber.org/zap"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// validator for validating Kubermatic Machine CRD.
+type validator struct {
+	log        *zap.SugaredLogger
+	seedClient ctrlruntimeclient.Client
+}
+
+// NewValidator returns a new Machine validator.
+func NewValidator(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *validator {
+	log.Named("machine-validator")
+	return &validator{
+		log:        log,
+		seedClient: seedClient,
+	}
+}
+
+var _ admission.CustomValidator = &validator{}
+
+func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	machine, ok := obj.(*v1alpha1.Machine)
+	if !ok {
+		return errors.New("object is not a Machine")
+	}
+
+	log := v.log.With("machine", machine.Name)
+	log.Debug("validating create")
+
+	return validateQuota(ctx, log, v.seedClient, machine)
+}
+
+// ValidateUpdate validates Machine updates. As mutating Machine spec is disallowed by the Machine Mutating webhook,
+// no need to check anything here.
+func (v *validator) ValidateUpdate(_ context.Context, _, _ runtime.Object) error {
+	return nil
+}
+
+func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"errors"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"go.uber.org/zap"
 
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // validator for validating Kubermatic Machine CRD.

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -37,7 +37,6 @@ type validator struct {
 
 // NewValidator returns a new Machine validator.
 func NewValidator(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *validator {
-	log.Named("machine-validator")
 	return &validator{
 		log:        log,
 		seedClient: seedClient,

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -1,0 +1,33 @@
+//go:build !ee
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ *v1alpha1.Machine) error {
+	return nil
+}

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -1,0 +1,35 @@
+//go:build ee
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
+)
+
+func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *v1alpha1.Machine) error {
+	return eemachinevalidation.ValidateQuota(ctx, log, seedClient, machine)
+}

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -24,10 +24,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 )
 
 func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *v1alpha1.Machine) error {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Part of #9412. This PR adds a machine validating webhook for resource quotas.

As we dont have yet the ResourceQuotas for projects implemented, or its calculation, so for now getting the quotas are hardcoded with some fake value. Also getting the resource requirements for the machine, per provider, will be implemented in the next PRs, so for now no providers are supported - meaning the webhook wont do anything yet and will just pass the validation.

What this PR brings is the scaffolding of the resource quota validation, with the checks for requested resources vs. quota and current quota usage.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9625 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a Machine validating webhook which checks the Machine resource request(CPU, Memory, Storage) against its projects resource quota(if set). This is an EE feature only. 
```
