### PR TITLE
Add support for prometheus.io/scheme annotation in Prometheus chart

### DIFF
--- a/charts/monitoring/prometheus/config/scraping/pods.yaml
+++ b/charts/monitoring/prometheus/config/scraping/pods.yaml
@@ -80,6 +80,12 @@ relabel_configs:
   replacement: $1:$2
   target_label: __address__
 
+# allow to override the scrape scheme with https (defaults to plain http) via prometheus.io/scheme
+- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+  action: replace
+  regex: (https?)
+  target_label: __scheme__
+
 # refine labels further
 - action: labelmap
   regex: __meta_kubernetes_pod_label_(.+)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

I was looking at #9560 and #8467 and wondered why that later PR introduced a completely new scraping config instead of just properly annotating the minio Pods ... Until I figured out that we don't support the `prometheus.io/scheme` annotation in the `prometheus` chart under `charts/monitoring`. _However_, we support that standard annotation in user clusters via the MLA Prometheus created there:

https://github.com/kubermatic/kubermatic/blob/d61215605dbd093add135cac67f5e06b9279e4dc/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/configmap.go#L128-L132

This PR adds support for `prometheus.io/scheme=https` to the Master/Seed MLA Prometheus as well, allowing us to potentially swap out the minio scraping configuration (or others) with something much simpler and giving Master/Seed administrators the expected set of `prometheus.io` annotations they know from other Prometheus installations.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Master/Seed MLA Prometheus from `charts/monitoring/prometheus` supports annotating Pods with `prometheus.io/scheme=https` to use HTTPS
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
