### PR TITLE
Fetch dependencies for MLA charts before installing them

### DIFF
--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -41,28 +41,23 @@ git clone "$URL" "$tempdir"
 
   # due to the anti affinities, getting more than 1 replica can take forever in kind,
   # so we reduce the replica count for all those components
-  yq write --inplace config/cortex/values.yaml ingester.replicas 1
-  yq write --inplace config/cortex/values.yaml distrbutor.replicas 1
-  yq write --inplace config/cortex/values.yaml alertmanager.replicas 1
+  yq write --inplace config/cortex/values.yaml cortex.ingester.replicas 1
+  yq write --inplace config/cortex/values.yaml cortex.distributor.replicas 1
+  yq write --inplace config/cortex/values.yaml cortex.alertmanager.replicas 1
 
-  yq write --inplace config/cortex/values.yaml ingester.startupProbe.initialDelaySeconds 30
-  yq write --inplace config/cortex/values.yaml ingester.startupProbe.periodSeconds 5
-  yq write --inplace config/cortex/values.yaml compactor.startupProbe.initialDelaySeconds 30
-  yq write --inplace config/cortex/values.yaml compactor.startupProbe.periodSeconds 5
-  yq write --inplace config/cortex/values.yaml store_gateway.startupProbe.initialDelaySeconds 30
-  yq write --inplace config/cortex/values.yaml store_gateway.startupProbe.periodSeconds 5
+  yq write --inplace config/loki/values.yaml loki-distributed.ingester.replicas 1
+  yq write --inplace config/loki/values.yaml loki-distributed.distributor.replicas 1
 
-  yq write --inplace config/loki/values.yaml ingester.replicas 1
-  yq write --inplace config/loki/values.yaml distributor.replicas 1
+  # ensure that dependencies are fetched and stored in the corresponding charts dir
+  echodate "Fetching dependencies for the charts"
+  hack/fetch-chart-dependencies.sh
 
   helm --namespace mla upgrade --atomic --create-namespace --install mla-secrets charts/mla-secrets --values config/mla-secrets/values.yaml
   helm --namespace mla upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
   helm --namespace mla upgrade --atomic --create-namespace --install grafana charts/grafana --values config/grafana/values.yaml
   kubectl apply -f dashboards/
-  kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
-  helm dependency update charts/cortex # need that to store memcached in charts directory
   helm --namespace mla upgrade --atomic --create-namespace --install consul charts/consul --values config/consul/values.yaml
-  helm --namespace mla upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml --timeout 20m
+  helm --namespace mla upgrade --atomic --create-namespace --install --debug cortex charts/cortex --values config/cortex/values.yaml --timeout 20m
   helm --namespace mla upgrade --atomic --create-namespace --install loki-distributed charts/loki-distributed --values config/loki/values.yaml --timeout 10m
   helm --namespace mla upgrade --atomic --create-namespace --install alertmanager-proxy charts/alertmanager-proxy
   helm --namespace mla upgrade --atomic --create-namespace --install minio-lifecycle-mgr charts/minio-lifecycle-mgr --values config/minio-lifecycle-mgr/values.yaml

--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -56,6 +56,7 @@ git clone "$URL" "$tempdir"
   helm --namespace mla upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
   helm --namespace mla upgrade --atomic --create-namespace --install grafana charts/grafana --values config/grafana/values.yaml
   kubectl apply -f dashboards/
+  kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
   helm --namespace mla upgrade --atomic --create-namespace --install consul charts/consul --values config/consul/values.yaml
   helm --namespace mla upgrade --atomic --create-namespace --install --debug cortex charts/cortex --values config/cortex/values.yaml --timeout 20m
   helm --namespace mla upgrade --atomic --create-namespace --install loki-distributed charts/loki-distributed --values config/loki/values.yaml --timeout 10m


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
With https://github.com/kubermatic/mla/pull/89 we moved to upstream charts. This PR ensures that we fetch those dependencies locally before installing these charts. Else installation of helm charts would fail.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
