### PR TITLE
Don't set '--kubelet-certificate-authority' for 'bring-your-own' user clusters

### DIFF
--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -310,7 +310,15 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--client-ca-file", "/etc/kubernetes/pki/ca/ca.crt",
 		"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
 		"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
-		"--kubelet-certificate-authority", "/etc/kubernetes/pki/ca/ca.crt",
+	}
+
+	// the "bring-your-own" provider does not support automatic TLS rotation in kubelets yet,
+	// and because of that certs might expire and kube-apiserver cannot validate the connection anymore.
+	if cluster.Spec.Cloud.BringYourOwn == nil {
+		flags = append(flags, "--kubelet-certificate-authority", "/etc/kubernetes/pki/ca/ca.crt")
+	}
+
+	flags = append(flags,
 		"--requestheader-client-ca-file", "/etc/kubernetes/pki/front-proxy/ca/ca.crt",
 		"--requestheader-allowed-names", "apiserver-aggregator",
 		"--requestheader-extra-headers-prefix", "X-Remote-Extra-",
@@ -318,7 +326,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--requestheader-username-headers", "X-Remote-User",
 		// this can't be passed as two strings as the other parameters
 		"--profiling=false",
-	}
+	)
 
 	// pre-pend to have advertise-address as first argument and avoid
 	// triggering unneeded redeployments.

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -193,8 +193,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-certificate-authority
-        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -193,8 +193,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-certificate-authority
-        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-apiserver.yaml
@@ -193,8 +193,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-certificate-authority
-        - /etc/kubernetes/pki/ca/ca.crt
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
As per #9673, the "kubeadm" provider is special because it does not automatically rotate kubelet server TLS certificates, and the `--kubelet-certificate-authority` flag is problematic in that case. Eventually, we should make sure that TLS rotation properly happens on those clusters as well, but this PR (temporarily?) disables the flag for "kubeadm" clusters and this PR will be cherry-picked into 2.20 and 2.19. #8091 will likely end up being the complete fix, and after that is implemented this PR can be reverted.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9673

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The flag `--kubelet-certificate-authority` (introduced in KKP 2.19) is not set for "kubeadm" / "bringyourown" user clusters anymore
```
