### PR TITLE
fix promtail client config

### DIFF
--- a/charts/logging/promtail/test/default.yaml.out
+++ b/charts/logging/promtail/test/default.yaml.out
@@ -32,20 +32,13 @@ stringData:
     
     clients:
       - url: http://loki:3100/loki/api/v1/push
-      |
-        # Maximum wait period before sending batch
-        batchwait: 1s
-        # Maximum batch size to accrue before sending, unit is byte
-        batchsize: 102400
-        # Maximum time to wait for server to respond to a request
-        timeout: 10s
-        backoff_config:
-          # Initial backoff time between retries
-          min_period: 100ms
-          # Maximum backoff time between retries
+      - backoff_config:
           max_period: 5s
-          # Maximum number of retries when sending batches, 0 means infinite retries
           max_retries: 20
+          min_period: 100ms
+        batchsize: 102400
+        batchwait: 1s
+        timeout: 10s
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -385,7 +378,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 1be12d9bac9f9fdcf9a6b43bca02e631cac85531c2adb0144fb9fd1bafb06577
+        checksum/config: 0e33e6f83fc886f1ce61c7e04800e5a15ac5fc9b646449acac8b11c301350f22
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:

--- a/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
@@ -32,20 +32,13 @@ stringData:
     
     clients:
       - url: http://loki:3100/loki/api/v1/push
-      |
-        # Maximum wait period before sending batch
-        batchwait: 1s
-        # Maximum batch size to accrue before sending, unit is byte
-        batchsize: 102400
-        # Maximum time to wait for server to respond to a request
-        timeout: 10s
-        backoff_config:
-          # Initial backoff time between retries
-          min_period: 100ms
-          # Maximum backoff time between retries
+      - backoff_config:
           max_period: 5s
-          # Maximum number of retries when sending batches, 0 means infinite retries
           max_retries: 20
+          min_period: 100ms
+        batchsize: 102400
+        batchwait: 1s
+        timeout: 10s
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -385,7 +378,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 1be12d9bac9f9fdcf9a6b43bca02e631cac85531c2adb0144fb9fd1bafb06577
+        checksum/config: 0e33e6f83fc886f1ce61c7e04800e5a15ac5fc9b646449acac8b11c301350f22
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:

--- a/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
@@ -32,20 +32,13 @@ stringData:
     
     clients:
       - url: http://loki:3100/loki/api/v1/push
-      |
-        # Maximum wait period before sending batch
-        batchwait: 1s
-        # Maximum batch size to accrue before sending, unit is byte
-        batchsize: 102400
-        # Maximum time to wait for server to respond to a request
-        timeout: 10s
-        backoff_config:
-          # Initial backoff time between retries
-          min_period: 100ms
-          # Maximum backoff time between retries
+      - backoff_config:
           max_period: 5s
-          # Maximum number of retries when sending batches, 0 means infinite retries
           max_retries: 20
+          min_period: 100ms
+        batchsize: 102400
+        batchwait: 1s
+        timeout: 10s
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -385,7 +378,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 1be12d9bac9f9fdcf9a6b43bca02e631cac85531c2adb0144fb9fd1bafb06577
+        checksum/config: 0e33e6f83fc886f1ce61c7e04800e5a15ac5fc9b646449acac8b11c301350f22
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -82,20 +82,21 @@ promtail:
       # Period to resync directories being watched and files being tailed
       sync_period: 10s
     snippets:
-      extraClientConfigs: |
-        # Maximum wait period before sending batch
-        batchwait: 1s
-        # Maximum batch size to accrue before sending, unit is byte
-        batchsize: 102400
-        # Maximum time to wait for server to respond to a request
-        timeout: 10s
-        backoff_config:
-          # Initial backoff time between retries
-          min_period: 100ms
-          # Maximum backoff time between retries
-          max_period: 5s
-          # Maximum number of retries when sending batches, 0 means infinite retries
-          max_retries: 20
+      extraClientConfigs:
+        -
+          # Maximum wait period before sending batch
+          batchwait: 1s
+          # Maximum batch size to accrue before sending, unit is byte
+          batchsize: 102400
+          # Maximum time to wait for server to respond to a request
+          timeout: 10s
+          backoff_config:
+            # Initial backoff time between retries
+            min_period: 100ms
+            # Maximum backoff time between retries
+            max_period: 5s
+            # Maximum number of retries when sending batches, 0 means infinite retries
+            max_retries: 20
 
       scrapeConfigs: |
         - job_name: kubernetes-pods-name


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In #9648 we updated promtail to v2.5, but I missed that the client configuration was changed since previous versions (via grafana/helm-charts#1119). Since then the client config is not an inline YAML string anymore, but a regular data structure that is YAML-i-fied by the chart itself.

This PR updates our default config to match this new behaviour. Yes it looks weird that we supposedly create a client that only has `url` specified, but that's how the upstream chat works: https://github.com/grafana/helm-charts/blob/5a990ab9883bf2c001204cf9bc867b6a286f4363/charts/promtail/values.yaml#L347-L351

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
