### PR TITLE
Update Prometheus to 2.35

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: prometheus
 version: v9.9.9-dev
-appVersion: v2.34.0
+appVersion: v2.35.0
 description: Prometheus Monitoring for Kubernetes
 keywords:
   - kubermatic

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -16,7 +16,7 @@ prometheus:
   replicas: 2
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.34.0
+    tag: v2.35.0
     pullPolicy: IfNotPresent
 
   host: ''


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
What it says on the tin.

Note that this disables support for TLS 1.0 and 1.1 in Prometheus, plus we will now reject SHA-1 certificates.

**Does this PR introduce a user-facing change?**:
```release-note
Update Prometheus to 2.35 (disables support for SHA-1 certificates and TLS 1.0/1.1)
```
