### PR TITLE
remove unused variable from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ LDFLAGS += -extldflags '-static' \
 LDFLAGS_EXTRA=-w
 BUILD_DEST ?= _build
 GOTOOLFLAGS ?= $(GOBUILDFLAGS) -ldflags '$(LDFLAGS_EXTRA) $(LDFLAGS)' $(GOTOOLFLAGS_EXTRA)
-GOBUILDIMAGE ?= golang:1.17.5
 DOCKER_BIN := $(shell which docker)
 
 .PHONY: all


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
`GOBUILDIMAGE` is not used anywhere in this repo anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
