### PR TITLE
KubeVirt cluster update flow: reconcile VirtualMachineInstancePreset

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	kubevirtRegistryAddr  = "http://10.244.2.19"
+	kubevirtRegistryAddr  = "http://10.244.1.19"
 	kubevirtCPUs          = "2"
 	kubevirtMemory        = "4Gi"
 	kubevirtDiskSize      = "25Gi"

--- a/pkg/handler/v2/provider/kubevirt.go
+++ b/pkg/handler/v2/provider/kubevirt.go
@@ -66,7 +66,7 @@ func KubeVirtVMIPresetsEndpoint(presetsProvider provider.PresetProvider, userInf
 				kubeconfig = credentials.Kubeconfig
 			}
 		}
-		return providercommon.KubeVirtVMIPresets(ctx, kubeconfig)
+		return providercommon.KubeVirtVMIPresets(ctx, kubeconfig, nil)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
In the update cluster flow, when we get the VirtualMachineInstancePresets in the `default` namespace, we also reconcile them into the dedicated namespace (`cluster-xxyy`). 
In the cluster creation flow, this is already handled by the ReconcileCluster. There is also a periodic reconciliation.
What was not working is if you created a new VirtualMachineInstancePresets in the `default` namespace before the ReconcileCluster is reconciled again and select it in the UI, then it needed to be reconciled in the dedicated namespace.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9697 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: reconcile the VirtualMachineInstancePresets from `default` namespace into the dedicated namespace `cluster-xxyy` in the update cluster flow.
```
