### PR TITLE
update golang images used for various scripts

### DIFF
--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.17.5 as builder
+FROM docker.io/golang:1.18.1 as builder
 
 # import the GOPROXY variable from Buildah via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.17.5 as builder
+FROM docker.io/golang:1.18.1 as builder
 
 # import the GOPROXY variable from Buildah via an arg and then use
 # that arg to define the environment variable later on

--- a/hack/gen-api-client.sh
+++ b/hack/gen-api-client.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.17.5 containerize ./hack/gen-api-client.sh
+CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/gen-api-client.sh
 
 cd cmd/kubermatic-api/
 SWAGGER_FILE="swagger.json"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.17.5 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/update-codegen.sh
 
 echodate "Running go generate"
 go generate ./pkg/...

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.17.5 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.17.5 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/update-kubermatic-ca-bundle.sh
+++ b/hack/update-kubermatic-ca-bundle.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.17.5 containerize ./hack/update-kubermatic-ca-bundle.sh
+CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/update-kubermatic-ca-bundle.sh
 
 echodate "Updating CA bundle..."
 curl -Lo charts/kubermatic-operator/static/ca-bundle.pem https://curl.se/ca/cacert.pem

--- a/hack/update-swagger.sh
+++ b/hack/update-swagger.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.17.5 containerize ./hack/update-swagger.sh
+CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd cmd/kubermatic-api/

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.17-node-16-5 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.18-node-16-0 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.17-node-16-5 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.18-node-16-0 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
There were still a few spots where we used Go 1.17. None of them "mattered", but it's still nice to be consistent.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
