### PR TITLE
Web terminal: restricting access to admins or users belonging to groups "owners" or "editors"

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -187,7 +187,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 				log.Logger.Debug(err)
 				return
 			}
-			if !strings.HasPrefix(userInfo.Group, "owners") && !strings.HasPrefix(userInfo.Group, "editors") {
+			if strings.HasPrefix(userInfo.Group, "viewers") {
 				return
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Hugo Bernardo <hugo@kubermatic.com>

**What does this PR do / Why do we need it**:
Restricts access to cluster web terminal to admins or users belonging to groups "owners" or "editors".

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
