### PR TITLE
Get kubeone machinedeployments and nodes

### DIFF
--- a/pkg/handler/v2/external_cluster/node.go
+++ b/pkg/handler/v2/external_cluster/node.go
@@ -259,6 +259,12 @@ func ListMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, proje
 				}
 				machineDeployments = np
 			}
+			if cloud.KubeOne != nil {
+				machineDeployments, err = getKubeOneMachineDeployments(ctx, cluster, clusterProvider)
+				if err != nil {
+					return nil, common.KubernetesErrorToHTTPError(err)
+				}
+			}
 		}
 
 		return machineDeployments, nil
@@ -657,7 +663,7 @@ func GetMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projec
 				if err != nil {
 					return nil, err
 				}
-				machineDeployment = *createAPIMachineDeployment(md)
+				machineDeployment = createAPIMachineDeployment(*md)
 			}
 		}
 
@@ -730,7 +736,7 @@ func PatchMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, proj
 				if err != nil {
 					return nil, err
 				}
-				md := createAPIMachineDeployment(machineDeployment)
+				md := createAPIMachineDeployment(*machineDeployment)
 				mdToPatch.NodeDeployment = md.NodeDeployment
 				if err := patchMD(&mdToPatch, &patchedMD, req.Patch); err != nil {
 					return nil, err

--- a/pkg/handler/v2/external_cluster/node.go
+++ b/pkg/handler/v2/external_cluster/node.go
@@ -260,7 +260,7 @@ func ListMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, proje
 				machineDeployments = np
 			}
 			if cloud.KubeOne != nil {
-				machineDeployments, err = getKubeOneMachineDeployments(ctx, cluster, clusterProvider)
+				machineDeployments, err = getKubeOneAPIMachineDeployments(ctx, cluster, clusterProvider)
 				if err != nil {
 					return nil, common.KubernetesErrorToHTTPError(err)
 				}
@@ -318,6 +318,13 @@ func getMachineDeploymentNodes(ctx context.Context, userInfoGetter provider.User
 		}
 		if cloud.AKS != nil {
 			n, err := getAKSNodes(ctx, cluster, machineDeploymentID, clusterProvider)
+			if err != nil {
+				return nil, common.KubernetesErrorToHTTPError(err)
+			}
+			nodes = n
+		}
+		if cloud.KubeOne != nil {
+			n, err := getKubeOneNodes(ctx, cluster, machineDeploymentID, clusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -659,11 +666,11 @@ func GetMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projec
 				machineDeployment = *np
 			}
 			if cloud.KubeOne != nil {
-				md, err := getKubeOneMachineDeployment(ctx, req.MachineDeploymentID, cluster, clusterProvider)
+				md, err := getKubeOneAPIMachineDeployment(ctx, req.MachineDeploymentID, cluster, clusterProvider)
 				if err != nil {
-					return nil, err
+					return nil, common.KubernetesErrorToHTTPError(err)
 				}
-				machineDeployment = createAPIMachineDeployment(*md)
+				machineDeployment = *md
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**: Extend externalcluster get endpoints for kubeone machinedeployments and nodes (nodes are filtered for machinedeployment using workerset label)

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9709

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
