### PR TITLE
Scale kubeone machinedeployment replicas

### DIFF
--- a/pkg/handler/v2/external_cluster/kubeone.go
+++ b/pkg/handler/v2/external_cluster/kubeone.go
@@ -274,7 +274,21 @@ func patchKubeOneMachineDeployment(ctx context.Context, machineDeployment *v1alp
 	currentVersion := oldmd.NodeDeployment.Spec.Template.Versions.Kubelet
 	desiredVersion := newmd.NodeDeployment.Spec.Template.Versions.Kubelet
 	if desiredVersion != currentVersion {
-		machineDeployment.Spec.Template.Spec.Versions.Kubelet = newmd.NodeDeployment.Spec.Template.Versions.Kubelet
+		machineDeployment.Spec.Template.Spec.Versions.Kubelet = desiredVersion
+		userClusterClient, err := clusterProvider.GetClient(ctx, cluster)
+		if err != nil {
+			return nil, err
+		}
+		if err := userClusterClient.Update(ctx, machineDeployment); err != nil && !meta.IsNoMatchError(err) {
+			return nil, fmt.Errorf("failed to update MachineDeployment: %w", err)
+		}
+		return newmd, nil
+	}
+
+	currentReplicas := oldmd.NodeDeployment.Spec.Replicas
+	desiredReplicas := newmd.NodeDeployment.Spec.Replicas
+	if desiredReplicas != currentReplicas {
+		machineDeployment.Spec.Replicas = &desiredReplicas
 		userClusterClient, err := clusterProvider.GetClient(ctx, cluster)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**: Extend externalcluster patch endpoint to Scale kubeone machinedeployment replicas by updating machinedeployments with desired replicas

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9492

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
