### PR TITLE
Excluding metering reports from being fetched at the metering pod init

### DIFF
--- a/pkg/ee/metering/deployment.go
+++ b/pkg/ee/metering/deployment.go
@@ -70,7 +70,7 @@ func deploymentCreator(seed *kubermaticv1.Seed, getRegistry registry.WithOverwri
 					Args: []string{
 						"-c",
 						`mc config host add s3 $S3_ENDPOINT $ACCESS_KEY_ID $SECRET_ACCESS_KEY
-mc mirror --newer-than "32d0h0m" s3/$S3_BUCKET /metering-data || true`,
+mc mirror --newer-than "32d0h0m" --exclude "report-*.csv" --exclude "**/report-*.csv" s3/$S3_BUCKET /metering-data || true`,
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The pod hosting metering tool runs a sidecar which re-uploads files fetched at the init phase every 5 minutes. It makes sense for metering-data but we don't need to fetch metering reports. Moreover, re-uploads of metering reports makes it impossible to remove them. I added `--exclude` flag to mirror command to avoid fetching metering reports.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9711 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
