### PR TITLE
Resource quota webhook providers - AWS, GCP, Azure, KubeVirt, vSphere, Openstack

### DIFF
--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -116,7 +116,7 @@ func main() {
 	applicationinstallationvalidation.NewAdmissionHandler(mgr.GetClient()).SetupWebhookWithManager(mgr)
 
 	// Setup Machine Webhook
-	machineValidator := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log)
+	machineValidator := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle)
 	if err := builder.WebhookManagedBy(seedMgr).For(&clusterv1alpha1.Machine{}).WithValidator(machineValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup Machine validation webhook", zap.Error(err))
 	}

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -113,7 +113,7 @@ func main() {
 	// setup webhooks
 
 	// Setup the validation admission handler for ApplicationInstallation CRDs
-	applicationinstallationvalidation.NewAdmissionHandler(mgr.GetClient()).SetupWebhookWithManager(mgr)
+	applicationinstallationvalidation.NewAdmissionHandler(seedMgr.GetClient()).SetupWebhookWithManager(seedMgr)
 
 	// Setup Machine Webhook
 	machineValidator := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle)

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -89,7 +89,7 @@ func main() {
 		log.Fatalw("Failed to create the seed cluster manager", zap.Error(err))
 	}
 
-	userMgr, err := manager.New(userCfg, manager.Options{})
+	userMgr, err := manager.New(userCfg, manager.Options{MetricsBindAddress: "0"})
 	if err != nil {
 		log.Fatalw("Failed to create the user cluster manager", zap.Error(err))
 	}

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -55,27 +55,27 @@ func getAWSResourceRequirements(ctx context.Context, client ctrlruntimeclient.Cl
 
 	instanceType, err := configVarResolver.GetConfigVarStringValue(rawConfig.InstanceType)
 	if err != nil {
-		return nil, fmt.Errorf("error getting AWS instance type from machine config: %v", err)
+		return nil, fmt.Errorf("error getting AWS instance type from machine config: %w", err)
 	}
 
 	awsSize, err := provider.GetAWSInstance(instanceType)
 	if err != nil {
-		return nil, fmt.Errorf("error getting AWS instance type data: %v", err)
+		return nil, fmt.Errorf("error getting AWS instance type data: %w", err)
 	}
 
 	// parse the AWS resource requests
 	// memory and storage are given in GB
 	cpuReq, err := resource.ParseQuantity(strconv.Itoa(awsSize.VCPUs))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
 	memReq, err := resource.ParseQuantity(fmt.Sprintf("%fG", awsSize.Memory))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}
 	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.DiskSize))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 
 	return NewResourceDetails(cpuReq, memReq, storageReq), nil
@@ -91,35 +91,35 @@ func getGCPResourceRequirements(ctx context.Context, client ctrlruntimeclient.Cl
 
 	serviceAccount, err := configVarResolver.GetConfigVarStringValue(rawConfig.ServiceAccount)
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP service account from machine config: %v", err)
+		return nil, fmt.Errorf("error getting GCP service account from machine config: %w", err)
 	}
 	machineType, err := configVarResolver.GetConfigVarStringValue(rawConfig.MachineType)
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP machine type from machine config: %v", err)
+		return nil, fmt.Errorf("error getting GCP machine type from machine config: %w", err)
 	}
 	zone, err := configVarResolver.GetConfigVarStringValue(rawConfig.Zone)
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP zone from machine config: %v", err)
+		return nil, fmt.Errorf("error getting GCP zone from machine config: %w", err)
 	}
 
 	machineSize, err := provider.GetGCPInstanceSize(ctx, machineType, serviceAccount, zone)
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP machine size data %v", err)
+		return nil, fmt.Errorf("error getting GCP machine size data %w", err)
 	}
 
 	// parse the GCP resource requests
 	// memory is given in MB and storage in GB
 	cpuReq, err := resource.ParseQuantity(strconv.FormatInt(machineSize.VCPUs, 10))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
 	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dM", machineSize.Memory))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}
 	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.DiskSize))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 
 	return NewResourceDetails(cpuReq, memReq, storageReq), nil
@@ -135,53 +135,53 @@ func getAzureResourceRequirements(ctx context.Context, client ctrlruntimeclient.
 
 	subId, err := configVarResolver.GetConfigVarStringValue(rawConfig.SubscriptionID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure subscription ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Azure subscription ID from machine config: %w", err)
 	}
 	clientId, err := configVarResolver.GetConfigVarStringValue(rawConfig.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure client ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Azure client ID from machine config: %w", err)
 	}
 	clientSecret, err := configVarResolver.GetConfigVarStringValue(rawConfig.ClientSecret)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure client secret from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Azure client secret from machine config: %w", err)
 	}
 	tenantId, err := configVarResolver.GetConfigVarStringValue(rawConfig.TenantID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure tenant ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Azure tenant ID from machine config: %w", err)
 	}
 	location, err := configVarResolver.GetConfigVarStringValue(rawConfig.Location)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure location from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Azure location from machine config: %w", err)
 	}
 	vmSizeName, err := configVarResolver.GetConfigVarStringValue(rawConfig.VMSize)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure vm size name from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Azure vm size name from machine config: %w", err)
 	}
 
 	vmSize, err := provider.GetAzureVMSize(ctx, subId, clientId, clientSecret, tenantId, location, vmSizeName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Azure vm size data %v", err)
+		return nil, fmt.Errorf("error getting Azure vm size data %w", err)
 	}
 
 	// parse the Azure resource requests
 	// memory is given in MB and storage in GB
 	cpuReq, err := resource.ParseQuantity(strconv.Itoa(int(vmSize.NumberOfCores)))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
 	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dM", vmSize.MemoryInMB))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}
 
 	// Azure allows for setting os and data disk size separately
 	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.DataDiskSize))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 	osDiskStorageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.OSDiskSize))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 	storageReq.Add(osDiskStorageReq)
 
@@ -198,42 +198,42 @@ func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclie
 
 	cpu, err := configVarResolver.GetConfigVarStringValue(rawConfig.VirtualMachine.Template.CPUs)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Kubevirt cpu request from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Kubevirt cpu request from machine config: %w", err)
 	}
 	memory, err := configVarResolver.GetConfigVarStringValue(rawConfig.VirtualMachine.Template.Memory)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Kubevirt memory request from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Kubevirt memory request from machine config: %w", err)
 	}
 
 	storage, err := configVarResolver.GetConfigVarStringValue(rawConfig.VirtualMachine.Template.PrimaryDisk.Size)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Kubevirt primary disk size from machine config: %v", err)
+		return nil, fmt.Errorf("error getting Kubevirt primary disk size from machine config: %w", err)
 	}
 
 	// parse the KubeVirt resource requests
 	// memory is in MB and storage is given in GB
 	cpuReq, err := resource.ParseQuantity(cpu)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
 	memReq, err := resource.ParseQuantity(memory)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}
 	storageReq, err := resource.ParseQuantity(storage)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 
 	// Add all secondary disks
 	for _, d := range rawConfig.VirtualMachine.Template.SecondaryDisks {
 		secondaryStorage, err := configVarResolver.GetConfigVarStringValue(d.Size)
 		if err != nil {
-			return nil, fmt.Errorf("error getting Kubevirt secondary disk size from machine config: %v", err)
+			return nil, fmt.Errorf("error getting Kubevirt secondary disk size from machine config: %w", err)
 		}
 		secondaryStorageReq, err := resource.ParseQuantity(secondaryStorage)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+			return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 		}
 		storageReq.Add(secondaryStorageReq)
 	}
@@ -252,15 +252,15 @@ func getVsphereResourceRequirements(config *types.Config) (*ResourceDetails, err
 	// memory is in MB and storage is given in GB
 	cpuReq, err := resource.ParseQuantity(strconv.Itoa(int(rawConfig.CPUs)))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
 	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dM", rawConfig.MemoryMB))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}
 	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.DiskSizeGB))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 
 	return NewResourceDetails(cpuReq, memReq, storageReq), nil
@@ -276,55 +276,55 @@ func getOpenstackResourceRequirements(ctx context.Context, client ctrlruntimecli
 
 	identityEndpoint, err := configVarResolver.GetConfigVarStringValue(rawConfig.IdentityEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack identity endpoint from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack identity endpoint from machine config: %w", err)
 	}
 	region, err := configVarResolver.GetConfigVarStringValue(rawConfig.Region)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack region from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack region from machine config: %w", err)
 	}
 	username, err := configVarResolver.GetConfigVarStringValue(rawConfig.Username)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack username from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack username from machine config: %w", err)
 	}
 	password, err := configVarResolver.GetConfigVarStringValue(rawConfig.Password)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack password from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack password from machine config: %w", err)
 	}
 	tenantId, err := configVarResolver.GetConfigVarStringValue(rawConfig.TenantID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack tenant ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack tenant ID from machine config: %w", err)
 	}
 	projectId, err := configVarResolver.GetConfigVarStringValue(rawConfig.ProjectID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack project ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack project ID from machine config: %w", err)
 	}
 	tenantName, err := configVarResolver.GetConfigVarStringValue(rawConfig.TenantName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack tenant name from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack tenant name from machine config: %w", err)
 	}
 	projectName, err := configVarResolver.GetConfigVarStringValue(rawConfig.ProjectName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack tenant name from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack tenant name from machine config: %w", err)
 	}
 	appCredId, err := configVarResolver.GetConfigVarStringValue(rawConfig.ApplicationCredentialID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack application credential ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack application credential ID from machine config: %w", err)
 	}
 	appCredSecret, err := configVarResolver.GetConfigVarStringValue(rawConfig.ApplicationCredentialSecret)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack application credential secret from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack application credential secret from machine config: %w", err)
 	}
 	tokenId, err := configVarResolver.GetConfigVarStringValue(rawConfig.TokenID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack token ID from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack token ID from machine config: %w", err)
 	}
 	domainName, err := configVarResolver.GetConfigVarStringValue(rawConfig.DomainName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack domain name from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack domain name from machine config: %w", err)
 	}
 	flavor, err := configVarResolver.GetConfigVarStringValue(rawConfig.Flavor)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack flavor from machine config: %v", err)
+		return nil, fmt.Errorf("error getting OpenStack flavor from machine config: %w", err)
 	}
 
 	creds := &resources.OpenstackCredentials{
@@ -348,22 +348,22 @@ func getOpenstackResourceRequirements(ctx context.Context, client ctrlruntimecli
 
 	flavorSize, err := provider.GetOpenStackFlavorSize(creds, identityEndpoint, region, caBundle.CertPool(), flavor)
 	if err != nil {
-		return nil, fmt.Errorf("error getting OpenStack flavor size data %v", err)
+		return nil, fmt.Errorf("error getting OpenStack flavor size data %w", err)
 	}
 
 	// parse the Openstack resource requests
 	// memory and storage are in GB
 	cpuReq, err := resource.ParseQuantity(strconv.Itoa(flavorSize.VCPUs))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
 	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", flavorSize.Memory))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}
 	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", flavorSize.Disk))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
+		return nil, fmt.Errorf("error parsing machine storage request to quantity: %w", err)
 	}
 
 	return NewResourceDetails(cpuReq, memReq, storageReq), nil

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -211,7 +211,6 @@ func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclie
 	}
 
 	// parse the KubeVirt resource requests
-	// memory is in MB and storage is given in GB
 	cpuReq, err := resource.ParseQuantity(cpu)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -1,0 +1,75 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package machine
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	awstypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/types"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8c.io/kubermatic/v2/pkg/handler/common/provider"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getAWSResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceQuota, error) {
+	// extract storage and image info from provider config
+	configVarResolver := providerconfig.NewConfigVarResolver(ctx, client)
+	rawConfig, err := awstypes.GetConfig(*config)
+	if err != nil {
+		return nil, fmt.Errorf("error getting aws raw config: %w", err)
+	}
+
+	instanceType, err := configVarResolver.GetConfigVarStringValue(rawConfig.InstanceType)
+	if err != nil {
+		return nil, fmt.Errorf("error getting AWS instance type from machine config: %v", err)
+	}
+
+	awsSize, err := provider.GetAWSInstance(instanceType)
+	if err != nil {
+		return nil, fmt.Errorf("error getting AWS instance type data: %v", err)
+	}
+
+	// parse the AWS resource requests
+	// memory and storage are given in GB
+	cpuReq, err := resource.ParseQuantity(strconv.Itoa(awsSize.VCPUs))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
+	}
+	memReq, err := resource.ParseQuantity(fmt.Sprintf("%fG", awsSize.Memory))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
+	}
+	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.DiskSize))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing machine storege request to quantity: %v", err)
+	}
+
+	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+}

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -113,7 +113,7 @@ func getGCPResourceRequirements(ctx context.Context, client ctrlruntimeclient.Cl
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
 	}
-	memReq, err := resource.ParseQuantity(fmt.Sprintf("%fM", machineSize.Memory))
+	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dM", machineSize.Memory))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
 	}
@@ -169,7 +169,7 @@ func getAzureResourceRequirements(ctx context.Context, client ctrlruntimeclient.
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %v", err)
 	}
-	memReq, err := resource.ParseQuantity(fmt.Sprintf("%fM", vmSize.MemoryInMB))
+	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dM", vmSize.MemoryInMB))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine memory request to quantity: %v", err)
 	}

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -352,12 +352,12 @@ func getOpenstackResourceRequirements(ctx context.Context, client ctrlruntimecli
 	}
 
 	// parse the Openstack resource requests
-	// memory and storage are in GB
+	// memory is in MB and storage is in GB
 	cpuReq, err := resource.ParseQuantity(strconv.Itoa(flavorSize.VCPUs))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine cpu request to quantity: %w", err)
 	}
-	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", flavorSize.Memory))
+	memReq, err := resource.ParseQuantity(fmt.Sprintf("%dM", flavorSize.Memory))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 	}

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -45,7 +45,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getAWSResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceQuota, error) {
+func getAWSResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
 	// extract storage and image info from provider config
 	configVarResolver := providerconfig.NewConfigVarResolver(ctx, client)
 	rawConfig, err := awstypes.GetConfig(*config)
@@ -78,10 +78,10 @@ func getAWSResourceRequirements(ctx context.Context, client ctrlruntimeclient.Cl
 		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
 	}
 
-	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+	return NewResourceDetails(cpuReq, memReq, storageReq), nil
 }
 
-func getGCPResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceQuota, error) {
+func getGCPResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
 	// extract storage and image info from provider config
 	configVarResolver := providerconfig.NewConfigVarResolver(ctx, client)
 	rawConfig, err := gcptypes.GetConfig(*config)
@@ -122,10 +122,10 @@ func getGCPResourceRequirements(ctx context.Context, client ctrlruntimeclient.Cl
 		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
 	}
 
-	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+	return NewResourceDetails(cpuReq, memReq, storageReq), nil
 }
 
-func getAzureResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceQuota, error) {
+func getAzureResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
 	// extract storage and image info from provider config
 	configVarResolver := providerconfig.NewConfigVarResolver(ctx, client)
 	rawConfig, err := azuretypes.GetConfig(*config)
@@ -185,10 +185,10 @@ func getAzureResourceRequirements(ctx context.Context, client ctrlruntimeclient.
 	}
 	storageReq.Add(osDiskStorageReq)
 
-	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+	return NewResourceDetails(cpuReq, memReq, storageReq), nil
 }
 
-func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceQuota, error) {
+func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
 	// extract storage and image info from provider config
 	configVarResolver := providerconfig.NewConfigVarResolver(ctx, client)
 	rawConfig, err := kubevirttypes.GetConfig(*config)
@@ -238,10 +238,10 @@ func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclie
 		storageReq.Add(secondaryStorageReq)
 	}
 
-	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+	return NewResourceDetails(cpuReq, memReq, storageReq), nil
 }
 
-func getVsphereResourceRequirements(config *types.Config) (*ResourceQuota, error) {
+func getVsphereResourceRequirements(config *types.Config) (*ResourceDetails, error) {
 	// extract storage and image info from provider config
 	rawConfig, err := vspheretypes.GetConfig(*config)
 	if err != nil {
@@ -263,10 +263,10 @@ func getVsphereResourceRequirements(config *types.Config) (*ResourceQuota, error
 		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
 	}
 
-	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+	return NewResourceDetails(cpuReq, memReq, storageReq), nil
 }
 
-func getOpenstackResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config, caBundle *certificates.CABundle) (*ResourceQuota, error) {
+func getOpenstackResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config, caBundle *certificates.CABundle) (*ResourceDetails, error) {
 	// extract storage and image info from provider config
 	configVarResolver := providerconfig.NewConfigVarResolver(ctx, client)
 	rawConfig, err := openstacktypes.GetConfig(*config)
@@ -366,5 +366,5 @@ func getOpenstackResourceRequirements(ctx context.Context, client ctrlruntimecli
 		return nil, fmt.Errorf("error parsing machine storage request to quantity: %v", err)
 	}
 
-	return NewResourceQuota(cpuReq, memReq, storageReq), nil
+	return NewResourceDetails(cpuReq, memReq, storageReq), nil
 }

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -61,7 +61,12 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 	case types.CloudProviderGoogle:
 		quotaReq, err = getGCPResourceRequirements(ctx, userClient, config)
 		if err != nil {
-			return fmt.Errorf("error getting aws quota request: %w", err)
+			return fmt.Errorf("error getting gcp quota request: %w", err)
+		}
+	case types.CloudProviderAzure:
+		quotaReq, err = getAzureResourceRequirements(ctx, userClient, config)
+		if err != nil {
+			return fmt.Errorf("error getting azure quota request: %w", err)
 		}
 	default:
 		// TODO skip for now, when all providers are added, throw error

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -51,7 +51,12 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 	case types.CloudProviderFake:
 		quotaReq, err = getFakeQuotaRequest(config)
 		if err != nil {
-			return fmt.Errorf("error getting fake quota req: %w", err)
+			return fmt.Errorf("error getting fake quota reqest: %w", err)
+		}
+	case types.CloudProviderAWS:
+		quotaReq, err = getAWSResourceRequirements(ctx, seedClient, config)
+		if err != nil {
+			return fmt.Errorf("error getting aws quota request: %w", err)
 		}
 	default:
 		// TODO skip for now, when all providers are added, throw error

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -68,6 +68,11 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 		if err != nil {
 			return fmt.Errorf("error getting azure quota request: %w", err)
 		}
+	case types.CloudProviderKubeVirt:
+		quotaReq, err = getKubeVirtResourceRequirements(ctx, userClient, config)
+		if err != nil {
+			return fmt.Errorf("error getting kubevirt quota request: %w", err)
+		}
 	default:
 		// TODO skip for now, when all providers are added, throw error
 		log.Debugf("provider %q not supported", config.CloudProvider)

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -129,7 +129,8 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 
 // TODO we should get it from the ResourceQuota CRD for the project, for now just some hardcoded values for tests.
 func getResourceQuota() (*ResourceDetails, *ResourceDetails, error) {
-	cpu, err := resource.ParseQuantity("5")
+	cpu, err := resource.ParseQuantity("50")
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
@@ -138,7 +139,7 @@ func getResourceQuota() (*ResourceDetails, *ResourceDetails, error) {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
-	mem, err := resource.ParseQuantity("5G")
+	mem, err := resource.ParseQuantity("50G")
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
@@ -147,7 +148,7 @@ func getResourceQuota() (*ResourceDetails, *ResourceDetails, error) {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
 
-	storage, err := resource.ParseQuantity("100G")
+	storage, err := resource.ParseQuantity("1000G")
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing quantity: %w", err)
 	}

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -73,6 +73,11 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 		if err != nil {
 			return fmt.Errorf("error getting kubevirt quota request: %w", err)
 		}
+	case types.CloudProviderVsphere:
+		quotaReq, err = getVsphereResourceRequirements(config)
+		if err != nil {
+			return fmt.Errorf("error getting vsphere quota request: %w", err)
+		}
 	default:
 		// TODO skip for now, when all providers are added, throw error
 		log.Debugf("provider %q not supported", config.CloudProvider)

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -32,13 +32,15 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.
-func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
+func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client,
+	machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle) error {
 	config, err := types.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -53,37 +53,37 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 	case types.CloudProviderFake:
 		quotaReq, err = getFakeQuotaRequest(config)
 		if err != nil {
-			return fmt.Errorf("error getting fake quota reqest: %w", err)
+			return fmt.Errorf("error getting fake resource requirements: %w", err)
 		}
 	case types.CloudProviderAWS:
 		quotaReq, err = getAWSResourceRequirements(ctx, userClient, config)
 		if err != nil {
-			return fmt.Errorf("error getting aws quota request: %w", err)
+			return fmt.Errorf("error getting aws resource requirements: %w", err)
 		}
 	case types.CloudProviderGoogle:
 		quotaReq, err = getGCPResourceRequirements(ctx, userClient, config)
 		if err != nil {
-			return fmt.Errorf("error getting gcp quota request: %w", err)
+			return fmt.Errorf("error getting gcp resource requirements: %w", err)
 		}
 	case types.CloudProviderAzure:
 		quotaReq, err = getAzureResourceRequirements(ctx, userClient, config)
 		if err != nil {
-			return fmt.Errorf("error getting azure quota request: %w", err)
+			return fmt.Errorf("error getting azure resource requirements: %w", err)
 		}
 	case types.CloudProviderKubeVirt:
 		quotaReq, err = getKubeVirtResourceRequirements(ctx, userClient, config)
 		if err != nil {
-			return fmt.Errorf("error getting kubevirt quota request: %w", err)
+			return fmt.Errorf("error getting kubevirt resource requirements: %w", err)
 		}
 	case types.CloudProviderVsphere:
 		quotaReq, err = getVsphereResourceRequirements(config)
 		if err != nil {
-			return fmt.Errorf("error getting vsphere quota request: %w", err)
+			return fmt.Errorf("error getting vsphere resource requirements: %w", err)
 		}
 	case types.CloudProviderOpenstack:
 		quotaReq, err = getOpenstackResourceRequirements(ctx, userClient, config, caBundle)
 		if err != nil {
-			return fmt.Errorf("error getting openstack quota request: %w", err)
+			return fmt.Errorf("error getting openstack resource requirements: %w", err)
 		}
 	default:
 		// TODO skip for now, when all providers are added, throw error

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -58,6 +58,11 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 		if err != nil {
 			return fmt.Errorf("error getting aws quota request: %w", err)
 		}
+	case types.CloudProviderGoogle:
+		quotaReq, err = getGCPResourceRequirements(ctx, userClient, config)
+		if err != nil {
+			return fmt.Errorf("error getting aws quota request: %w", err)
+		}
 	default:
 		// TODO skip for now, when all providers are added, throw error
 		log.Debugf("provider %q not supported", config.CloudProvider)

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -38,7 +38,7 @@ import (
 )
 
 // ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.
-func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
+func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
 	config, err := types.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)
@@ -54,7 +54,7 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlr
 			return fmt.Errorf("error getting fake quota reqest: %w", err)
 		}
 	case types.CloudProviderAWS:
-		quotaReq, err = getAWSResourceRequirements(ctx, seedClient, config)
+		quotaReq, err = getAWSResourceRequirements(ctx, userClient, config)
 		if err != nil {
 			return fmt.Errorf("error getting aws quota request: %w", err)
 		}

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -80,6 +80,11 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 		if err != nil {
 			return fmt.Errorf("error getting vsphere quota request: %w", err)
 		}
+	case types.CloudProviderOpenstack:
+		quotaReq, err = getOpenstackResourceRequirements(ctx, userClient, config, caBundle)
+		if err != nil {
+			return fmt.Errorf("error getting openstack quota request: %w", err)
+		}
 	default:
 		// TODO skip for now, when all providers are added, throw error
 		log.Debugf("provider %q not supported", config.CloudProvider)

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -50,17 +50,17 @@ func TestResourceQuotaValidation(t *testing.T) {
 		},
 		{
 			name:        "should fail with CPU quota exceeded",
-			machine:     genFakeMachine("5", "2G", "10G"),
+			machine:     genFakeMachine("50", "2G", "10G"),
 			expectedErr: true,
 		},
 		{
 			name:        "should fail with Memory quota exceeded",
-			machine:     genFakeMachine("2", "5G", "10G"),
+			machine:     genFakeMachine("2", "50G", "10G"),
 			expectedErr: true,
 		},
 		{
 			name:        "should fail with Storage quota exceeded",
-			machine:     genFakeMachine("2", "2G", "50G"),
+			machine:     genFakeMachine("2", "2G", "5000G"),
 			expectedErr: true,
 		},
 	}

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -67,7 +67,7 @@ func TestResourceQuotaValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := machine.ValidateQuota(context.Background(), l, nil, tc.machine)
+			err := machine.ValidateQuota(context.Background(), l, nil, nil, tc.machine, nil)
 			if err != nil {
 				if !tc.expectedErr {
 					t.Fatalf("unexpected error: %v", err)

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -232,7 +232,8 @@ func AWSSizes(region, architecture string, quota kubermaticv1.MachineDeploymentV
 	}
 
 	sizes := apiv1.AWSSizeList{}
-	for _, i := range *data {
+	for a, i := range *data {
+		fmt.Println(fmt.Sprintf("%d type: %s, CPU: %d, MEM: %f", a, i.InstanceType, i.VCPU, i.Memory))
 		pricing, ok := i.Pricing[region]
 		if !ok {
 			continue
@@ -319,4 +320,21 @@ type AWSCredential struct {
 	SecretAccessKey      string
 	AssumeRoleARN        string
 	AssumeRoleExternalID string
+}
+
+func GetAWSInstance(instanceType string) (*apiv1.AWSSize, error) {
+	if data == nil {
+		return nil, fmt.Errorf("AWS instance type data not initialized")
+	}
+
+	for _, i := range *data {
+		if strings.EqualFold(i.InstanceType, instanceType) {
+			return &apiv1.AWSSize{
+				Memory: i.Memory,
+				VCPUs:  i.VCPU,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find instance %q in aws instance type data", instanceType)
 }

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -232,8 +232,7 @@ func AWSSizes(region, architecture string, quota kubermaticv1.MachineDeploymentV
 	}
 
 	sizes := apiv1.AWSSizeList{}
-	for a, i := range *data {
-		fmt.Println(fmt.Sprintf("%d type: %s, CPU: %d, MEM: %f", a, i.InstanceType, i.VCPU, i.Memory))
+	for _, i := range *data {
 		pricing, ok := i.Pricing[region]
 		if !ok {
 			continue

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -327,6 +328,24 @@ func ListGCPSizes(ctx context.Context, quota kubermaticv1.MachineDeploymentVMRes
 	})
 
 	return filterGCPByQuota(sizes, quota), err
+}
+
+func GetGCPInstanceSize(ctx context.Context, machineType, sa, zone string) (*apiv1.GCPMachineSize, error) {
+	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)
+	if err != nil {
+		return nil, err
+	}
+
+	req := computeService.MachineTypes.Get(project, zone, machineType)
+	m, err := req.Do()
+	if err != nil {
+		return nil, fmt.Errorf("error getting GCP Instance Size: %w", err)
+	}
+
+	return &apiv1.GCPMachineSize{
+		Memory: m.MemoryMb,
+		VCPUs:  m.GuestCpus,
+	}, nil
 }
 
 func filterGCPByQuota(instances apiv1.GCPMachineSizeList, quota kubermaticv1.MachineDeploymentVMResourceQuota) apiv1.GCPMachineSizeList {

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -302,7 +302,6 @@ func GetOpenstackSizes(credentials *resources.OpenstackCredentials, datacenter *
 
 func GetOpenStackFlavorSize(credentials *resources.OpenstackCredentials, authURL, region string,
 	caBundle *x509.CertPool, flavorName string) (*apiv1.OpenstackSize, error) {
-
 	flavors, err := openstack.GetFlavors(authURL, region, credentials, caBundle)
 	if err != nil {
 		return nil, err

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-user-cluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-user-cluster-webhook-externalCloudProvider.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-user-cluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-user-cluster-webhook-externalCloudProvider.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-user-cluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-user-cluster-webhook-externalCloudProvider.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-user-cluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-user-cluster-webhook-externalCloudProvider.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-user-cluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-user-cluster-webhook-externalCloudProvider.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-user-cluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-user-cluster-webhook-externalCloudProvider.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-user-cluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-user-cluster-webhook.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       containers:
       - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - -webhook-cert-dir=/opt/webhook-serving-cert/
         - -webhook-cert-name=serving.crt
         - -webhook-key-name=serving.key
+        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
         - -v=2
         command:
         - user-cluster-webhook
@@ -55,6 +58,12 @@ spec:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
           readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /opt/ca-bundle/
+          name: ca-bundle
+          readOnly: true
       imagePullSecrets:
       - name: dockercfg
       serviceAccountName: user-cluster-webhook
@@ -62,4 +71,10 @@ spec:
       - name: webhook-serving-cert
         secret:
           secretName: user-cluster-webhook-serving-cert
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
 status: {}

--- a/pkg/resources/user-cluster-webhook/deployment.go
+++ b/pkg/resources/user-cluster-webhook/deployment.go
@@ -80,6 +80,7 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 				"-webhook-cert-dir=/opt/webhook-serving-cert/",
 				fmt.Sprintf("-webhook-cert-name=%s", resources.ServingCertSecretKey),
 				fmt.Sprintf("-webhook-key-name=%s", resources.ServingCertKeySecretKey),
+				fmt.Sprintf("-ca-bundle=/opt/ca-bundle/%s", resources.CABundleConfigMapKey),
 			}
 
 			if data.Cluster().Spec.DebugLog {
@@ -105,6 +106,16 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 						},
 					},
 				},
+				{
+					Name: "ca-bundle",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: resources.CABundleConfigMapName,
+							},
+						},
+					},
+				},
 			}
 
 			volumeMounts := []corev1.VolumeMount{
@@ -116,6 +127,11 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 				{
 					Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
 					MountPath: "/etc/kubernetes/kubeconfig",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "ca-bundle",
+					MountPath: "/opt/ca-bundle/",
 					ReadOnly:  true,
 				},
 			}

--- a/pkg/resources/user-cluster-webhook/deployment.go
+++ b/pkg/resources/user-cluster-webhook/deployment.go
@@ -76,6 +76,7 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 			}
 
 			args := []string{
+				"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 				"-webhook-cert-dir=/opt/webhook-serving-cert/",
 				fmt.Sprintf("-webhook-cert-name=%s", resources.ServingCertSecretKey),
 				fmt.Sprintf("-webhook-key-name=%s", resources.ServingCertKeySecretKey),
@@ -96,12 +97,25 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 						},
 					},
 				},
+				{
+					Name: resources.InternalUserClusterAdminKubeconfigSecretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
+						},
+					},
+				},
 			}
 
 			volumeMounts := []corev1.VolumeMount{
 				{
 					Name:      "webhook-serving-cert",
 					MountPath: "/opt/webhook-serving-cert/",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
+					MountPath: "/etc/kubernetes/kubeconfig",
 					ReadOnly:  true,
 				},
 			}

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,14 +35,16 @@ type validator struct {
 	log        *zap.SugaredLogger
 	seedClient ctrlruntimeclient.Client
 	userClient ctrlruntimeclient.Client
+	caBundle   *certificates.CABundle
 }
 
 // NewValidator returns a new Machine validator.
-func NewValidator(seedClient, userClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *validator {
+func NewValidator(seedClient, userClient ctrlruntimeclient.Client, log *zap.SugaredLogger, caBundle *certificates.CABundle) *validator {
 	return &validator{
 		log:        log,
 		seedClient: seedClient,
 		userClient: userClient,
+		caBundle:   caBundle,
 	}
 }
 
@@ -56,7 +59,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) erro
 	log := v.log.With("machine", machine.Name)
 	log.Debug("validating create")
 
-	return validateQuota(ctx, log, v.seedClient, v.userClient, machine)
+	return validateQuota(ctx, log, v.seedClient, v.userClient, machine, v.caBundle)
 }
 
 // ValidateUpdate validates Machine updates. As mutating Machine spec is disallowed by the Machine Mutating webhook,

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -78,7 +78,7 @@ func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) error {
 
 // Gets resource quota for the project. Not implemented yet because the ResourceQuota CRD is not implemented.
 // For now this just stops resource quota check, as there are no resource quotas.
-// TODO implement when ResourceQuota CRD is available
+// TODO implement when ResourceQuota CRD is available.
 func getResourceQuota() runtime.Object {
 	return nil
 }

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -33,13 +33,15 @@ import (
 type validator struct {
 	log        *zap.SugaredLogger
 	seedClient ctrlruntimeclient.Client
+	userClient ctrlruntimeclient.Client
 }
 
 // NewValidator returns a new Machine validator.
-func NewValidator(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *validator {
+func NewValidator(seedClient, userClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *validator {
 	return &validator{
 		log:        log,
 		seedClient: seedClient,
+		userClient: userClient,
 	}
 }
 
@@ -54,7 +56,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) erro
 	log := v.log.With("machine", machine.Name)
 	log.Debug("validating create")
 
-	return validateQuota(ctx, log, v.seedClient, machine)
+	return validateQuota(ctx, log, v.seedClient, v.userClient, machine)
 }
 
 // ValidateUpdate validates Machine updates. As mutating Machine spec is disallowed by the Machine Mutating webhook,

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -59,7 +59,11 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) erro
 	log := v.log.With("machine", machine.Name)
 	log.Debug("validating create")
 
-	return validateQuota(ctx, log, v.seedClient, v.userClient, machine, v.caBundle)
+	quota := getResourceQuota()
+	if quota != nil {
+		return validateQuota(ctx, log, v.seedClient, v.userClient, machine, v.caBundle)
+	}
+	return nil
 }
 
 // ValidateUpdate validates Machine updates. As mutating Machine spec is disallowed by the Machine Mutating webhook,
@@ -69,5 +73,12 @@ func (v *validator) ValidateUpdate(_ context.Context, _, _ runtime.Object) error
 }
 
 func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+// Gets resource quota for the project. Not implemented yet because the ResourceQuota CRD is not implemented.
+// For now this just stops resource quota check, as there are no resource quotas.
+// TODO implement when ResourceQuota CRD is available
+func getResourceQuota() runtime.Object {
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -29,6 +29,6 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(_ context.Context, _ *zap.SugaredLogger, _, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine,_ *certificates.CABundle) error {
+func validateQuota(_ context.Context, _ *zap.SugaredLogger, _, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine, _ *certificates.CABundle) error {
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -28,6 +28,6 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine) error {
+func validateQuota(_ context.Context, _ *zap.SugaredLogger, _, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine) error {
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -24,10 +24,11 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(_ context.Context, _ *zap.SugaredLogger, _, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine) error {
+func validateQuota(_ context.Context, _ *zap.SugaredLogger, _, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine,_ *certificates.CABundle) error {
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -29,6 +29,6 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
-	return eemachinevalidation.ValidateQuota(ctx, log, seedClient, machine)
+func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
+	return eemachinevalidation.ValidateQuota(ctx, log, seedClient, userClient, machine)
 }

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -25,10 +25,12 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
-	return eemachinevalidation.ValidateQuota(ctx, log, seedClient, userClient, machine)
+func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client,
+	machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle) error {
+	return eemachinevalidation.ValidateQuota(ctx, log, seedClient, userClient, machine, caBundle)
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
adds logic for getting providers(AWS, GCP, Azure, KubeVirt, vSphere, Openstack) machine resource details to the resource quota machine webhook.

For now getting the ResourceQuota for the project is still hardcoded (because ResourceQuota is not implemented yet), so the resource calculation is skipped until the full implementation.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9626

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
