### PR TITLE
Including "machine deployment count" to list cluster v2 route

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -9885,7 +9885,7 @@
         "tags": [
           "project"
         ],
-        "summary": "Lists clusters for the specified project.",
+        "summary": "Lists clusters for the specified project. If query parameter `show_dm_count` is set to `true` then the endpoint will also return the number of machine deployments of each cluster.",
         "operationId": "listClustersV2",
         "parameters": [
           {
@@ -9894,6 +9894,12 @@
             "name": "project_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "x-go-name": "ShowDeploymentMachineCount",
+            "name": "show_dm_count",
+            "in": "query"
           }
         ],
         "responses": {
@@ -21645,6 +21651,11 @@
             "type": "string"
           },
           "x-go-name": "Labels"
+        },
+        "machine_deployment_count": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "MachineDeploymentCount"
         },
         "name": {
           "description": "Name represents human readable name for the resource",

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -21652,7 +21652,7 @@
           },
           "x-go-name": "Labels"
         },
-        "machine_deployment_count": {
+        "machineDeploymentCount": {
           "type": "integer",
           "format": "int64",
           "x-go-name": "MachineDeploymentCount"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -823,10 +823,11 @@ type Cluster struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 	InheritedLabels map[string]string `json:"inheritedLabels,omitempty"`
 	// Type is deprecated and not used anymore.
-	Type       string        `json:"type"`
-	Credential string        `json:"credential,omitempty"`
-	Spec       ClusterSpec   `json:"spec"`
-	Status     ClusterStatus `json:"status"`
+	Type                   string        `json:"type"`
+	Credential             string        `json:"credential,omitempty"`
+	Spec                   ClusterSpec   `json:"spec"`
+	Status                 ClusterStatus `json:"status"`
+	MachineDeploymentCount *int          `json:"machine_deployment_count,omitempty"`
 }
 
 // ClusterSpec defines the cluster specification.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -827,7 +827,7 @@ type Cluster struct {
 	Credential             string        `json:"credential,omitempty"`
 	Spec                   ClusterSpec   `json:"spec"`
 	Status                 ClusterStatus `json:"status"`
-	MachineDeploymentCount *int          `json:"machine_deployment_count,omitempty"`
+	MachineDeploymentCount *int          `json:"machineDeploymentCount,omitempty"`
 }
 
 // ClusterSpec defines the cluster specification.

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"go.uber.org/zap"
 
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -93,7 +93,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(ListReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
-		apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, configGetter)
+		apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, configGetter, false)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -126,7 +126,7 @@ func ListAllEndpoint(
 				kubermaticlog.Logger.Errorw("failed to create cluster provider", "seed", seed.Name, zap.Error(err))
 				continue
 			}
-			apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, configGetter)
+			apiClusters, err := handlercommon.GetClusters(ctx, userInfoGetter, clusterProvider, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, configGetter, false)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}

--- a/pkg/handler/v1/common/request.go
+++ b/pkg/handler/v1/common/request.go
@@ -55,7 +55,7 @@ type ProjectIDGetter interface {
 }
 
 // GetProjectRq defines HTTP request for getProject endpoint
-// swagger:parameters getProject getUsersForProject listClustersForProject listServiceAccounts listClustersV2
+// swagger:parameters getProject getUsersForProject listClustersForProject listServiceAccounts
 type GetProjectRq struct {
 	ProjectReq
 }

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -970,7 +970,7 @@ func (r Routing) createCluster() http.Handler {
 
 // swagger:route GET /api/v2/projects/{project_id}/clusters project listClustersV2
 //
-//     Lists clusters for the specified project.
+//     Lists clusters for the specified project. If query parameter `show_dm_count` is set to `true` then the endpoint will also return the number of machine deployments of each cluster.
 //
 //     Produces:
 //     - application/json
@@ -986,7 +986,7 @@ func (r Routing) listClusters() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
 		)(cluster.ListEndpoint(r.projectProvider, r.privilegedProjectProvider, r.seedsGetter, r.clusterProviderGetter, r.userInfoGetter, r.kubermaticConfigGetter)),
-		common.DecodeGetProject,
+		cluster.DecodeListClustersReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/pkg/test/e2e/utils/apiclient/client/project/list_clusters_v2_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/project/list_clusters_v2_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewListClustersV2Params creates a new ListClustersV2Params object,
@@ -61,6 +62,9 @@ type ListClustersV2Params struct {
 
 	// ProjectID.
 	ProjectID string
+
+	// ShowDmCount.
+	ShowDeploymentMachineCount *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -126,6 +130,17 @@ func (o *ListClustersV2Params) SetProjectID(projectID string) {
 	o.ProjectID = projectID
 }
 
+// WithShowDeploymentMachineCount adds the showDmCount to the list clusters v2 params
+func (o *ListClustersV2Params) WithShowDeploymentMachineCount(showDmCount *bool) *ListClustersV2Params {
+	o.SetShowDeploymentMachineCount(showDmCount)
+	return o
+}
+
+// SetShowDeploymentMachineCount adds the showDmCount to the list clusters v2 params
+func (o *ListClustersV2Params) SetShowDeploymentMachineCount(showDmCount *bool) {
+	o.ShowDeploymentMachineCount = showDmCount
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListClustersV2Params) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -137,6 +152,23 @@ func (o *ListClustersV2Params) WriteToRequest(r runtime.ClientRequest, reg strfm
 	// path param project_id
 	if err := r.SetPathParam("project_id", o.ProjectID); err != nil {
 		return err
+	}
+
+	if o.ShowDeploymentMachineCount != nil {
+
+		// query param show_dm_count
+		var qrShowDmCount bool
+
+		if o.ShowDeploymentMachineCount != nil {
+			qrShowDmCount = *o.ShowDeploymentMachineCount
+		}
+		qShowDmCount := swag.FormatBool(qrShowDmCount)
+		if qShowDmCount != "" {
+
+			if err := r.SetQueryParam("show_dm_count", qShowDmCount); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/pkg/test/e2e/utils/apiclient/client/project/project_client.go
+++ b/pkg/test/e2e/utils/apiclient/client/project/project_client.go
@@ -3426,7 +3426,7 @@ func (a *Client) ListClustersForProject(params *ListClustersForProjectParams, au
 }
 
 /*
-  ListClustersV2 lists clusters for the specified project
+  ListClustersV2 lists clusters for the specified project if query parameter show dm count is set to true then the endpoint will also return the number of machine deployments of each cluster
 */
 func (a *Client) ListClustersV2(params *ListClustersV2Params, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListClustersV2OK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/test/e2e/utils/apiclient/models/cluster.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster.go
@@ -47,7 +47,7 @@ type Cluster struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// machine deployment count
-	MachineDeploymentCount int64 `json:"machine_deployment_count,omitempty"`
+	MachineDeploymentCount int64 `json:"machineDeploymentCount,omitempty"`
 
 	// Name represents human readable name for the resource
 	Name string `json:"name,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/cluster.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster.go
@@ -46,6 +46,9 @@ type Cluster struct {
 	// labels
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// machine deployment count
+	MachineDeploymentCount int64 `json:"machine_deployment_count,omitempty"`
+
 	// Name represents human readable name for the resource
 	Name string `json:"name,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Hugo Bernardo <hugo@kubermatic.com>

**What does this PR do / Why do we need it**:
Returns the machine deployment count for each cluster in the GET route `/api/v2/projects/{project_id}/clusters`.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9639

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
