### PR TITLE
Enable leader election for kubermatic-operator chart by default

### DIFF
--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
         - -log-debug=true
         - -v=8
         {{- end }}
+        {{- if .Values.kubermaticOperator.leaderElection }}
+        - -enable-leader-election
+        {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/charts/kubermatic-operator/values.yaml
+++ b/charts/kubermatic-operator/values.yaml
@@ -25,6 +25,7 @@ kubermaticOperator:
     }
 
   debug: false
+  leaderElection: true
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
For your consideration. We discussed this recently and wondered if the operator does leader elections - Turns out, it does, just not by default. In my opinion, we should enable this, to prevent situations where two operators from different versions are working against each other.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubermatic-operator is deployed with leader election by default, can be disabled from Chart values
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
