### PR TITLE
fix cluster mutating with none Cni

### DIFF
--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -195,45 +195,44 @@ func (h *AdmissionHandler) mutateUpdate(oldCluster, newCluster *kubermaticv1.Clu
 		curVersion = newCluster.Spec.Version
 	}
 
-	// This part handles CNI upgrade from unsupported CNI version to the default Canal version.
-	// This upgrade is necessary for k8s versions >= 1.22, where v1beta1 CRDs used in old Canal version (v3.8)
-	// are not supported anymore.
-	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal &&
-		newCluster.Spec.CNIPlugin.Version == cni.CanalCNILastUnspecifiedVersion {
-		upgradeConstraint, err := semver.NewConstraint(">= 1.22")
-		if err != nil {
-			return fmt.Errorf("parsing CNI upgrade constraint failed: %w", err)
+	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal {
+		// This part handles CNI upgrade from unsupported CNI version to the default Canal version.
+		// This upgrade is necessary for k8s versions >= 1.22, where v1beta1 CRDs used in old Canal version (v3.8)
+		// are not supported anymore.
+		if newCluster.Spec.CNIPlugin.Version == cni.CanalCNILastUnspecifiedVersion {
+			upgradeConstraint, err := semver.NewConstraint(">= 1.22")
+			if err != nil {
+				return fmt.Errorf("parsing CNI upgrade constraint failed: %w", err)
+			}
+			if curVersion.String() != "" && upgradeConstraint.Check(curVersion.Semver()) {
+				newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
+					Type:    kubermaticv1.CNIPluginTypeCanal,
+					Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
+				}
+			}
 		}
-		if curVersion.String() != "" && upgradeConstraint.Check(curVersion.Semver()) {
+
+		// This part handles Canal version upgrade for clusters with Kubernetes version 1.23 and higher,
+		// where the minimal Canal version is v3.22.
+		cniVersion, err := semver.NewVersion(newCluster.Spec.CNIPlugin.Version)
+		if err != nil {
+			return fmt.Errorf("CNI plugin version parsing failed: %w", err)
+		}
+		lowerThan322, err := semver.NewConstraint("< 3.22")
+		if err != nil {
+			return fmt.Errorf("semver constraint parsing failed: %w", err)
+		}
+		equalOrHigherThan123, err := semver.NewConstraint(">= 1.23")
+		if err != nil {
+			return fmt.Errorf("semver constraint parsing failed: %w", err)
+		}
+		if lowerThan322.Check(cniVersion) && curVersion.String() != "" && equalOrHigherThan123.Check(curVersion.Semver()) {
 			newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
 				Type:    kubermaticv1.CNIPluginTypeCanal,
-				Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
+				Version: "v3.22",
 			}
 		}
 	}
-
-	// This part handles Canal version upgrade for clusters with Kubernetes version 1.23 and higher,
-	// where the minimal Canal version is v3.22.
-	cniVersion, err := semver.NewVersion(newCluster.Spec.CNIPlugin.Version)
-	if err != nil {
-		return fmt.Errorf("CNI plugin version parsing failed: %w", err)
-	}
-	lowerThan322, err := semver.NewConstraint("< 3.22")
-	if err != nil {
-		return fmt.Errorf("semver constraint parsing failed: %w", err)
-	}
-	equalOrHigherThan123, err := semver.NewConstraint(">= 1.23")
-	if err != nil {
-		return fmt.Errorf("semver constraint parsing failed: %w", err)
-	}
-	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal && lowerThan322.Check(cniVersion) &&
-		curVersion.String() != "" && equalOrHigherThan123.Check(curVersion.Semver()) {
-		newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
-			Type:    kubermaticv1.CNIPluginTypeCanal,
-			Version: "v3.22",
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -1155,6 +1155,52 @@ func TestHandle(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(defaultPatches, defaultNetworkingPatchesIptablesProxyMode...),
 		},
+		{
+			name: "Update cluster with CNI none",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{
+							Name: "foo",
+							CloudSpec: kubermaticv1.CloudSpec{
+								ProviderName:   string(kubermaticv1.HetznerCloudProvider),
+								DatacenterName: "hetzner-dc",
+								Hetzner:        &kubermaticv1.HetznerCloudSpec{},
+							},
+							ExternalCloudProvider: true,
+							CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
+								Type:    kubermaticv1.CNIPluginTypeNone,
+								Version: "",
+							},
+						}.Do(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw: rawClusterGen{
+							Name: "foo",
+							CloudSpec: kubermaticv1.CloudSpec{
+								ProviderName:   string(kubermaticv1.HetznerCloudProvider),
+								DatacenterName: "hetzner-dc",
+								Hetzner:        &kubermaticv1.HetznerCloudSpec{},
+							},
+							ExternalCloudProvider: false,
+							CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
+								Type:    kubermaticv1.CNIPluginTypeNone,
+								Version: "",
+							},
+						}.Do(),
+					},
+				},
+			},
+			wantAllowed: true,
+			wantPatches: append(defaultPatches, defaultNetworkingPatchesIptablesProxyMode...),
+		},
 	}
 	for _, tt := range tests {
 		d, err := admission.NewDecoder(testScheme)


### PR DESCRIPTION
The mutating validation was failing with the error "CNI plugin version parsing failed" because we parse the CNI version to check Canal CNI upgrade. But with None CNI the version is empty.


**What does this PR do / Why do we need it**:

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:


**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Mutating webhook for None CNI
```
