### PR TITLE
update telemetry to 0.2.0

### DIFF
--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 name: telemetry
 description: A Helm chart to install Kubermatic telemetry agents
 version: v9.9.9-dev
-appVersion: v0.1.0
+appVersion: v0.2.0
 keywords:
   - telemetry
 maintainers:

--- a/charts/telemetry/templates/cronjob.yaml
+++ b/charts/telemetry/templates/cronjob.yaml
@@ -31,6 +31,8 @@ spec:
             - name: kubernetes-agent
               image: "{{ .Values.telemetry.kubernetesAgent.image.repository }}:{{ .Values.telemetry.kubernetesAgent.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.telemetry.kubernetesAgent.image.pullPolicy }}
+              command:
+                - kubernetes-agent
               args:
                 - "--record-dir=$(RECORD_DIR)"
               env:
@@ -44,6 +46,8 @@ spec:
             - name: kubermatic-agent
               image: "{{ .Values.telemetry.kubermaticAgent.image.repository }}:{{ .Values.telemetry.kubermaticAgent.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.telemetry.kubermaticAgent.image.pullPolicy }}
+              command:
+                - kubermatic-agent
               args:
                 - "--record-dir=$(RECORD_DIR)"
               env:
@@ -58,6 +62,8 @@ spec:
             - name: reporter
               image: "{{ .Values.telemetry.reporter.image.repository }}:{{ .Values.telemetry.reporter.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.telemetry.reporter.image.pullPolicy }}
+              command:
+                - reporter
               args:
                 - "http"
                 - "--client-uuid=$(CLIENT_UUID)"

--- a/charts/telemetry/templates/kubermatic-role.yaml
+++ b/charts/telemetry/templates/kubermatic-role.yaml
@@ -18,20 +18,19 @@ metadata:
   name: {{ .Release.Name }}-kubermatic-agent-role
 rules:
 - apiGroups:
-  - kubermatic.k8c.io
-  resources:
-  - seeds
-  - clusters
-  - users
-  - projects
-  - usersshkeies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - secrets
   verbs:
   - get
+- apiGroups:
+  - kubermatic.k8c.io
+  resources:
+  - clusters
+  - kubermaticconfigurations
+  - projects
+  - seeds
+  - users
+  - usersshkeys
+  verbs:
+  - list

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -22,21 +22,18 @@ telemetry:
 
   kubermaticAgent:
     image:
-      repository: quay.io/kubermatic/telemetry-kubermatic-agent
-      pullPolicy: Always
-      tag: "v0.1.0"
+      repository: quay.io/kubermatic/telemetry-agent
+      tag: "v0.2.0"
 
   kubernetesAgent:
     image:
-      repository: quay.io/kubermatic/telemetry-kubernetes-agent
-      pullPolicy: Always
-      tag: "v0.1.0"
+      repository: quay.io/kubermatic/telemetry-agent
+      tag: "v0.2.0"
 
   reporter:
     image:
-      repository: quay.io/kubermatic/telemetry-reporter
-      pullPolicy: Always
-      tag: "v0.1.0"
+      repository: quay.io/kubermatic/telemetry-agent
+      tag: "v0.2.0"
 
   resources:
     limits:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
v0.1.0 of our telemetry-client is not compatible with KKP 2.20. We forgot to take care of that during the CRD migraiton.

I since then refactored a huuuuge chunk of the telemetry-client and released v0.2.0, which fixes the compatibility. This PR here updates the chart in KKP and needs to be backported to release/v2.20.

**Does this PR introduce a user-facing change?**:
```release-note
Fix telemetry CronJob not producing data
```
