### PR TITLE
Add e2e Tests for Telemetry

### DIFF
--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 name: telemetry
 description: A Helm chart to install Kubermatic telemetry agents
 version: v9.9.9-dev
-appVersion: v0.2.0
+appVersion: v0.2.2
 keywords:
   - telemetry
 maintainers:

--- a/charts/telemetry/templates/cronjob.yaml
+++ b/charts/telemetry/templates/cronjob.yaml
@@ -16,9 +16,9 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-job
-  namespace:  {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  schedule:  {{ .Values.telemetry.schedule }}
+  schedule: {{ .Values.telemetry.schedule | quote }}
   jobTemplate:
     spec:
       template:

--- a/charts/telemetry/templates/cronjob.yaml
+++ b/charts/telemetry/templates/cronjob.yaml
@@ -65,15 +65,12 @@ spec:
               command:
                 - reporter
               args:
-                - "http"
-                - "--client-uuid=$(CLIENT_UUID)"
-                - "--url=$(URL)"
-                - "--record-dir=$(RECORD_DIR)"
+                {{- toYaml .Values.telemetry.reporterArgs | nindent 16 }}
               env:
                 - name: RECORD_DIR
                   value: "/records"
                 - name: URL
-                  value: "https://telemetry.k8c.io/api/v1"
+                  value: {{ .Values.telemetry.targetURL | quote }}
                 - name: CLIENT_UUID
                   valueFrom:
                     secretKeyRef:

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -42,3 +42,13 @@ telemetry:
     requests:
       cpu: "0.5"
       memory: 100Mi
+
+  # the URL telemetry reports are sent to
+  targetURL: https://telemetry.k8c.io/api/v1
+
+  # arguments for the reporter container
+  reporterArgs:
+    - http
+    - --client-uuid=$(CLIENT_UUID)
+    - --url=$(URL)
+    - --record-dir=$(RECORD_DIR)

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -23,17 +23,17 @@ telemetry:
   kubermaticAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.2.0"
+      tag: "v0.2.2"
 
   kubernetesAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.2.0"
+      tag: "v0.2.2"
 
   reporter:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.2.0"
+      tag: "v0.2.2"
 
   resources:
     limits:

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -543,6 +543,15 @@ func (r *TestRunner) testCluster(
 		log.Errorf("failed to verify security context for control plane pods: %v", err)
 	}
 
+	// Check telemetry is working
+	if err := util.JUnitWrapper("[KKP] Test telemetry", report, func() error {
+		return util.RetryN(maxTestAttempts, func(attempt int) error {
+			return tests.TestTelemetry(ctx, log, r.opts)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify telemetry is working: %v", err)
+	}
+
 	log.Info("All tests completed.")
 
 	return nil

--- a/cmd/conformance-tester/pkg/tests/telemetry.go
+++ b/cmd/conformance-tester/pkg/tests/telemetry.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"go.uber.org/zap"
+
+	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
+	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type telemetryReport struct {
+	Version string `json:"version"`
+	Records []struct {
+		Kind string `json:"kind"`
+	} `json:"records"`
+}
+
+// TestTelemetry checks if there are telemetry pods available and
+// gets the logs from the most recent one, assuming that it output
+// a big JSON document with KKP and k8s statistics.
+func TestTelemetry(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options) error {
+	log.Info("Testing telemetry availability...")
+
+	pod, err := getLatestTelemetryPod(ctx, opts.SeedClusterClient, kubermaticmaster.TelemetryNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to determine latest completed telemetry Pod: %w", err)
+	}
+	if pod == nil {
+		return errors.New("no completed telemetry Pod found (either telemetry was not installed or no Pod completed successfully)")
+	}
+
+	output, err := getContainerLogs(ctx, opts.SeedGeneratedClient, pod.Namespace, pod.Name, "reporter")
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Pod logs: %w", err)
+	}
+
+	report := telemetryReport{}
+	if err := json.Unmarshal([]byte(output), &report); err != nil {
+		return fmt.Errorf("Pod did not output valid JSON, but %q: %w", output, err)
+	}
+
+	if report.Version == "" {
+		return fmt.Errorf("telemetry output does not contain a version: %q", output)
+	}
+
+	hasKKP := false
+	hasK8s := false
+
+	for _, record := range report.Records {
+		switch record.Kind {
+		case "kubermatic":
+			hasKKP = true
+		case "kubernetes":
+			hasK8s = true
+		}
+	}
+
+	if !hasKKP || !hasK8s {
+		return fmt.Errorf("telemetry output does not contain both kubermatic and kubernetes records; kubermatic=%v, kubernetes=%v", hasKKP, hasK8s)
+	}
+
+	log.Info("Successfully validated telemetry.")
+	return nil
+}
+
+func getLatestTelemetryPod(ctx context.Context, client ctrlruntimeclient.Client, namespace string) (*corev1.Pod, error) {
+	podList := corev1.PodList{}
+	if err := client.List(ctx, &podList, ctrlruntimeclient.MatchingLabels{"control-plane": "telemetry"}); err != nil {
+		return nil, err
+	}
+
+	var (
+		latest    time.Time
+		latestPod *corev1.Pod
+	)
+
+	for i, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodSucceeded && pod.CreationTimestamp.Time.After(latest) {
+			latestPod = &podList.Items[i]
+			latest = pod.CreationTimestamp.Time
+		}
+	}
+
+	return latestPod, nil
+}
+
+func getContainerLogs(ctx context.Context, client kubernetes.Interface, namespace, name, containerName string) (string, error) {
+	readCloser, err := client.
+		CoreV1().
+		Pods(namespace).
+		GetLogs(name, &corev1.PodLogOptions{Container: containerName}).
+		Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer readCloser.Close()
+
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, readCloser); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -157,6 +157,21 @@ minio:
 nginx:
   controller:
     replicaCount: 1
+
+telemetry:
+  # this is a meaningless, random UUID; we use a static one to,
+  # if we ever had to, easily filter its data out of any data collector
+  uuid: "559a1b90-b5d0-40aa-a74d-bd9e808ec10f"
+
+  # ensure that we create at least one report
+  schedule: "* * * * *"
+
+  # instead of sending the data anywhere, we just print it to stdout
+  # and later check if telemetry pods exist and if they output something
+  reporterArgs:
+    - stdout
+    - --client-uuid=$(CLIENT_UUID)
+    - --record-dir=$(RECORD_DIR)
 EOF
 
 # append custom Dex configuration
@@ -166,7 +181,7 @@ cat hack/ci/testdata/oauth_values.yaml >> $HELM_VALUES_FILE
 copy_crds_to_chart
 
 # install dependencies and Kubermatic Operator into cluster
-./_build/kubermatic-installer deploy kubermatic-master --disable-telemetry \
+./_build/kubermatic-installer deploy kubermatic-master \
   --storageclass copy-default \
   --config "$KUBERMATIC_CONFIG" \
   --helm-values "$HELM_VALUES_FILE"

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -170,8 +170,8 @@ telemetry:
   # and later check if telemetry pods exist and if they output something
   reporterArgs:
     - stdout
-    - --client-uuid=$(CLIENT_UUID)
-    - --record-dir=$(RECORD_DIR)
+    - --client-uuid=\$(CLIENT_UUID)
+    - --record-dir=\$(RECORD_DIR)
 EOF
 
 # append custom Dex configuration


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
After we noticed that KKP 2.20-2.20.2 shipped a broken telemetry client, we should add an e2e test to ensure the telemetry is working. This is what this PR does.

We now install telemetry and configure the reporter to output data on stdout. This is simpler than creating a server and/or deployment the telemetry receiver into the cluster as well (because then we need to check how to get the data out of the receiver, which itself also only has stdout or bigquery endpoints).

The telemetry tests happen during all regular e2e tests and are very fast to validate (just check if the pod exists and get its logs). The data collection happens during the cluster setup, so it won't slow down the tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
