### PR TITLE
Make sure that kubelet-configmap(s) are up-to-date after updating KKP

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -362,6 +362,8 @@ spec:
           kind: Addon
           metadata:
             name: kubelet-configmap
+            labels:
+              addons.kubermatic.io/ensure: true
         - apiVersion: kubermatic.k8c.io/v1
           kind: Addon
           metadata:

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -890,6 +890,8 @@ items:
   kind: Addon
   metadata:
     name: kubelet-configmap
+    labels:
+      addons.kubermatic.io/ensure: true
 - apiVersion: kubermatic.k8c.io/v1
   kind: Addon
   metadata:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The fix prevent the case of missing new kubelet-configmap(s) after KKP upgrade (meaning new k8s versions as well)

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make sure that kubelet-configmap(s) are up-to-date after updating KKP
```
