### PR TITLE
make cluster name a valid rfc1035 label

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -156,6 +156,12 @@ func CreateEndpoint(
 	return ConvertInternalClusterToExternal(newCluster, dc, true, supportManager.GetIncompatibilities()...), nil
 }
 
+func makeClusterName() string {
+	alpha := "abcdefghijklmnopqrstuvwxyz"
+	r := rand.Intn(len(alpha))
+	return fmt.Sprintf("%c%s", alpha[r], rand.String(9))
+}
+
 func GenerateCluster(
 	ctx context.Context,
 	projectID string,
@@ -229,7 +235,7 @@ func GenerateCluster(
 	}
 
 	// Generate the name here so that it can be used below.
-	partialCluster.Name = rand.String(10)
+	partialCluster.Name = makeClusterName()
 
 	// Serialize initial machine deployment request into annotation if it is in the body and provider different than
 	// BringYourOwn was selected. The request will be transformed into machine deployment by the controller once cluster

--- a/pkg/test/e2e/ccm-migration/providers/openstack.go
+++ b/pkg/test/e2e/ccm-migration/providers/openstack.go
@@ -51,7 +51,7 @@ type OpenstackClusterJig struct {
 func NewClusterJigOpenstack(seedClient ctrlruntimeclient.Client, version semver.Semver, seedDatacenter string, credentials OpenstackCredentialsType) *OpenstackClusterJig {
 	return &OpenstackClusterJig{
 		CommonClusterJig: CommonClusterJig{
-			name:           rand.String(10),
+			name:           "c" + rand.String(9),
 			DatacenterName: seedDatacenter,
 			Version:        version,
 			SeedClient:     seedClient,

--- a/pkg/test/e2e/ccm-migration/providers/vsphere.go
+++ b/pkg/test/e2e/ccm-migration/providers/vsphere.go
@@ -51,7 +51,7 @@ type VsphereClusterJig struct {
 func NewClusterJigVsphere(seedClient ctrlruntimeclient.Client, version semver.Semver, seedDatacenter string, credentials VsphereCredentialsType) *VsphereClusterJig {
 	return &VsphereClusterJig{
 		CommonClusterJig: CommonClusterJig{
-			name:           rand.String(10),
+			name:           "c" + rand.String(9),
 			DatacenterName: seedDatacenter,
 			Version:        version,
 			SeedClient:     seedClient,

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -43,7 +43,7 @@ var _ = ginkgo.Describe("The Tunneling strategy", func() {
 		clusterJig = &ClusterJig{
 			Log:            e2eutils.DefaultLogger,
 			Client:         k8scli,
-			Name:           rand.String(10),
+			Name:           "c" + rand.String(9),
 			DatacenterName: options.datacenter,
 			Version:        options.kubernetesVersion,
 		}

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -1597,6 +1597,32 @@ func TestHandle(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
+			name: "Reject invalid rfc1035 name",
+			op:   admissionv1.Create,
+			cluster: rawClusterGen{
+				Name:      "4foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project2.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.192.0.0/20"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32000",
+					},
+				},
+				Version: semver.NewSemverOrDie("1.0.0"),
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
 			name: "Reject unsupported Kubernetes version update",
 			op:   admissionv1.Create,
 			cluster: rawClusterGen{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
GCP  refuses to delete instance if its name starts with a number with log message like this [1]

```
> E0501 12:05:31.901609       1 machine_controller.go:381] Failed to reconcile machine "2kcj8bgchx-worker-zl7vb6-68cd96cd4b-ndzlp": An error of type = InvalidConfiguration, with message = Failed to delete instance: googleapi: Error 400: Invalid value for field 'instance': '2kcj8bgchx-worker-zl7vb6-68cd96cd4b-ndzlp'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid occurred
```

These are  the requirements for name of an instance.

```
	// Name: The name of the resource, provided by the client when initially
	// creating the resource. The resource name must be 1-63 characters
	// long, and comply with RFC1035. Specifically, the name must be 1-63
	// characters long and match the regular expression
	// `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be
	// a lowercase letter, and all following characters must be a dash,
	// lowercase letter, or digit, except the last character, which cannot
	// be a dash.
	Name string `json:"name,omitempty"`
```

We generate clustername using [rand.String](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/rand#String) function which can return  strings that start with a number. 

This PR makes sure that the first char of the string is alphabet. 

Earlier we had `27^10` possible clusters name due to choosing randomly from `bcdfghjklmnpqrstvwxz2456789`.
Now we  have `27^9 x  26` possible cluster names because the first char is now from `a-z`. Still plenty!


[1] https://kubermatic.slack.com/archives/CM5CXH8A3/p1651406901097239

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
