### PR TITLE
Duplicate S3 collector and make it run inside the seed-ctrl-mgr

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -218,6 +218,8 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 	// and return errors otherwise.
 	// Ideally, the cache wouldn't require the leader lease:
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/677
+	log.Debug("Starting cluster backup collector")
+	collectors.MustRegisterClusterBackupCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader(), log, options.caBundle, seedGetter)
 	log.Debug("Starting clusters collector")
 	collectors.MustRegisterClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 	log.Debug("Starting addons collector")

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdbackup"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type clusterBackupCollector struct {
+	ObjectCount            *prometheus.Desc
+	ObjectLastModifiedDate *prometheus.Desc
+	EmptyObjectCount       *prometheus.Desc
+	QuerySuccess           *prometheus.Desc
+	client                 ctrlruntimeclient.Reader
+	logger                 *zap.SugaredLogger
+	caBundle               *certificates.CABundle
+	seedGetter             provider.SeedGetter
+}
+
+// MustRegisterClusterBackupCollector registers the cluster backup collector.
+func MustRegisterClusterBackupCollector(
+	registry prometheus.Registerer,
+	client ctrlruntimeclient.Reader,
+	logger *zap.SugaredLogger,
+	caBundle *certificates.CABundle,
+	seedGetter provider.SeedGetter,
+) {
+	collector := clusterBackupCollector{}
+	collector.client = client
+	collector.logger = logger
+	collector.caBundle = caBundle
+	collector.seedGetter = seedGetter
+
+	collector.ObjectCount = prometheus.NewDesc(
+		"kubermatic_etcdbackup_object_count",
+		"The amount of objects partitioned by backup destination and cluster",
+		[]string{"destination", "cluster"}, nil)
+	collector.ObjectLastModifiedDate = prometheus.NewDesc(
+		"kubermatic_etcdbackup_object_last_modified_time_seconds",
+		"Modification time of the last modified object",
+		[]string{"destination", "cluster"}, nil)
+	collector.EmptyObjectCount = prometheus.NewDesc(
+		"kubermatic_etcdbackup_empty_object_count",
+		"The amount of empty objects (size=0) partitioned by backup destination and cluster",
+		[]string{"destination", "cluster"}, nil)
+	collector.QuerySuccess = prometheus.NewDesc(
+		"kubermatic_etcdbackup_query_success",
+		"Whether querying the S3 was successful",
+		[]string{"destination"}, nil)
+
+	registry.MustRegister(&collector)
+}
+
+func (c *clusterBackupCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.ObjectCount
+	ch <- c.ObjectLastModifiedDate
+	ch <- c.EmptyObjectCount
+	ch <- c.QuerySuccess
+}
+
+func (c *clusterBackupCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(context.Background(), ch); err != nil {
+		c.logger.Errorw("Failed to collect metrics", zap.Error(err))
+	}
+}
+
+func (c *clusterBackupCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	seed, err := c.seedGetter()
+	if err != nil {
+		return err
+	}
+
+	// For the legacy backup mechanism, the S3 credentials
+	// are never configured directly in KKP, instead the admin
+	// only configures full BackupContainerSpecs.
+	// Because of that, this collector can only work with the
+	// new backup/restore mechanism.
+	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
+		return nil
+	}
+
+	var clusterList *kubermaticv1.ClusterList
+	if err := c.client.List(ctx, clusterList); err != nil {
+		return fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	for destName, destination := range seed.Spec.EtcdBackupRestore.Destinations {
+		logger := c.logger.With("destination", destName)
+		logger.Debug("Collecting metrics")
+
+		success := float64(1)
+
+		if err := c.collectDestination(ctx, ch, clusterList.Items, destName, destination); err != nil {
+			// do not return an error, but try to keep gathering data for the other destinations
+			logger.Errorw("Failed to collect metrics for backup destination", zap.Error(err))
+			success = 0
+		}
+
+		ch <- prometheus.MustNewConstMetric(c.QuerySuccess, prometheus.GaugeValue, success, destName)
+	}
+
+	return nil
+}
+
+func (c *clusterBackupCollector) collectDestination(ctx context.Context, ch chan<- prometheus.Metric, clusters []kubermaticv1.Cluster, destName string, destination *kubermaticv1.BackupDestination) error {
+	listOpts := minio.ListObjectsOptions{
+		Recursive: true,
+	}
+
+	s3Client, err := c.getS3Client(ctx, destination)
+	if err != nil {
+		return fmt.Errorf("failed to create S3 client: %w", err)
+	}
+
+	var objects []minio.ObjectInfo
+	for listerObject := range s3Client.ListObjects(ctx, destination.BucketName, listOpts) {
+		if listerObject.Err != nil {
+			return fmt.Errorf("failed to list objects in bucket: %w", listerObject.Err)
+		}
+
+		objects = append(objects, listerObject)
+	}
+
+	for _, cluster := range clusters {
+		c.setMetricsForCluster(ch, destination, objects, destName, cluster.Name)
+	}
+
+	return nil
+}
+
+func (c *clusterBackupCollector) setMetricsForCluster(ch chan<- prometheus.Metric, destination *kubermaticv1.BackupDestination, allObjects []minio.ObjectInfo, destName string, clusterName string) {
+	var clusterObjects []minio.ObjectInfo
+	for _, object := range allObjects {
+		if strings.HasPrefix(object.Key, fmt.Sprintf("%s-", clusterName)) {
+			clusterObjects = append(clusterObjects, object)
+		}
+	}
+
+	labelValues := []string{destName, clusterName}
+
+	ch <- prometheus.MustNewConstMetric(c.ObjectCount, prometheus.GaugeValue, float64(len(clusterObjects)), labelValues...)
+	ch <- prometheus.MustNewConstMetric(c.ObjectLastModifiedDate, prometheus.GaugeValue, float64(getLastModifiedTimestamp(clusterObjects).UnixNano()), labelValues...)
+	ch <- prometheus.MustNewConstMetric(c.EmptyObjectCount, prometheus.GaugeValue, float64(getEmptyObjectCount(clusterObjects)), labelValues...)
+}
+
+func (c *clusterBackupCollector) getS3Client(ctx context.Context, destination *kubermaticv1.BackupDestination) (*minio.Client, error) {
+	key := types.NamespacedName{
+		Name:      destination.Credentials.Name,
+		Namespace: destination.Credentials.Namespace,
+	}
+
+	var creds *corev1.Secret
+	if err := c.client.Get(ctx, key, creds); err != nil {
+		return nil, fmt.Errorf("failed to retrieve credentials secret: %w", err)
+	}
+
+	accessKey := string(creds.Data[etcdbackup.AccessKeyIdEnvVarKey])
+	secretKey := string(creds.Data[etcdbackup.SecretAccessKeyEnvVarKey])
+	if accessKey == "" || secretKey == "" {
+		return nil, fmt.Errorf("backup credentials do not contain %q or %q keys", etcdbackup.AccessKeyIdEnvVarKey, etcdbackup.SecretAccessKeyEnvVarKey)
+	}
+
+	secure := !strings.HasPrefix(destination.Endpoint, "http://")
+	endpoint := strings.TrimPrefix(destination.Endpoint, "http://")
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+
+	options := &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure: secure,
+	}
+
+	if c.caBundle != nil {
+		options.Transport = &http.Transport{
+			TLSClientConfig:    &tls.Config{RootCAs: c.caBundle.CertPool()},
+			DisableCompression: true,
+		}
+	}
+
+	return minio.New(endpoint, options)
+}
+
+func getLastModifiedTimestamp(objects []minio.ObjectInfo) (lastmodifiedTimestamp time.Time) {
+	for _, object := range objects {
+		if object.LastModified.After(lastmodifiedTimestamp) {
+			lastmodifiedTimestamp = object.LastModified
+		}
+	}
+
+	return lastmodifiedTimestamp
+}
+
+func getEmptyObjectCount(objects []minio.ObjectInfo) (emptyObjects int) {
+	for _, object := range objects {
+		if object.Size == 0 {
+			emptyObjects++
+		}
+	}
+
+	return emptyObjects
+}

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -28,7 +28,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdbackup"
@@ -36,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/collectors/s3.go
+++ b/pkg/collectors/s3.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/prometheus/client_golang/prometheus"
@@ -134,23 +133,4 @@ func (e *s3Collector) setMetricsForCluster(ch chan<- prometheus.Metric, allObjec
 		prometheus.GaugeValue,
 		float64(getEmptyObjectCount(clusterObjects)),
 		clusterName)
-}
-
-func getLastModifiedTimestamp(objects []minio.ObjectInfo) (lastmodifiedTimestamp time.Time) {
-	for _, object := range objects {
-		if object.LastModified.After(lastmodifiedTimestamp) {
-			lastmodifiedTimestamp = object.LastModified
-		}
-	}
-
-	return lastmodifiedTimestamp
-}
-
-func getEmptyObjectCount(objects []minio.ObjectInfo) (emptyObjects int) {
-	for _, object := range objects {
-		if object.Size == 0 {
-			emptyObjects++
-		}
-	}
-	return emptyObjects
 }

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -86,10 +86,10 @@ const (
 	backupKeepCountEnvVarKey = "BACKUP_KEEP_COUNT"
 	// backupConfigEnvVarKey defines the environment variable key for the name of the backup configuration resource.
 	backupConfigEnvVarKey = "BACKUP_CONFIG"
-	// accessKeyIdEnvVarKey defines the environment variable key for the backup credentials access key id.
-	accessKeyIdEnvVarKey = "ACCESS_KEY_ID"
-	// secretAccessKeyEnvVarKey defines the environment variable key for the backup credentials secret access key.
-	secretAccessKeyEnvVarKey = "SECRET_ACCESS_KEY"
+	// AccessKeyIdEnvVarKey defines the environment variable key for the backup credentials access key id.
+	AccessKeyIdEnvVarKey = "ACCESS_KEY_ID"
+	// SecretAccessKeyEnvVarKey defines the environment variable key for the backup credentials secret access key.
+	SecretAccessKeyEnvVarKey = "SECRET_ACCESS_KEY"
 	// bucketNameEnvVarKey defines the environment variable key for the backup bucket name.
 	bucketNameEnvVarKey = "BUCKET_NAME"
 	// backupEndpointEnvVarKey defines the environment variable key for the backup endpoint.
@@ -840,8 +840,8 @@ func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, clus
 
 	// If destination is set, we need to set the credentials and backup bucket details to match the destination
 	if destination != nil {
-		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(accessKeyIdEnvVarKey, accessKeyIdEnvVarKey, destination))
-		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(secretAccessKeyEnvVarKey, secretAccessKeyEnvVarKey, destination))
+		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, destination))
+		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, destination))
 		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
 			Name:  bucketNameEnvVarKey,
 			Value: destination.BucketName,
@@ -994,8 +994,8 @@ func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig
 
 	// If destination is set, we need to set the credentials and backup bucket details to match the destination
 	if destination != nil {
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(accessKeyIdEnvVarKey, accessKeyIdEnvVarKey, destination))
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(secretAccessKeyEnvVarKey, secretAccessKeyEnvVarKey, destination))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, destination))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, destination))
 		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
 			Name:  bucketNameEnvVarKey,
 			Value: destination.BucketName,

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -1594,8 +1594,8 @@ func TestMultipleBackupDestination(t *testing.T) {
 				return c
 			}(),
 			expectedJobEnvVars: []corev1.EnvVar{
-				genSecretEnvVar(accessKeyIdEnvVarKey, accessKeyIdEnvVarKey, genDefaultBackupDestination()),
-				genSecretEnvVar(secretAccessKeyEnvVarKey, secretAccessKeyEnvVarKey, genDefaultBackupDestination()),
+				genSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, genDefaultBackupDestination()),
+				genSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, genDefaultBackupDestination()),
 				{
 					Name:  bucketNameEnvVarKey,
 					Value: genDefaultBackupDestination().BucketName,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The S3-Exporter is only here to produce Prometheus metrics tailored towards KKP's etcd backups (which is the reason we're not just using a generic S3 exporter). It was added in #1482.

The exporter has a couple of issues:

* It is packaged as a Helm chart that strongly depends on our `minio` Helm chart, because the Minio chart is creating the `kube-system/s3-credentials` secret, which is consumed by the S3-Exporter. So even though the exporter code itself is fairly generic, its chart is only useful if you also a) installed Minio and b) installed Minio using **our** Helm chart.
* It cannot deal with the modern etcd backup/restore controllers, which allow the admin to define multiple backup destinations.
* It must be installed "manually" using the KKP installer, which will also setup Minio on the seed. If an admin doesn't want to use Minio at all (but still use a single backup location), they must install the exporter even more manuallalier.

As in the future we want to reconcile more things automatically on seeds (like #9748), so it would be nice if the tiny S3 exporter is also managed automatically and learns how to deal with the multiple backup destinations. This is what this PR achieves.

This PR *duplicates* the old S3 collector because the new implementation is built around having access to the S3 bucket via the credentials configured in KKP (as apposed to relying on the s3-credentials Secret). The old backup configuration doesn't allow to specify credentials (again, it relies on this Secret created by our Minio chart) and so the new exporter cannot handle the old configuration and the old exporter cannot handle the new configuration.

Until we deprecate the old backup configuration, it's simply easier to just have this new collector run side-by-side and deal with the new configuration (etcd backup/restore) only.

The new exporter also runs as part of the seed-ctrl-mgr. There is little to gain by splitting it apart into a dedicated binary (or at least I cannot see the advantage) and since the seed-ctrl-mgr already manages the backups, it makes sense IMHO to let it also handle the metrics.

Once we remove the old backup configuration stuff, we can `rm -rf charts/s3-exporter cmd/s3-exporter`. At that point we can then also finally get rid of the `s3-credentials` secret (which I have hated for a long time).

**Does this PR introduce a user-facing change?**:
```release-note
The seed-controller-manager is now providing Prometheus metrics regarding etcd backups (only for the new etcd backup/restore controllers).
```
