### PR TITLE
wwhrd.yml: add github.com/yvasiyarov/go-metrics and github.com/bugsnag/osext to the exception list

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To add a license, we follow https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md.
+
 denylist:
   - GPL-2.0
   - LGPL-3.0
@@ -44,3 +46,5 @@ exceptions:
   - github.com/hashicorp/hcl/json/scanner # MPL-2.0
   - github.com/hashicorp/hcl/json/token # MPL-2.0
   - github.com/hashicorp/go-version # MPL-2.0
+  - github.com/yvasiyarov/go-metrics # BSD-2-Clause-Views required for https://github.com/distribution/distribution (used by Helm)
+  - github.com/bugsnag/osext # Zlib required for https://github.com/distribution/distribution (used by Helm)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

For the PR to add helm client #9721,  we are using Helm and [github.com/distribution/distribution](http://github.com/distribution/distribution) as dependencies. Distribution is a dependency of Helm for handling charts stored in OCI. Both are released under the Apache 2 license.

[github.com/distribution/distribution](http://github.com/distribution/distribution) use dependencies under the following licenses which do not belong to our allowList.
* [BSD-2-Clause-Views](https://spdx.org/licenses/BSD-2-Clause-Views.html)
* [Zlib](https://spdx.org/licenses/Zlib.html)


**More information about the licenses:**
[BSD-2-Clause-Views](https://spdx.org/licenses/BSD-2-Clause-Views.html): according to https://spdx.org/licenses/BSD-2-Clause-Views.html, BSD-2-Clause-Views is identical to BSD-2-Clause with the addition of the “views and conclusions” sentence at the end. 

*note: we already allow BSD-2-Clause*


[Zlib](https://spdx.org/licenses/Zlib.html): according to https://spdx.org/licenses/, Zlib is listed as both `FSF Free/Libre` and `OSI Approved`




**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
