### PR TITLE
Use importas linter to have consistent import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,3 +125,6 @@ linters-settings:
       # Controller Runtime
       - pkg: sigs.k8s.io/controller-runtime/pkg/client
         alias: ctrlruntimeclient
+      # Misc
+      - pkg: github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1
+        alias: clusterv1alpha1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,7 @@ linters:
     - gofmt
     - gosimple
     - govet
+    - importas
     - ineffassign
     - misspell
     - noctx
@@ -91,3 +92,10 @@ linters-settings:
     packages:
       - io/ioutil # https://go.dev/doc/go1.16#ioutil
       - github.com/ghodss/yaml # use sigs.k8s.io/yaml instead
+
+  importas:
+    no-unaliased: true
+    alias:
+      # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,3 +109,5 @@ linters-settings:
         alias: apiextensionsv1
       - pkg: k8s.io/apimachinery/pkg/api/errors
         alias: apierrors
+      - pkg: k8s.io/apimachinery/pkg/util/errors
+        alias: kerrors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,6 +99,8 @@ linters-settings:
       # KKP
       - pkg: k8c.io/kubermatic/v2/pkg/api/v1
         alias: apiv1
+      - pkg: k8c.io/kubermatic/v2/pkg/api/v2
+        alias: apiv2
       - pkg: k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1
         alias: appskubermaticv1
       - pkg: k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,8 @@ linters-settings:
     no-unaliased: true
     alias:
       # KKP
+      - pkg: k8c.io/kubermatic/v2/pkg/api/v1
+        alias: apiv1
       - pkg: k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1
         alias: appskubermaticv1
       - pkg: k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,3 +111,6 @@ linters-settings:
         alias: apierrors
       - pkg: k8s.io/apimachinery/pkg/util/errors
         alias: kerrors
+      # Controller Runtime
+      - pkg: sigs.k8s.io/controller-runtime/pkg/client
+        alias: ctrlruntimeclient

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,3 +107,5 @@ linters-settings:
         alias: rbacv1
       - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
         alias: apiextensionsv1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,6 +101,8 @@ linters-settings:
         alias: appskubermaticv1
       - pkg: k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1
         alias: kubermaticv1
+      - pkg: k8c.io/kubermatic/v2/pkg/util/errors
+        alias: utilerrors
       # Kubernetes
       - pkg: k8s.io/api/apps/v1
         alias: appsv1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,5 +97,9 @@ linters-settings:
     no-unaliased: true
     alias:
       # Kubernetes
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
       - pkg: k8s.io/api/core/v1
         alias: corev1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,3 +103,7 @@ linters-settings:
         alias: corev1
       - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
         alias: metav1
+      - pkg: k8s.io/api/rbac/v1
+        alias: rbacv1
+      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+        alias: apiextensionsv1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,9 @@ linters-settings:
   importas:
     no-unaliased: true
     alias:
+      # KKP
+      - pkg: k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1
+        alias: appskubermaticv1
       # Kubernetes
       - pkg: k8s.io/api/apps/v1
         alias: appsv1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,14 +108,10 @@ linters-settings:
       - pkg: k8c.io/kubermatic/v2/pkg/util/errors
         alias: utilerrors
       # Kubernetes
-      - pkg: k8s.io/api/apps/v1
-        alias: appsv1
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
+      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
       - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
         alias: metav1
-      - pkg: k8s.io/api/rbac/v1
-        alias: rbacv1
       - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
         alias: apiextensionsv1
       - pkg: k8s.io/apimachinery/pkg/api/errors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,6 +99,8 @@ linters-settings:
       # KKP
       - pkg: k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1
         alias: appskubermaticv1
+      - pkg: k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1
+        alias: kubermaticv1
       # Kubernetes
       - pkg: k8s.io/api/apps/v1
         alias: appsv1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,3 +128,5 @@ linters-settings:
       # Misc
       - pkg: github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1
         alias: clusterv1alpha1
+      - pkg: github.com/Masterminds/semver/v3
+        alias: semverlib

--- a/cmd/conformance-tester/pkg/runner/logs.go
+++ b/cmd/conformance-tester/pkg/runner/logs.go
@@ -27,7 +27,7 @@ import (
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 
 	corev1 "k8s.io/api/core/v1"
-	utilerror "k8s.io/apimachinery/pkg/util/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -54,12 +54,12 @@ func printEventsAndLogsForAllPods(ctx context.Context, log *zap.SugaredLogger, c
 		}
 		log.Info("Printing logs for pod")
 		if err := printLogsForPod(ctx, log, k8sclient, &pod); err != nil {
-			log.Errorw("Failed to print logs for pod", zap.Error(utilerror.NewAggregate(err)))
+			log.Errorw("Failed to print logs for pod", zap.Error(kerrors.NewAggregate(err)))
 			errs = append(errs, err...)
 		}
 	}
 
-	return utilerror.NewAggregate(errs)
+	return kerrors.NewAggregate(errs)
 }
 
 func printLogsForPod(ctx context.Context, log *zap.SugaredLogger, k8sclient kubernetes.Interface, pod *corev1.Pod) []error {

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/tests"
 	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -335,8 +335,8 @@ func (r *TestRunner) executeTests(
 				return err
 			}
 			cluster.Finalizers = append(cluster.Finalizers,
-				kubermaticapiv1.InClusterPVCleanupFinalizer,
-				kubermaticapiv1.InClusterLBCleanupFinalizer,
+				apiv1.InClusterPVCleanupFinalizer,
+				apiv1.InClusterLBCleanupFinalizer,
 			)
 			return r.opts.SeedClusterClient.Update(ctx, cluster)
 		})

--- a/cmd/conformance-tester/pkg/runner/waiters.go
+++ b/cmd/conformance-tester/pkg/runner/waiters.go
@@ -29,7 +29,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +44,7 @@ func waitForControlPlane(ctx context.Context, log *zap.SugaredLogger, opts *ctyp
 		newCluster := &kubermaticv1.Cluster{}
 
 		if err := opts.SeedClusterClient.Get(ctx, namespacedClusterName, newCluster); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 		}

--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/go-openapi/runtime"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -228,7 +228,7 @@ func (o *Options) effectiveDistributions() (sets.String, error) {
 }
 
 func getLatestMinorVersions(versions []kubermativsemver.Semver) []string {
-	minorMap := map[uint64]*semver.Version{}
+	minorMap := map[uint64]*semverlib.Version{}
 
 	for _, version := range versions {
 		sversion := version.Semver()

--- a/cmd/image-loader/helm.go
+++ b/cmd/image-loader/helm.go
@@ -25,7 +25,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 
@@ -108,7 +108,7 @@ func getHelmClient(binary string) (helm.Client, error) {
 		return nil, fmt.Errorf("failed to check Helm version: %w", err)
 	}
 
-	if helmVersion.LessThan(semver.MustParse("3.0.0")) {
+	if helmVersion.LessThan(semverlib.MustParse("3.0.0")) {
 		return nil, fmt.Errorf("the image-loader requires Helm 3, detected %s", helmVersion.String())
 	}
 

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -44,7 +44,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
-	kubermaticversion "k8c.io/kubermatic/v2/pkg/version"
+	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -240,7 +240,7 @@ func processImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, ima
 	return nil
 }
 
-func getImagesForVersion(log *zap.SugaredLogger, clusterVersion *kubermaticversion.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, config *kubermaticv1.KubermaticConfiguration, addonsPath string, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (images []string, err error) {
+func getImagesForVersion(log *zap.SugaredLogger, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, config *kubermaticv1.KubermaticConfiguration, addonsPath string, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (images []string, err error) {
 	templateData, err := getTemplateData(clusterVersion, cloudSpec, cniPlugin, kubermaticVersions, caBundle)
 	if err != nil {
 		return nil, err
@@ -328,7 +328,7 @@ func getImagesFromPodSpec(spec corev1.PodSpec) (images []string) {
 	return images
 }
 
-func getTemplateData(clusterVersion *kubermaticversion.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (*resources.TemplateData, error) {
+func getTemplateData(clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (*resources.TemplateData, error) {
 	// We need listers and a set of objects to not have our deployment/statefulset creators fail
 	cloudConfigConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -511,8 +511,8 @@ func createNamedSecrets(secretNames []string) *corev1.SecretList {
 	return &secretList
 }
 
-func getVersions(log *zap.SugaredLogger, config *kubermaticv1.KubermaticConfiguration, versionsFile, versionFilter string) ([]*kubermaticversion.Version, error) {
-	var versions []*kubermaticversion.Version
+func getVersions(log *zap.SugaredLogger, config *kubermaticv1.KubermaticConfiguration, versionsFile, versionFilter string) ([]*version.Version, error) {
+	var versions []*version.Version
 
 	log = log.With("versions-filter", versionFilter)
 
@@ -527,7 +527,7 @@ func getVersions(log *zap.SugaredLogger, config *kubermaticv1.KubermaticConfigur
 		var err error
 
 		log.Debugw("Loading versions", "file", versionsFile)
-		versions, err = kubermaticversion.LoadVersions(versionsFile)
+		versions, err = version.LoadVersions(versionsFile)
 		if err != nil {
 			return nil, err
 		}
@@ -543,7 +543,7 @@ func getVersions(log *zap.SugaredLogger, config *kubermaticv1.KubermaticConfigur
 		return nil, fmt.Errorf("failed to parse version filter %q: %w", versionFilter, err)
 	}
 
-	var filteredVersions []*kubermaticversion.Version
+	var filteredVersions []*version.Version
 	for _, ver := range versions {
 		if constraint.Check(ver.Version) {
 			filteredVersions = append(filteredVersions, ver)

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -538,7 +538,7 @@ func getVersions(log *zap.SugaredLogger, config *kubermaticv1.KubermaticConfigur
 	}
 
 	log.Debug("Filtering versions")
-	constraint, err := semver.NewConstraint(versionFilter)
+	constraint, err := semverlib.NewConstraint(versionFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version filter %q: %w", versionFilter, err)
 	}

--- a/cmd/image-loader/operator.go
+++ b/cmd/image-loader/operator.go
@@ -24,7 +24,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
-	kubermaticversion "k8c.io/kubermatic/v2/pkg/version"
+	"k8c.io/kubermatic/v2/pkg/version"
 
 	"sigs.k8s.io/yaml"
 )
@@ -50,11 +50,11 @@ func loadKubermaticConfiguration(log *zap.SugaredLogger, filename string) (*kube
 	return defaulted, nil
 }
 
-func getVersionsFromKubermaticConfiguration(config *kubermaticv1.KubermaticConfiguration) []*kubermaticversion.Version {
-	versions := []*kubermaticversion.Version{}
+func getVersionsFromKubermaticConfiguration(config *kubermaticv1.KubermaticConfiguration) []*version.Version {
+	versions := []*version.Version{}
 
 	for _, v := range config.Spec.Versions.Versions {
-		versions = append(versions, &kubermaticversion.Version{
+		versions = append(versions, &version.Version{
 			Version: v.Semver(),
 		})
 	}

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -46,7 +46,7 @@ import (
 )
 
 var (
-	MinHelmVersion = semver.MustParse("v3.0.0")
+	MinHelmVersion = semverlib.MustParse("v3.0.0")
 )
 
 type DeployOptions struct {

--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -215,8 +215,8 @@ func addAPIs(dst *runtime.Scheme, log *zap.SugaredLogger) {
 	if err := osmv1alpha1.AddToScheme(dst); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", osmv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
-	if err := appkubermaticv1.AddToScheme(dst); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", appkubermaticv1.SchemeGroupVersion), zap.Error(err))
+	if err := appskubermaticv1.AddToScheme(dst); err != nil {
+		log.Fatalw("Failed to register scheme", zap.Stringer("api", appskubermaticv1.SchemeGroupVersion), zap.Error(err))
 	}
 }
 

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/collectors"
@@ -142,8 +142,8 @@ func main() {
 	if err := osmv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", osmv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
-	if err := appkubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", appkubermaticv1.SchemeGroupVersion), zap.Error(err))
+	if err := appskubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatalw("Failed to register scheme", zap.Stringer("api", appskubermaticv1.SchemeGroupVersion), zap.Error(err))
 	}
 
 	// Check if the CRD for the VerticalPodAutoscaler is registered by allocating an informer

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
@@ -126,7 +126,7 @@ func addAPIs(dst *runtime.Scheme, log *zap.SugaredLogger) {
 	if err := clusterv1alpha1.AddToScheme(dst); err != nil {
 		log.Fatalw("failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
-	if err := appkubermaticv1.AddToScheme(dst); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", appkubermaticv1.SchemeGroupVersion), zap.Error(err))
+	if err := appskubermaticv1.AddToScheme(dst); err != nil {
+		log.Fatalw("Failed to register scheme", zap.Stringer("api", appskubermaticv1.SchemeGroupVersion), zap.Error(err))
 	}
 }

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -215,9 +215,9 @@ func main() {
 			},
 			{
 				ResourceName:       "ApplicationDefinition",
-				ImportAlias:        "appkubermaticv1",
+				ImportAlias:        "appskubermaticv1",
 				ResourceImportPath: "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1",
-				APIVersionPrefix:   "AppKubermaticV1",
+				APIVersionPrefix:   "AppsKubermaticV1",
 			},
 			{
 				ResourceName:       "VirtualMachineInstancePreset",

--- a/docs/cluster-defaulting-validation.md
+++ b/docs/cluster-defaulting-validation.md
@@ -47,7 +47,7 @@ If no initial defaults are set, keep in mind that a change later will again trig
 Default values in `Cluster` objects are persisted, so that changed defaults **do not**
 affect existing clusters. This is different to the `KubermaticConfiguration`/`Seed`, where defaulting
 happens only at runtime, because we do want new defaults (like new `spec.versions` in the `KubermaticConfiguration`)
-to also apply to existing KKP installations. 
+to also apply to existing KKP installations.
 
 ## Validation
 
@@ -67,13 +67,13 @@ The openapi package can be easily integrated into your custom validation funcs. 
 
 ```Go
 import (
-	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/validation/openapi"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func ValidateApplicationDefinition(ad *kubermaticv1.ApplicationDefinition) field.ErrorList {
+func ValidateApplicationDefinition(ad *appskubermaticv1.ApplicationDefinition) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	v, _ := openapi.ValidatorForType(&ad.TypeMeta)
@@ -81,7 +81,7 @@ func ValidateApplicationDefinition(ad *kubermaticv1.ApplicationDefinition) field
 
 	// your custom validation code
 	// ...
-	
+
 	return allErrs
 ```
 
@@ -107,7 +107,7 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, ...) field.ErrorList {
 
 	// your custom validation code
 	// ...
-	
+
 	return allErrs
 ```
 

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -42,7 +42,7 @@ type ClusterData struct {
 	// the configured datacenters.
 	CloudProviderName string
 	// Version is the exact current cluster version.
-	Version *semver.Version
+	Version *semverlib.Version
 	// MajorMinorVersion is a shortcut for common testing on "Major.Minor" on the
 	// current cluster version.
 	MajorMinorVersion string

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/Masterminds/sprig/v3"
 	"go.uber.org/zap"
 
@@ -119,7 +119,7 @@ func NewTemplateData(
 			OwnerEmail:        cluster.Status.UserEmail,
 			Address:           cluster.Address,
 			CloudProviderName: providerName,
-			Version:           semver.MustParse(cluster.Status.Versions.ControlPlane.String()),
+			Version:           semverlib.MustParse(cluster.Status.Versions.ControlPlane.String()),
 			MajorMinorVersion: cluster.Status.Versions.ControlPlane.MajorMinor(),
 			Features:          sets.StringKeySet(cluster.Spec.Features),
 			Network: ClusterNetwork{
@@ -185,7 +185,7 @@ type ClusterData struct {
 	// the configured datacenters.
 	CloudProviderName string
 	// Version is the exact current cluster version.
-	Version *semver.Version
+	Version *semverlib.Version
 	// MajorMinorVersion is a shortcut for common testing on "Major.Minor" on the
 	// current cluster version.
 	MajorMinorVersion string

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -2226,8 +2226,8 @@ type ApplicationRef struct {
 type NodeDeployment struct {
 	ObjectMeta `json:",inline"`
 
-	Spec   NodeDeploymentSpec               `json:"spec"`
-	Status v1alpha1.MachineDeploymentStatus `json:"status"`
+	Spec   NodeDeploymentSpec                      `json:"spec"`
+	Status clusterv1alpha1.MachineDeploymentStatus `json:"status"`
 }
 
 // NodeDeploymentSpec node deployment specification

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 
@@ -2218,7 +2218,7 @@ type ApplicationRef struct {
 	Name string `json:"name" required:"true"`
 
 	// Version of the Application. Must be a valid SemVer version
-	Version appkubermaticv1.Version `json:"version" required:"true"`
+	Version appskubermaticv1.Version `json:"version" required:"true"`
 }
 
 // NodeDeployment represents a set of worker nodes that is part of a cluster

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
@@ -790,8 +790,8 @@ type VersionList []MasterVersion
 // MasterVersion describes a version of the master components
 // swagger:model MasterVersion
 type MasterVersion struct {
-	Version *semver.Version `json:"version"`
-	Default bool            `json:"default,omitempty"`
+	Version *semverlib.Version `json:"version"`
+	Default bool               `json:"default,omitempty"`
 
 	// If true, then given version control plane version is not compatible
 	// with one of the kubelets inside cluster and shouldn't be used.

--- a/pkg/apis/kubermatic/v1/helper/helper.go
+++ b/pkg/apis/kubermatic/v1/helper/helper.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -99,7 +99,7 @@ func ClusterReconcileWrapper(
 		}
 	}
 
-	return result, utilerrors.NewAggregate(errs)
+	return result, kerrors.NewAggregate(errs)
 }
 
 // SetClusterCondition sets a condition on the given cluster using the provided type, status,

--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -36,12 +36,12 @@ type ApplicationInstallerRecorder struct {
 	DeleteEvents sync.Map
 }
 
-func (a *ApplicationInstallerRecorder) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+func (a *ApplicationInstallerRecorder) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	a.ApplyEvents.Store(applicationInstallation.Name, *applicationInstallation.DeepCopy())
 	return nil
 }
 
-func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	a.DeleteEvents.Store(applicationInstallation.Name, *applicationInstallation.DeepCopy())
 	return nil
 }
@@ -50,12 +50,12 @@ func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.Suga
 type ApplicationInstallerLogger struct {
 }
 
-func (a ApplicationInstallerLogger) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+func (a ApplicationInstallerLogger) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	log.Debugf("Install application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
 	return nil
 }
 
-func (a ApplicationInstallerLogger) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *v1.ApplicationInstallation) error {
+func (a ApplicationInstallerLogger) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	log.Debugf("Uninstall application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
 	return nil
 }

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -108,7 +108,7 @@ func (a *ApplicationManager) deleteNamespace(ctx context.Context, log *zap.Sugar
 			},
 		}
 
-		if err := userClient.Delete(ctx, ns); err != nil && !errors.IsNotFound(err) {
+		if err := userClient.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete namespace: %w", err)
 		}
 	}

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -34,10 +34,10 @@ import (
 // ApplicationInstaller handles the installation / uninstallation of an Application on the user cluster.
 type ApplicationInstaller interface {
 	// Apply function installs the application on the user-cluster and returns an error if the installation has failed; this is idempotent.
-	Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
+	Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 
 	// Delete function uninstalls the application on the user-cluster and returns an error if the uninstallation has failed; this is idempotent.
-	Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error
+	Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 
 // ApplicationManager handles the installation / uninstallation of an Application on the user-cluster.
@@ -45,7 +45,7 @@ type ApplicationManager struct {
 }
 
 // Apply creates the namespace where the application will be installed (if necessary) and installs the application.
-func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error {
+func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	if err := a.reconcileNamespace(ctx, log, applicationInstallation, userClient); err != nil {
 		return err
 	}
@@ -54,13 +54,13 @@ func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, 
 }
 
 // Delete uninstalls the application and deletes the namespace where the application was installed if necessary.
-func (a *ApplicationManager) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appkubermaticv1.ApplicationInstallation) error {
+func (a *ApplicationManager) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	// todo logic to uninstall application
 	return a.deleteNamespace(ctx, log, applicationInstallation, userClient)
 }
 
 // reconcileNamespace ensures namespace is created and has desired labels and annotations if applicationInstallation.Spec.Namespace.Create flag is set.
-func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.SugaredLogger, applicationInstallation *appkubermaticv1.ApplicationInstallation, userClient ctrlruntimeclient.Client) error {
+func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.SugaredLogger, applicationInstallation *appskubermaticv1.ApplicationInstallation, userClient ctrlruntimeclient.Client) error {
 	desiredNs := applicationInstallation.Spec.Namespace
 	if desiredNs.Create {
 		log.Infof("reconciling namespace '%s'", desiredNs.Name)
@@ -98,7 +98,7 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 }
 
 // deleteNamespace delete the namespace if applicationInstallation.Spec.Namespace.Create flag is set.
-func (a *ApplicationManager) deleteNamespace(ctx context.Context, log *zap.SugaredLogger, applicationInstallation *appkubermaticv1.ApplicationInstallation, userClient ctrlruntimeclient.Client) error {
+func (a *ApplicationManager) deleteNamespace(ctx context.Context, log *zap.SugaredLogger, applicationInstallation *appskubermaticv1.ApplicationInstallation, userClient ctrlruntimeclient.Client) error {
 	desiredNs := applicationInstallation.Spec.Namespace
 	if desiredNs.Create {
 		log.Infof("deleting namespace '%s'", desiredNs.Name)

--- a/pkg/applications/installer_test.go
+++ b/pkg/applications/installer_test.go
@@ -23,7 +23,7 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,14 +42,14 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 	testCases := []struct {
 		name          string
 		userClient    ctrlruntimeclient.Client
-		namespaceSpec appkubermaticv1.NamespaceSpec
+		namespaceSpec appskubermaticv1.NamespaceSpec
 	}{
 		{
 			name: "scenario 1: when Namespace.create=true and no labels or annotations are defined then namespace should be cretated without labels or annotations",
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
-			namespaceSpec: appkubermaticv1.NamespaceSpec{
+			namespaceSpec: appskubermaticv1.NamespaceSpec{
 				Name:        "foo",
 				Create:      true,
 				Labels:      nil,
@@ -61,7 +61,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
-			namespaceSpec: appkubermaticv1.NamespaceSpec{
+			namespaceSpec: appskubermaticv1.NamespaceSpec{
 				Name:        "foo",
 				Create:      true,
 				Labels:      map[string]string{"label-1": "value-1", "label-2": "value-2"},
@@ -73,7 +73,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
-			namespaceSpec: appkubermaticv1.NamespaceSpec{
+			namespaceSpec: appskubermaticv1.NamespaceSpec{
 				Name:        "foo",
 				Create:      true,
 				Labels:      nil,
@@ -85,7 +85,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
-			namespaceSpec: appkubermaticv1.NamespaceSpec{
+			namespaceSpec: appskubermaticv1.NamespaceSpec{
 				Name:        "foo",
 				Create:      true,
 				Labels:      map[string]string{"label-1": "value-1", "label-2": "value-2"},
@@ -124,7 +124,7 @@ func TestApplicationManager_applyNamespaceDoNotCreateNsWhenCreateNamespaceFlagIs
 		NewClientBuilder().
 		Build()
 
-	namespaceSpec := appkubermaticv1.NamespaceSpec{
+	namespaceSpec := appskubermaticv1.NamespaceSpec{
 		Name:        "foo",
 		Create:      false,
 		Labels:      nil,
@@ -156,7 +156,7 @@ func TestApplicationManager_applyNamespaceDoNotSetLabelsAndAnnotationWhenCreateN
 			genNamespace(nsName), genNamespace(defaultNamespace)).
 		Build()
 
-	namespaceSpec := appkubermaticv1.NamespaceSpec{
+	namespaceSpec := appskubermaticv1.NamespaceSpec{
 		Name:        nsName,
 		Create:      false,
 		Labels:      nil,
@@ -216,7 +216,7 @@ func TestApplicationManager_deleteNamespace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			app := genApplicationInstallation(appkubermaticv1.NamespaceSpec{
+			app := genApplicationInstallation(appskubermaticv1.NamespaceSpec{
 				Name:        nsName,
 				Create:      tc.createNamespace,
 				Labels:      nil,
@@ -272,20 +272,20 @@ func contains(actual map[string]string, expected map[string]string) error {
 	return nil
 }
 
-func genApplicationInstallation(namspaceSpec appkubermaticv1.NamespaceSpec) *appkubermaticv1.ApplicationInstallation {
-	return &appkubermaticv1.ApplicationInstallation{
+func genApplicationInstallation(namspaceSpec appskubermaticv1.NamespaceSpec) *appskubermaticv1.ApplicationInstallation {
+	return &appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "app-",
 			Namespace:    defaultNamespace,
 		},
-		Spec: appkubermaticv1.ApplicationInstallationSpec{
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
 			Namespace: namspaceSpec,
-			ApplicationRef: appkubermaticv1.ApplicationRef{
+			ApplicationRef: appskubermaticv1.ApplicationRef{
 				Name:    "applicationDef1",
-				Version: appkubermaticv1.Version{Version: *semverlib.MustParse("1.0.0")},
+				Version: appskubermaticv1.Version{Version: *semverlib.MustParse("1.0.0")},
 			},
 		},
-		Status: appkubermaticv1.ApplicationInstallationStatus{},
+		Status: appskubermaticv1.ApplicationInstallationStatus{},
 	}
 }
 

--- a/pkg/applications/installer_test.go
+++ b/pkg/applications/installer_test.go
@@ -27,7 +27,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -142,7 +142,7 @@ func TestApplicationManager_applyNamespaceDoNotCreateNsWhenCreateNamespaceFlagIs
 	if err == nil {
 		t.Error("namespace should not have been created")
 	}
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Errorf("can not check that namespace has not been created: %v", err)
 	}
 }
@@ -170,7 +170,7 @@ func TestApplicationManager_applyNamespaceDoNotSetLabelsAndAnnotationWhenCreateN
 	}
 
 	ns := &corev1.Namespace{}
-	if err := userClient.Get(ctx, types.NamespacedName{Name: nsName}, ns); err != nil && !errors.IsNotFound(err) {
+	if err := userClient.Get(ctx, types.NamespacedName{Name: nsName}, ns); err != nil && !apierrors.IsNotFound(err) {
 		t.Errorf("failed to get manually created namespace: %v", err)
 	}
 
@@ -233,11 +233,11 @@ func TestApplicationManager_deleteNamespace(t *testing.T) {
 				if err == nil {
 					t.Error("namespace should have been delete")
 				}
-				if !errors.IsNotFound(err) {
+				if !apierrors.IsNotFound(err) {
 					t.Errorf("can not check that namespace has been deleted: %v", err)
 				}
 			} else if err != nil {
-				if errors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					t.Error("namespace should not have been delete")
 				} else {
 					t.Errorf("can not check that namespace has not been deleted: %v", err)

--- a/pkg/clusterdeletion/clusterrolebindings.go
+++ b/pkg/clusterdeletion/clusterrolebindings.go
@@ -19,7 +19,7 @@ package clusterdeletion
 import (
 	"context"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 )
@@ -27,5 +27,5 @@ import (
 // cleanupClusterRoleBindings is deprecated and should be removed in KKP 2.20+, because
 // nowadays we use owner references for cleanup and this manual step is not needed anymore.
 func (d *Deletion) cleanupClusterRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.ClusterRoleBindingsCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.ClusterRoleBindingsCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/constraints.go
+++ b/pkg/clusterdeletion/constraints.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -36,7 +36,7 @@ func (d *Deletion) cleanupConstraints(ctx context.Context, cluster *kubermaticv1
 		return err
 	}
 
-	// `kubermaticapiv1.GatekeeperConstraintCleanupFinalizer` is added by user-cluster-controller-manager/constraints-syncer.
+	// `apiv1.GatekeeperConstraintCleanupFinalizer` is added by user-cluster-controller-manager/constraints-syncer.
 	// It could be the case that during cluster deletion, user-cluster-controller-manager is deleted before it removes
 	// the finalizer from constraints object, in this case, the user-cluster namespace will get stuck on deletion.
 	// So here we just remove the finalizer from constraints so that user-cluster namespace can be garbage-collected.
@@ -47,11 +47,11 @@ func (d *Deletion) cleanupConstraints(ctx context.Context, cluster *kubermaticv1
 	}
 
 	for _, constraint := range constraintList.Items {
-		err := kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, &constraint, kubermaticapiv1.GatekeeperConstraintCleanupFinalizer)
+		err := kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, &constraint, apiv1.GatekeeperConstraintCleanupFinalizer)
 		if err != nil {
 			return fmt.Errorf("failed to remove constraint finalizer %s: %w", constraint.Name, err)
 		}
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.KubermaticConstraintCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.KubermaticConstraintCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -62,8 +62,8 @@ func (d *Deletion) CleanupCluster(ctx context.Context, log *zap.SugaredLogger, c
 	// If cleanup didn't finish we have to go back, because if there are controllers running
 	// inside the cluster and we delete the nodes, we get stuck.
 	if kuberneteshelper.HasAnyFinalizer(cluster,
-		kubermaticapiv1.InClusterLBCleanupFinalizer,
-		kubermaticapiv1.InClusterPVCleanupFinalizer) {
+		apiv1.InClusterLBCleanupFinalizer,
+		apiv1.InClusterPVCleanupFinalizer) {
 		return nil
 	}
 
@@ -81,7 +81,7 @@ func (d *Deletion) CleanupCluster(ctx context.Context, log *zap.SugaredLogger, c
 	}
 
 	// If we still have nodes, we must not cleanup other infrastructure at the cloud provider
-	if kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
+	if kuberneteshelper.HasFinalizer(cluster, apiv1.NodeDeletionFinalizer) {
 		return nil
 	}
 
@@ -89,7 +89,7 @@ func (d *Deletion) CleanupCluster(ctx context.Context, log *zap.SugaredLogger, c
 	// finalizers, we need to ensure that the credentials are not removed until the cloud provider is cleaned
 	// up, or in other words, all other finalizers have been removed from the cluster, and the
 	// CredentialsSecretsCleanupFinalizer is the only finalizer left.
-	if kuberneteshelper.HasOnlyFinalizer(cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer) {
+	if kuberneteshelper.HasOnlyFinalizer(cluster, apiv1.CredentialsSecretsCleanupFinalizer) {
 		if err := d.cleanUpCredentialsSecrets(ctx, cluster); err != nil {
 			return err
 		}
@@ -101,8 +101,8 @@ func (d *Deletion) CleanupCluster(ctx context.Context, log *zap.SugaredLogger, c
 func (d *Deletion) cleanupInClusterResources(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
 	log = log.Named("in-cluster-resources")
 
-	shouldDeleteLBs := kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.InClusterLBCleanupFinalizer)
-	shouldDeletePVs := kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.InClusterPVCleanupFinalizer)
+	shouldDeleteLBs := kuberneteshelper.HasFinalizer(cluster, apiv1.InClusterLBCleanupFinalizer)
+	shouldDeletePVs := kuberneteshelper.HasFinalizer(cluster, apiv1.InClusterPVCleanupFinalizer)
 
 	// If no relevant finalizer exists, directly return
 	if !shouldDeleteLBs && !shouldDeletePVs {
@@ -149,5 +149,5 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, log *zap.Sugar
 		return nil
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.InClusterLBCleanupFinalizer, kubermaticapiv1.InClusterPVCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.InClusterLBCleanupFinalizer, apiv1.InClusterPVCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/deletion_test.go
+++ b/pkg/clusterdeletion/deletion_test.go
@@ -27,7 +27,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,7 +116,7 @@ func TestCleanUpPVUsingWorkloads(t *testing.T) {
 				objCopy := object.DeepCopyObject().(ctrlruntimeclient.Object)
 
 				err := client.Get(ctx, nn, objCopy)
-				if kerrors.IsNotFound(err) != tc.objDeletionExpected {
+				if apierrors.IsNotFound(err) != tc.objDeletionExpected {
 					t.Errorf("Expected object %q to be deleted=%t", nn.String(), tc.objDeletionExpected)
 				}
 			}

--- a/pkg/clusterdeletion/deletion_test.go
+++ b/pkg/clusterdeletion/deletion_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
@@ -133,14 +133,14 @@ func TestNodesRemainUntilInClusterResourcesAreGone(t *testing.T) {
 	}{
 		{
 			name:    "Nodes remain because LB finalizer exists",
-			cluster: getClusterWithFinalizer(clusterName, kubermaticapiv1.InClusterLBCleanupFinalizer),
+			cluster: getClusterWithFinalizer(clusterName, apiv1.InClusterLBCleanupFinalizer),
 			objects: []ctrlruntimeclient.Object{&corev1.Service{
 				Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
 			}},
 		},
 		{
 			name:    "Nodes remain because PV finalizer exists",
-			cluster: getClusterWithFinalizer(clusterName, kubermaticapiv1.InClusterPVCleanupFinalizer),
+			cluster: getClusterWithFinalizer(clusterName, apiv1.InClusterPVCleanupFinalizer),
 			objects: []ctrlruntimeclient.Object{&corev1.PersistentVolume{}},
 		},
 	}

--- a/pkg/clusterdeletion/etcdbackupconfig.go
+++ b/pkg/clusterdeletion/etcdbackupconfig.go
@@ -24,7 +24,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
-	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -34,7 +34,7 @@ func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kuberm
 
 	// always attempt to cleanup, even if the controllers might be disabled now
 	backupConfigs := &kubermaticv1.EtcdBackupConfigList{}
-	if err := d.seedClient.List(ctx, backupConfigs, controllerruntimeclient.InNamespace(cluster.Status.NamespaceName)); err != nil {
+	if err := d.seedClient.List(ctx, backupConfigs, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName)); err != nil {
 		return fmt.Errorf("failed to get EtcdBackupConfigs: %w", err)
 	}
 

--- a/pkg/clusterdeletion/etcdbackupconfig.go
+++ b/pkg/clusterdeletion/etcdbackupconfig.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -28,7 +28,7 @@ import (
 )
 
 func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.EtcdBackupConfigCleanupFinalizer) {
+	if !kuberneteshelper.HasFinalizer(cluster, apiv1.EtcdBackupConfigCleanupFinalizer) {
 		return nil
 	}
 
@@ -48,5 +48,5 @@ func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kuberm
 		return nil
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.EtcdBackupConfigCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.EtcdBackupConfigCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/node.go
+++ b/pkg/clusterdeletion/node.go
@@ -22,7 +22,7 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	eviction "github.com/kubermatic/machine-controller/pkg/node/eviction/types"
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -33,7 +33,7 @@ import (
 )
 
 func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
+	if !kuberneteshelper.HasFinalizer(cluster, apiv1.NodeDeletionFinalizer) {
 		return nil
 	}
 
@@ -109,5 +109,5 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 		return nil
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.NodeDeletionFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.NodeDeletionFinalizer)
 }

--- a/pkg/clusterdeletion/secret.go
+++ b/pkg/clusterdeletion/secret.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -48,7 +48,7 @@ func (d *Deletion) deleteSecret(ctx context.Context, cluster *kubermaticv1.Clust
 	name := types.NamespacedName{Name: secretName, Namespace: resources.KubermaticNamespace}
 	err := d.seedClient.Get(ctx, name, secret)
 	// It's already gone
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 

--- a/pkg/clusterdeletion/secret.go
+++ b/pkg/clusterdeletion/secret.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -35,7 +35,7 @@ func (d *Deletion) cleanUpCredentialsSecrets(ctx context.Context, cluster *kuber
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.CredentialsSecretsCleanupFinalizer)
 }
 
 func (d *Deletion) deleteSecret(ctx context.Context, cluster *kubermaticv1.Cluster) error {

--- a/pkg/clusterdeletion/volumes.go
+++ b/pkg/clusterdeletion/volumes.go
@@ -24,7 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -79,7 +79,7 @@ func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Clu
 
 	// Delete PVC's
 	for _, pvc := range pvcList.Items {
-		if err := userClusterClient.Delete(ctx, &pvc); err != nil && !kerrors.IsNotFound(err) {
+		if err := userClusterClient.Delete(ctx, &pvc); err != nil && !apierrors.IsNotFound(err) {
 			return deletedSomeResource, fmt.Errorf("failed to delete PVC '%s/%s' from user cluster: %w", pvc.Namespace, pvc.Name, err)
 		}
 		deletedSomeResource = true
@@ -121,7 +121,7 @@ func (d *Deletion) cleanupPVCUsingPods(ctx context.Context, userClusterClient ct
 	}
 
 	for _, pod := range pvUsingPods {
-		if err := userClusterClient.Delete(ctx, pod); err != nil && !kerrors.IsNotFound(err) {
+		if err := userClusterClient.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete pod %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -41,7 +41,7 @@ import (
 
 func init() {
 	utilruntime.Must(kubermaticv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(appkubermaticv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(appskubermaticv1.AddToScheme(scheme.Scheme))
 }
 
 const applicationDefinitionName = "app-def-1"
@@ -50,7 +50,7 @@ func TestReconcile(t *testing.T) {
 	testCases := []struct {
 		name                          string
 		requestName                   string
-		expectedApplicationDefinition *appkubermaticv1.ApplicationDefinition
+		expectedApplicationDefinition *appskubermaticv1.ApplicationDefinition
 		masterClient                  ctrlruntimeclient.Client
 		seedClient                    ctrlruntimeclient.Client
 	}{
@@ -96,7 +96,7 @@ func TestReconcile(t *testing.T) {
 				t.Fatalf("reconciling failed: %v", err)
 			}
 
-			seedApplicationDef := &appkubermaticv1.ApplicationDefinition{}
+			seedApplicationDef := &appskubermaticv1.ApplicationDefinition{}
 			err := tc.seedClient.Get(ctx, request.NamespacedName, seedApplicationDef)
 
 			if tc.expectedApplicationDefinition == nil {
@@ -127,8 +127,8 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func generateApplicationDef(name string, deleted bool) *appkubermaticv1.ApplicationDefinition {
-	applicationDef := &appkubermaticv1.ApplicationDefinition{
+func generateApplicationDef(name string, deleted bool) *appskubermaticv1.ApplicationDefinition {
+	applicationDef := &appskubermaticv1.ApplicationDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
@@ -138,18 +138,18 @@ func generateApplicationDef(name string, deleted bool) *appkubermaticv1.Applicat
 				"someAnnotationKey": "someAnnotationValue",
 			},
 		},
-		Spec: appkubermaticv1.ApplicationDefinitionSpec{
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
 			Description: "sample app",
-			Versions: []appkubermaticv1.ApplicationVersion{
+			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: "version 1",
-					Constraints: appkubermaticv1.ApplicationConstraints{
+					Constraints: appskubermaticv1.ApplicationConstraints{
 						K8sVersion: "> 1.0.0",
 						KKPVersion: "> 1.1.1",
 					},
-					Template: appkubermaticv1.ApplicationTemplate{
-						Source: appkubermaticv1.ApplicationSource{
-							Helm: &appkubermaticv1.HelmSource{
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
 								URL:          "https://my-chart-repo.local",
 								ChartName:    "sample-app",
 								ChartVersion: "1.0",
@@ -163,7 +163,7 @@ func generateApplicationDef(name string, deleted bool) *appkubermaticv1.Applicat
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		applicationDef.DeletionTimestamp = &deleteTime
-		applicationDef.Finalizers = append(applicationDef.Finalizers, appkubermaticv1.ApplicationDefinitionSeedCleanupFinalizer)
+		applicationDef.Finalizers = append(applicationDef.Finalizers, appskubermaticv1.ApplicationDefinitionSeedCleanupFinalizer)
 	}
 
 	return applicationDef

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -102,7 +102,7 @@ func TestReconcile(t *testing.T) {
 			if tc.expectedApplicationDefinition == nil {
 				if err == nil {
 					t.Fatal("failed clean up application definition on the seed cluster")
-				} else if !errors.IsNotFound(err) {
+				} else if !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to get application definition: %v", err)
 				}
 			} else {

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -109,7 +109,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, clusterTemplate, kubermaticapiv1.ClusterTemplateSeedCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, clusterTemplate, apiv1.ClusterTemplateSeedCleanupFinalizer); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -128,7 +128,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, template *kubermaticv1.ClusterTemplate) error {
-	if kuberneteshelper.HasFinalizer(template, kubermaticapiv1.ClusterTemplateSeedCleanupFinalizer) {
+	if kuberneteshelper.HasFinalizer(template, apiv1.ClusterTemplateSeedCleanupFinalizer) {
 		if err := r.syncAllSeeds(log, template, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
 			err := seedClient.Delete(ctx, &kubermaticv1.ClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
@@ -141,12 +141,12 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return err
 		}
 
-		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, template, kubermaticapiv1.ClusterTemplateSeedCleanupFinalizer); err != nil {
+		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, template, apiv1.ClusterTemplateSeedCleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to remove cluster template finalizer %s: %w", template.Name, err)
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(template, kubermaticapiv1.CredentialsSecretsCleanupFinalizer) {
+	if kuberneteshelper.HasFinalizer(template, apiv1.CredentialsSecretsCleanupFinalizer) {
 		if err := r.syncAllSeeds(log, template, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
 			err := seedClient.Delete(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return err
 		}
 
-		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, template, kubermaticapiv1.CredentialsSecretsCleanupFinalizer); err != nil {
+		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, template, apiv1.CredentialsSecretsCleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to remove credential secret finalizer %s: %w", template.Name, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -130,7 +130,7 @@ func generateClusterTemplate(name string, deleted bool) *kubermaticv1.ClusterTem
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		ct.DeletionTimestamp = &deleteTime
-		ct.Finalizers = append(ct.Finalizers, v1.ClusterTemplateSeedCleanupFinalizer)
+		ct.Finalizers = append(ct.Finalizers, apiv1.ClusterTemplateSeedCleanupFinalizer)
 	}
 	return ct
 }

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 			if tc.expectedClusterTemplate == nil {
 				if err == nil {
 					t.Fatal("failed clean up template on the seed cluster")
-				} else if !errors.IsNotFound(err) {
+				} else if !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to get template: %v", err)
 				}
 			} else {

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	icl := &kubermaticv1.ExternalCluster{}
 	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: metav1.NamespaceAll, Name: resourceName}, icl); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("Could not find imported cluster")
 			return reconcile.Result{}, nil
 		}
@@ -214,7 +214,7 @@ func (r *Reconciler) deleteSecret(ctx context.Context, secretName string) error 
 	name := types.NamespacedName{Name: secretName, Namespace: resources.KubermaticNamespace}
 	err := r.Get(ctx, name, secret)
 	// Its already gone
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 
@@ -309,7 +309,7 @@ func (r *Reconciler) updateKubeconfigSecret(ctx context.Context, config *api.Con
 	namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: kubeconfigSecretName}
 
 	existingSecret := &corev1.Secret{}
-	if err := r.Get(ctx, namespacedName, existingSecret); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.Get(ctx, namespacedName, existingSecret); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to probe for secret %v: %w", namespacedName, err)
 	}
 

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -94,13 +94,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if icl.DeletionTimestamp != nil {
-		if kuberneteshelper.HasFinalizer(icl, kubermaticapiv1.ExternalClusterKubeconfigCleanupFinalizer) {
+		if kuberneteshelper.HasFinalizer(icl, apiv1.ExternalClusterKubeconfigCleanupFinalizer) {
 			if err := r.cleanUpKubeconfigSecret(ctx, icl); err != nil {
 				log.Errorf("Could not delete kubeconfig secret, %v", err)
 				return reconcile.Result{}, err
 			}
 		}
-		if kuberneteshelper.HasFinalizer(icl, kubermaticapiv1.CredentialsSecretsCleanupFinalizer) {
+		if kuberneteshelper.HasFinalizer(icl, apiv1.CredentialsSecretsCleanupFinalizer) {
 			if err := r.cleanUpCredentialsSecret(ctx, icl); err != nil {
 				log.Errorf("Could not delete credentials secret, %v", err)
 				return reconcile.Result{}, err
@@ -194,7 +194,7 @@ func (r *Reconciler) cleanUpKubeconfigSecret(ctx context.Context, cluster *kuber
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, kubermaticapiv1.ExternalClusterKubeconfigCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
 }
 
 func (r *Reconciler) cleanUpCredentialsSecret(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
@@ -202,7 +202,7 @@ func (r *Reconciler) cleanUpCredentialsSecret(ctx context.Context, cluster *kube
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, apiv1.CredentialsSecretsCleanupFinalizer)
 }
 
 func (r *Reconciler) deleteSecret(ctx context.Context, secretName string) error {
@@ -330,7 +330,7 @@ func (r *Reconciler) updateKubeconfigSecret(ctx context.Context, config *api.Con
 		return err
 	}
 	cluster.Spec.KubeconfigReference = keyRef
-	kuberneteshelper.AddFinalizer(cluster, kubermaticapiv1.ExternalClusterKubeconfigCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(cluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
 
 	return r.Update(ctx, cluster)
 }

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller_test.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller_test.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -90,7 +90,7 @@ func TestReconcile(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected ExternalCluster to be gone, but found it anyway")
 			}
-			if !kerrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				t.Fatalf("expected not-found error, but got %v", err)
 			}
 
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected secret to be gone, but found it anyway")
 			}
-			if !kerrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				t.Fatalf("expected not-found error, but got %v", err)
 			}
 		})

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller_test.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -118,7 +118,7 @@ func genExternalCluster(name string, deletionTimestamp metav1.Time) *kubermaticv
 		},
 	}
 
-	kuberneteshelper.AddFinalizer(cluster, kubermaticapiv1.ExternalClusterKubeconfigCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(cluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
 
 	cluster.Spec.KubeconfigReference = &providerconfig.GlobalSecretKeySelector{
 		ObjectReference: corev1.ObjectReference{

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -267,7 +267,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, exte
 func (r *reconciler) initiateImportAction(ctx context.Context, log *zap.SugaredLogger, externalCluster *kubermaticv1.ExternalCluster) error {
 	kubeconfigSecret := &corev1.Secret{}
 	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: kubernetesprovider.GetKubeOneNamespaceName(externalCluster.Name), Name: resources.KubeOneKubeconfigSecretName}, kubeconfigSecret); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if err := r.importCluster(ctx, log, externalCluster); err != nil {
 				log.Debug("failed to import kubeone cluster %w", err)
 				return err
@@ -367,7 +367,7 @@ func (r *reconciler) initiateUpgradeAction(ctx context.Context,
 		upgradePod,
 	)
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 	} else {
@@ -419,7 +419,7 @@ func (r *reconciler) initiateMigrateAction(ctx context.Context,
 		migratePod,
 	)
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 	} else {
@@ -464,7 +464,7 @@ func (r *reconciler) checkPodStatusIfExists(ctx context.Context,
 		pod,
 	)
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -748,7 +748,7 @@ func (r *reconciler) upgradeCluster(ctx context.Context, log *zap.SugaredLogger,
 
 	log.Debug("Create kubeone pod to upgrade kubeone")
 	if err := r.Create(ctx, generatedPod); err != nil {
-		if !kerrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return nil, err
 		}
 	}
@@ -766,7 +766,7 @@ func (r *reconciler) migrateCluster(ctx context.Context, log *zap.SugaredLogger,
 
 	log.Debug("Create kubeone pod to migrate kubeone")
 	if err := r.Create(ctx, generatedPod); err != nil {
-		if !kerrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("could not create kubeone pod %s/%s to migrate kubeone cluster: %w", generatedPod.Name, generatedPod.Namespace, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -138,7 +138,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, constraint, kubermaticapiv1.GatekeeperSeedConstraintCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, constraint, apiv1.GatekeeperSeedConstraintCleanupFinalizer); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -153,7 +153,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, constraint *kubermaticv1.Constraint) error {
 	// if finalizer not set to master Constraint then return
-	if !kuberneteshelper.HasFinalizer(constraint, kubermaticapiv1.GatekeeperSeedConstraintCleanupFinalizer) {
+	if !kuberneteshelper.HasFinalizer(constraint, apiv1.GatekeeperSeedConstraintCleanupFinalizer) {
 		return nil
 	}
 
@@ -171,5 +171,5 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, constraint, kubermaticapiv1.GatekeeperSeedConstraintCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, constraint, apiv1.GatekeeperSeedConstraintCleanupFinalizer)
 }

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -111,8 +111,8 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("expected error status %s, instead got ct: %v", tc.expectedGetErrStatus, constraint)
 				}
 
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -137,7 +137,7 @@ func genConstraint(name, namespace, kind string, deleted bool) *kubermaticv1.Con
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		constraint.DeletionTimestamp = &deleteTime
-		constraint.Finalizers = append(constraint.Finalizers, v1.GatekeeperSeedConstraintCleanupFinalizer)
+		constraint.Finalizers = append(constraint.Finalizers, apiv1.GatekeeperSeedConstraintCleanupFinalizer)
 	}
 
 	return constraint

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -121,7 +121,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, constraintTemplate *kubermaticv1.ConstraintTemplate) error {
 	if constraintTemplate.DeletionTimestamp != nil {
-		if !kuberneteshelper.HasFinalizer(constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer) {
+		if !kuberneteshelper.HasFinalizer(constraintTemplate, apiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer) {
 			return nil
 		}
 
@@ -143,10 +143,10 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 			return err
 		}
 
-		return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
+		return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, constraintTemplate, apiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, constraintTemplate, kubermaticapiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, constraintTemplate, apiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -104,7 +104,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	constraintTemplate := &kubermaticv1.ConstraintTemplate{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, constraintTemplate); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("constraint template not found, returning")
 			return reconcile.Result{}, nil
 		}
@@ -132,7 +132,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 				},
 			})
 
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				log.Debug("constraint template not found, returning")
 				return nil
 			}

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -24,7 +24,7 @@ import (
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -137,7 +137,7 @@ func genConstraintTemplate(name string, deleted bool) *kubermaticv1.ConstraintTe
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		ct.DeletionTimestamp = &deleteTime
-		ct.Finalizers = append(ct.Finalizers, v1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
+		ct.Finalizers = append(ct.Finalizers, apiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
 	}
 
 	return ct

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -152,12 +152,12 @@ func genCTSpec() kubermaticv1.ConstraintTemplateSpec {
 					ShortNames: []string{"lc"},
 				},
 				Validation: &constrainttemplatev1.Validation{
-					OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
-						Properties: map[string]apiextensionv1.JSONSchemaProps{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"labels": {
 								Type: "array",
-								Items: &apiextensionv1.JSONSchemaPropsOrArray{
-									Schema: &apiextensionv1.JSONSchemaProps{
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
 										Type: "string",
 									},
 								},

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -30,7 +30,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -108,8 +108,8 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("expected error status %s, instead got ct: %v", tc.expectedGetErrStatus, ct)
 				}
 
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -108,7 +108,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, preset, kubermaticapiv1.PresetSeedCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, preset, apiv1.PresetSeedCleanupFinalizer); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -127,7 +127,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, preset *kubermaticv1.Preset) error {
-	if kuberneteshelper.HasFinalizer(preset, kubermaticapiv1.PresetSeedCleanupFinalizer) {
+	if kuberneteshelper.HasFinalizer(preset, apiv1.PresetSeedCleanupFinalizer) {
 		if err := r.syncAllSeeds(log, preset, func(seedClient ctrlruntimeclient.Client, preset *kubermaticv1.Preset) error {
 			err := seedClient.Delete(ctx, &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -140,7 +140,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return err
 		}
 
-		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, preset, kubermaticapiv1.PresetSeedCleanupFinalizer); err != nil {
+		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, preset, apiv1.PresetSeedCleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to remove preset finalizer %s: %w", preset.Name, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -132,7 +132,7 @@ func generatePreset(name string, deleted bool) *kubermaticv1.Preset {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		pr.DeletionTimestamp = &deleteTime
-		pr.Finalizers = append(pr.Finalizers, v1.PresetSeedCleanupFinalizer)
+		pr.Finalizers = append(pr.Finalizers, apiv1.PresetSeedCleanupFinalizer)
 	}
 	return pr
 }

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 			if tc.expectedPreset == nil {
 				if err == nil {
 					t.Fatal("failed clean up preset on the seed cluster")
-				} else if !errors.IsNotFound(err) {
+				} else if !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to get template: %v", err)
 				}
 			} else {

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -197,7 +197,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return kerrors.NewAggregate(errs)
 }
 
 func (r *reconciler) filterClustersByProjectID(

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -26,7 +26,7 @@ import (
 	helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
@@ -135,7 +135,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
 	project := &kubermaticv1.Project{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, project); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("Didn't find project, returning")
 			return nil
 		}

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -112,7 +112,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, project, kubermaticapiv1.SeedProjectCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, project, apiv1.SeedProjectCleanupFinalizer); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -156,7 +156,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, project, kubermaticapiv1.SeedProjectCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, project, apiv1.SeedProjectCleanupFinalizer)
 }
 
 func (r *reconciler) syncAllSeeds(

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -139,7 +139,7 @@ func generateProject(name string, deleted bool) *kubermaticv1.Project {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		project.DeletionTimestamp = &deleteTime
-		project.Finalizers = append(project.Finalizers, v1.SeedProjectCleanupFinalizer)
+		project.Finalizers = append(project.Finalizers, apiv1.SeedProjectCleanupFinalizer)
 	}
 	return project
 }

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -106,7 +106,7 @@ func TestReconcile(t *testing.T) {
 			if tc.expectedProject == nil {
 				if err == nil {
 					t.Fatal("failed clean up project on the seed cluster")
-				} else if !errors.IsNotFound(err) {
+				} else if !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to get project: %v", err)
 				}
 			} else {

--- a/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
@@ -26,7 +26,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 
-	k8scorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -104,7 +104,7 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 		},
 
 		{
-			object: &k8scorev1.Secret{
+			object: &corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Secret",

--- a/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
@@ -24,7 +24,7 @@ import (
 
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/util/workqueue"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,7 +121,7 @@ func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.
 func (c *resourcesController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	obj := c.objectType.DeepCopyObject().(ctrlruntimeclient.Object)
 	if err := c.client.Get(ctx, req.NamespacedName, obj); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controller/master-controller-manager/rbac/sync_project.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project.go
@@ -27,7 +27,7 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +40,7 @@ const (
 func (c *projectController) sync(ctx context.Context, key ctrlruntimeclient.ObjectKey) error {
 	project := &kubermaticv1.Project{}
 	if err := c.client.Get(ctx, key, project); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 
@@ -194,7 +194,7 @@ func ensureClusterRBACRoleForResource(ctx context.Context, log *zap.SugaredLogge
 	var sharedExistingClusterRole rbacv1.ClusterRole
 	key := types.NamespacedName{Name: generatedClusterRole.Name}
 	if err := c.Get(ctx, key, &sharedExistingClusterRole); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return c.Create(ctx, generatedClusterRole)
 		}
 
@@ -216,7 +216,7 @@ func ensureClusterRBACRoleBindingForResource(ctx context.Context, c ctrlruntimec
 	var sharedExistingClusterRoleBinding rbacv1.ClusterRoleBinding
 	key := types.NamespacedName{Name: generatedClusterRoleBinding.Name}
 	if err := c.Get(ctx, key, &sharedExistingClusterRoleBinding); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return c.Create(ctx, generatedClusterRoleBinding)
 		}
 
@@ -304,7 +304,7 @@ func ensureRBACRoleForResource(ctx context.Context, log *zap.SugaredLogger, c ct
 	var sharedExistingRole rbacv1.Role
 	key := types.NamespacedName{Name: generatedRole.Name, Namespace: generatedRole.Namespace}
 	if err := c.Get(ctx, key, &sharedExistingRole); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return c.Create(ctx, generatedRole)
 		}
 		return err
@@ -373,7 +373,7 @@ func ensureRBACRoleBindingForResource(ctx context.Context, c ctrlruntimeclient.C
 	var sharedExistingRoleBinding rbacv1.RoleBinding
 	key := types.NamespacedName{Name: generatedRoleBinding.Name, Namespace: generatedRoleBinding.Namespace}
 	if err := c.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return c.Create(ctx, generatedRoleBinding)
 		}
 		return err

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac/test"
 	fakeInformerProvider "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac/test/fake"
 
-	k8scorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
@@ -50,7 +50,7 @@ func getFakeRestMapper(t *testing.T) meta.RESTMapper {
 		t.Fatalf("getFakeRestMapper: %v", err)
 		t.FailNow()
 	}
-	if err := k8scorev1.AddToScheme(scheme); err != nil {
+	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("getFakeRestMapper: %v", err)
 		t.FailNow()
 	}
@@ -1189,7 +1189,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 			seedClusters:             1,
 			projectResourcesToSync: []projectResource{
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1198,7 +1198,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					namespace: "kubermatic",
 				},
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1218,7 +1218,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1232,7 +1232,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1249,7 +1249,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1263,7 +1263,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1280,7 +1280,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 			seedClusters:             1,
 			projectResourcesToSync: []projectResource{
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1289,7 +1289,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					namespace: "kubermatic",
 				},
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1309,7 +1309,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1323,7 +1323,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1339,7 +1339,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1353,7 +1353,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1368,7 +1368,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups: []string{corev1.SchemeGroupVersion.Group},
 							Resources: []string{"secrets"},
 							Verbs:     []string{"create"},
 						},
@@ -1492,7 +1492,7 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 			expectedActionsForMaster: []string{"create"},
 			projectResourcesToSync: []projectResource{
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1503,7 +1503,7 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 				},
 
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1603,7 +1603,7 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 			expectedActionsForMaster: []string{"update"},
 			projectResourcesToSync: []projectResource{
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1613,7 +1613,7 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 					namespace:   "kubermatic",
 				},
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1942,7 +1942,7 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 			projectResourcesToSync: []projectResource{
 
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",
@@ -1952,7 +1952,7 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 					namespace:   "kubermatic",
 				},
 				{
-					object: &k8scorev1.Secret{
+					object: &corev1.Secret{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "v1",
 							Kind:       "Secret",

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -260,7 +260,7 @@ func ensureClusterRBACRoleForNamedResource(ctx context.Context, log *zap.Sugared
 		var sharedExistingRole rbacv1.ClusterRole
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name}
 		if err := cli.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := cli.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -309,7 +309,7 @@ func ensureClusterRBACRoleBindingForNamedResource(ctx context.Context, log *zap.
 		var sharedExistingRoleBinding rbacv1.ClusterRoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name}
 		if err := cli.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := cli.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -372,7 +372,7 @@ func (c *resourcesController) ensureRBACRoleForNamedResource(ctx context.Context
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return nil
 				}
@@ -421,7 +421,7 @@ func (c *resourcesController) ensureRBACRoleBindingForNamedResource(ctx context.
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return nil
 				}
@@ -498,7 +498,7 @@ func (c *resourcesController) ensureRBACRoleForClusterAddons(ctx context.Context
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -548,7 +548,7 @@ func (c *resourcesController) ensureRBACRoleBindingForClusterAddons(ctx context.
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -592,7 +592,7 @@ func (c *resourcesController) ensureRBACRoleForEtcdLauncher(ctx context.Context,
 	var sharedExistingRole rbacv1.Role
 	key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 	if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if err := c.client.Create(ctx, generatedRole); err != nil {
 				return err
 			}
@@ -624,7 +624,7 @@ func (c *resourcesController) ensureRBACRoleBindingForEtcdLauncher(ctx context.C
 	var sharedExistingRoleBinding rbacv1.RoleBinding
 	key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 	if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 				return err
 			}
@@ -716,7 +716,7 @@ func (c *resourcesController) ensureClusterRBACRoleBindingForEtcdLauncher(ctx co
 	var sharedExistingRoleBinding rbacv1.ClusterRoleBinding
 	key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name}
 	if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 				return err
 			}
@@ -765,7 +765,7 @@ func (c *resourcesController) ensureRBACRoleForClusterAlertmanagers(ctx context.
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -817,7 +817,7 @@ func (c *resourcesController) ensureRBACRoleBindingForClusterAlertmanagers(ctx c
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -867,7 +867,7 @@ func (c *resourcesController) ensureRBACRoleForClusterAlertmanagerConfigSecrets(
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -919,7 +919,7 @@ func (c *resourcesController) ensureRBACRoleBindingForClusterAlertmanagerConfigS
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -968,7 +968,7 @@ func (c *resourcesController) ensureRBACRoleForClusterConstraints(ctx context.Co
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -1018,7 +1018,7 @@ func (c *resourcesController) ensureRBACRoleBindingForClusterConstraints(ctx con
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -1067,7 +1067,7 @@ func (c *resourcesController) ensureRBACRoleForClusterRuleGroups(ctx context.Con
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -1111,7 +1111,7 @@ func (c *resourcesController) ensureClusterRBACRoleForEtcdLauncher(ctx context.C
 	var existingClusterRole rbacv1.ClusterRole
 	key := ctrlruntimeclient.ObjectKey{Name: generatedClusterRole.Name}
 	if err := c.client.Get(ctx, key, &existingClusterRole); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if err := c.client.Create(ctx, generatedClusterRole); err != nil {
 				return err
 			}
@@ -1158,7 +1158,7 @@ func (c *resourcesController) ensureRBACRoleBindingForClusterRuleGroups(ctx cont
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -1245,7 +1245,7 @@ func (c *resourcesController) ensureRBACRoleForEtcdBackupConfigs(ctx context.Con
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -1295,7 +1295,7 @@ func (c *resourcesController) ensureRBACRoleBindingForEtcdBackupConfigs(ctx cont
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}
@@ -1344,7 +1344,7 @@ func (c *resourcesController) ensureRBACRoleForEtcdRestores(ctx context.Context,
 		var sharedExistingRole rbacv1.Role
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
 					return err
 				}
@@ -1394,7 +1394,7 @@ func (c *resourcesController) ensureRBACRoleBindingForEtcdRestores(ctx context.C
 		var sharedExistingRoleBinding rbacv1.RoleBinding
 		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name, Namespace: cluster.Status.NamespaceName}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
 					return err
 				}

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -28,7 +28,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac/test"
 
-	k8scorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -950,7 +950,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 			name:            "scenario 1: a proper set of RBAC Role/Binding is generated for secrets in kubermatic namespace",
 			expectedActions: []string{"create", "create"},
 
-			dependantToSync: &k8scorev1.Secret{
+			dependantToSync: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd",
 					Namespace: "kubermatic",
@@ -972,7 +972,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 						Namespace: "kubermatic",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: k8scorev1.SchemeGroupVersion.String(),
+								APIVersion: corev1.SchemeGroupVersion.String(),
 								Kind:       "Secret",
 								Name:       "abcd",
 								UID:        "abcdID", // set manually
@@ -982,7 +982,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups:     []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups:     []string{corev1.SchemeGroupVersion.Group},
 							Resources:     []string{"secrets"},
 							ResourceNames: []string{"abcd"},
 							Verbs:         []string{"get", "update", "delete"},
@@ -995,7 +995,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 						Namespace: "kubermatic",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: k8scorev1.SchemeGroupVersion.String(),
+								APIVersion: corev1.SchemeGroupVersion.String(),
 								Kind:       "Secret",
 								Name:       "abcd",
 								UID:        "abcdID", // set manually
@@ -1005,7 +1005,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups:     []string{k8scorev1.SchemeGroupVersion.Group},
+							APIGroups:     []string{corev1.SchemeGroupVersion.Group},
 							Resources:     []string{"secrets"},
 							ResourceNames: []string{"abcd"},
 							Verbs:         []string{"get", "update", "delete"},
@@ -1021,7 +1021,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 						Namespace: "kubermatic",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: k8scorev1.SchemeGroupVersion.String(),
+								APIVersion: corev1.SchemeGroupVersion.String(),
 								Kind:       "Secret",
 								Name:       "abcd",
 								UID:        "abcdID", // set manually
@@ -1048,7 +1048,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 						Namespace: "kubermatic",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: k8scorev1.SchemeGroupVersion.String(),
+								APIVersion: corev1.SchemeGroupVersion.String(),
 								Kind:       "Secret",
 								Name:       "abcd",
 								UID:        "abcdID", // set manually

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -29,7 +29,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,7 +90,7 @@ func (r *Reconciler) reconcile(ctx context.Context, seedName string, log *zap.Su
 
 	err = client.Get(ctx, types.NamespacedName{Name: seed.Namespace}, &corev1.Namespace{})
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to check for namespace %s in seed cluster: %w", seed.Namespace, err)
 		}
 
@@ -222,7 +222,7 @@ func (r *Reconciler) reconcileSeedRoleBindings(ctx context.Context, seed *kuberm
 func (r *Reconciler) reconcileSeedRBAC(ctx context.Context, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	err := client.Get(ctx, types.NamespacedName{Name: SeedMonitoringNamespace}, &corev1.Namespace{})
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debugw("skipping RBAC setup because monitoring namespace does not exist in master", "namespace", SeedMonitoringNamespace)
 			return nil
 		}
@@ -345,7 +345,7 @@ func (r *Reconciler) reconcileMasterServices(ctx context.Context, seed *kubermat
 func (r *Reconciler) reconcileMasterGrafanaProvisioning(ctx context.Context, seeds map[string]*kubermaticv1.Seed, log *zap.SugaredLogger) error {
 	err := r.Get(ctx, types.NamespacedName{Name: MasterGrafanaNamespace}, &corev1.Namespace{})
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to check for namespace %s: %w", MasterGrafanaNamespace, err)
 		}
 
@@ -368,7 +368,7 @@ func (r *Reconciler) deleteResource(ctx context.Context, client ctrlruntimeclien
 	key := types.NamespacedName{Name: name, Namespace: namespace}
 
 	if err := client.Get(ctx, key, obj); err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to probe for %s: %w", key, err)
 		}
 

--- a/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -75,7 +75,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	seed := &kubermaticv1.Seed{}
 	if err := r.Get(ctx, request.NamespacedName, seed); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 
@@ -131,7 +131,7 @@ func (r *Reconciler) updateKubeconfigValidCondition(ctx context.Context, log *za
 	ns := corev1.Namespace{}
 	key := types.NamespacedName{Name: seed.Namespace}
 	if err := client.Get(ctx, key, &ns); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debugw("KKP namespace does not exist", "namespace", seed.Namespace)
 			reason := fmt.Sprintf("namespace %q does not exist and must be created manually", seed.Namespace)
 			kubermaticv1helper.SetSeedCondition(seed, cond, corev1.ConditionFalse, SeedClusterUninitializedReason, reason)

--- a/pkg/controller/master-controller-manager/seed-sync/controller.go
+++ b/pkg/controller/master-controller-manager/seed-sync/controller.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -79,7 +79,7 @@ func Add(
 	}
 
 	// watch all KubermaticConfigurations in the given namespace
-	configHandler := func(o client.Object) []reconcile.Request {
+	configHandler := func(o ctrlruntimeclient.Object) []reconcile.Request {
 		seeds, err := seedsGetter()
 		if err != nil {
 			log.Errorw("Failed to retrieve seeds", zap.Error(err))

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	seed := &kubermaticv1.Seed{}
 	if err := r.Get(ctx, request.NamespacedName, seed); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 
@@ -169,14 +169,14 @@ func (r *Reconciler) cleanupDeletedSeed(ctx context.Context, configInMaster *kub
 	seedInSeed := &kubermaticv1.Seed{}
 
 	err := seedClient.Get(ctx, seedKey, seedInSeed)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to probe for %s: %w", seedKey, err)
 	}
 
 	configInSeed := &kubermaticv1.KubermaticConfiguration{}
 
 	err = seedClient.Get(ctx, configKey, configInSeed)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to probe for %s: %w", configKey, err)
 	}
 

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
@@ -27,7 +27,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -254,7 +254,7 @@ func TestReconcilingSeed(t *testing.T) {
 			key := ctrlruntimeclient.ObjectKeyFromObject(test.seed)
 
 			result := &kubermaticv1.Seed{}
-			if err := seedClient.Get(ctx, key, result); err != nil && kerrors.IsNotFound(err) {
+			if err := seedClient.Get(ctx, key, result); err != nil && apierrors.IsNotFound(err) {
 				t.Fatalf("could not find seed CR in seed cluster: %v", err)
 			}
 			if test.validate != nil {

--- a/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
+++ b/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
@@ -30,7 +30,7 @@ import (
 	serviceaccount "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -117,7 +117,7 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger) error {
 func (r *reconcileServiceAccountProjectBinding) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	sa := &kubermaticv1.User{}
 	if err := r.Get(ctx, request.NamespacedName, sa); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to get user: %w", err)
@@ -219,7 +219,7 @@ func (r *reconcileServiceAccountProjectBinding) ensureOwnerReference(ctx context
 	project := &kubermaticv1.Project{}
 	err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: user.Spec.Project}, project)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debugw("Project does not exist", "project", user.Spec.Project)
 			return nil
 		}

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -114,7 +114,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, userProjectBinding, kubermaticapiv1.SeedUserProjectBindingCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, userProjectBinding, apiv1.SeedUserProjectBindingCleanupFinalizer); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -144,7 +144,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, userProjectBinding, kubermaticapiv1.SeedUserProjectBindingCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, userProjectBinding, apiv1.SeedUserProjectBindingCleanupFinalizer)
 }
 
 func (r *reconciler) syncAllSeeds(

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -137,7 +137,7 @@ func generateUserProjectBinding(name string, deleted bool) *kubermaticv1.UserPro
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		userProjectBinding.DeletionTimestamp = &deleteTime
-		userProjectBinding.Finalizers = append(userProjectBinding.Finalizers, v1.SeedUserProjectBindingCleanupFinalizer)
+		userProjectBinding.Finalizers = append(userProjectBinding.Finalizers, apiv1.SeedUserProjectBindingCleanupFinalizer)
 	}
 	return userProjectBinding
 }

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller_test.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -105,7 +105,7 @@ func TestReconcile(t *testing.T) {
 			if tc.expectedUserProjectBinding == nil {
 				if err == nil {
 					t.Fatal("failed clean up userProjectBinding on the seed cluster")
-				} else if !errors.IsNotFound(err) {
+				} else if !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to get userProjectBinding: %v", err)
 				}
 			} else {

--- a/pkg/controller/master-controller-manager/user-project-binding/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -70,7 +70,7 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger) error {
 func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	projectBinding := &kubermaticv1.UserProjectBinding{}
 	if err := r.Get(ctx, request.NamespacedName, projectBinding); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -90,7 +90,7 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.SugaredLogger, projectBinding *kubermaticv1.UserProjectBinding) error {
 	project, err := r.getProjectForBinding(ctx, projectBinding)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return r.removeFinalizerFromBinding(ctx, projectBinding)
 		}
 
@@ -99,7 +99,7 @@ func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.Su
 
 	user, err := r.getUserForBinding(ctx, projectBinding)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return r.removeFinalizerFromBinding(ctx, projectBinding)
 		}
 

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -126,7 +126,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, user, kubermaticapiv1.SeedUserCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, user, apiv1.SeedUserCleanupFinalizer); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -170,7 +170,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, user, kubermaticapiv1.SeedUserCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, user, apiv1.SeedUserCleanupFinalizer)
 }
 
 func (r *reconciler) syncAllSeeds(

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -105,7 +105,7 @@ func TestReconcile(t *testing.T) {
 			if tc.expectedUser == nil {
 				if err == nil {
 					t.Fatal("failed clean up user on the seed cluster")
-				} else if !errors.IsNotFound(err) {
+				} else if !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to get user: %v", err)
 				}
 			} else {

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -132,7 +132,7 @@ func generateUser(name string, deleted bool) *kubermaticv1.User {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		user.DeletionTimestamp = &deleteTime
-		user.Finalizers = append(user.Finalizers, v1.SeedUserCleanupFinalizer)
+		user.Finalizers = append(user.Finalizers, apiv1.SeedUserCleanupFinalizer)
 	}
 	return user
 }

--- a/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
@@ -27,7 +27,7 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
@@ -108,7 +108,7 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger) error {
 func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	sshKey := &kubermaticv1.UserSSHKey{}
 	if err := r.Get(ctx, request.NamespacedName, sshKey); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -138,7 +138,7 @@ func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.Su
 	project := &kubermaticv1.Project{}
 	err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: sshKey.Spec.Project}, project)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debugw("Project does not exist", "project", sshKey.Spec.Project)
 			return nil
 		}

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
-	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := seedClient.Get(ctx, types.NamespacedName{Name: request.Name}, cluster); err != nil {
-		if kubeapierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("Could not find cluster")
 			return nil
 		}

--- a/pkg/controller/nodeport-proxy/envoymanager/controller.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -118,7 +117,7 @@ func (r *Reconciler) sync(ctx context.Context) error {
 	services := corev1.ServiceList{}
 	if err := r.List(ctx, &services,
 		ctrlruntimeclient.InNamespace(r.Namespace),
-		client.MatchingFields{r.ExposeAnnotationKey: "true"},
+		ctrlruntimeclient.MatchingFields{r.ExposeAnnotationKey: "true"},
 	); err != nil {
 		return fmt.Errorf("failed to list services: %w", err)
 	}
@@ -199,7 +198,7 @@ func (r *Reconciler) sync(ctx context.Context) error {
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrlruntime.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Service{}, r.ExposeAnnotationKey, func(raw client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Service{}, r.ExposeAnnotationKey, func(raw ctrlruntimeclient.Object) []string {
 		svc := raw.(*corev1.Service)
 		if isExposed(svc, r.ExposeAnnotationKey) {
 			return []string{"true"}

--- a/pkg/controller/nodeport-proxy/envoymanager/controller.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	envoycachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -163,7 +163,7 @@ func (r *Reconciler) sync(ctx context.Context) error {
 		return nil
 	}
 
-	lastUsedVersion, err := semver.NewVersion(currSnapshot.GetVersion(envoyresourcev3.ClusterType))
+	lastUsedVersion, err := semverlib.NewVersion(currSnapshot.GetVersion(envoyresourcev3.ClusterType))
 	if err != nil {
 		return fmt.Errorf("failed to parse version from last snapshot: %w", err)
 	}

--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -32,7 +32,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -198,7 +198,7 @@ func CleanupClusterResource(ctx context.Context, client ctrlruntimeclient.Client
 	key := types.NamespacedName{Name: name}
 
 	if err := client.Get(ctx, key, obj); err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to probe for %s: %w", key, err)
 		}
 
@@ -257,7 +257,7 @@ func DeleteObject(ctx context.Context, client ctrlruntimeclient.Client, name, na
 	}
 
 	if err := client.Get(ctx, key, obj); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
@@ -514,7 +514,7 @@ func ApplicationDefinitionValidatingWebhookConfigurationCreator(ctx context.Cont
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{
-								APIGroups:   []string{appkubermaticv1.GroupName},
+								APIGroups:   []string{appskubermaticv1.GroupName},
 								APIVersions: []string{"*"},
 								Resources:   []string{"applicationdefinitions"},
 								Scope:       &scope,

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -34,7 +34,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -61,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// find the requested configuration
 	config := &kubermaticv1.KubermaticConfiguration{}
 	if err := r.Get(ctx, request.NamespacedName, config); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -42,7 +42,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -139,7 +139,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 	}
 
 	if err := seedClient.Get(ctx, name, seedCopy); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			err = errors.New("seed cluster has not yet been provisioned and contains no Seed CR yet")
 
 			r.masterRecorder.Event(config, corev1.EventTypeWarning, "SeedReconcilingSkipped", fmt.Sprintf("%s: %v", seed.Name, err))

--- a/pkg/controller/operator/seed/reconciler_test.go
+++ b/pkg/controller/operator/seed/reconciler_test.go
@@ -34,7 +34,7 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta "k8s.io/api/batch/v1beta1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -417,7 +417,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 
 				seedClient := reconciler.seedClients[test.seedToReconcile]
 
-				cronJob := batchv1beta.CronJob{}
+				cronJob := batchv1beta1.CronJob{}
 				err := seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob)
 				if err != nil {
 					// cron jobs should be created only when running enterprise edition
@@ -452,7 +452,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 				seedClient := reconciler.seedClients[test.seedToReconcile]
 
 				// asserting that reporting cron job exists
-				cronJob := batchv1beta.CronJob{}
+				cronJob := batchv1beta1.CronJob{}
 				must(t, seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob))
 
 				seed := &kubermaticv1.Seed{}
@@ -503,7 +503,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 				seedClient := reconciler.seedClients[test.seedToReconcile]
 
 				// asserting that reporting cron job exists
-				cronJob := batchv1beta.CronJob{}
+				cronJob := batchv1beta1.CronJob{}
 				must(t, seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob))
 
 				// asserting that metering deployment exists

--- a/pkg/controller/operator/seed/reconciler_test.go
+++ b/pkg/controller/operator/seed/reconciler_test.go
@@ -37,7 +37,7 @@ import (
 	batchv1beta "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -421,7 +421,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 				err := seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob)
 				if err != nil {
 					// cron jobs should be created only when running enterprise edition
-					if edition == communityEdition && kerrors.IsNotFound(err) {
+					if edition == communityEdition && apierrors.IsNotFound(err) {
 						return nil
 					}
 					return fmt.Errorf("failed to find reporting cronjob: %w", err)
@@ -472,7 +472,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 					Namespace: "kubermatic",
 					Name:      "weekly-test",
 				}, &cronJob); err != nil {
-					if kerrors.IsNotFound(err) {
+					if apierrors.IsNotFound(err) {
 						return nil
 					}
 				}
@@ -530,7 +530,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 					Namespace: "kubermatic",
 					Name:      "weekly-test",
 				}, &cronJob); err != nil {
-					if !kerrors.IsNotFound(err) {
+					if !apierrors.IsNotFound(err) {
 						return fmt.Errorf("failed to remove reporting cron jobs")
 					}
 				}
@@ -539,7 +539,7 @@ func testBasicReconciling(t *testing.T, edition KubermaticEdition) {
 					Namespace: "kubermatic",
 					Name:      "kubermatic-metering",
 				}, &deployment); err != nil {
-					if !kerrors.IsNotFound(err) {
+					if !apierrors.IsNotFound(err) {
 						return fmt.Errorf("failed to remove metering deployment")
 					}
 				}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -41,7 +41,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -178,7 +178,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	addon := &kubermaticv1.Addon{}
 	if err := r.Get(ctx, request.NamespacedName, addon); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -187,7 +187,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: addon.Spec.Cluster.Name}, cluster); err != nil {
 		// If it's not a NotFound err, return it
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
 

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/addon"
@@ -464,7 +464,7 @@ func (r *Reconciler) setupManifestInteraction(ctx context.Context, log *zap.Suga
 	return kubeconfigFilename, manifestFilename, done, nil
 }
 
-func (r *Reconciler) getApplyCommand(ctx context.Context, kubeconfigFilename, manifestFilename string, selector fmt.Stringer, clusterVersion *semver.Version) (*exec.Cmd, error) {
+func (r *Reconciler) getApplyCommand(ctx context.Context, kubeconfigFilename, manifestFilename string, selector fmt.Stringer, clusterVersion *semverlib.Version) (*exec.Cmd, error) {
 	binary, err := kubectl.BinaryForClusterVersion(clusterVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine kubectl binary to use: %w", err)

--- a/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -97,7 +97,7 @@ func Add(
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -42,7 +42,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -195,7 +195,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: request.Name}, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -247,7 +247,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 				if err := r.Create(ctx, r.cleanupJob(cluster, backupCleanupContainer)); err != nil {
 					// Otherwise we end up in a loop when we are able to create the job but not
 					// remove the finalizer.
-					if !kerrors.IsAlreadyExists(err) {
+					if !apierrors.IsAlreadyExists(err) {
 						return err
 					}
 				}
@@ -552,12 +552,12 @@ func (r *Reconciler) deleteCronJob(ctx context.Context, cluster *kubermaticv1.Cl
 	cj := &batchv1beta1.CronJob{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: name}, cj)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	if err := r.Delete(ctx, cj, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.Delete(ctx, cj, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete cronjob %s: %w", name, err)
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
@@ -158,7 +158,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		log.Debug("Cleaning up cloud provider")
 
 		// in-cluster resources, like nodes, are still being cleaned up
-		if kuberneteshelper.HasAnyFinalizer(cluster, kubermaticapiv1.InClusterLBCleanupFinalizer, kubermaticapiv1.InClusterPVCleanupFinalizer, kubermaticapiv1.NodeDeletionFinalizer) {
+		if kuberneteshelper.HasAnyFinalizer(cluster, apiv1.InClusterLBCleanupFinalizer, apiv1.InClusterPVCleanupFinalizer, apiv1.NodeDeletionFinalizer) {
 			log.Debug("Cluster still has in-cluster cleanup finalizers, retrying later")
 			return &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}

--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -39,7 +39,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -111,7 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -180,7 +180,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	}
 
 	handleProviderError := func(err error) (*reconcile.Result, error) {
-		if kerrors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			// In case of conflict we just re-enqueue the item for later
 			// processing without returning an error.
 			r.log.Infow("failed to run cloud provider", zap.Error(err))

--- a/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -81,7 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,7 +101,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	instance := &kubermaticv1.ClusterTemplateInstance{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, instance); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -23,7 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -204,7 +204,7 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster); err != nil {
 		return err
 	}
-	kuberneteshelper.AddFinalizer(newCluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(newCluster, apiv1.CredentialsSecretsCleanupFinalizer)
 
 	// re-use our reconciling framework, because this is a special place where right after the Cluster
 	// creation, we must set some status fields and this requires us to wait for the Cluster object

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -104,8 +104,8 @@ func TestReconcile(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error status %v", tc.expectedGetErrStatus)
 				}
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"testing"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -119,7 +119,7 @@ func TestReconcile(t *testing.T) {
 				// ignore clusters that only have a deletion timestampa and
 				// the CredentialsSecretsCleanupFinalizer finalizer, as those
 				// would be cleaned up by another controller
-				if kuberneteshelper.HasOnlyFinalizer(&cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer) && !cluster.DeletionTimestamp.IsZero() {
+				if kuberneteshelper.HasOnlyFinalizer(&cluster, apiv1.CredentialsSecretsCleanupFinalizer) && !cluster.DeletionTimestamp.IsZero() {
 					continue
 				}
 
@@ -161,7 +161,7 @@ func genCluster(name, userEmail string, instance kubermaticv1.ClusterTemplateIns
 			Name:            name,
 			Labels:          map[string]string{kubermaticv1.ProjectIDLabelKey: instance.Spec.ProjectID, kubernetes.ClusterTemplateInstanceLabelKey: instance.Name},
 			ResourceVersion: "1",
-			Finalizers:      []string{kubermaticapiv1.CredentialsSecretsCleanupFinalizer},
+			Finalizers:      []string{apiv1.CredentialsSecretsCleanupFinalizer},
 			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail},
 		},
 		Spec: kubermaticv1.ClusterSpec{

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -23,7 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -49,7 +49,7 @@ import (
 const (
 	// This controller syncs the kubermatic constraints to constraint on the user cluster.
 	ControllerName = "kkp-constraint-synchronizer"
-	finalizer      = kubermaticapiv1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer
+	finalizer      = apiv1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer
 	Key            = "default"
 	AddAction      = "add"
 	RemoveAction   = "remove"

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
@@ -27,7 +27,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -125,8 +125,8 @@ func TestReconcile(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error status %s, instead got constraint: %v", tc.expectedGetErrStatus, constraint)
 				}
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -155,7 +155,7 @@ func genConstraint(name, namespace, kind string, label, deleted bool) *kubermati
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		constraint.DeletionTimestamp = &deleteTime
-		constraint.Finalizers = append(constraint.Finalizers, v1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer)
+		constraint.Finalizers = append(constraint.Finalizers, apiv1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer)
 	}
 	return constraint
 }

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
+	v1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"go.uber.org/zap"
 
 	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,7 +116,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	constraintTemplate := &kubermaticv1.ConstraintTemplate{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, constraintTemplate); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("constraint template not found, returning")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -23,7 +23,7 @@ import (
 	v1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -134,7 +134,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, constraintTemplate *kubermaticv1.ConstraintTemplate) error {
 	if constraintTemplate.DeletionTimestamp != nil {
-		if !kuberneteshelper.HasFinalizer(constraintTemplate, kubermaticapiv1.GatekeeperConstraintTemplateCleanupFinalizer) {
+		if !kuberneteshelper.HasFinalizer(constraintTemplate, apiv1.GatekeeperConstraintTemplateCleanupFinalizer) {
 			return nil
 		}
 
@@ -151,10 +151,10 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 			return err
 		}
 
-		return kuberneteshelper.TryRemoveFinalizer(ctx, r.seedClient, constraintTemplate, kubermaticapiv1.GatekeeperConstraintTemplateCleanupFinalizer)
+		return kuberneteshelper.TryRemoveFinalizer(ctx, r.seedClient, constraintTemplate, apiv1.GatekeeperConstraintTemplateCleanupFinalizer)
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.seedClient, constraintTemplate, kubermaticapiv1.GatekeeperConstraintTemplateCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.seedClient, constraintTemplate, apiv1.GatekeeperConstraintTemplateCleanupFinalizer); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -127,8 +127,8 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("expected error status %s, instead got ct: %v", tc.expectedGetErrStatus, ct)
 				}
 
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}
@@ -192,8 +192,8 @@ func TestDeleteWhenCTOnUserClusterIsMissing(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-	if errors.ReasonForError(err) != metav1.StatusReasonNotFound {
-		t.Fatalf("expected err: %v, got %v", metav1.StatusReasonNotFound, errors.ReasonForError(err))
+	if apierrors.ReasonForError(err) != metav1.StatusReasonNotFound {
+		t.Fatalf("expected err: %v, got %v", metav1.StatusReasonNotFound, apierrors.ReasonForError(err))
 	}
 }
 

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -231,12 +231,12 @@ func genCTSpec() kubermaticv1.ConstraintTemplateSpec {
 					ShortNames: []string{"lc"},
 				},
 				Validation: &constrainttemplatev1.Validation{
-					OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
-						Properties: map[string]apiextensionv1.JSONSchemaProps{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"labels": {
 								Type: "array",
-								Items: &apiextensionv1.JSONSchemaPropsOrArray{
-									Schema: &apiextensionv1.JSONSchemaProps{
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
 										Type: "string",
 									},
 								},

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -24,7 +24,7 @@ import (
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -205,7 +205,7 @@ func genConstraintTemplate(name string, deleted bool) *kubermaticv1.ConstraintTe
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		ct.DeletionTimestamp = &deleteTime
-		ct.Finalizers = append(ct.Finalizers, v1.GatekeeperConstraintTemplateCleanupFinalizer)
+		ct.Finalizers = append(ct.Finalizers, apiv1.GatekeeperConstraintTemplateCleanupFinalizer)
 	}
 
 	return ct

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -42,7 +42,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -199,7 +199,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	backupConfig := &kubermaticv1.EtcdBackupConfig{}
 	if err := r.Get(ctx, request.NamespacedName, backupConfig); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -234,7 +234,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		kubermaticv1.ClusterConditionNone,
 		func() (*reconcile.Result, error) {
 			result, err := r.reconcile(ctx, log, backupConfig, cluster, seed, config)
-			if kerrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				// benign update conflict -- remember this so we can
 				// suppress log.Error and event generation below
 				suppressedError = err
@@ -522,7 +522,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 				job := &batchv1.Job{}
 				err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: backup.JobName}, job)
 				if err != nil {
-					if !kerrors.IsNotFound(err) {
+					if !apierrors.IsNotFound(err) {
 						return nil, fmt.Errorf("error getting job for backup %s: %w", backup.BackupName, err)
 					}
 					// job not found. Apparently deleted externally.
@@ -545,7 +545,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 				}
 			} else if backup.BackupPhase == "" && r.clock.Now().Sub(backup.ScheduledTime.Time) >= 0 && backupConfig.DeletionTimestamp == nil {
 				job := r.backupJob(backupConfig, cluster, backup, destination, storeContainer)
-				if err := r.Create(ctx, job); err != nil && !kerrors.IsAlreadyExists(err) {
+				if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
 					return nil, fmt.Errorf("error creating job for backup %s: %w", backup.BackupName, err)
 				}
 				backup.BackupPhase = kubermaticv1.BackupStatusPhaseRunning
@@ -628,7 +628,7 @@ func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *ku
 	destination *kubermaticv1.BackupDestination, deleteContainer *corev1.Container) error {
 	if deleteContainer != nil {
 		job := r.backupDeleteJob(backupConfig, cluster, backup, destination, deleteContainer)
-		if err := r.Create(ctx, job); err != nil && !kerrors.IsAlreadyExists(err) {
+		if err := r.Create(ctx, job); err != nil && !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("error creating delete job for backup %s: %w", backup.BackupName, err)
 		}
 		backup.DeletePhase = kubermaticv1.BackupStatusPhaseRunning
@@ -660,7 +660,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 			job := &batchv1.Job{}
 			err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: backup.DeleteJobName}, job)
 			if err != nil {
-				if !kerrors.IsNotFound(err) {
+				if !apierrors.IsNotFound(err) {
 					return nil, fmt.Errorf("error getting delete job for backup %s: %w", backup.BackupName, err)
 				}
 				// job not found. Apparently deleted, either externally or by us in a previous cycle.
@@ -677,7 +677,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 					// delete jobs are the only things that know how to delete a backup.
 					// Ideally jobs would support recreating failed or hanging pods themselves, but
 					// they don't under all circumstances -- see https://github.com/kubernetes/kubernetes/issues/95431
-					if err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !kerrors.IsNotFound(err) {
+					if err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
 						return nil, fmt.Errorf("backup %s: failed to delete failed delete job %s: %w", backup.BackupName, backup.JobName, err)
 					}
 					deleteJobsToRestart = append(deleteJobsToRestart, DeleteJobToRestart{backup, fmt.Sprintf("Job failed: %s. Restarted.", cond.Message)})
@@ -749,15 +749,15 @@ func (r *Reconciler) deleteFinishedBackupJobs(ctx context.Context, log *zap.Suga
 
 				err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: backup.JobName}, job)
 				switch {
-				case kerrors.IsNotFound(err):
+				case apierrors.IsNotFound(err):
 					backupJobDeleted = true
 				case err == nil:
 					err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground))
-					if err != nil && !kerrors.IsNotFound(err) {
+					if err != nil && !apierrors.IsNotFound(err) {
 						return nil, fmt.Errorf("backup %s: failed to delete backup job %s: %w", backup.BackupName, backup.JobName, err)
 					}
 					backupJobDeleted = true
-				case !kerrors.IsNotFound(err):
+				case !apierrors.IsNotFound(err):
 					return nil, fmt.Errorf("backup %s: failed to get backup job %s: %w", backup.BackupName, backup.JobName, err)
 				}
 			}
@@ -783,15 +783,15 @@ func (r *Reconciler) deleteFinishedBackupJobs(ctx context.Context, log *zap.Suga
 
 				err := r.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: backup.DeleteJobName}, job)
 				switch {
-				case kerrors.IsNotFound(err):
+				case apierrors.IsNotFound(err):
 					deleteJobDeleted = true
 				case err == nil:
 					err := r.Delete(ctx, job, ctrlruntimeclient.PropagationPolicy(metav1.DeletePropagationBackground))
-					if err != nil && !kerrors.IsNotFound(err) {
+					if err != nil && !apierrors.IsNotFound(err) {
 						return nil, fmt.Errorf("backup %s: failed to delete job %s: %w", backup.BackupName, backup.DeleteJobName, err)
 					}
 					deleteJobDeleted = true
-				case !kerrors.IsNotFound(err):
+				case !apierrors.IsNotFound(err):
 					return nil, fmt.Errorf("backup %s: failed to get job %s: %w", backup.BackupName, backup.DeleteJobName, err)
 				}
 			}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -449,7 +449,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			}
 
 			readbackBackupConfig := &kubermaticv1.EtcdBackupConfig{}
-			if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
+			if err := reconciler.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
 				t.Fatalf("Error reading back completed backupConfig: %v", err)
 			}
 
@@ -622,7 +622,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			backupConfig.SetCreationTimestamp(metav1.Time{Time: clock.Now()})
 			backupConfig.Status.CurrentBackups = tc.existingBackups
 
-			initObjs := []client.Object{
+			initObjs := []ctrlruntimeclient.Object{
 				cluster,
 				backupConfig,
 			}
@@ -649,7 +649,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			}
 
 			readbackBackupConfig := &kubermaticv1.EtcdBackupConfig{}
-			if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
+			if err := reconciler.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
 				t.Fatalf("Error reading back completed backupConfig: %v", err)
 			}
 
@@ -937,7 +937,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			backupConfig.Spec.Keep = intPtr(tc.keep)
 			backupConfig.Status.CurrentBackups = tc.existingBackups
 
-			initObjs := []client.Object{
+			initObjs := []ctrlruntimeclient.Object{
 				cluster,
 				backupConfig,
 			}
@@ -964,7 +964,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			}
 
 			readbackBackupConfig := &kubermaticv1.EtcdBackupConfig{}
-			if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
+			if err := reconciler.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
 				t.Fatalf("Error reading back completed backupConfig: %v", err)
 			}
 
@@ -1205,7 +1205,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 			backupConfig.SetCreationTimestamp(metav1.Time{Time: clock.Now()})
 			backupConfig.Status.CurrentBackups = tc.existingBackups
 
-			initObjs := []client.Object{
+			initObjs := []ctrlruntimeclient.Object{
 				cluster,
 				backupConfig,
 			}
@@ -1231,7 +1231,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 			}
 
 			readbackBackupConfig := &kubermaticv1.EtcdBackupConfig{}
-			if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
+			if err := reconciler.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
 				t.Fatalf("Error reading back completed backupConfig: %v", err)
 			}
 
@@ -1502,7 +1502,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 			backupConfig.SetCreationTimestamp(metav1.Time{Time: clock.Now()})
 			backupConfig.Status.CurrentBackups = tc.existingBackups
 
-			initObjs := []client.Object{
+			initObjs := []ctrlruntimeclient.Object{
 				cluster,
 				backupConfig,
 			}
@@ -1528,7 +1528,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 			}
 
 			readbackBackupConfig := &kubermaticv1.EtcdBackupConfig{}
-			if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
+			if err := reconciler.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: backupConfig.GetNamespace(), Name: backupConfig.GetName()}, readbackBackupConfig); err != nil {
 				t.Fatalf("Error reading back completed backupConfig: %v", err)
 			}
 
@@ -1630,7 +1630,7 @@ func TestMultipleBackupDestination(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			initObjs := []client.Object{
+			initObjs := []ctrlruntimeclient.Object{
 				genTestCluster(),
 				tc.backupConfig,
 				genClusterRootCaSecret(),

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -35,7 +35,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	restore := &kubermaticv1.EtcdRestore{}
 	if err := r.Get(ctx, request.NamespacedName, restore); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -227,7 +227,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 		}
 		cluster.Annotations[ActiveRestoreAnnotationName] = thisRestore
 		if err := r.Client.Update(ctx, cluster); err != nil {
-			if kerrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return &reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 			}
 			return nil, fmt.Errorf("error updating cluster active restore annotation: %w", err)
@@ -255,10 +255,10 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 	sts := &appsv1.StatefulSet{}
 	err = r.Get(ctx, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.EtcdStatefulSetName}, sts)
 	if err == nil {
-		if err := r.Delete(ctx, sts); err != nil && !kerrors.IsNotFound(err) {
+		if err := r.Delete(ctx, sts); err != nil && !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to delete etcd statefulset: %w", err)
 		}
-	} else if !kerrors.IsNotFound(err) {
+	} else if !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get etcd statefulset: %w", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
@@ -176,20 +176,20 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 }
 
 func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, client ctrlruntimeclient.Client, application v1.Application, cluster *kubermaticv1.Cluster) error {
-	applicationInstallation := appkubermaticv1.ApplicationInstallation{
+	applicationInstallation := appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        application.Name,
 			Namespace:   metav1.NamespaceSystem,
 			Annotations: application.Annotations,
 		},
-		Spec: appkubermaticv1.ApplicationInstallationSpec{
-			Namespace: appkubermaticv1.NamespaceSpec{
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
+			Namespace: appskubermaticv1.NamespaceSpec{
 				Name:        application.Spec.Namespace.Name,
 				Create:      application.Spec.Namespace.Create,
 				Labels:      application.Spec.Namespace.Labels,
 				Annotations: application.Spec.Namespace.Annotations,
 			},
-			ApplicationRef: appkubermaticv1.ApplicationRef{
+			ApplicationRef: appskubermaticv1.ApplicationRef{
 				Name:    application.Spec.ApplicationRef.Name,
 				Version: application.Spec.ApplicationRef.Version,
 			},

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-openapi/errors"
 	"go.uber.org/zap"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
@@ -85,7 +85,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
 
-	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(v1.InitialApplicationInstallationsRequestAnnotation, "", false)); err != nil {
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(apiv1.InitialApplicationInstallationsRequestAnnotation, "", false)); err != nil {
 		return fmt.Errorf("failed to create watch: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// there is no annotation anymore
-	request := cluster.Annotations[v1.InitialApplicationInstallationsRequestAnnotation]
+	request := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]
 	if request == "" {
 		return nil, nil
 	}
@@ -175,7 +175,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	return nil, nil
 }
 
-func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, client ctrlruntimeclient.Client, application v1.Application, cluster *kubermaticv1.Cluster) error {
+func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, client ctrlruntimeclient.Client, application apiv1.Application, cluster *kubermaticv1.Cluster) error {
 	applicationInstallation := appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        application.Name,
@@ -212,8 +212,8 @@ func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, 
 	return nil
 }
 
-func (r *Reconciler) parseApplications(cluster *kubermaticv1.Cluster, request string) ([]v1.Application, error) {
-	var applications []v1.Application
+func (r *Reconciler) parseApplications(cluster *kubermaticv1.Cluster, request string) ([]apiv1.Application, error) {
+	var applications []apiv1.Application
 	if err := json.Unmarshal([]byte(request), &applications); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal initial Applications request: %w", err)
 	}
@@ -222,6 +222,6 @@ func (r *Reconciler) parseApplications(cluster *kubermaticv1.Cluster, request st
 
 func (r *Reconciler) removeAnnotation(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	oldCluster := cluster.DeepCopy()
-	delete(cluster.Annotations, v1.InitialApplicationInstallationsRequestAnnotation)
+	delete(cluster.Annotations, apiv1.InitialApplicationInstallationsRequestAnnotation)
 	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,7 +95,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -200,7 +200,7 @@ func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, 
 	err := client.Create(ctx, &applicationInstallation)
 	if err != nil {
 		// If the application already exists, we just ignore the error and move forward.
-		if kerrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return nil
 		}
 

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
@@ -28,7 +28,7 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -53,7 +53,7 @@ const (
 )
 
 func init() {
-	utilruntime.Must(appkubermaticv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(appskubermaticv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterv1alpha1.AddToScheme(scheme.Scheme))
 }
 
@@ -142,7 +142,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
-				apps := appkubermaticv1.ApplicationInstallationList{}
+				apps := appskubermaticv1.ApplicationInstallationList{}
 				if err := userClusterClient.List(context.Background(), &apps); err != nil {
 					return fmt.Errorf("failed to list ApplicationInstallations in user cluster: %w", err)
 				}
@@ -176,7 +176,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
-				apps := appkubermaticv1.ApplicationInstallationList{}
+				apps := appskubermaticv1.ApplicationInstallationList{}
 				if err := userClusterClient.List(context.Background(), &apps); err != nil {
 					return fmt.Errorf("failed to list ApplicationInstallations in user cluster: %w", err)
 				}
@@ -293,7 +293,7 @@ func generateApplication(name string) v1.Application {
 			},
 			ApplicationRef: v1.ApplicationRef{
 				Name:    name,
-				Version: appkubermaticv1.Version{Version: *semverlib.MustParse("1.0.0")},
+				Version: appskubermaticv1.Version{Version: *semverlib.MustParse("1.0.0")},
 			},
 			Values: values,
 		},

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
@@ -76,7 +76,7 @@ func genCluster(annotation string) *kubermaticv1.Cluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testcluster",
 			Annotations: map[string]string{
-				v1.InitialApplicationInstallationsRequestAnnotation: annotation,
+				apiv1.InitialApplicationInstallationsRequestAnnotation: annotation,
 			},
 			Labels: map[string]string{
 				kubermaticv1.ProjectIDLabelKey: projectID,
@@ -124,7 +124,7 @@ func TestReconcile(t *testing.T) {
 			name: "create a single ApplicationInstallation from the annotation",
 			cluster: func() *kubermaticv1.Cluster {
 				app := generateApplication(applicationName)
-				applications := []v1.Application{app}
+				applications := []apiv1.Application{app}
 
 				data, err := json.Marshal(applications)
 				if err != nil {
@@ -138,7 +138,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("reconciling should not have caused an error, but did: %w", reconcileErr)
 				}
 
-				if ann, ok := cluster.Annotations[v1.InitialApplicationInstallationsRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]; ok {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -159,7 +159,7 @@ func TestReconcile(t *testing.T) {
 			cluster: func() *kubermaticv1.Cluster {
 				app := generateApplication(applicationName)
 				app2 := generateApplication("kold")
-				applications := []v1.Application{app, app2}
+				applications := []apiv1.Application{app, app2}
 
 				data, err := json.Marshal(applications)
 				if err != nil {
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("reconciling should not have caused an error, but did: %w", reconcileErr)
 				}
 
-				if ann, ok := cluster.Annotations[v1.InitialApplicationInstallationsRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]; ok {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -196,7 +196,7 @@ func TestReconcile(t *testing.T) {
 					return errors.New("reconciling a bad annotation should have produced an error, but got nil")
 				}
 
-				if ann, ok := cluster.Annotations[v1.InitialApplicationInstallationsRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]; ok {
 					return fmt.Errorf("bad annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -273,25 +273,25 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func generateApplication(name string) v1.Application {
+func generateApplication(name string) apiv1.Application {
 	var values json.RawMessage
 	_ = json.Unmarshal([]byte(`{
 		"key": "value",
 		"key2": "value2",
 	}`), &values)
 
-	return v1.Application{
-		ObjectMeta: v1.ObjectMeta{
+	return apiv1.Application{
+		ObjectMeta: apiv1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1.ApplicationSpec{
-			Namespace: v1.NamespaceSpec{
+		Spec: apiv1.ApplicationSpec{
+			Namespace: apiv1.NamespaceSpec{
 				Name:        fmt.Sprintf("app-%s", name),
 				Create:      true,
 				Labels:      map[string]string{"key": "value"},
 				Annotations: map[string]string{"key": "value"},
 			},
-			ApplicationRef: v1.ApplicationRef{
+			ApplicationRef: apiv1.ApplicationRef{
 				Name:    name,
 				Version: appskubermaticv1.Version{Version: *semverlib.MustParse("1.0.0")},
 			},

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
@@ -23,7 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
@@ -86,7 +86,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
 
-	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(v1.InitialMachineDeploymentRequestAnnotation, "", false)); err != nil {
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(apiv1.InitialMachineDeploymentRequestAnnotation, "", false)); err != nil {
 		return fmt.Errorf("failed to create watch: %w", err)
 	}
 
@@ -126,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// there is no annotation anymore
-	request := cluster.Annotations[v1.InitialMachineDeploymentRequestAnnotation]
+	request := cluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]
 	if request == "" {
 		return nil, nil
 	}
@@ -163,8 +163,8 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	return nil, nil
 }
 
-func (r *Reconciler) parseNodeDeployment(cluster *kubermaticv1.Cluster, request string) (*v1.NodeDeployment, error) {
-	var nodeDeployment *v1.NodeDeployment
+func (r *Reconciler) parseNodeDeployment(cluster *kubermaticv1.Cluster, request string) (*apiv1.NodeDeployment, error) {
+	var nodeDeployment *apiv1.NodeDeployment
 	if err := json.Unmarshal([]byte(request), &nodeDeployment); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal initial MachineDeployment request: %w", err)
 	}
@@ -177,7 +177,7 @@ func (r *Reconciler) parseNodeDeployment(cluster *kubermaticv1.Cluster, request 
 	return nodeDeployment, nil
 }
 
-func (r *Reconciler) createInitialMachineDeployment(ctx context.Context, nodeDeployment *v1.NodeDeployment, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) error {
+func (r *Reconciler) createInitialMachineDeployment(ctx context.Context, nodeDeployment *apiv1.NodeDeployment, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) error {
 	datacenter, err := r.getTargetDatacenter(cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get target datacenter: %w", err)
@@ -255,6 +255,6 @@ func (r *Reconciler) getSSHKeys(ctx context.Context, cluster *kubermaticv1.Clust
 
 func (r *Reconciler) removeAnnotation(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	oldCluster := cluster.DeepCopy()
-	delete(cluster.Annotations, v1.InitialMachineDeploymentRequestAnnotation)
+	delete(cluster.Annotations, apiv1.InitialMachineDeploymentRequestAnnotation)
 	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -96,7 +96,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -204,7 +204,7 @@ func (r *Reconciler) createInitialMachineDeployment(ctx context.Context, nodeDep
 		// in case we created the MD before but then failed to cleanup the Cluster resource's
 		// annotations, we can silently ignore AlreadyExists errors here and then re-try removing
 		// the annotation afterwards
-		if kerrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return nil
 		}
 

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller_test.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -73,7 +73,7 @@ func genCluster(annotation string) *kubermaticv1.Cluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testcluster",
 			Annotations: map[string]string{
-				v1.InitialMachineDeploymentRequestAnnotation: annotation,
+				apiv1.InitialMachineDeploymentRequestAnnotation: annotation,
 			},
 			Labels: map[string]string{
 				kubermaticv1.ProjectIDLabelKey: projectID,
@@ -121,21 +121,21 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "vanilla case, create a MachineDeployment from the annotation",
 			cluster: func() *kubermaticv1.Cluster {
-				nd := v1.NodeDeployment{
-					ObjectMeta: v1.ObjectMeta{
+				nd := apiv1.NodeDeployment{
+					ObjectMeta: apiv1.ObjectMeta{
 						Name: "test",
 					},
-					Spec: v1.NodeDeploymentSpec{
+					Spec: apiv1.NodeDeploymentSpec{
 						Replicas: 1,
-						Template: v1.NodeSpec{
-							Versions: v1.NodeVersionInfo{
+						Template: apiv1.NodeSpec{
+							Versions: apiv1.NodeVersionInfo{
 								Kubelet: kubernetesVersion,
 							},
-							OperatingSystem: v1.OperatingSystemSpec{
-								Ubuntu: &v1.UbuntuSpec{},
+							OperatingSystem: apiv1.OperatingSystemSpec{
+								Ubuntu: &apiv1.UbuntuSpec{},
 							},
-							Cloud: v1.NodeCloudSpec{
-								Hetzner: &v1.HetznerNodeSpec{
+							Cloud: apiv1.NodeCloudSpec{
+								Hetzner: &apiv1.HetznerNodeSpec{
 									Type:    "big",
 									Network: "test",
 								},
@@ -156,7 +156,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("reconciling should not have caused an error, but did: %w", reconcileErr)
 				}
 
-				if ann, ok := cluster.Annotations[v1.InitialMachineDeploymentRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]; ok {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -181,7 +181,7 @@ func TestReconcile(t *testing.T) {
 					return errors.New("reconciling a bad annotation should have produced an error, but got nil")
 				}
 
-				if ann, ok := cluster.Annotations[v1.InitialMachineDeploymentRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]; ok {
 					return fmt.Errorf("bad annotation should be have been removed, but found %q on the cluster", ann)
 				}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -42,7 +42,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
@@ -211,7 +211,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("Could not find cluster")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -28,7 +28,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -135,11 +135,11 @@ func (r *Reconciler) machineControllerHealthCheck(ctx context.Context, cluster *
 	key := types.NamespacedName{Name: resources.MachineControllerMutatingWebhookConfigurationName}
 	webhookMutatingConf := &admissionregistrationv1.MutatingWebhookConfiguration{}
 	err = userClient.Get(ctx, key, webhookMutatingConf)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return kubermaticv1.HealthStatusDown, err
 	}
 	// if the mutatingWebhookConfiguration doesn't exist yet, return StatusDown
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return kubermaticv1.HealthStatusDown, nil
 	}
 
@@ -181,11 +181,11 @@ func (r *Reconciler) applicationControllerHealthCheck(ctx context.Context, clust
 	key := types.NamespacedName{Name: applications.ApplicationInstallationAdmissionWebhookName}
 	webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 	err = userClient.Get(ctx, key, webhook)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return kubermaticv1.HealthStatusDown, err
 	}
 	// if the ValidatingWebhookConfiguration doesn't exist yet, return StatusDown
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return kubermaticv1.HealthStatusDown, nil
 	}
 
@@ -221,7 +221,7 @@ func (r *Reconciler) statefulSetHealthCheck(ctx context.Context, c *kubermaticv1
 
 	if err != nil {
 		// if the StatefulSet for etcd doesn't exist yet, there's nothing to worry about
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		} else {
 			return false, err

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -30,7 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // clusterIsReachable checks if the cluster is reachable via its external name.
@@ -64,7 +64,7 @@ func (r *Reconciler) etcdUseStrictTLS(ctx context.Context, c *kubermaticv1.Clust
 	pods := &corev1.PodList{}
 	labelSet := etcd.GetBasePodLabels(c)
 
-	err = r.Client.List(ctx, pods, &client.ListOptions{
+	err = r.Client.List(ctx, pods, &ctrlruntimeclient.ListOptions{
 		Namespace:     c.Status.NamespaceName,
 		LabelSelector: labels.SelectorFromSet(labelSet),
 	})

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -27,7 +27,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +54,7 @@ func (r *Reconciler) etcdUseStrictTLS(ctx context.Context, c *kubermaticv1.Clust
 
 	if err != nil {
 		// if the StatefulSet for etcd doesn't exist yet, a new one can be deployed with strict TLS peers
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		} else {
 			return false, err

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -38,8 +38,8 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		return nil, err
 	}
 
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.EtcdBackupConfigCleanupFinalizer) {
-		res, err := r.AddFinalizers(ctx, cluster, kubermaticapiv1.EtcdBackupConfigCleanupFinalizer)
+	if !kuberneteshelper.HasFinalizer(cluster, apiv1.EtcdBackupConfigCleanupFinalizer) {
+		res, err := r.AddFinalizers(ctx, cluster, apiv1.EtcdBackupConfigCleanupFinalizer)
 		if err != nil {
 			return nil, err
 		}
@@ -76,13 +76,13 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 
 		// Only add the node deletion finalizer when the cluster is actually running
 		// Otherwise we fail to delete the nodes and are stuck in a loop
-		if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
-			finalizers = append(finalizers, kubermaticapiv1.NodeDeletionFinalizer)
+		if !kuberneteshelper.HasFinalizer(cluster, apiv1.NodeDeletionFinalizer) {
+			finalizers = append(finalizers, apiv1.NodeDeletionFinalizer)
 		}
 	}
 
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.KubermaticConstraintCleanupFinalizer) {
-		finalizers = append(finalizers, kubermaticapiv1.KubermaticConstraintCleanupFinalizer)
+	if !kuberneteshelper.HasFinalizer(cluster, apiv1.KubermaticConstraintCleanupFinalizer) {
+		finalizers = append(finalizers, apiv1.KubermaticConstraintCleanupFinalizer)
 	}
 
 	if len(finalizers) > 0 {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -50,7 +50,7 @@ import (
 	webterminal "k8c.io/kubermatic/v2/pkg/resources/web-terminal"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -237,7 +237,7 @@ func (r *Reconciler) ensureNamespaceExists(ctx context.Context, cluster *kuberma
 	if err == nil {
 		return ns, nil // found it
 	}
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return nil, err // something bad happened when trying to get the namespace
 	}
 
@@ -716,7 +716,7 @@ func (r *Reconciler) ensureEtcdBackupConfigs(ctx context.Context, c *kubermaticv
 	ebc := &kubermaticv1.EtcdBackupConfig{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: resources.EtcdDefaultBackupConfigName, Namespace: c.Status.NamespaceName}, ebc)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
@@ -726,7 +726,7 @@ func (r *Reconciler) ensureEtcdBackupConfigs(ctx context.Context, c *kubermaticv
 
 func (r *Reconciler) ensureOldOPAIntegrationIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range gatekeeper.GetResourcesToRemoveOnDelete(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !errors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure old OPA integration version resources are removed/not present: %w", err)
 		}
 	}
@@ -737,7 +737,7 @@ func (r *Reconciler) ensureOldOPAIntegrationIsRemoved(ctx context.Context, data 
 func (r *Reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range kubernetesdashboard.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
 		err := r.Client.Delete(ctx, resource)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure kubernetes-dashboard resources are removed/not present: %w", err)
 		}
 	}
@@ -747,7 +747,7 @@ func (r *Reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Co
 func (r *Reconciler) ensureOSMResourcesAreRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range operatingsystemmanager.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
 		err := r.Client.Delete(ctx, resource)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure OSM resources are removed/not present: %w", err)
 		}
 	}
@@ -756,17 +756,17 @@ func (r *Reconciler) ensureOSMResourcesAreRemoved(ctx context.Context, data *res
 
 func (r *Reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range openvpn.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !errors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure OpenVPN resources are removed/not present: %w", err)
 		}
 	}
 	for _, resource := range metricsserver.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !errors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure metrics-server resources are removed/not present: %w", err)
 		}
 	}
 	for _, resource := range dns.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !errors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure dns-resolver resources are removed/not present: %w", err)
 		}
 	}
@@ -776,7 +776,7 @@ func (r *Reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context, data *reso
 			Namespace: data.Cluster().Status.NamespaceName,
 		},
 	}
-	if err := r.Client.Delete(ctx, dnatControllerSecret); err != nil && !errors.IsNotFound(err) {
+	if err := r.Client.Delete(ctx, dnatControllerSecret); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to ensure DNAT controller resources are removed/not present: %w", err)
 	}
 	return nil
@@ -784,7 +784,7 @@ func (r *Reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context, data *reso
 
 func (r *Reconciler) ensureKonnectivitySetupIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range konnectivity.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !errors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure Konnectivity resources are removed/not present: %w", err)
 		}
 	}

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -330,7 +330,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 					assert.False(t, alertmanager.Status.ConfigStatus.LastUpdated.IsZero())
 				}
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 				secretList := &corev1.SecretList{}
 				err = reconciler.List(ctx, secretList, ctrlruntimeclient.InNamespace(cluster.Status.NamespaceName))
 				assert.Nil(t, err)

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
@@ -189,7 +189,7 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 	project := &kubermaticv1.Project{}
 	err = r.Get(ctx, types.NamespacedName{Name: projectID}, project)
 	if err != nil {
-		if apiErrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// if project removed before cluster we need only to remove resources and finalizer
 			if err := r.handleDeletion(ctx, cluster, nil); err != nil {
 				return nil, fmt.Errorf("handling deletion: %w", err)
@@ -230,7 +230,7 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		Build()
 
 	settings := &kubermaticv1.MLAAdminSetting{}
-	if err := r.Get(ctx, types.NamespacedName{Name: resources.MLAAdminSettingsName, Namespace: cluster.Status.NamespaceName}, settings); err != nil && !apiErrors.IsNotFound(err) {
+	if err := r.Get(ctx, types.NamespacedName{Name: resources.MLAAdminSettingsName, Namespace: cluster.Status.NamespaceName}, settings); err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get MLAAdminSetting: %w", err)
 	}
 
@@ -368,7 +368,7 @@ func (r *datasourceGrafanaController) cleanUpMlaGatewayHealthStatus(ctx context.
 	return kubermaticv1helper.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
 		// Remove the health status in Cluster CR
 		c.Status.ExtendedHealth.MLAGateway = nil
-		if resourceDeletionErr != nil && !apiErrors.IsNotFound(resourceDeletionErr) {
+		if resourceDeletionErr != nil && !apierrors.IsNotFound(resourceDeletionErr) {
 			down := kubermaticv1.HealthStatusDown
 			c.Status.ExtendedHealth.MLAGateway = &down
 		}
@@ -397,7 +397,7 @@ func (r *datasourceGrafanaController) handleDeletion(ctx context.Context, cluste
 			if errH := r.cleanUpMlaGatewayHealthStatus(ctx, cluster, err); errH != nil {
 				return fmt.Errorf("failed to update mlaGateway status in cluster: %w", errH)
 			}
-			if err != nil && !apiErrors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("failed to delete %s: %w", resource.GetName(), err)
 			}
 		}

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -38,7 +38,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -552,7 +552,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			if tc.hasResources {
 				assert.Nil(t, err)
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			}
 
 			dp := &appsv1.Deployment{}
@@ -561,7 +561,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			if tc.hasResources {
 				assert.Nil(t, err)
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			}
 
 			svc := &corev1.Service{}
@@ -570,7 +570,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			if tc.hasResources {
 				assert.Nil(t, err)
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			}
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Name: gatewayExternalName, Namespace: cluster.Status.NamespaceName}}
 			err = controller.Get(ctx, request.NamespacedName, svc)
@@ -578,7 +578,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 				assert.Nil(t, err)
 				assert.EqualValues(t, tc.expectExposeAnnotations, svc.Annotations)
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			}
 
 			secret := &corev1.Secret{}
@@ -587,14 +587,14 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			if tc.hasResources {
 				assert.Nil(t, err)
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			}
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Name: resources.MLAGatewayCertificatesSecretName, Namespace: cluster.Status.NamespaceName}}
 			err = controller.Get(ctx, request.NamespacedName, secret)
 			if tc.hasResources {
 				assert.Nil(t, err)
 			} else {
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			}
 
 			assertExpectation()

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
@@ -169,7 +169,7 @@ func (r *orgUserGrafanaController) CleanUp(ctx context.Context) error {
 func (r *orgUserGrafanaController) handleDeletion(ctx context.Context, userProjectBinding *kubermaticv1.UserProjectBinding, grafanaClient *grafanasdk.Client) error {
 	if grafanaClient != nil {
 		project := &kubermaticv1.Project{}
-		if err := r.Get(ctx, types.NamespacedName{Name: userProjectBinding.Spec.ProjectID}, project); err != nil && !kerrors.IsNotFound(err) {
+		if err := r.Get(ctx, types.NamespacedName{Name: userProjectBinding.Spec.ProjectID}, project); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get project: %w", err)
 		}
 		org, err := getOrgByProject(ctx, grafanaClient, project)

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
@@ -161,7 +161,7 @@ func (r *ruleGroupReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: ruleGroup.Spec.Cluster.Name}, cluster); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// If cluster object is already gone, but rule group is still found in the namespace, we need to handle deletion
 			// and remove finalizer for it so that it will not block the deletion of cluster namespace.
 			requestURL, err := r.ruleGroupController.getRequestURL(ruleGroup)

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -33,7 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,7 +156,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kubeapierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster: %w", err)

--- a/pkg/controller/seed-controller-manager/preset-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/record"
@@ -88,7 +88,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	preset := &kubermaticv1.Preset{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, preset); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -131,7 +131,7 @@ func genCluster(name, userEmail, preset string) *kubermaticv1.Cluster {
 			Name:            name,
 			Labels:          map[string]string{kubermaticv1.IsCredentialPresetLabelKey: "true"},
 			ResourceVersion: "1",
-			Finalizers:      []string{kubermaticapiv1.CredentialsSecretsCleanupFinalizer},
+			Finalizers:      []string{apiv1.CredentialsSecretsCleanupFinalizer},
 			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail, kubermaticv1.PresetNameAnnotation: preset},
 		},
 		Spec: kubermaticv1.ClusterSpec{

--- a/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
@@ -26,7 +26,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -103,8 +103,8 @@ func TestReconcile(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error status %v", tc.expectedGetErrStatus)
 				}
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}

--- a/pkg/controller/seed-controller-manager/project/controller.go
+++ b/pkg/controller/seed-controller-manager/project/controller.go
@@ -27,7 +27,7 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,7 +84,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile
 
 	project := &kubermaticv1.Project{}
 	if err := r.Get(ctx, req.NamespacedName, project); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
+++ b/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
@@ -29,7 +29,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -90,7 +90,7 @@ func Add(
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.client.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster %q: %w", request.Name, err)

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -33,7 +33,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -108,7 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +43,7 @@ var _ = Describe("application Installation controller", func() {
 			def := createApplicationDef(appDefName)
 			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0"))).To(Succeed())
 
-			app := &appkubermaticv1.ApplicationInstallation{}
+			app := &appskubermaticv1.ApplicationInstallation{}
 			Eventually(func() bool {
 				if err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, app); err != nil {
 					return false
@@ -67,7 +67,7 @@ var _ = Describe("application Installation controller", func() {
 			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, "app-def-not-exist", "1.0.0"))).To(Succeed())
 
 			By("wait for application to be created")
-			app := appkubermaticv1.ApplicationInstallation{}
+			app := appskubermaticv1.ApplicationInstallation{}
 			Eventually(func() bool {
 				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, &app)
 				return err == nil
@@ -94,7 +94,7 @@ var _ = Describe("application Installation controller", func() {
 			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0-not-exist"))).To(Succeed())
 
 			By("wait for application to be created")
-			app := appkubermaticv1.ApplicationInstallation{}
+			app := appskubermaticv1.ApplicationInstallation{}
 			Eventually(func() bool {
 				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, &app)
 				return err == nil
@@ -121,7 +121,7 @@ var _ = Describe("application Installation controller", func() {
 			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0"))).To(Succeed())
 
 			By("wait for application to be created")
-			app := &appkubermaticv1.ApplicationInstallation{}
+			app := &appskubermaticv1.ApplicationInstallation{}
 			Eventually(func() bool {
 				if err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, app); err != nil {
 					return false
@@ -136,7 +136,7 @@ var _ = Describe("application Installation controller", func() {
 
 			By("Checking application Installation CR is removed")
 			Eventually(func() bool {
-				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, &appkubermaticv1.ApplicationInstallation{})
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, &appskubermaticv1.ApplicationInstallation{})
 
 				return err != nil && apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
@@ -154,7 +154,7 @@ var _ = Describe("application Installation controller", func() {
 			Expect(userClient.Create(ctx, genApplicationInstallation(appInstallName, appDefName, "1.0.0"))).To(Succeed())
 
 			By("wait for application to be created")
-			app := &appkubermaticv1.ApplicationInstallation{}
+			app := &appskubermaticv1.ApplicationInstallation{}
 			Eventually(func() bool {
 				if err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, app); err != nil {
 					return false
@@ -167,16 +167,16 @@ var _ = Describe("application Installation controller", func() {
 			previousVersion := def.Spec.Versions[0]
 
 			By("removing applicationVersion from applicationDefinition")
-			def.Spec.Versions = []appkubermaticv1.ApplicationVersion{
+			def.Spec.Versions = []appskubermaticv1.ApplicationVersion{
 				{
 					Version: "3.0.0",
-					Constraints: appkubermaticv1.ApplicationConstraints{
+					Constraints: appskubermaticv1.ApplicationConstraints{
 						K8sVersion: "> 1.19",
 						KKPVersion: "> 2.0",
 					},
-					Template: appkubermaticv1.ApplicationTemplate{
-						Source: appkubermaticv1.ApplicationSource{
-							Helm: &appkubermaticv1.HelmSource{
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
 								URL:          "http://helmrepo.local",
 								ChartName:    "someChartName",
 								ChartVersion: "12",
@@ -191,7 +191,7 @@ var _ = Describe("application Installation controller", func() {
 
 			By("Checking application Installation CR is removed")
 			Eventually(func() bool {
-				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, &appkubermaticv1.ApplicationInstallation{})
+				err := userClient.Get(ctx, types.NamespacedName{Name: appInstallName, Namespace: applicationNamespace}, &appskubermaticv1.ApplicationInstallation{})
 
 				return err != nil && apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
@@ -202,10 +202,10 @@ var _ = Describe("application Installation controller", func() {
 
 })
 
-func createApplicationDef(appDefName string) *appkubermaticv1.ApplicationDefinition {
+func createApplicationDef(appDefName string) *appskubermaticv1.ApplicationDefinition {
 	Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
 
-	def := &appkubermaticv1.ApplicationDefinition{}
+	def := &appskubermaticv1.ApplicationDefinition{}
 	EventuallyWithOffset(1, func(g Gomega) {
 		g.Expect(userClient.Get(ctx, types.NamespacedName{Name: appDefName}, def)).To(Succeed())
 	}, timeout, interval).Should(Succeed())
@@ -213,24 +213,24 @@ func createApplicationDef(appDefName string) *appkubermaticv1.ApplicationDefinit
 	return def
 }
 
-func expectApplicationInstalledWithVersion(appName string, expectedVersion appkubermaticv1.ApplicationVersion) {
+func expectApplicationInstalledWithVersion(appName string, expectedVersion appskubermaticv1.ApplicationVersion) {
 	By("check application has been installed")
 	EventuallyWithOffset(1, func(g Gomega) {
 		result, found := applicationInstallerRecorder.ApplyEvents.Load(appName)
 		g.Expect(found).To(BeTrue(), "Application "+appName+" has not been installed")
 
-		currentVersion := result.(appkubermaticv1.ApplicationInstallation)
+		currentVersion := result.(appskubermaticv1.ApplicationInstallation)
 		g.Expect(*currentVersion.Status.ApplicationVersion).To(Equal(expectedVersion))
 	}, timeout, interval).Should(Succeed())
 }
 
-func expectApplicationUninstalledWithVersion(appName string, expectedVersion appkubermaticv1.ApplicationVersion) {
+func expectApplicationUninstalledWithVersion(appName string, expectedVersion appskubermaticv1.ApplicationVersion) {
 	By("Checking application Installation has been uninstalled")
 	EventuallyWithOffset(1, func(g Gomega) {
 		result, found := applicationInstallerRecorder.DeleteEvents.Load(appName)
 		g.Expect(found).To(BeTrue(), "Application "+appName+" has not been uninstalled")
 
-		currentVersion := result.(appkubermaticv1.ApplicationInstallation)
+		currentVersion := result.(appskubermaticv1.ApplicationInstallation)
 		g.Expect(*currentVersion.Status.ApplicationVersion).To(Equal(expectedVersion))
 	}, timeout, interval).Should(Succeed())
 }

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -23,7 +23,7 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/onsi/gomega"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	utilruntime.Must(appkubermaticv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(appskubermaticv1.AddToScheme(scheme.Scheme))
 }
 
 const (
@@ -45,7 +45,7 @@ const (
 func TestEnqueueApplicationInstallation(t *testing.T) {
 	testCases := []struct {
 		name                      string
-		applicationDefinition     *appkubermaticv1.ApplicationDefinition
+		applicationDefinition     *appskubermaticv1.ApplicationDefinition
 		userClient                ctrlruntimeclient.Client
 		expectedReconcileRequests []reconcile.Request
 	}{
@@ -98,22 +98,22 @@ func TestEnqueueApplicationInstallation(t *testing.T) {
 	}
 }
 
-func genApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinition {
-	return &appkubermaticv1.ApplicationDefinition{
+func genApplicationDefinition(name string) *appskubermaticv1.ApplicationDefinition {
+	return &appskubermaticv1.ApplicationDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: appkubermaticv1.ApplicationDefinitionSpec{
-			Versions: []appkubermaticv1.ApplicationVersion{
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
+			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: "1.0.0",
-					Constraints: appkubermaticv1.ApplicationConstraints{
+					Constraints: appskubermaticv1.ApplicationConstraints{
 						K8sVersion: "> 1.19",
 						KKPVersion: "> 2.0",
 					},
-					Template: appkubermaticv1.ApplicationTemplate{
-						Source: appkubermaticv1.ApplicationSource{
-							Helm: &appkubermaticv1.HelmSource{
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
 								URL:          "http://helmrepo.local",
 								ChartName:    "someChartName",
 								ChartVersion: "12",
@@ -126,13 +126,13 @@ func genApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinitio
 				},
 				{
 					Version: "2.0.0",
-					Constraints: appkubermaticv1.ApplicationConstraints{
+					Constraints: appskubermaticv1.ApplicationConstraints{
 						K8sVersion: ">= 1.21",
 						KKPVersion: "> 2.0",
 					},
-					Template: appkubermaticv1.ApplicationTemplate{
-						Source: appkubermaticv1.ApplicationSource{
-							Git: &appkubermaticv1.GitSource{
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Git: &appskubermaticv1.GitSource{
 								Remote:      "git@somerepo.local",
 								Ref:         "v13",
 								Path:        "/",
@@ -148,23 +148,23 @@ func genApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinitio
 	}
 }
 
-func genApplicationInstallation(name string, applicationDefName string, appVersion string) *appkubermaticv1.ApplicationInstallation {
-	return &appkubermaticv1.ApplicationInstallation{
+func genApplicationInstallation(name string, applicationDefName string, appVersion string) *appskubermaticv1.ApplicationInstallation {
+	return &appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: applicationNamespace,
 		},
-		Spec: appkubermaticv1.ApplicationInstallationSpec{
-			Namespace: appkubermaticv1.NamespaceSpec{
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
+			Namespace: appskubermaticv1.NamespaceSpec{
 				Name:   "default",
 				Create: false,
 			},
 
-			ApplicationRef: appkubermaticv1.ApplicationRef{
+			ApplicationRef: appskubermaticv1.ApplicationRef{
 				Name:    applicationDefName,
-				Version: appkubermaticv1.Version{Version: *semverlib.MustParse(appVersion)},
+				Version: appskubermaticv1.Version{Version: *semverlib.MustParse(appVersion)},
 			},
 		},
-		Status: appkubermaticv1.ApplicationInstallationStatus{},
+		Status: appskubermaticv1.ApplicationInstallationStatus{},
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/suite_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/suite_test.go
@@ -30,7 +30,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -112,13 +112,13 @@ var _ = AfterSuite(func() {
 func cleanupAppsNamespace() {
 	ns := &corev1.Namespace{}
 	err := userClient.Get(ctx, types.NamespacedName{Name: applicationNamespace}, ns)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		Fail(err.Error())
 	}
 
 	// Delete ns if it exists
 	err = userClient.Delete(ctx, ns)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		Fail(err.Error())
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -108,7 +108,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("cluster not found, returning")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
@@ -77,7 +77,7 @@ func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.M
 
 	// Watch for changes to Machines
 	if err = c.Watch(
-		&source.Kind{Type: &v1alpha1.Machine{}},
+		&source.Kind{Type: &clusterv1alpha1.Machine{}},
 		handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) []reconcile.Request {
 			return []reconcile.Request{
 				{
@@ -125,7 +125,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	machines := &v1alpha1.MachineList{}
+	machines := &clusterv1alpha1.MachineList{}
 	if err := r.userClient.List(ctx, machines); err != nil {
 		return fmt.Errorf("failed to list machines in user cluster: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -42,14 +42,14 @@ func TestReconcile(t *testing.T) {
 	testCases := []struct {
 		name                     string
 		clusterName              string
-		machines                 []*v1alpha1.Machine
+		machines                 []*clusterv1alpha1.Machine
 		userCluster              *kubermaticv1.Cluster
 		expectedClusterCondition *kubermaticv1.ClusterCondition
 	}{
 		{
 			name:        "Machines not migrate",
 			clusterName: "clusterNotToMigrate",
-			machines: []*v1alpha1.Machine{
+			machines: []*clusterv1alpha1.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "Machine",
@@ -69,7 +69,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name:        "Some machines migrated",
 			clusterName: "clusterToMigrate",
-			machines: []*v1alpha1.Machine{
+			machines: []*clusterv1alpha1.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "migratedMachine",
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name:        "All machines migrated",
 			clusterName: "clusterToMigrate",
-			machines: []*v1alpha1.Machine{
+			machines: []*clusterv1alpha1.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "migratedMachine1",
@@ -136,7 +136,7 @@ func TestReconcile(t *testing.T) {
 
 			scheme := runtime.NewScheme()
 			_ = kubermaticv1.AddToScheme(scheme)
-			_ = v1alpha1.AddToScheme(scheme)
+			_ = clusterv1alpha1.AddToScheme(scheme)
 
 			seedClientBuilder := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme)
 			seedClientBuilder.WithObjects(tc.userCluster)

--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
@@ -28,7 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -88,7 +88,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	clusterRole := &rbacv1.ClusterRole{}
 	if err := r.client.Get(ctx, request.NamespacedName, clusterRole); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("cluster role not found, returning")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -99,7 +99,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	constraint := &kubermaticv1.Constraint{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, constraint); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("constraint not found, returning")
 			return reconcile.Result{}, nil
 		}
@@ -140,7 +140,7 @@ func (r *reconciler) cleanupConstraint(ctx context.Context, constraint *kubermat
 	})
 	toDelete.SetName(constraint.Name)
 
-	if err := r.userClient.Delete(ctx, toDelete); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.userClient.Delete(ctx, toDelete); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete constraint: %w", err)
 	}
 	log.Debugw("constraint deleted")

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -101,7 +101,7 @@ func TestReconcile(t *testing.T) {
 					c := test.GenConstraint(constraintName, "namespace", kind)
 					deleteTime := metav1.NewTime(time.Now())
 					c.DeletionTimestamp = &deleteTime
-					c.Finalizers = []string{kubermaticapiv1.GatekeeperConstraintCleanupFinalizer}
+					c.Finalizers = []string{apiv1.GatekeeperConstraintCleanupFinalizer}
 					return c
 				}()).
 				Build(),
@@ -129,7 +129,7 @@ func TestReconcile(t *testing.T) {
 					c := test.GenConstraint(constraintName, "namespace", kind)
 					deleteTime := metav1.NewTime(time.Now())
 					c.DeletionTimestamp = &deleteTime
-					c.Finalizers = []string{kubermaticapiv1.GatekeeperConstraintCleanupFinalizer}
+					c.Finalizers = []string{apiv1.GatekeeperConstraintCleanupFinalizer}
 					return c
 				}()).
 				Build(),

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -32,7 +32,7 @@ import (
 	constrainthandler "k8c.io/kubermatic/v2/pkg/handler/v2/constraint"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -234,8 +234,8 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("expected error status %s, instead got constraint: %v", tc.expectedGetErrStatus, reqLabel)
 				}
 
-				if tc.expectedGetErrStatus != errors.ReasonForError(err) {
-					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, errors.ReasonForError(err))
+				if tc.expectedGetErrStatus != apierrors.ReasonForError(err) {
+					t.Fatalf("Expected error status %s differs from the expected one %s", tc.expectedGetErrStatus, apierrors.ReasonForError(err))
 				}
 				return
 			}

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ce.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ce.go
@@ -24,13 +24,13 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 )
 
 func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
-	finalizer := kubermaticapiv1.GatekeeperConstraintCleanupFinalizer
+	finalizer := apiv1.GatekeeperConstraintCleanupFinalizer
 
 	// constraint deletion
 	if constraint.DeletionTimestamp != nil {

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ee.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ee.go
@@ -24,13 +24,13 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 )
 
 func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
-	finalizer := kubermaticapiv1.GatekeeperConstraintCleanupFinalizer
+	finalizer := apiv1.GatekeeperConstraintCleanupFinalizer
 
 	// constraint deletion
 	if constraint.Spec.Disabled {

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/delete.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/delete.go
@@ -22,7 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -87,7 +87,7 @@ func EnsureAllDeleted(ctx context.Context, client ctrlruntimeclient.Client) erro
 
 func ensureDeleted(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) error {
 	if err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		// error is 'not found', we're done here

--- a/pkg/controller/user-cluster-controller-manager/ipam/ipam_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ipam/ipam_controller.go
@@ -31,7 +31,7 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -83,7 +83,7 @@ func Add(mgr manager.Manager, cidrRanges []Network, log *zap.SugaredLogger) erro
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	machine := &clusterv1alpha1.Machine{}
 	if err := r.Get(ctx, request.NamespacedName, machine); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/node-labeler/node_labeleler.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/node_labeleler.go
@@ -27,7 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -91,7 +91,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	node := &corev1.Node{}
 	if err := r.client.Get(ctx, request.NamespacedName, node); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("Node not found, returning")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -113,7 +113,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.seedClient.Get(ctx, types.NamespacedName{Name: r.clusterName}, cluster); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/controller/user-cluster-controller-manager/pause.go
+++ b/pkg/controller/user-cluster-controller-manager/pause.go
@@ -24,12 +24,12 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type IsPausedChecker func(context.Context) (bool, error)
 
-func NewClusterPausedChecker(seedClient client.Client, clusterName string) IsPausedChecker {
+func NewClusterPausedChecker(seedClient ctrlruntimeclient.Client, clusterName string) IsPausedChecker {
 	return func(ctx context.Context) (bool, error) {
 		cluster := &kubermaticv1.Cluster{}
 		if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/pause.go
+++ b/pkg/controller/user-cluster-controller-manager/pause.go
@@ -22,7 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +33,7 @@ func NewClusterPausedChecker(seedClient client.Client, clusterName string) IsPau
 	return func(ctx context.Context) (bool, error) {
 		cluster := &kubermaticv1.Cluster{}
 		if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -137,7 +137,7 @@ func Add(
 	}
 
 	var err error
-	if r.clusterSemVer, err = semver.NewVersion(r.version); err != nil {
+	if r.clusterSemVer, err = semverlib.NewVersion(r.version); err != nil {
 		return err
 	}
 	r.Client = mgr.GetClient()
@@ -277,7 +277,7 @@ type reconciler struct {
 	ctrlruntimeclient.Client
 	seedClient                   ctrlruntimeclient.Client
 	version                      string
-	clusterSemVer                *semver.Version
+	clusterSemVer                *semverlib.Version
 	cache                        cache.Cache
 	namespace                    string
 	clusterURL                   *url.URL

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -40,7 +40,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -179,7 +179,7 @@ func Add(
 		&admissionregistrationv1.ValidatingWebhookConfiguration{},
 		&apiextensionsv1.CustomResourceDefinition{},
 		&appsv1.Deployment{},
-		&v1beta1.PodDisruptionBudget{},
+		&policyv1beta1.PodDisruptionBudget{},
 		&networkingv1.NetworkPolicy{},
 		&appsv1.DaemonSet{},
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -353,7 +353,7 @@ func (r *reconciler) userSSHKeys(ctx context.Context) (map[string][]byte, error)
 		types.NamespacedName{Namespace: r.namespace, Name: resources.UserSSHKeys},
 		secret,
 	); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -420,7 +420,7 @@ func (r *reconciler) reconcileDefaultServiceAccount(ctx context.Context, namespa
 		Name:      resources.DefaultServiceAccountName,
 	}, &serviceAccount)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/applications/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/applications/webhook.go
@@ -20,7 +20,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -60,7 +60,7 @@ func ApplicationInstallationValidatingWebhookConfigurationCreator(caCert *x509.C
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{
-								APIGroups:   []string{appkubermaticv1.GroupName},
+								APIGroups:   []string{appskubermaticv1.GroupName},
 								APIVersions: []string{"*"},
 								Resources:   []string{"applicationinstallations"},
 								Scope:       &scope,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -19,7 +19,7 @@ package coredns
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/dns"
@@ -51,7 +51,7 @@ var (
 )
 
 // DeploymentCreator returns the function to create and update the CoreDNS deployment.
-func DeploymentCreator(kubernetesVersion *semver.Version, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(kubernetesVersion *semverlib.Version, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.CoreDNSDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.CoreDNSDeploymentName
@@ -124,7 +124,7 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 }
 
 func getContainers(
-	clusterVersion *semver.Version,
+	clusterVersion *semverlib.Version,
 	registryWithOverwrite registry.WithOverwriteFunc,
 ) []corev1.Container {
 	return []corev1.Container{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes/endpoints.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes/endpoints.go
@@ -21,7 +21,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -40,7 +40,7 @@ func EndpointsCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.N
 		return serviceName, func(ep *corev1.Endpoints) (*corev1.Endpoints, error) {
 			// our controller is reconciling the endpoint slice, do not mirror with EndpointSliceMirroring controller
 			ep.Labels = map[string]string{
-				discovery.LabelSkipMirror: "true",
+				discoveryv1.LabelSkipMirror: "true",
 			}
 			ep.Subsets = []corev1.EndpointSubset{
 				{
@@ -66,23 +66,23 @@ func EndpointsCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.N
 // EndpointSliceCreator returns the func to create/update the endpoint slice of the kubernetes service.
 func EndpointSliceCreator(clusterAddress *kubermaticv1.ClusterAddress) reconciling.NamedEndpointSliceCreatorGetter {
 	return func() (string, reconciling.EndpointSliceCreator) {
-		return endpointSliceName, func(es *discovery.EndpointSlice) (*discovery.EndpointSlice, error) {
-			es.AddressType = discovery.AddressTypeIPv4
+		return endpointSliceName, func(es *discoveryv1.EndpointSlice) (*discoveryv1.EndpointSlice, error) {
+			es.AddressType = discoveryv1.AddressTypeIPv4
 			es.Labels = map[string]string{
-				discovery.LabelServiceName: serviceName,
+				discoveryv1.LabelServiceName: serviceName,
 			}
-			es.Endpoints = []discovery.Endpoint{
+			es.Endpoints = []discoveryv1.Endpoint{
 				{
 					Addresses: []string{
 						clusterAddress.IP,
 					},
-					Conditions: discovery.EndpointConditions{
+					Conditions: discoveryv1.EndpointConditions{
 						Ready: pointer.BoolPtr(true),
 					},
 				},
 			}
 			protoTCP := corev1.ProtocolTCP
-			es.Ports = []discovery.EndpointPort{
+			es.Ports = []discoveryv1.EndpointPort{
 				{
 					Name:     pointer.String("https"),
 					Port:     pointer.Int32Ptr(clusterAddress.Port),

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller.go
@@ -30,7 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -112,7 +112,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	role := &rbacv1.Role{}
 	if err := r.client.Get(ctx, request.NamespacedName, role); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("role not found, returning")
 			return reconcile.Result{}, nil
 		}
@@ -162,7 +162,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, log *zap.SugaredLogger,
 						Namespace: namespace,
 					},
 				}); err != nil {
-					if kerrors.IsNotFound(err) {
+					if apierrors.IsNotFound(err) {
 						continue
 					}
 					return fmt.Errorf("failed to delete Role in namespace %q: %w", namespace, err)

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -151,7 +151,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, role
 }
 
 func (r *reconciler) reconcileRoles(ctx context.Context, log *zap.SugaredLogger, oldRole *rbacv1.Role, namespaces []string) error {
-	finalizer := kubermaticapiv1.UserClusterRoleCleanupFinalizer
+	finalizer := apiv1.UserClusterRoleCleanupFinalizer
 
 	if oldRole.DeletionTimestamp != nil {
 		if kuberneteshelper.HasFinalizer(oldRole, finalizer) {

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"testing"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
@@ -61,7 +61,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "view",
 						Namespace:         "kube-system",
-						Finalizers:        []string{kubermaticapiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers:        []string{apiv1.UserClusterRoleCleanupFinalizer},
 						Labels:            map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 						DeletionTimestamp: &nowTime,
 					},
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{kubermaticapiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 				},
@@ -145,7 +145,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{kubermaticapiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -190,7 +190,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{kubermaticapiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -235,7 +235,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{kubermaticapiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -266,7 +266,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{kubermaticapiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -155,7 +155,7 @@ func (r *Reconciler) watchAuthorizedKeys(paths []string) error {
 func (r *Reconciler) fetchUserSSHKeySecret(ctx context.Context, namespace string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: resources.UserSSHKeys, Namespace: namespace}, secret); err != nil {
-		if kubeapierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			r.log.Debugw("Secret is not found", "secret", secret.Name)
 			return nil, nil
 		}

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -32,7 +32,7 @@ import (
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"go.uber.org/zap"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -91,7 +91,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, allowedRegistry *kubermaticv1.AllowedRegistry) error {
-	finalizer := kubermaticapiv1.AllowedRegistryCleanupFinalizer
+	finalizer := apiv1.AllowedRegistryCleanupFinalizer
 
 	regSet, err := r.getRegistrySet(ctx)
 	if err != nil {

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -39,7 +39,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	allowedRegistry := &kubermaticv1.AllowedRegistry{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, allowedRegistry); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("allowed registry not found, returning")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -33,7 +33,7 @@ import (
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	allowedregistrycontroller "k8c.io/kubermatic/v2/pkg/ee/allowed-registry-controller"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -239,7 +239,7 @@ func genAllowedRegistry(name, registry string, deleted bool) *kubermaticv1.Allow
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		wr.DeletionTimestamp = &deleteTime
-		wr.Finalizers = append(wr.Finalizers, v1.AllowedRegistryCleanupFinalizer)
+		wr.Finalizers = append(wr.Finalizers, apiv1.AllowedRegistryCleanupFinalizer)
 	}
 
 	return wr

--- a/pkg/ee/metering/handler.go
+++ b/pkg/ee/metering/handler.go
@@ -38,7 +38,7 @@ import (
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -186,7 +186,7 @@ func CreateOrUpdateCredentials(ctx context.Context, request interface{}, seedsGe
 
 func createOrUpdateMeteringToolSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, secretData map[string][]byte) error {
 	existingSecret := &corev1.Secret{}
-	if err := seedClient.Get(ctx, secretNamespacedName, existingSecret); err != nil && !kerrors.IsNotFound(err) {
+	if err := seedClient.Get(ctx, secretNamespacedName, existingSecret); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to probe for secret %q: %w", SecretName, err)
 	}
 

--- a/pkg/ee/metering/handler.go
+++ b/pkg/ee/metering/handler.go
@@ -35,7 +35,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -88,11 +88,11 @@ func DecodeMeteringConfigurationsReq(r *http.Request) (interface{}, error) {
 func CreateOrUpdateConfigurations(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(configurationReq)
 	if !ok {
-		return k8cerrors.NewBadRequest("invalid request")
+		return utilerrors.NewBadRequest("invalid request")
 	}
 	err := req.Validate()
 	if err != nil {
-		return k8cerrors.NewBadRequest(err.Error())
+		return utilerrors.NewBadRequest(err.Error())
 	}
 
 	seedList := &kubermaticv1.SeedList{}
@@ -156,7 +156,7 @@ func CreateOrUpdateCredentials(ctx context.Context, request interface{}, seedsGe
 
 	req, ok := request.(credentialReq)
 	if !ok {
-		return k8cerrors.NewBadRequest("invalid request")
+		return utilerrors.NewBadRequest("invalid request")
 	}
 
 	if err := req.Validate(); err != nil {

--- a/pkg/ee/metering/pvc.go
+++ b/pkg/ee/metering/pvc.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -44,7 +44,7 @@ import (
 func persistentVolumeClaimCreator(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) error {
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := client.Get(ctx, types.NamespacedName{Namespace: seed.Namespace, Name: meteringDataName}, pvc); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			pvc.ObjectMeta.Name = meteringDataName
 			pvc.ObjectMeta.Namespace = resources.KubermaticNamespace
 			pvc.ObjectMeta.Labels = map[string]string{

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -36,7 +36,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -172,7 +172,7 @@ func fetchExistingReportingCronJobs(ctx context.Context, client ctrlruntimeclien
 		ctrlruntimeclient.ListOption(ctrlruntimeclient.HasLabels{MeteringLabelKey}),
 	}
 	if err := client.List(ctx, existingReportingCronJobs, listOpts...); err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to list reporting cronjobs: %w", err)
 		}
 	}
@@ -181,7 +181,7 @@ func fetchExistingReportingCronJobs(ctx context.Context, client ctrlruntimeclien
 
 func cleanupResource(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName, obj ctrlruntimeclient.Object) error {
 	if err := client.Get(ctx, key, obj); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/ee/metering/report_config_handler.go
+++ b/pkg/ee/metering/report_config_handler.go
@@ -37,7 +37,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,16 +72,16 @@ type createReportConfigurationReq struct {
 
 func (m createReportConfigurationReq) Validate() error {
 	if !validation.MeteringReportNameValidator.MatchString(m.Name) {
-		return k8cerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
+		return utilerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
 	}
 
 	cronExpressionParser := validation.GetCronExpressionParser()
 	if _, err := cronExpressionParser.Parse(m.Body.Schedule); err != nil {
-		return k8cerrors.NewBadRequest("invalid cron expression format: %s", m.Body.Schedule)
+		return utilerrors.NewBadRequest("invalid cron expression format: %s", m.Body.Schedule)
 	}
 
 	if m.Body.Interval < 1 {
-		return k8cerrors.NewBadRequest("interval value cannot be smaller than 1.")
+		return utilerrors.NewBadRequest("interval value cannot be smaller than 1.")
 	}
 
 	return nil
@@ -102,13 +102,13 @@ type updateReportConfigurationReq struct {
 
 func (m updateReportConfigurationReq) Validate() error {
 	if !validation.MeteringReportNameValidator.MatchString(m.Name) {
-		return k8cerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
+		return utilerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
 	}
 
 	if m.Body.Schedule != "" {
 		cronExpressionParser := validation.GetCronExpressionParser()
 		if _, err := cronExpressionParser.Parse(m.Body.Schedule); err != nil {
-			return k8cerrors.NewBadRequest("invalid cron expression format: %s", m.Body.Schedule)
+			return utilerrors.NewBadRequest("invalid cron expression format: %s", m.Body.Schedule)
 		}
 	}
 
@@ -121,7 +121,7 @@ func DecodeGetMeteringReportConfigurationReq(r *http.Request) (interface{}, erro
 	req.Name = mux.Vars(r)["name"]
 
 	if req.Name == "" {
-		return nil, k8cerrors.NewBadRequest("`name` cannot be empty")
+		return nil, utilerrors.NewBadRequest("`name` cannot be empty")
 	}
 
 	return req, nil
@@ -133,7 +133,7 @@ func DecodeCreateMeteringReportConfigurationReq(r *http.Request) (interface{}, e
 	req.Name = mux.Vars(r)["name"]
 
 	if req.Name == "" {
-		return nil, k8cerrors.NewBadRequest("`name` cannot be empty")
+		return nil, utilerrors.NewBadRequest("`name` cannot be empty")
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
@@ -149,7 +149,7 @@ func DecodeUpdateMeteringReportConfigurationReq(r *http.Request) (interface{}, e
 	req.Name = mux.Vars(r)["name"]
 
 	if req.Name == "" {
-		return nil, k8cerrors.NewBadRequest("`name` cannot be empty")
+		return nil, utilerrors.NewBadRequest("`name` cannot be empty")
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
@@ -165,7 +165,7 @@ func DecodeDeleteMeteringReportConfigurationReq(r *http.Request) (interface{}, e
 	req.Name = mux.Vars(r)["name"]
 
 	if req.Name == "" {
-		return nil, k8cerrors.NewBadRequest("`name` cannot be empty")
+		return nil, utilerrors.NewBadRequest("`name` cannot be empty")
 	}
 
 	return req, nil
@@ -180,7 +180,7 @@ func GetMeteringReportConfiguration(seedsGetter provider.SeedsGetter, request in
 
 	req, ok := request.(getMeteringReportConfig)
 	if !ok {
-		return nil, k8cerrors.NewBadRequest("invalid request")
+		return nil, utilerrors.NewBadRequest("invalid request")
 	}
 
 	seeds, err := seedsGetter()
@@ -203,7 +203,7 @@ func GetMeteringReportConfiguration(seedsGetter provider.SeedsGetter, request in
 		}
 	}
 
-	return nil, k8cerrors.NewNotFound("MeteringReportConfiguration", req.Name)
+	return nil, utilerrors.NewNotFound("MeteringReportConfiguration", req.Name)
 }
 
 // ListMeteringReportConfigurations lists metering report configurations.
@@ -242,11 +242,11 @@ func ListMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]apiv1
 func CreateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(createReportConfigurationReq)
 	if !ok {
-		return k8cerrors.NewBadRequest("invalid request")
+		return utilerrors.NewBadRequest("invalid request")
 	}
 
 	if err := req.Validate(); err != nil {
-		return k8cerrors.NewBadRequest(err.Error())
+		return utilerrors.NewBadRequest(err.Error())
 	}
 
 	seedList := &kubermaticv1.SeedList{}
@@ -267,11 +267,11 @@ func CreateMeteringReportConfiguration(ctx context.Context, request interface{},
 func UpdateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(updateReportConfigurationReq)
 	if !ok {
-		return k8cerrors.NewBadRequest("invalid request")
+		return utilerrors.NewBadRequest("invalid request")
 	}
 
 	if err := req.Validate(); err != nil {
-		return k8cerrors.NewBadRequest(err.Error())
+		return utilerrors.NewBadRequest(err.Error())
 	}
 
 	seedList := &kubermaticv1.SeedList{}
@@ -292,7 +292,7 @@ func UpdateMeteringReportConfiguration(ctx context.Context, request interface{},
 func DeleteMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(deleteMeteringReportConfig)
 	if !ok {
-		return k8cerrors.NewBadRequest("invalid request")
+		return utilerrors.NewBadRequest("invalid request")
 	}
 
 	seedList := &kubermaticv1.SeedList{}
@@ -319,7 +319,7 @@ func createMeteringReportConfiguration(ctx context.Context, reportCfgReq createR
 	}
 
 	if _, exists := seed.Spec.Metering.ReportConfigurations[reportCfgReq.Name]; exists {
-		return k8cerrors.New(
+		return utilerrors.New(
 			http.StatusConflict,
 			fmt.Sprintf("report configuration %q already exists", reportCfgReq.Name))
 	}
@@ -342,7 +342,7 @@ func updateMeteringReportConfiguration(ctx context.Context, reportCfgReq updateR
 	}
 
 	if _, exists := seed.Spec.Metering.ReportConfigurations[reportCfgReq.Name]; !exists {
-		return k8cerrors.New(
+		return utilerrors.New(
 			http.StatusNotFound,
 			fmt.Sprintf("report configuration %q does not exists", reportCfgReq.Name))
 	}

--- a/pkg/ee/metering/report_config_handler_test.go
+++ b/pkg/ee/metering/report_config_handler_test.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
@@ -60,7 +60,7 @@ func TestGetMeteringReportConfigEndpoint(t *testing.T) {
 		name                   string
 		reportName             string
 		existingKubermaticObjs []ctrlruntimeclient.Object
-		existingAPIUser        *v1.User
+		existingAPIUser        *apiv1.User
 		httpStatus             int
 		expectedResponse       string
 	}{
@@ -155,7 +155,7 @@ func TestCreateMeteringReportConfigEndpoint(t *testing.T) {
 		reportName             string
 		body                   string
 		existingKubermaticObjs []ctrlruntimeclient.Object
-		existingAPIUser        *v1.User
+		existingAPIUser        *apiv1.User
 		httpStatus             int
 		expectedResponse       string
 	}{
@@ -282,7 +282,7 @@ func TestUpdateMeteringReportConfigEndpoint(t *testing.T) {
 		reportName             string
 		body                   string
 		existingKubermaticObjs []ctrlruntimeclient.Object
-		existingAPIUser        *v1.User
+		existingAPIUser        *apiv1.User
 		httpStatus             int
 		expectedResponse       string
 	}{
@@ -378,7 +378,7 @@ func TestDeleteMeteringReportConfigEndpoint(t *testing.T) {
 		name                   string
 		reportName             string
 		existingKubermaticObjs []ctrlruntimeclient.Object
-		existingAPIUser        *v1.User
+		existingAPIUser        *apiv1.User
 		httpStatus             int
 		expectedResponse       string
 	}{

--- a/pkg/ee/metering/report_handler.go
+++ b/pkg/ee/metering/report_handler.go
@@ -38,7 +38,7 @@ import (
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +57,7 @@ func ListReports(ctx context.Context, req interface{}, seedsGetter provider.Seed
 
 	request, ok := req.(listReportReq)
 	if !ok {
-		return nil, k8cerrors.NewBadRequest("invalid request")
+		return nil, utilerrors.NewBadRequest("invalid request")
 	}
 
 	seedsMap, err := seedsGetter()
@@ -100,7 +100,7 @@ func GetReport(ctx context.Context, req interface{}, seedsGetter provider.SeedsG
 
 	request, ok := req.(getReportReq)
 	if !ok {
-		return "", k8cerrors.NewBadRequest("invalid request")
+		return "", utilerrors.NewBadRequest("invalid request")
 	}
 
 	reportPath := request.ReportName
@@ -138,7 +138,7 @@ func GetReport(ctx context.Context, req interface{}, seedsGetter provider.SeedsG
 		return urlString, nil
 	}
 
-	return "", k8cerrors.New(404, "report not found")
+	return "", utilerrors.New(404, "report not found")
 }
 
 func DeleteReport(ctx context.Context, req interface{}, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) error {
@@ -148,7 +148,7 @@ func DeleteReport(ctx context.Context, req interface{}, seedsGetter provider.See
 
 	request, ok := req.(deleteReportReq)
 	if !ok {
-		return k8cerrors.NewBadRequest("invalid request")
+		return utilerrors.NewBadRequest("invalid request")
 	}
 
 	reportPath := request.ReportName
@@ -180,7 +180,7 @@ func DeleteReport(ctx context.Context, req interface{}, seedsGetter provider.See
 		return nil
 	}
 
-	return k8cerrors.New(404, "report not found")
+	return utilerrors.New(404, "report not found")
 }
 
 func getReportsForSeed(ctx context.Context, options minio.ListObjectsOptions, seedClient ctrlruntimeclient.Client) ([]apiv1.MeteringReport, error) {
@@ -284,7 +284,7 @@ func DecodeListMeteringReportReq(r *http.Request) (interface{}, error) {
 	} else {
 		mK, err := strconv.Atoi(maxKeys)
 		if err != nil {
-			return nil, k8cerrors.NewBadRequest("invalid value for `may_keys`")
+			return nil, utilerrors.NewBadRequest("invalid value for `may_keys`")
 		}
 		req.MaxKeys = mK
 	}
@@ -301,7 +301,7 @@ func DecodeGetMeteringReportReq(r *http.Request) (interface{}, error) {
 	req.ReportName = mux.Vars(r)["report_name"]
 
 	if req.ReportName == "" {
-		return nil, k8cerrors.NewBadRequest("`report_name` cannot be empty")
+		return nil, utilerrors.NewBadRequest("`report_name` cannot be empty")
 	}
 
 	req.ConfigurationName = r.URL.Query().Get("configuration_name")
@@ -314,7 +314,7 @@ func DecodeDeleteMeteringReportReq(r *http.Request) (interface{}, error) {
 	req.ReportName = mux.Vars(r)["report_name"]
 
 	if req.ReportName == "" {
-		return nil, k8cerrors.NewBadRequest("`report_name` cannot be empty")
+		return nil, utilerrors.NewBadRequest("`report_name` cannot be empty")
 	}
 
 	req.ConfigurationName = r.URL.Query().Get("configuration_name")

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -30,7 +30,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,7 +38,7 @@ import (
 )
 
 // ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.
-func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *v1alpha1.Machine) error {
+func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
 	config, err := types.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -40,7 +40,7 @@ func TestResourceQuotaValidation(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		machine     *v1alpha1.Machine
+		machine     *clusterv1alpha1.Machine
 		expectedErr bool
 	}{
 		{
@@ -81,7 +81,7 @@ func TestResourceQuotaValidation(t *testing.T) {
 	}
 }
 
-func genFakeMachine(cpu, memory, storage string) *v1alpha1.Machine {
+func genFakeMachine(cpu, memory, storage string) *clusterv1alpha1.Machine {
 	return test.GenTestMachine("fake",
 		fmt.Sprintf(`{"cloudProvider":"fake", "cloudProviderSpec":{"cpu":"%s","memory":"%s","storage":"%s"}}`, cpu, memory, storage),
 		nil, nil)

--- a/pkg/handler/auth/plugin.go
+++ b/pkg/handler/auth/plugin.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // TokenClaims holds various claims extracted from the id_token.
@@ -87,7 +87,7 @@ func (p *TokenVerifierPlugins) Verify(ctx context.Context, token string) (TokenC
 
 		errList = append(errList, err)
 	}
-	return TokenClaims{}, k8cerrors.NewAggregate(errList)
+	return TokenClaims{}, utilerrors.NewAggregate(errList)
 }
 
 var _ TokenExtractor = &TokenExtractorPlugins{}
@@ -118,5 +118,5 @@ func (p *TokenExtractorPlugins) Extract(r *http.Request) (string, error) {
 		}
 		errList = append(errList, err)
 	}
-	return "", k8cerrors.NewAggregate(errList)
+	return "", utilerrors.NewAggregate(errList)
 }

--- a/pkg/handler/auth/sa.go
+++ b/pkg/handler/auth/sa.go
@@ -24,7 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // ServiceAccountAuthClient implements TokenExtractorVerifier interface.
@@ -56,7 +56,7 @@ func (s *ServiceAccountAuthClient) Verify(ctx context.Context, token string) (To
 
 	tokenExpiredMsg := fmt.Sprintf("sa: the token %s has been revoked for %s", customClaims.TokenID, customClaims.Email)
 	tokenList, err := s.saTokenProvider.ListUnsecured(ctx, &provider.ServiceAccountTokenListOptions{TokenID: customClaims.TokenID})
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return TokenClaims{}, &TokenExpiredError{msg: tokenExpiredMsg}
 	}
 	if len(tokenList) > 1 {

--- a/pkg/handler/common/binding.go
+++ b/pkg/handler/common/binding.go
@@ -25,7 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,10 +77,10 @@ func BindUserToRoleEndpoint(ctx context.Context, userInfoGetter provider.UserInf
 	oldBinding := existingRoleBinding.DeepCopy()
 	for _, subject := range existingRoleBinding.Subjects {
 		if roleUser.UserEmail != "" && strings.EqualFold(subject.Name, roleUser.UserEmail) {
-			return nil, errors.NewBadRequest("user %s already connected to role %s", roleUser.UserEmail, roleID)
+			return nil, utilerrors.NewBadRequest("user %s already connected to role %s", roleUser.UserEmail, roleID)
 		}
 		if roleUser.Group != "" && subject.Name == roleUser.Group {
-			return nil, errors.NewBadRequest("group %s already connected to role %s", roleUser.Group, roleID)
+			return nil, utilerrors.NewBadRequest("group %s already connected to role %s", roleUser.Group, roleID)
 		}
 	}
 
@@ -145,10 +145,10 @@ func BindUserToClusterRoleEndpoint(ctx context.Context, userInfoGetter provider.
 	oldBinding := existingClusterRoleBinding.DeepCopy()
 	for _, subject := range existingClusterRoleBinding.Subjects {
 		if clusterRoleUser.UserEmail != "" && strings.EqualFold(subject.Name, clusterRoleUser.UserEmail) {
-			return nil, errors.NewBadRequest("user %s already connected to the cluster role %s", clusterRoleUser.UserEmail, roleID)
+			return nil, utilerrors.NewBadRequest("user %s already connected to the cluster role %s", clusterRoleUser.UserEmail, roleID)
 		}
 		if clusterRoleUser.Group != "" && subject.Name == clusterRoleUser.Group {
-			return nil, errors.NewBadRequest("group %s already connected to the cluster role %s", clusterRoleUser.Group, roleID)
+			return nil, utilerrors.NewBadRequest("group %s already connected to the cluster role %s", clusterRoleUser.Group, roleID)
 		}
 	}
 
@@ -207,7 +207,7 @@ func UnbindUserFromRoleBindingEndpoint(ctx context.Context, userInfoGetter provi
 	}
 
 	if existingRoleBinding == nil {
-		return nil, errors.NewBadRequest("the role binding not found in namespace %s", namespace)
+		return nil, utilerrors.NewBadRequest("the role binding not found in namespace %s", namespace)
 	}
 
 	binding := existingRoleBinding.DeepCopy()
@@ -261,7 +261,7 @@ func UnbindUserFromClusterRoleBindingEndpoint(ctx context.Context, userInfoGette
 	}
 
 	if existingClusterRoleBinding == nil {
-		return nil, errors.NewBadRequest("the cluster role binding not found")
+		return nil, utilerrors.NewBadRequest("the cluster role binding not found")
 	}
 
 	binding := existingClusterRoleBinding.DeepCopy()

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -44,7 +44,7 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/cluster"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version"
 
@@ -117,7 +117,7 @@ func CreateEndpoint(
 	}
 
 	if len(existingClusters.Items) > 0 {
-		return nil, kubermaticerrors.NewAlreadyExists("cluster", partialCluster.Spec.HumanReadableName)
+		return nil, utilerrors.NewAlreadyExists("cluster", partialCluster.Spec.HumanReadableName)
 	}
 
 	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {
@@ -150,7 +150,7 @@ func CreateEndpoint(
 		return true, nil
 	}); err != nil {
 		log.Error("Timed out waiting for cluster to become ready")
-		return ConvertInternalClusterToExternal(newCluster, dc, true, supportManager.GetIncompatibilities()...), kubermaticerrors.New(http.StatusInternalServerError, "timed out waiting for cluster to become ready")
+		return ConvertInternalClusterToExternal(newCluster, dc, true, supportManager.GetIncompatibilities()...), utilerrors.New(http.StatusInternalServerError, "timed out waiting for cluster to become ready")
 	}
 
 	return ConvertInternalClusterToExternal(newCluster, dc, true, supportManager.GetIncompatibilities()...), nil
@@ -195,7 +195,7 @@ func GenerateCluster(
 	if len(credentialName) > 0 {
 		cloudSpec, err := credentialManager.SetCloudCredentials(ctx, adminUserInfo, credentialName, body.Cluster.Spec.Cloud, dc)
 		if err != nil {
-			return nil, kubermaticerrors.NewBadRequest("invalid credentials: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid credentials: %v", err)
 		}
 		body.Cluster.Spec.Cloud = *cloudSpec
 		partialCluster.Labels[kubermaticv1.IsCredentialPresetLabelKey] = "true"
@@ -213,7 +213,7 @@ func GenerateCluster(
 	secretKeyGetter := provider.SecretKeySelectorValueFuncFactory(ctx, seedClient)
 	spec, err := cluster.Spec(ctx, body.Cluster, defaultingTemplate, seed, dc, config, secretKeyGetter, caBundle, features)
 	if err != nil {
-		return nil, kubermaticerrors.NewBadRequest("invalid cluster: %v", err)
+		return nil, utilerrors.NewBadRequest("invalid cluster: %v", err)
 	}
 
 	if err = validation.ValidateUpdateWindow(spec.UpdateWindow); err != nil {
@@ -239,7 +239,7 @@ func GenerateCluster(
 	if body.NodeDeployment != nil {
 		isBYO, err := common.IsBringYourOwnProvider(spec.Cloud)
 		if err != nil {
-			return nil, kubermaticerrors.NewBadRequest("cannot verify the provider due to an invalid spec: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot verify the provider due to an invalid spec: %v", err)
 		}
 		if !isBYO {
 			if body.NodeDeployment.Name == "" {
@@ -323,7 +323,7 @@ func GetClusters(ctx context.Context, userInfoGetter provider.UserInfoGetter, cl
 		_, dc, err := provider.DatacenterFromSeedMap(adminUserInfo, seedsGetter, internalCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			// Ignore 403 errors and omit clusters with not accessible datacenters in the result.
-			var errHttp *kubermaticerrors.HTTPError
+			var errHttp *utilerrors.HTTPError
 			if errors.As(err, &errHttp) && errHttp.StatusCode() == http.StatusForbidden {
 				continue
 			}
@@ -384,7 +384,7 @@ func listClusterMachineDeployments(ctx context.Context, userInfoGetter func(ctx 
 func GetCluster(ctx context.Context, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter, projectID, clusterID string, options *provider.ClusterGetOptions) (*kubermaticv1.Cluster, error) {
 	clusterProvider, ok := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 	if !ok {
-		return nil, kubermaticerrors.New(http.StatusInternalServerError, "no cluster in request")
+		return nil, utilerrors.New(http.StatusInternalServerError, "no cluster in request")
 	}
 	privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 	project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, projectID, nil)
@@ -473,7 +473,7 @@ func PatchEndpoint(
 
 	userInfo, err := userInfoGetter(ctx, "")
 	if err != nil {
-		return nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	seed, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, oldInternalCluster.Spec.Cloud.DatacenterName)
 	if err != nil {
@@ -499,18 +499,18 @@ func PatchEndpoint(
 
 	existingClusterJSON, err := json.Marshal(clusterToPatch)
 	if err != nil {
-		return nil, kubermaticerrors.NewBadRequest("cannot decode existing cluster: %v", err)
+		return nil, utilerrors.NewBadRequest("cannot decode existing cluster: %v", err)
 	}
 
 	patchedClusterJSON, err := jsonpatch.MergePatch(existingClusterJSON, patch)
 	if err != nil {
-		return nil, kubermaticerrors.NewBadRequest("cannot patch cluster: %v", err)
+		return nil, utilerrors.NewBadRequest("cannot patch cluster: %v", err)
 	}
 
 	var patchedCluster *apiv1.Cluster
 	err = json.Unmarshal(patchedClusterJSON, &patchedCluster)
 	if err != nil {
-		return nil, kubermaticerrors.NewBadRequest("cannot decode patched cluster: %v", err)
+		return nil, utilerrors.NewBadRequest("cannot decode patched cluster: %v", err)
 	}
 
 	// Only specific fields from old internal cluster will be updated by a patch.
@@ -543,7 +543,7 @@ func PatchEndpoint(
 		return nil, fmt.Errorf("failed to check existing nodes' version skew: %w", err)
 	}
 	if len(incompatibleKubelets) > 0 {
-		return nil, kubermaticerrors.NewBadRequest("Cluster contains nodes running the following incompatible kubelet versions: %v. Upgrade your nodes before you upgrade the cluster.", incompatibleKubelets)
+		return nil, utilerrors.NewBadRequest("Cluster contains nodes running the following incompatible kubelet versions: %v. Upgrade your nodes before you upgrade the cluster.", incompatibleKubelets)
 	}
 
 	// find the defaulting template
@@ -588,7 +588,7 @@ func PatchEndpoint(
 
 	// validate the new cluster
 	if errs := validation.ValidateClusterUpdate(ctx, newInternalCluster, oldInternalCluster, dc, cloudProvider, features).ToAggregate(); errs != nil {
-		return nil, kubermaticerrors.NewBadRequest("invalid cluster: %v", errs)
+		return nil, utilerrors.NewBadRequest("invalid cluster: %v", errs)
 	}
 	if err = validation.ValidateUpdateWindow(newInternalCluster.Spec.UpdateWindow); err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
@@ -743,11 +743,11 @@ func MigrateEndpointToExternalCCM(ctx context.Context, userInfoGetter provider.U
 	}
 
 	if !cloudcontroller.MigrationToExternalCloudControllerSupported(dc, oldCluster, version.NewFromConfiguration(config).GetIncompatibilities()...) {
-		return nil, kubermaticerrors.NewBadRequest("external CCM not supported by the given provider")
+		return nil, utilerrors.NewBadRequest("external CCM not supported by the given provider")
 	}
 
 	if ok := oldCluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; ok {
-		return nil, kubermaticerrors.NewBadRequest("external CCM already enabled, cannot be disabled")
+		return nil, utilerrors.NewBadRequest("external CCM already enabled, cannot be disabled")
 	}
 
 	newCluster := oldCluster.DeepCopy()
@@ -799,7 +799,7 @@ func AssignSSHKeyEndpoint(ctx context.Context, userInfoGetter provider.UserInfoG
 	clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 	privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 	if len(keyID) == 0 {
-		return nil, kubermaticerrors.NewBadRequest("please provide an SSH key")
+		return nil, utilerrors.NewBadRequest("please provide an SSH key")
 	}
 
 	project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, projectID, nil)
@@ -884,7 +884,7 @@ func DetachSSHKeyEndpoint(ctx context.Context, userInfoGetter provider.UserInfoG
 			}
 		}
 		if !found {
-			return nil, kubermaticerrors.NewNotFound("sshkey", keyID)
+			return nil, utilerrors.NewNotFound("sshkey", keyID)
 		}
 	}
 
@@ -923,7 +923,7 @@ func ListSSHKeysEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGe
 func UpdateClusterSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGetter, sshKeyProvider provider.SSHKeyProvider, privilegedSSHKeyProvider provider.PrivilegedSSHKeyProvider, clusterSSHKey *kubermaticv1.UserSSHKey, projectID string) error {
 	adminUserInfo, err := userInfoGetter(ctx, "")
 	if err != nil {
-		return kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if adminUserInfo.IsAdmin {
 		if _, err := privilegedSSHKeyProvider.UpdateUnsecured(ctx, clusterSSHKey); err != nil {
@@ -933,7 +933,7 @@ func UpdateClusterSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGe
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
-		return kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if _, err = sshKeyProvider.Update(ctx, userInfo, clusterSSHKey); err != nil {
 		return common.KubernetesErrorToHTTPError(err)
@@ -959,7 +959,7 @@ func updateCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 func updateAndDeleteCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, privilegedClusterProvider provider.PrivilegedClusterProvider, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) error {
 	adminUserInfo, err := userInfoGetter(ctx, "")
 	if err != nil {
-		return kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if adminUserInfo.IsAdmin {
 		cluster, err := privilegedClusterProvider.UpdateUnsecured(ctx, project, cluster)
@@ -979,7 +979,7 @@ func updateAndDeleteCluster(ctx context.Context, userInfoGetter provider.UserInf
 func updateAndDeleteClusterForRegularUser(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) error {
 	userInfo, err := userInfoGetter(ctx, project.Name)
 	if err != nil {
-		return kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if _, err = clusterProvider.Update(ctx, project, userInfo, cluster); err != nil {
 		return common.KubernetesErrorToHTTPError(err)
@@ -1201,14 +1201,14 @@ func ConvertClusterMetrics(podMetrics *v1beta1.PodMetricsList, nodeMetrics []v1b
 func getSSHKey(ctx context.Context, userInfoGetter provider.UserInfoGetter, sshKeyProvider provider.SSHKeyProvider, privilegedSSHKeyProvider provider.PrivilegedSSHKeyProvider, projectID, keyName string) (*kubermaticv1.UserSSHKey, error) {
 	adminUserInfo, err := userInfoGetter(ctx, "")
 	if err != nil {
-		return nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	if adminUserInfo.IsAdmin {
 		return privilegedSSHKeyProvider.GetUnsecured(ctx, keyName)
 	}
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
-		return nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	return sshKeyProvider.Get(ctx, userInfo, keyName)
 }

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -49,7 +49,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -1046,7 +1046,7 @@ func getClusterForRegularUser(ctx context.Context, userInfoGetter provider.UserI
 }
 
 func isStatus(err error, status int32) bool {
-	var statusErr *kerrors.StatusError
+	var statusErr *apierrors.StatusError
 
 	return errors.As(err, &statusErr) && status == statusErr.Status().Code
 }

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	jsonpatch "github.com/evanphx/json-patch"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -477,7 +477,7 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 		return nil, fmt.Errorf("cannot decode patched cluster: %w", err)
 	}
 
-	kversion, err := semver.NewVersion(patchedNodeDeployment.Spec.Template.Versions.Kubelet)
+	kversion, err := semverlib.NewVersion(patchedNodeDeployment.Spec.Template.Versions.Kubelet)
 	if err != nil {
 		return nil, utilerrors.NewBadRequest("failed to parse kubelet version: %v", err)
 	}

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	machineresource "k8c.io/kubermatic/v2/pkg/resources/machine"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +78,7 @@ func CreateMachineDeployment(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 	if isBYO {
-		return nil, k8cerrors.NewBadRequest("You cannot create a node deployment for KubeAdm provider")
+		return nil, utilerrors.NewBadRequest("You cannot create a node deployment for KubeAdm provider")
 	}
 
 	keys, err := sshKeyProvider.List(ctx, project, &provider.SSHKeyListOptions{ClusterName: clusterID})
@@ -102,12 +102,12 @@ func CreateMachineDeployment(ctx context.Context, userInfoGetter provider.UserIn
 
 	nd, err := machineresource.Validate(&machineDeployment, cluster.Spec.Version.Semver())
 	if err != nil {
-		return nil, k8cerrors.NewBadRequest(fmt.Sprintf("node deployment validation failed: %s", err.Error()))
+		return nil, utilerrors.NewBadRequest(fmt.Sprintf("node deployment validation failed: %s", err.Error()))
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, k8cerrors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider, can not create secret")
+		return nil, utilerrors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider, can not create secret")
 	}
 
 	data := common.CredentialsData{
@@ -202,7 +202,7 @@ func DeleteMachineNode(ctx context.Context, userInfoGetter provider.UserInfoGett
 		return nil, err
 	}
 	if machine == nil && node == nil {
-		return nil, k8cerrors.NewNotFound("Node", machineID)
+		return nil, utilerrors.NewNotFound("Node", machineID)
 	}
 
 	if machine != nil {
@@ -479,10 +479,10 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 
 	kversion, err := semver.NewVersion(patchedNodeDeployment.Spec.Template.Versions.Kubelet)
 	if err != nil {
-		return nil, k8cerrors.NewBadRequest("failed to parse kubelet version: %v", err)
+		return nil, utilerrors.NewBadRequest("failed to parse kubelet version: %v", err)
 	}
 	if err = nodeupdate.EnsureVersionCompatible(cluster.Spec.Version.Semver(), kversion); err != nil {
-		return nil, k8cerrors.NewBadRequest(err.Error())
+		return nil, utilerrors.NewBadRequest(err.Error())
 	}
 
 	_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
@@ -497,7 +497,7 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, k8cerrors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider, can not create nodeDeployment")
+		return nil, utilerrors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider, can not create nodeDeployment")
 	}
 	data := common.CredentialsData{
 		Ctx:               ctx,

--- a/pkg/handler/common/provider/alibaba.go
+++ b/pkg/handler/common/provider/alibaba.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/alibaba"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -46,14 +46,14 @@ func AlibabaInstanceTypesWithClusterCredentialsEndpoint(ctx context.Context, use
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Alibaba == nil {
-		return nil, errors.NewNotFound("cloud spec for %s", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for %s", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")
@@ -90,7 +90,7 @@ func ListAlibabaInstanceTypes(accessKeyID string, accessKeySecret string, region
 
 	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to create client: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to create client: %v", err))
 	}
 
 	// get all families that are available for the Region
@@ -100,7 +100,7 @@ func ListAlibabaInstanceTypes(accessKeyID string, accessKeySecret string, region
 
 	instTypeFamilies, err := client.DescribeInstanceTypeFamilies(requestFamilies)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list instance type families: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list instance type families: %v", err))
 	}
 
 	if quota.EnableGPU {
@@ -119,7 +119,7 @@ func ListAlibabaInstanceTypes(accessKeyID string, accessKeySecret string, region
 
 	instTypes, err := client.DescribeInstanceTypes(requestInstanceTypes)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list instance types: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list instance types: %v", err))
 	}
 
 	for _, instType := range instTypes.InstanceTypes.InstanceType {
@@ -168,14 +168,14 @@ func AlibabaZonesWithClusterCredentialsEndpoint(ctx context.Context, userInfoGet
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Alibaba == nil {
-		return nil, errors.NewNotFound("cloud spec for %s", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for %s", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")
@@ -201,7 +201,7 @@ func ListAlibabaZones(accessKeyID string, accessKeySecret string, region string)
 
 	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to create client: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to create client: %v", err))
 	}
 
 	requestZones := ecs.CreateDescribeZonesRequest()
@@ -209,7 +209,7 @@ func ListAlibabaZones(accessKeyID string, accessKeySecret string, region string)
 
 	responseZones, err := client.DescribeZones(requestZones)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list zones: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list zones: %v", err))
 	}
 
 	for _, zone := range responseZones.Zones.Zone {
@@ -227,7 +227,7 @@ func ListAlibabaVSwitches(accessKeyID string, accessKeySecret string, region str
 
 	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to create client: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to create client: %v", err))
 	}
 
 	requestVSwitches := ecs.CreateDescribeVSwitchesRequest()
@@ -235,7 +235,7 @@ func ListAlibabaVSwitches(accessKeyID string, accessKeySecret string, region str
 
 	responseVswitches, err := client.DescribeVSwitches(requestVSwitches)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list vSwitches: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list vSwitches: %v", err))
 	}
 
 	for _, vSwitch := range responseVswitches.VSwitches.VSwitch {
@@ -256,14 +256,14 @@ func AlibabaVswitchesWithClusterCredentialsEndpoint(ctx context.Context, userInf
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Alibaba == nil {
-		return nil, errors.NewNotFound("cloud spec for %s", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for %s", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")

--- a/pkg/handler/common/provider/anexia.go
+++ b/pkg/handler/common/provider/anexia.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/anexia"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func ListAnexiaVlans(ctx context.Context, token string) (apiv1.AnexiaVlanList, error) {
@@ -40,12 +40,12 @@ func ListAnexiaVlans(ctx context.Context, token string) (apiv1.AnexiaVlanList, e
 
 	cli, err := getClient(token)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	v := vlan.NewAPI(cli)
 	vlans, err := v.List(ctx, 1, 1000, "")
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	for _, vlan := range vlans {
@@ -63,12 +63,12 @@ func ListAnexiaTemplates(ctx context.Context, token, locationID string) (apiv1.A
 
 	cli, err := getClient(token)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 	t := templates.NewAPI(cli)
 	templates, err := t.List(ctx, locationID, "templates", 1, 1000)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	for _, template := range templates {
@@ -89,11 +89,11 @@ func AnexiaVlansWithClusterCredentialsEndpoint(ctx context.Context, userInfoGett
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Anexia == nil {
-		return nil, errors.NewNotFound("cloud spec for %s", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for %s", clusterID)
 	}
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -113,14 +113,14 @@ func AnexiaTemplatesWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Anexia == nil {
-		return nil, errors.NewNotFound("cloud spec for %s", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for %s", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -134,7 +134,7 @@ func AnexiaTemplatesWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 	}
 	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to find Datacenter %q: %v", datacenterName, err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to find Datacenter %q: %v", datacenterName, err))
 	}
 
 	return ListAnexiaTemplates(ctx, token, datacenter.Spec.Anexia.LocationID)

--- a/pkg/handler/common/provider/aws.go
+++ b/pkg/handler/common/provider/aws.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	awsprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/aws"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,7 +55,7 @@ func AWSSubnetNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider
 		return nil, err
 	}
 	if cluster.Spec.Cloud.AWS == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")
@@ -64,11 +64,11 @@ func AWSSubnetNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider
 	}
 	_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 	if err != nil {
-		return nil, errors.NewBadRequest(err.Error())
+		return nil, utilerrors.NewBadRequest(err.Error())
 	}
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -101,7 +101,7 @@ func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.U
 		return nil, err
 	}
 	if cluster.Spec.Cloud.AWS == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")
@@ -110,11 +110,11 @@ func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.U
 	}
 	dc, err := dc.GetDatacenter(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	if dc.Spec.AWS == nil {
-		return nil, errors.NewNotFound("cloud spec (dc) for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec (dc) for ", clusterID)
 	}
 
 	settings, err := settingsProvider.GetGlobalSettings(ctx)
@@ -127,7 +127,7 @@ func AWSSizeNoCredentialsEndpoint(ctx context.Context, userInfoGetter provider.U
 
 func ListAWSSubnets(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleID string, assumeRoleExternalID string, vpcID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSSubnetList, error) {
 	if datacenter.Spec.AWS == nil {
-		return nil, errors.NewBadRequest("datacenter is not an AWS datacenter")
+		return nil, utilerrors.NewBadRequest("datacenter is not an AWS datacenter")
 	}
 
 	subnetResults, err := awsprovider.GetSubnets(ctx, accessKeyID, secretAccessKey, assumeRoleID, assumeRoleExternalID, datacenter.Spec.AWS.Region, vpcID)
@@ -197,7 +197,7 @@ func SetDefaultSubnet(machineDeployments *clusterv1alpha1.MachineDeploymentList,
 			return nil, fmt.Errorf("failed to get node cloud spec from machine deployment: %w", err)
 		}
 		if cloudSpec.AWS == nil {
-			return nil, errors.NewBadRequest("cloud spec missing")
+			return nil, utilerrors.NewBadRequest("cloud spec missing")
 		}
 		if md.Spec.Replicas != nil {
 			replicas = *md.Spec.Replicas

--- a/pkg/handler/common/provider/azure.go
+++ b/pkg/handler/common/provider/azure.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/azure"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu
@@ -179,7 +179,7 @@ func AzureSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Azure == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")
@@ -188,17 +188,17 @@ func AzureSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter
 	}
 	datacenter, err := dc.GetDatacenter(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	if datacenter.Spec.Azure == nil {
-		return nil, errors.NewNotFound("cloud spec (dc) for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec (dc) for ", clusterID)
 	}
 
 	azureLocation := datacenter.Spec.Azure.Location
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -221,7 +221,7 @@ func AzureAvailabilityZonesWithClusterCredentialsEndpoint(ctx context.Context, u
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Azure == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")
@@ -230,17 +230,17 @@ func AzureAvailabilityZonesWithClusterCredentialsEndpoint(ctx context.Context, u
 	}
 	datacenter, err := dc.GetDatacenter(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, err.Error())
+		return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	if datacenter.Spec.Azure == nil {
-		return nil, errors.NewNotFound("cloud spec (dc) for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec (dc) for ", clusterID)
 	}
 
 	azureLocation := datacenter.Spec.Azure.Location
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())

--- a/pkg/handler/common/provider/digitalocean.go
+++ b/pkg/handler/common/provider/digitalocean.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	doprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/digitalocean"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 var reStandard = regexp.MustCompile("(^s|S)")
@@ -47,12 +47,12 @@ func DigitaloceanSizeWithClusterCredentialsEndpoint(ctx context.Context, userInf
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Digitalocean == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -45,12 +45,12 @@ func GCPSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter p
 		return nil, err
 	}
 	if cluster.Spec.Cloud.GCP == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -74,12 +74,12 @@ func GCPZoneWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter p
 		return nil, err
 	}
 	if cluster.Spec.Cloud.GCP == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -101,12 +101,12 @@ func GCPNetworkWithClusterCredentialsEndpoint(ctx context.Context, userInfoGette
 		return nil, err
 	}
 	if cluster.Spec.Cloud.GCP == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -124,12 +124,12 @@ func GCPSubnetworkWithClusterCredentialsEndpoint(ctx context.Context, userInfoGe
 		return nil, err
 	}
 	if cluster.Spec.Cloud.GCP == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -152,12 +152,12 @@ func GCPDiskTypesWithClusterCredentialsEndpoint(ctx context.Context, userInfoGet
 		return nil, err
 	}
 	if cluster.Spec.Cloud.GCP == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
@@ -198,11 +198,11 @@ func ListGCPDiskTypes(ctx context.Context, sa string, zone string) (apiv1.GCPDis
 func ListGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datacenterName string, sa string, networkName string, seedsGetter provider.SeedsGetter) (apiv1.GCPSubnetworkList, error) {
 	datacenter, err := dc.GetDatacenter(userInfo, seedsGetter, datacenterName)
 	if err != nil {
-		return nil, errors.NewBadRequest("%v", err)
+		return nil, utilerrors.NewBadRequest("%v", err)
 	}
 
 	if datacenter.Spec.GCP == nil {
-		return nil, errors.NewBadRequest("%s is not a GCP datacenter", datacenterName)
+		return nil, utilerrors.NewBadRequest("%s is not a GCP datacenter", datacenterName)
 	}
 
 	subnetworks := apiv1.GCPSubnetworkList{}
@@ -277,11 +277,11 @@ func ListGCPNetworks(ctx context.Context, sa string) (apiv1.GCPNetworkList, erro
 func ListGCPZones(ctx context.Context, userInfo *provider.UserInfo, sa, datacenterName string, seedsGetter provider.SeedsGetter) (apiv1.GCPZoneList, error) {
 	datacenter, err := dc.GetDatacenter(userInfo, seedsGetter, datacenterName)
 	if err != nil {
-		return nil, errors.NewBadRequest("%v", err)
+		return nil, utilerrors.NewBadRequest("%v", err)
 	}
 
 	if datacenter.Spec.GCP == nil {
-		return nil, errors.NewBadRequest("the %s is not GCP datacenter", datacenterName)
+		return nil, utilerrors.NewBadRequest("the %s is not GCP datacenter", datacenterName)
 	}
 
 	computeService, project, err := gcp.ConnectToComputeService(ctx, sa)

--- a/pkg/handler/common/provider/hetzner.go
+++ b/pkg/handler/common/provider/hetzner.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/hetzner"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 var reStandardSize = regexp.MustCompile("(^cx|^cpx)")
@@ -47,12 +47,12 @@ func HetznerSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGett
 	}
 
 	if cluster.Spec.Cloud.Hetzner == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())

--- a/pkg/handler/common/provider/kubevirt.go
+++ b/pkg/handler/common/provider/kubevirt.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,12 +74,12 @@ func getKvKubeConfigFromCredentials(ctx context.Context, projectProvider provide
 	}
 
 	if cluster.Spec.Cloud.Kubevirt == nil {
-		return "", errors.NewNotFound("cloud spec for ", clusterID)
+		return "", utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return "", errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return "", utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())

--- a/pkg/handler/common/provider/nutanix.go
+++ b/pkg/handler/common/provider/nutanix.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	nutanixprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/nutanix"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 type NutanixCredentials struct {
@@ -164,14 +164,14 @@ func getClientSetFromCluster(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, "", "", err
 	}
 	if cluster.Spec.Cloud.Nutanix == nil {
-		return nil, "", "", errors.NewNotFound("no cloud spec for %s", clusterID)
+		return nil, "", "", utilerrors.NewNotFound("no cloud spec for %s", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, "", "", errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, "", "", utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	userInfo, err := userInfoGetter(ctx, "")

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/openstack"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func OpenstackSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
@@ -376,7 +376,7 @@ func getClusterForOpenstack(ctx context.Context, projectProvider provider.Projec
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Openstack == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 	return cluster, nil
 }
@@ -402,7 +402,7 @@ func getCredentials(ctx context.Context, cloudSpec kubermaticv1.CloudSpec) (*res
 	clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())

--- a/pkg/handler/common/provider/packet.go
+++ b/pkg/handler/common/provider/packet.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/packet"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // Used to decode response object.
@@ -48,12 +48,12 @@ func PacketSizesWithClusterCredentialsEndpoint(ctx context.Context, userInfoGett
 		return nil, err
 	}
 	if cluster.Spec.Cloud.Packet == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider")
 	}
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 	apiKey, projectID, err := packet.GetCredentialsForCluster(cluster.Spec.Cloud, secretKeySelector)

--- a/pkg/handler/common/provider/vsphere.go
+++ b/pkg/handler/common/provider/vsphere.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/vsphere"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func VsphereNetworksWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
@@ -43,14 +43,14 @@ func VsphereNetworksWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 		return nil, err
 	}
 	if cluster.Spec.Cloud.VSphere == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 
@@ -105,13 +105,13 @@ func VsphereFoldersWithClusterCredentialsEndpoint(ctx context.Context, userInfoG
 		return nil, err
 	}
 	if cluster.Spec.Cloud.VSphere == nil {
-		return nil, errors.NewNotFound("cloud spec for ", clusterID)
+		return nil, utilerrors.NewNotFound("cloud spec for ", clusterID)
 	}
 
 	datacenterName := cluster.Spec.Cloud.DatacenterName
 	assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -124,7 +124,7 @@ func UpgradeNodeDeploymentsEndpoint(ctx context.Context, userInfoGetter provider
 		return nil, err
 	}
 
-	requestedKubeletVersion, err := semver.NewVersion(version.Version.String())
+	requestedKubeletVersion, err := semverlib.NewVersion(version.Version.String())
 	if err != nil {
 		return nil, utilerrors.NewBadRequest(err.Error())
 	}
@@ -160,7 +160,7 @@ func UpgradeNodeDeploymentsEndpoint(ctx context.Context, userInfoGetter provider
 
 func isRestrictedByKubeletVersions(controlPlaneVersion *version.Version, mds []clusterv1alpha1.MachineDeployment) (bool, error) {
 	for _, md := range mds {
-		kubeletVersion, err := semver.NewVersion(md.Spec.Template.Spec.Versions.Kubelet)
+		kubeletVersion, err := semverlib.NewVersion(md.Spec.Template.Spec.Versions.Kubelet)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	"k8c.io/kubermatic/v2/pkg/version"
 
@@ -126,11 +126,11 @@ func UpgradeNodeDeploymentsEndpoint(ctx context.Context, userInfoGetter provider
 
 	requestedKubeletVersion, err := semver.NewVersion(version.Version.String())
 	if err != nil {
-		return nil, kubermaticerrors.NewBadRequest(err.Error())
+		return nil, utilerrors.NewBadRequest(err.Error())
 	}
 
 	if err = nodeupdate.EnsureVersionCompatible(cluster.Spec.Version.Semver(), requestedKubeletVersion); err != nil {
-		return nil, kubermaticerrors.NewBadRequest(err.Error())
+		return nil, utilerrors.NewBadRequest(err.Error())
 	}
 
 	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
@@ -152,7 +152,7 @@ func UpgradeNodeDeploymentsEndpoint(ctx context.Context, userInfoGetter provider
 	}
 
 	if len(updateErrors) > 0 {
-		return nil, kubermaticerrors.NewWithDetails(http.StatusInternalServerError, "failed to update some node deployments", updateErrors)
+		return nil, utilerrors.NewWithDetails(http.StatusInternalServerError, "failed to update some node deployments", updateErrors)
 	}
 
 	return nil, nil

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 
 	"k8c.io/kubermatic/v2/pkg/log"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 const (
@@ -66,7 +66,7 @@ func ErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	errorCode := http.StatusInternalServerError
 	msg := err.Error()
 
-	var httpErr kubermaticerrors.HTTPError
+	var httpErr utilerrors.HTTPError
 	if errors.As(err, &httpErr) {
 		errorCode = httpErr.StatusCode()
 		msg = httpErr.Error()

--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/util/hash"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -169,7 +169,7 @@ func UserSaver(userProvider provider.UserProvider) endpoint.Middleware {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			rawAuthenticatesUser := ctx.Value(AuthenticatedUserContextKey)
 			if rawAuthenticatesUser == nil {
-				return nil, k8cerrors.New(http.StatusInternalServerError, "no user in context found")
+				return nil, utilerrors.New(http.StatusInternalServerError, "no user in context found")
 			}
 			authenticatedUser := rawAuthenticatesUser.(apiv1.User)
 
@@ -223,11 +223,11 @@ func UserInfoUnauthorized(userProjectMapper provider.ProjectMemberMapper, userPr
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			userIDGetter, ok := request.(common.UserIDGetter)
 			if !ok {
-				return nil, k8cerrors.NewBadRequest("you can only use userInfoMiddlewareUnauthorized for endpoints that accepts user ID")
+				return nil, utilerrors.NewBadRequest("you can only use userInfoMiddlewareUnauthorized for endpoints that accepts user ID")
 			}
 			prjIDGetter, ok := request.(common.ProjectIDGetter)
 			if !ok {
-				return nil, k8cerrors.NewBadRequest("you can only use userInfoMiddlewareUnauthorized for endpoints that accepts project ID")
+				return nil, utilerrors.NewBadRequest("you can only use userInfoMiddlewareUnauthorized for endpoints that accepts project ID")
 			}
 			userID := userIDGetter.GetUserID()
 			projectID := prjIDGetter.GetProjectID()
@@ -256,31 +256,31 @@ func TokenVerifier(tokenVerifier auth.TokenVerifier, userProvider provider.UserP
 			if rawTokenNotFoundErr := ctx.Value(noTokenFoundKey); rawTokenNotFoundErr != nil {
 				tokenNotFoundErr, ok := rawTokenNotFoundErr.(error)
 				if !ok {
-					return nil, k8cerrors.NewNotAuthorized()
+					return nil, utilerrors.NewNotAuthorized()
 				}
-				return nil, k8cerrors.NewWithDetails(http.StatusUnauthorized, "not authorized", []string{tokenNotFoundErr.Error()})
+				return nil, utilerrors.NewWithDetails(http.StatusUnauthorized, "not authorized", []string{tokenNotFoundErr.Error()})
 			}
 
 			t := ctx.Value(RawTokenContextKey)
 			token, ok := t.(string)
 			if !ok || token == "" {
-				return nil, k8cerrors.NewNotAuthorized()
+				return nil, utilerrors.NewNotAuthorized()
 			}
 
 			verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
 			claims, err := tokenVerifier.Verify(verifyCtx, token)
 			if err != nil {
-				return nil, k8cerrors.New(http.StatusUnauthorized, fmt.Sprintf("access denied, invalid token: %v", err))
+				return nil, utilerrors.New(http.StatusUnauthorized, fmt.Sprintf("access denied, invalid token: %v", err))
 			}
 
 			if claims.Subject == "" {
-				return nil, k8cerrors.NewNotAuthorized()
+				return nil, utilerrors.NewNotAuthorized()
 			}
 
 			id, err := hash.GetUserID(claims.Subject)
 			if err != nil {
-				return nil, k8cerrors.NewNotAuthorized()
+				return nil, utilerrors.NewNotAuthorized()
 			}
 
 			user := apiv1.User{
@@ -292,7 +292,7 @@ func TokenVerifier(tokenVerifier auth.TokenVerifier, userProvider provider.UserP
 			}
 
 			if user.ID == "" {
-				return nil, k8cerrors.NewNotAuthorized()
+				return nil, utilerrors.NewNotAuthorized()
 			}
 
 			if err := checkBlockedTokens(ctx, claims.Email, token, userProvider); err != nil {
@@ -347,7 +347,7 @@ func getAddonProvider(ctx context.Context, clusterProviderGetter provider.Cluste
 		for _, seed := range seeds {
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
-				return nil, k8cerrors.NewNotFound("cluster-provider", clusterID)
+				return nil, utilerrors.NewNotFound("cluster-provider", clusterID)
 			}
 			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
@@ -395,7 +395,7 @@ func GetClusterProvider(ctx context.Context, request interface{}, seedsGetter pr
 	}
 	seeds, err := seedsGetter()
 	if err != nil {
-		return nil, ctx, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+		return nil, ctx, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
 	if getter.GetSeedCluster().ClusterID != "" {
 		return getClusterProviderByClusterID(ctx, seeds, clusterProviderGetter, getter.GetSeedCluster().ClusterID)
@@ -403,13 +403,13 @@ func GetClusterProvider(ctx context.Context, request interface{}, seedsGetter pr
 
 	seed, exists := seeds[getter.GetSeedCluster().SeedName]
 	if !exists {
-		return nil, ctx, k8cerrors.NewNotFound("seed", getter.GetSeedCluster().SeedName)
+		return nil, ctx, utilerrors.NewNotFound("seed", getter.GetSeedCluster().SeedName)
 	}
 	ctx = context.WithValue(ctx, datacenterContextKey, seed)
 
 	clusterProvider, err := clusterProviderGetter(seed)
 	if err != nil {
-		return nil, ctx, k8cerrors.NewNotFound("cluster-provider", getter.GetSeedCluster().SeedName)
+		return nil, ctx, utilerrors.NewNotFound("cluster-provider", getter.GetSeedCluster().SeedName)
 	}
 
 	return clusterProvider, ctx, nil
@@ -419,13 +419,13 @@ func getClusterProviderByClusterID(ctx context.Context, seeds map[string]*kuberm
 	for _, seed := range seeds {
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
-			return nil, ctx, k8cerrors.NewNotFound("cluster-provider", clusterID)
+			return nil, ctx, utilerrors.NewNotFound("cluster-provider", clusterID)
 		}
 		if clusterProvider.IsCluster(ctx, clusterID) {
 			return clusterProvider, ctx, nil
 		}
 	}
-	return nil, ctx, k8cerrors.NewNotFound("cluster-provider", clusterID)
+	return nil, ctx, utilerrors.NewNotFound("cluster-provider", clusterID)
 }
 
 func checkBlockedTokens(ctx context.Context, email, token string, userProvider provider.UserProvider) error {
@@ -442,7 +442,7 @@ func checkBlockedTokens(ctx context.Context, email, token string, userProvider p
 	}
 	tokenSet := sets.NewString(blockedTokens...)
 	if tokenSet.Has(token) {
-		return k8cerrors.NewNotAuthorized()
+		return utilerrors.NewNotAuthorized()
 	}
 
 	return nil
@@ -497,7 +497,7 @@ func getConstraintProvider(ctx context.Context, clusterProviderGetter provider.C
 		for _, seed := range seeds {
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
-				return nil, k8cerrors.NewNotFound("cluster-provider", clusterID)
+				return nil, utilerrors.NewNotFound("cluster-provider", clusterID)
 			}
 			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name
@@ -839,7 +839,7 @@ func BackupCredentials(backupCredentialsProviderGetter provider.BackupCredential
 
 			seed, found := seeds[seedCluster.SeedName]
 			if !found {
-				return nil, k8cerrors.NewBadRequest("couldn't find seed %q", seedCluster.SeedName)
+				return nil, utilerrors.NewBadRequest("couldn't find seed %q", seedCluster.SeedName)
 			}
 
 			backupCredentialsProvider, err := backupCredentialsProviderGetter(seed)

--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -35,7 +35,7 @@ import (
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/util/hash"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -181,7 +181,7 @@ func UserSaver(userProvider provider.UserProvider) endpoint.Middleware {
 				// handling ErrNotFound
 				user, err = userProvider.CreateUser(ctx, authenticatedUser.ID, authenticatedUser.Name, authenticatedUser.Email)
 				if err != nil {
-					if !kerrors.IsAlreadyExists(err) {
+					if !apierrors.IsAlreadyExists(err) {
 						return nil, common.KubernetesErrorToHTTPError(err)
 					}
 					if user, err = userProvider.UserByEmail(ctx, authenticatedUser.Email); err != nil {
@@ -203,7 +203,7 @@ func UserSaver(userProvider provider.UserProvider) endpoint.Middleware {
 
 			// Ignore conflict error during update of the lastSeen field as it is not super important.
 			// It can be updated next time.
-			if kerrors.IsConflict(err) {
+			if apierrors.IsConflict(err) {
 				return next(context.WithValue(ctx, kubermaticcontext.UserCRContextKey, user), request)
 			}
 

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/auth"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
@@ -239,13 +239,13 @@ type terminalReq struct {
 	ClusterID string
 }
 
-func (req terminalReq) GetSeedCluster() v1.SeedCluster {
-	return v1.SeedCluster{
+func (req terminalReq) GetSeedCluster() apiv1.SeedCluster {
+	return apiv1.SeedCluster{
 		ClusterID: req.ClusterID,
 	}
 }
 
-func verifyAuthorizationToken(req *http.Request, tokenVerifier auth.TokenVerifier, tokenExtractor auth.TokenExtractor) (*v1.User, error) {
+func verifyAuthorizationToken(req *http.Request, tokenVerifier auth.TokenVerifier, tokenExtractor auth.TokenExtractor) (*apiv1.User, error) {
 	token, err := tokenExtractor.Extract(req)
 	if err != nil {
 		return nil, err
@@ -265,8 +265,8 @@ func verifyAuthorizationToken(req *http.Request, tokenVerifier auth.TokenVerifie
 		return nil, utilerrors.NewNotAuthorized()
 	}
 
-	user := &v1.User{
-		ObjectMeta: v1.ObjectMeta{
+	user := &apiv1.User{
+		ObjectMeta: apiv1.ObjectMeta{
 			ID:   id,
 			Name: claims.Name,
 		},

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -37,7 +37,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/util/hash"
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
@@ -257,12 +257,12 @@ func verifyAuthorizationToken(req *http.Request, tokenVerifier auth.TokenVerifie
 	}
 
 	if claims.Subject == "" {
-		return nil, errors.NewNotAuthorized()
+		return nil, utilerrors.NewNotAuthorized()
 	}
 
 	id, err := hash.GetUserID(claims.Subject)
 	if err != nil {
-		return nil, errors.NewNotAuthorized()
+		return nil, utilerrors.NewNotAuthorized()
 	}
 
 	user := &v1.User{
@@ -274,7 +274,7 @@ func verifyAuthorizationToken(req *http.Request, tokenVerifier auth.TokenVerifie
 	}
 
 	if user.ID == "" {
-		return nil, errors.NewNotAuthorized()
+		return nil, utilerrors.NewNotAuthorized()
 	}
 
 	return user, nil

--- a/pkg/handler/routing.go
+++ b/pkg/handler/routing.go
@@ -37,7 +37,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Routing represents an object which binds endpoints to http handlers.
@@ -46,7 +46,7 @@ type Routing struct {
 	logger                                log.Logger
 	versions                              kubermatic.Versions
 	presetProvider                        provider.PresetProvider
-	masterClient                          client.Client
+	masterClient                          ctrlruntimeclient.Client
 	seedsGetter                           provider.SeedsGetter
 	seedsClientGetter                     provider.SeedClientGetter
 	kubermaticConfigGetter                provider.KubermaticConfigurationGetter
@@ -85,7 +85,7 @@ type Routing struct {
 }
 
 // NewRouting creates a new Routing.
-func NewRouting(routingParams RoutingParams, masterClient client.Client) Routing {
+func NewRouting(routingParams RoutingParams, masterClient ctrlruntimeclient.Client) Routing {
 	return Routing{
 		log:                                   routingParams.Log,
 		logger:                                log.NewLogfmtLogger(os.Stderr),

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -124,7 +124,7 @@ func (f *FakePrivilegedProjectProvider) UpdateUnsecured(ctx context.Context, pro
 }
 
 func createError(status int32, message string) error {
-	return &kerrors.StatusError{ErrStatus: metav1.Status{
+	return &apierrors.StatusError{ErrStatus: metav1.Status{
 		Status:  metav1.StatusFailure,
 		Code:    status,
 		Reason:  metav1.StatusReasonBadRequest,

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewTestRouting is a hack that helps us avoid circular imports
@@ -92,7 +92,7 @@ func NewTestRouting(
 	etcdRestoreProjectProviderGetter provider.EtcdRestoreProjectProviderGetter,
 	backupCredentialsProviderGetter provider.BackupCredentialsProviderGetter,
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter,
-	masterClient client.Client,
+	masterClient ctrlruntimeclient.Client,
 	featureGatesProvider provider.FeatureGatesProvider,
 	seedProvider provider.SeedProvider,
 	features features.FeatureGate) http.Handler {

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -74,7 +74,6 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -216,7 +215,7 @@ type newRoutingFunc func(
 	etcdRestoreProjectProviderGetter provider.EtcdRestoreProjectProviderGetter,
 	backupCredentialsProviderGetter provider.BackupCredentialsProviderGetter,
 	privilegedMLAAdminSettingProviderGetter provider.PrivilegedMLAAdminSettingProviderGetter,
-	masterClient client.Client,
+	masterClient ctrlruntimeclient.Client,
 	featureGatesProvider provider.FeatureGatesProvider,
 	seedProvider provider.SeedProvider,
 	features features.FeatureGate,

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -61,7 +61,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -92,7 +92,7 @@ func init() {
 	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme metrics/v1beta1", "error", err)
 	}
-	if err := apiextensionv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+	if err := apiextensionsv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme apiextension/v1beta1", "error", err)
 	}
 	if err := gatekeeperconfigv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
@@ -1464,12 +1464,12 @@ func GenDefaultConstraintTemplate(name string) apiv2.ConstraintTemplate {
 						ShortNames: []string{"lc"},
 					},
 					Validation: &constrainttemplatev1.Validation{
-						OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
-							Properties: map[string]apiextensionv1.JSONSchemaProps{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"labels": {
 									Type: "array",
-									Items: &apiextensionv1.JSONSchemaPropsOrArray{
-										Schema: &apiextensionv1.JSONSchemaProps{
+									Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+										Schema: &apiextensionsv1.JSONSchemaProps{
 											Type: "string",
 										},
 									},
@@ -1531,12 +1531,12 @@ func GenConstraintTemplate(name string) *kubermaticv1.ConstraintTemplate {
 					ShortNames: []string{"lc"},
 				},
 				Validation: &constrainttemplatev1.Validation{
-					OpenAPIV3Schema: &apiextensionv1.JSONSchemaProps{
-						Properties: map[string]apiextensionv1.JSONSchemaProps{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"labels": {
 								Type: "array",
-								Items: &apiextensionv1.JSONSchemaPropsOrArray{
-									Schema: &apiextensionv1.JSONSchemaProps{
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
 										Type: "string",
 									},
 								},

--- a/pkg/handler/v1/admin/admin.go
+++ b/pkg/handler/v1/admin/admin.go
@@ -26,7 +26,7 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // GetAdminEndpoint returns list of admin users.
@@ -56,7 +56,7 @@ func SetAdminEndpoint(userInfoGetter provider.UserInfoGetter, adminProvider prov
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(setAdminReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
@@ -91,7 +91,7 @@ type setAdminReq struct {
 // Validate setAdminReq request.
 func (r setAdminReq) Validate() error {
 	if len(r.Body.Email) == 0 {
-		return k8cerrors.NewBadRequest("the email address cannot be empty")
+		return utilerrors.NewBadRequest("the email address cannot be empty")
 	}
 	return nil
 }

--- a/pkg/handler/v1/admin/admission_plugin.go
+++ b/pkg/handler/v1/admin/admission_plugin.go
@@ -29,7 +29,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // ListAdmissionPluginEndpoint returns admission plugin list.
@@ -57,7 +57,7 @@ func GetAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admissio
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(admissionPluginReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -77,7 +77,7 @@ func DeleteAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admis
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(admissionPluginReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -97,11 +97,11 @@ func UpdateAdmissionPluginEndpoint(userInfoGetter provider.UserInfoGetter, admis
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(updateAdmissionPluginReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, k8cerrors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {

--- a/pkg/handler/v1/admin/backupdestination.go
+++ b/pkg/handler/v1/admin/backupdestination.go
@@ -27,11 +27,11 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DeleteBackupDestinationEndpoint deletes a backup destination from a seed.
-func DeleteBackupDestinationEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient client.Client) endpoint.Endpoint {
+func DeleteBackupDestinationEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(backupDestinationReq)
 		if !ok {

--- a/pkg/handler/v1/admin/backupdestination.go
+++ b/pkg/handler/v1/admin/backupdestination.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"k8c.io/kubermatic/v2/pkg/provider"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -35,7 +35,7 @@ func DeleteBackupDestinationEndpoint(userInfoGetter provider.UserInfoGetter, see
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(backupDestinationReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		seed, err := getSeed(ctx, req.seedReq, userInfoGetter, seedsGetter)
 		if err != nil {
@@ -43,12 +43,12 @@ func DeleteBackupDestinationEndpoint(userInfoGetter provider.UserInfoGetter, see
 		}
 
 		if seed.Spec.EtcdBackupRestore == nil {
-			return nil, k8cerrors.New(http.StatusNotFound, fmt.Sprintf("backup destination %q does not exist for seed %q", req.BackupDestination, req.Name))
+			return nil, utilerrors.New(http.StatusNotFound, fmt.Sprintf("backup destination %q does not exist for seed %q", req.BackupDestination, req.Name))
 		}
 
 		_, ok = seed.Spec.EtcdBackupRestore.Destinations[req.BackupDestination]
 		if !ok {
-			return nil, k8cerrors.New(http.StatusNotFound, fmt.Sprintf("backup destination %q does not exist for seed %q", req.BackupDestination, req.Name))
+			return nil, utilerrors.New(http.StatusNotFound, fmt.Sprintf("backup destination %q does not exist for seed %q", req.BackupDestination, req.Name))
 		}
 
 		delete(seed.Spec.EtcdBackupRestore.Destinations, req.BackupDestination)

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -26,7 +26,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateOrUpdateMeteringCredentials creates or updates metering tool SecretReq.
@@ -49,7 +49,7 @@ func CreateOrUpdateMeteringCredentials(userInfoGetter provider.UserInfoGetter, s
 }
 
 // CreateOrUpdateMeteringConfigurations configures kkp metering tool.
-func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter, masterClient client.Client) endpoint.Endpoint {
+func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -108,7 +108,7 @@ func ListMeteringReportConfigurationsEndpoint(userInfoGetter provider.UserInfoGe
 }
 
 // CreateMeteringReportConfigurationEndpoint creates report configuration entry for kkp metering tool.
-func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient client.Client) endpoint.Endpoint {
+func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -127,7 +127,7 @@ func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 }
 
 // UpdateMeteringReportConfigurationEndpoint updates existing report configuration entry for kkp metering tool.
-func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient client.Client) endpoint.Endpoint {
+func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -146,7 +146,7 @@ func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 }
 
 // DeleteMeteringReportConfigurationEndpoint deletes report configuration entry for kkp metering tool.
-func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient client.Client) endpoint.Endpoint {
+func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -24,7 +24,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,7 +37,7 @@ func CreateOrUpdateMeteringCredentials(userInfoGetter provider.UserInfoGetter, s
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		if err := createOrUpdateMeteringCredentials(ctx, req, seedsGetter, seedClientGetter); err != nil {
@@ -56,7 +56,7 @@ func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		if err := createOrUpdateMeteringConfigurations(ctx, req, masterClient); err != nil {
@@ -75,7 +75,7 @@ func GetMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGett
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		resp, err := getMeteringReportConfiguration(seedsGetter, req)
@@ -95,7 +95,7 @@ func ListMeteringReportConfigurationsEndpoint(userInfoGetter provider.UserInfoGe
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		resp, err := listMeteringReportConfigurations(seedsGetter)
@@ -115,7 +115,7 @@ func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		if err := createMeteringReportConfiguration(ctx, req, masterClient); err != nil {
@@ -134,7 +134,7 @@ func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		if err := updateMeteringReportConfiguration(ctx, req, masterClient); err != nil {
@@ -153,7 +153,7 @@ func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		if err := deleteMeteringReportConfiguration(ctx, req, masterClient); err != nil {
@@ -172,7 +172,7 @@ func ListMeteringReportsEndpoint(userInfoGetter provider.UserInfoGetter, seedsGe
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		exports, err := listMeteringReports(ctx, req, seedsGetter, seedClientGetter)
@@ -192,7 +192,7 @@ func GetMeteringReportEndpoint(userInfoGetter provider.UserInfoGetter, seedsGett
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		report, err := getMeteringReport(ctx, req, seedsGetter, seedClientGetter)
@@ -212,7 +212,7 @@ func DeleteMeteringReportEndpoint(userInfoGetter provider.UserInfoGetter, seedsG
 			return nil, err
 		}
 		if !userInfo.IsAdmin {
-			return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
 		err = deleteMeteringReport(ctx, req, seedsGetter, seedClientGetter)

--- a/pkg/handler/v1/admin/seed.go
+++ b/pkg/handler/v1/admin/seed.go
@@ -36,7 +36,7 @@ import (
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var resourceNameValidator = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
@@ -87,7 +87,7 @@ func GetSeedEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provide
 }
 
 // UpdateSeedEndpoint updates seed element.
-func UpdateSeedEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient client.Client) endpoint.Endpoint {
+func UpdateSeedEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(updateSeedReq)
 		if !ok {
@@ -135,7 +135,7 @@ func UpdateSeedEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter prov
 }
 
 // DeleteSeedEndpoint deletes seed CRD element with the given name from the Kubermatic.
-func DeleteSeedEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient client.Client) endpoint.Endpoint {
+func DeleteSeedEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(seedReq)
 		if !ok {

--- a/pkg/handler/v1/admin/settings.go
+++ b/pkg/handler/v1/admin/settings.go
@@ -29,7 +29,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // KubermaticSettingsEndpoint returns global settings.
@@ -71,17 +71,17 @@ func UpdateKubermaticSettingsEndpoint(userInfoGetter provider.UserInfoGetter, se
 		}
 		existingGlobalSettingsSpecJSON, err := json.Marshal(existingGlobalSettings.Spec)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot decode existing settings: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot decode existing settings: %v", err)
 		}
 
 		patchedGlobalSettingsSpecJSON, err := jsonpatch.MergePatch(existingGlobalSettingsSpecJSON, req.Patch)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot patch global settings: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot patch global settings: %v", err)
 		}
 		var patchedGlobalSettingsSpec *kubermaticv1.SettingSpec
 		err = json.Unmarshal(patchedGlobalSettingsSpecJSON, &patchedGlobalSettingsSpec)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot decode patched settings: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot decode patched settings: %v", err)
 		}
 
 		existingGlobalSettings.Spec = *patchedGlobalSettingsSpec

--- a/pkg/handler/v1/admin/settings.go
+++ b/pkg/handler/v1/admin/settings.go
@@ -25,7 +25,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-kit/kit/endpoint"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -40,7 +40,7 @@ func KubermaticSettingsEndpoint(settingsProvider provider.SettingsProvider) endp
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return v1.GlobalSettings(globalSettings.Spec), nil
+		return apiv1.GlobalSettings(globalSettings.Spec), nil
 	}
 }
 
@@ -52,7 +52,7 @@ func KubermaticCustomLinksEndpoint(settingsProvider provider.SettingsProvider) e
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return v1.GlobalCustomLinks(globalSettings.Spec.CustomLinks), nil
+		return apiv1.GlobalCustomLinks(globalSettings.Spec.CustomLinks), nil
 	}
 }
 
@@ -90,7 +90,7 @@ func UpdateKubermaticSettingsEndpoint(userInfoGetter provider.UserInfoGetter, se
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return v1.GlobalSettings(globalSettings.Spec), nil
+		return apiv1.GlobalSettings(globalSettings.Spec), nil
 	}
 }
 

--- a/pkg/handler/v1/admin/wrappers_ce.go
+++ b/pkg/handler/v1/admin/wrappers_ce.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"net/http"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
@@ -41,7 +41,7 @@ func getMeteringReportConfiguration(_ provider.SeedsGetter, _ interface{}) (*kub
 	return nil, nil
 }
 
-func listMeteringReportConfigurations(_ provider.SeedsGetter) ([]v1.MeteringReportConfiguration, error) {
+func listMeteringReportConfigurations(_ provider.SeedsGetter) ([]apiv1.MeteringReportConfiguration, error) {
 	return nil, nil
 }
 
@@ -57,7 +57,7 @@ func deleteMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlr
 	return nil
 }
 
-func listMeteringReports(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ provider.SeedClientGetter) ([]v1.MeteringReport, error) {
+func listMeteringReports(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ provider.SeedClientGetter) ([]apiv1.MeteringReport, error) {
 	return nil, nil
 }
 

--- a/pkg/handler/v1/admin/wrappers_ce.go
+++ b/pkg/handler/v1/admin/wrappers_ce.go
@@ -26,14 +26,14 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func createOrUpdateMeteringCredentials(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ provider.SeedClientGetter) error {
 	return nil
 }
 
-func createOrUpdateMeteringConfigurations(_ context.Context, _ interface{}, masterClient client.Client) error {
+func createOrUpdateMeteringConfigurations(_ context.Context, _ interface{}, masterClient ctrlruntimeclient.Client) error {
 	return nil
 }
 
@@ -45,15 +45,15 @@ func listMeteringReportConfigurations(_ provider.SeedsGetter) ([]v1.MeteringRepo
 	return nil, nil
 }
 
-func createMeteringReportConfiguration(_ context.Context, _ interface{}, _ client.Client) error {
+func createMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlruntimeclient.Client) error {
 	return nil
 }
 
-func updateMeteringReportConfiguration(_ context.Context, _ interface{}, _ client.Client) error {
+func updateMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlruntimeclient.Client) error {
 	return nil
 }
 
-func deleteMeteringReportConfiguration(_ context.Context, _ interface{}, _ client.Client) error {
+func deleteMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlruntimeclient.Client) error {
 	return nil
 }
 

--- a/pkg/handler/v1/admin/wrappers_ee.go
+++ b/pkg/handler/v1/admin/wrappers_ee.go
@@ -26,14 +26,14 @@ import (
 	"k8c.io/kubermatic/v2/pkg/ee/metering"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func createOrUpdateMeteringCredentials(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) error {
 	return metering.CreateOrUpdateCredentials(ctx, request, seedsGetter, seedClientGetter)
 }
 
-func createOrUpdateMeteringConfigurations(ctx context.Context, request interface{}, masterClient client.Client) error {
+func createOrUpdateMeteringConfigurations(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	return metering.CreateOrUpdateConfigurations(ctx, request, masterClient)
 }
 
@@ -45,15 +45,15 @@ func listMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]v1.Me
 	return metering.ListMeteringReportConfigurations(seedsGetter)
 }
 
-func createMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient client.Client) error {
+func createMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	return metering.CreateMeteringReportConfiguration(ctx, request, masterClient)
 }
 
-func updateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient client.Client) error {
+func updateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	return metering.UpdateMeteringReportConfiguration(ctx, request, masterClient)
 }
 
-func deleteMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient client.Client) error {
+func deleteMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
 	return metering.DeleteMeteringReportConfiguration(ctx, request, masterClient)
 }
 

--- a/pkg/handler/v1/admin/wrappers_ee.go
+++ b/pkg/handler/v1/admin/wrappers_ee.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"net/http"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/ee/metering"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
@@ -37,11 +37,11 @@ func createOrUpdateMeteringConfigurations(ctx context.Context, request interface
 	return metering.CreateOrUpdateConfigurations(ctx, request, masterClient)
 }
 
-func getMeteringReportConfiguration(seedsGetter provider.SeedsGetter, request interface{}) (*v1.MeteringReportConfiguration, error) {
+func getMeteringReportConfiguration(seedsGetter provider.SeedsGetter, request interface{}) (*apiv1.MeteringReportConfiguration, error) {
 	return metering.GetMeteringReportConfiguration(seedsGetter, request)
 }
 
-func listMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]v1.MeteringReportConfiguration, error) {
+func listMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]apiv1.MeteringReportConfiguration, error) {
 	return metering.ListMeteringReportConfigurations(seedsGetter)
 }
 
@@ -57,7 +57,7 @@ func deleteMeteringReportConfiguration(ctx context.Context, request interface{},
 	return metering.DeleteMeteringReportConfiguration(ctx, request, masterClient)
 }
 
-func listMeteringReports(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) ([]v1.MeteringReport, error) {
+func listMeteringReports(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) ([]apiv1.MeteringReport, error) {
 	return metering.ListReports(ctx, request, seedsGetter, seedClientGetter)
 }
 

--- a/pkg/handler/v1/cluster/binding.go
+++ b/pkg/handler/v1/cluster/binding.go
@@ -29,7 +29,7 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func BindUserToRoleEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
@@ -37,7 +37,7 @@ func BindUserToRoleEndpoint(projectProvider provider.ProjectProvider, privileged
 		req := request.(roleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.BindUserToRoleEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID, req.Namespace)
@@ -49,7 +49,7 @@ func UnbindUserFromRoleBindingEndpoint(projectProvider provider.ProjectProvider,
 		req := request.(roleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.UnbindUserFromRoleBindingEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID, req.Namespace)
@@ -100,7 +100,7 @@ func BindUserToClusterRoleEndpoint(projectProvider provider.ProjectProvider, pri
 		req := request.(clusterRoleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.BindUserToClusterRoleEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID)
@@ -112,7 +112,7 @@ func UnbindUserFromClusterRoleBindingEndpoint(projectProvider provider.ProjectPr
 		req := request.(clusterRoleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.UnbindUserFromClusterRoleBindingEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID)

--- a/pkg/handler/v1/cluster/cluster.go
+++ b/pkg/handler/v1/cluster/cluster.go
@@ -38,8 +38,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
 )
 
@@ -65,7 +64,7 @@ func CreateEndpoint(
 
 		err = req.Validate(version.NewFromConfiguration(config))
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return handlercommon.CreateEndpoint(ctx, req.ProjectID, req.Body, projectProvider, privilegedProjectProvider, seedsGetter, credentialManager, exposeStrategy, userInfoGetter, caBundle, configGetter, features)
@@ -549,21 +548,21 @@ func GetClusterProviderFromRequest(
 ) (*kubermaticv1.Cluster, *kubernetesprovider.ClusterProvider, error) {
 	req, ok := request.(common.GetClusterReq)
 	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusBadRequest, "invalid request")
+		return nil, nil, utilerrors.New(http.StatusBadRequest, "invalid request")
 	}
 
 	cluster, err := handlercommon.GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, req.ProjectID, req.ClusterID, nil)
 	if err != nil {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	rawClusterProvider, ok := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, "no clusterProvider in request")
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, "no clusterProvider in request")
 	}
 	clusterProvider, ok := rawClusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 	return cluster, clusterProvider, nil
 }

--- a/pkg/handler/v1/cluster/role.go
+++ b/pkg/handler/v1/cluster/role.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +44,7 @@ func CreateClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 		req := request.(createClusterRoleReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 		userInfo, err := userInfoGetter(ctx, req.ProjectID)
 		if err != nil {
@@ -64,7 +64,7 @@ func CreateClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 
 		clusterRole, err := generateRBACClusterRole(userClusterAPIRole.Name, userClusterAPIRole.Rules)
 		if err != nil {
-			return nil, errors.NewBadRequest("invalid cluster role: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid cluster role: %v", err)
 		}
 
 		if err := client.Create(ctx, clusterRole); err != nil {
@@ -79,7 +79,7 @@ func CreateRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 		req := request.(createRoleReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 		userInfo, err := userInfoGetter(ctx, req.ProjectID)
 		if err != nil {
@@ -99,7 +99,7 @@ func CreateRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 
 		role, err := generateRBACRole(apiRole.Name, apiRole.Namespace, apiRole.Rules)
 		if err != nil {
-			return nil, errors.NewBadRequest("invalid cluster role: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid cluster role: %v", err)
 		}
 
 		if err := client.Create(ctx, role); err != nil {
@@ -480,18 +480,18 @@ func PatchRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint
 
 		existingRoleJSON, err := json.Marshal(existingRole)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot decode existing role: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot decode existing role: %v", err)
 		}
 
 		patchedRoleJSON, err := jsonpatch.MergePatch(existingRoleJSON, req.Patch)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot patch role: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot patch role: %v", err)
 		}
 
 		var patchedRole *rbacv1.Role
 		err = json.Unmarshal(patchedRoleJSON, &patchedRole)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot decode patched role: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot decode patched role: %v", err)
 		}
 
 		if err := client.Update(ctx, patchedRole); err != nil {
@@ -575,18 +575,18 @@ func PatchClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.E
 
 		existingClusterRoleJSON, err := json.Marshal(existingClusterRole)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot decode existing cluster role: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot decode existing cluster role: %v", err)
 		}
 
 		patchedClusterRoleJSON, err := jsonpatch.MergePatch(existingClusterRoleJSON, req.Patch)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot patch cluster role: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot patch cluster role: %v", err)
 		}
 
 		var patchedClusterRole *rbacv1.ClusterRole
 		err = json.Unmarshal(patchedClusterRoleJSON, &patchedClusterRole)
 		if err != nil {
-			return nil, errors.NewBadRequest("cannot decode patched role: %v", err)
+			return nil, utilerrors.NewBadRequest("cannot decode patched role: %v", err)
 		}
 
 		if err := client.Update(ctx, patchedClusterRole); err != nil {

--- a/pkg/handler/v1/cluster/upgrade.go
+++ b/pkg/handler/v1/cluster/upgrade.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/go-kit/kit/endpoint"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -82,7 +82,7 @@ func GetNodeUpgrades(configGetter provider.KubermaticConfigurationGetter) endpoi
 			return nil, err
 		}
 
-		controlPlaneVersion, err := semver.NewVersion(req.ControlPlaneVersion)
+		controlPlaneVersion, err := semverlib.NewVersion(req.ControlPlaneVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse control plane version: %w", err)
 		}
@@ -101,7 +101,7 @@ func GetNodeUpgrades(configGetter provider.KubermaticConfigurationGetter) endpoi
 	}
 }
 
-func filterIncompatibleVersions(possibleKubeletVersions []*version.Version, controlPlaneVersion *semver.Version) ([]*version.Version, error) {
+func filterIncompatibleVersions(possibleKubeletVersions []*version.Version, controlPlaneVersion *semverlib.Version) ([]*version.Version, error) {
 	var compatibleVersions []*version.Version
 	for _, v := range possibleKubeletVersions {
 		if err := nodeupdate.EnsureVersionCompatible(controlPlaneVersion, v.Version); err == nil {

--- a/pkg/handler/v1/cluster/upgrade.go
+++ b/pkg/handler/v1/cluster/upgrade.go
@@ -30,7 +30,7 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	"k8c.io/kubermatic/v2/pkg/version"
 )
@@ -39,7 +39,7 @@ func GetUpgradesEndpoint(configGetter provider.KubermaticConfigurationGetter, pr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(common.GetClusterReq)
 		if !ok {
-			return nil, kubermaticerrors.NewWrongMethod(request, common.GetClusterReq{})
+			return nil, utilerrors.NewWrongMethod(request, common.GetClusterReq{})
 		}
 		return handlercommon.GetUpgradesEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, projectProvider, privilegedProjectProvider, configGetter)
 	}
@@ -71,11 +71,11 @@ func GetNodeUpgrades(configGetter provider.KubermaticConfigurationGetter) endpoi
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(NodeUpgradesReq)
 		if !ok {
-			return nil, kubermaticerrors.NewWrongMethod(request, NodeUpgradesReq{})
+			return nil, utilerrors.NewWrongMethod(request, NodeUpgradesReq{})
 		}
 		err := req.TypeReq.Validate()
 		if err != nil {
-			return nil, kubermaticerrors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		config, err := configGetter(ctx)
 		if err != nil {
@@ -142,7 +142,7 @@ func UpgradeNodeDeploymentsEndpoint(projectProvider provider.ProjectProvider, pr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(UpgradeNodeDeploymentsReq)
 		if !ok {
-			return nil, kubermaticerrors.NewWrongMethod(request, common.GetClusterReq{})
+			return nil, utilerrors.NewWrongMethod(request, common.GetClusterReq{})
 		}
 		return handlercommon.UpgradeNodeDeploymentsEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, req.Body, projectProvider, privilegedProjectProvider)
 	}
@@ -153,7 +153,7 @@ func GetMasterVersionsEndpoint(configGetter provider.KubermaticConfigurationGett
 		req := request.(TypeReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, kubermaticerrors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		config, err := configGetter(ctx)

--- a/pkg/handler/v1/cluster/upgrade_test.go
+++ b/pkg/handler/v1/cluster/upgrade_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -69,10 +69,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser:                    *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version: semver.MustParse("1.7.0"),
+					Version: semverlib.MustParse("1.7.0"),
 				},
 			},
 			versions: []k8csemver.Semver{
@@ -114,10 +114,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser: *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version:                    semver.MustParse("1.7.0"),
+					Version:                    semverlib.MustParse("1.7.0"),
 					RestrictedByKubeletVersion: true,
 				},
 			},
@@ -156,7 +156,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser: *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.21.1"),
+					Version: semverlib.MustParse("1.21.1"),
 				},
 			},
 			versions: []k8csemver.Semver{
@@ -226,10 +226,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser:                    *test.GenAPIUser("John", "john@acme.com"),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version: semver.MustParse("1.7.0"),
+					Version: semverlib.MustParse("1.7.0"),
 				},
 			},
 			versions: []k8csemver.Semver{
@@ -462,22 +462,22 @@ func TestGetNodeUpgrades(t *testing.T) {
 			},
 			expectedOutput: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.0"),
+					Version: semverlib.MustParse("1.6.0"),
 				},
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version: semver.MustParse("1.4.0"),
+					Version: semverlib.MustParse("1.4.0"),
 				},
 				{
-					Version: semver.MustParse("1.4.1"),
+					Version: semverlib.MustParse("1.4.1"),
 				},
 				{
-					Version: semver.MustParse("1.5.0"),
+					Version: semverlib.MustParse("1.5.0"),
 				},
 				{
-					Version: semver.MustParse("1.5.1"),
+					Version: semverlib.MustParse("1.5.1"),
 				},
 			},
 		},
@@ -542,10 +542,10 @@ func TestGetMasterVersionsEndpoint(t *testing.T) {
 			},
 			expectedOutput: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.13.5"),
+					Version: semverlib.MustParse("1.13.5"),
 				},
 				{
-					Version: semver.MustParse("3.11.5"),
+					Version: semverlib.MustParse("3.11.5"),
 				},
 			},
 		},

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -33,7 +33,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
@@ -124,7 +124,7 @@ func GetReadyPod(ctx context.Context, client corev1interface.PodInterface, label
 
 	readyPods := getReadyPods(pods)
 	if len(readyPods.Items) < 1 {
-		return nil, kubermaticerrors.New(http.StatusBadRequest, "pod is not ready")
+		return nil, utilerrors.New(http.StatusBadRequest, "pod is not ready")
 	}
 
 	return &readyPods.Items[0], nil
@@ -222,9 +222,9 @@ func WaitForPortForwarder(duration time.Duration, p *portforward.PortForwarder, 
 func WriteHTTPError(log *zap.SugaredLogger, w http.ResponseWriter, err error) {
 	log.Debugw("Encountered error", zap.Error(err))
 
-	var httpErr kubermaticerrors.HTTPError
+	var httpErr utilerrors.HTTPError
 	if !errors.As(err, &httpErr) {
-		httpErr = kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		httpErr = utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	w.WriteHeader(httpErr.StatusCode())

--- a/pkg/handler/v1/common/error.go
+++ b/pkg/handler/v1/common/error.go
@@ -21,13 +21,13 @@ import (
 
 	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // kubernetesErrorToHTTPError constructs HTTPError only if the given err is of type *StatusError.
 // Otherwise unmodified err will be returned to the caller.
 func KubernetesErrorToHTTPError(err error) error {
-	var errStatus *kerrors.StatusError
+	var errStatus *apierrors.StatusError
 
 	if errors.As(err, &errStatus) {
 		httpCode := errStatus.Status().Code

--- a/pkg/handler/v1/common/error.go
+++ b/pkg/handler/v1/common/error.go
@@ -19,7 +19,7 @@ package common
 import (
 	"errors"
 
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -33,7 +33,7 @@ func KubernetesErrorToHTTPError(err error) error {
 		httpCode := errStatus.Status().Code
 		httpMessage := errStatus.Status().Message
 
-		return kubermaticerrors.New(int(httpCode), httpMessage)
+		return utilerrors.New(int(httpCode), httpMessage)
 	}
 
 	return err

--- a/pkg/handler/v1/common/event.go
+++ b/pkg/handler/v1/common/event.go
@@ -19,7 +19,7 @@ package common
 import (
 	"context"
 
-	kubermaticapiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,12 +28,12 @@ import (
 )
 
 // FilterEventsByType filters Kubernetes Events based on their type. Empty type string will return all of them.
-func FilterEventsByType(events []kubermaticapiv1.Event, eventType string) []kubermaticapiv1.Event {
+func FilterEventsByType(events []apiv1.Event, eventType string) []apiv1.Event {
 	if len(eventType) == 0 || len(events) == 0 {
 		return events
 	}
 
-	resultEvents := make([]kubermaticapiv1.Event, 0)
+	resultEvents := make([]apiv1.Event, 0)
 	for _, event := range events {
 		if event.Type == eventType {
 			resultEvents = append(resultEvents, event)
@@ -43,7 +43,7 @@ func FilterEventsByType(events []kubermaticapiv1.Event, eventType string) []kube
 }
 
 // GetEvents returns events related to an object in a given namespace.
-func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj metav1.Object, objNamespace string) ([]kubermaticapiv1.Event, error) {
+func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj metav1.Object, objNamespace string) ([]apiv1.Event, error) {
 	events := &corev1.EventList{}
 	listOpts := &ctrlruntimeclient.ListOptions{
 		Namespace:     objNamespace,
@@ -53,7 +53,7 @@ func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj metav1.
 		return nil, err
 	}
 
-	kubermaticEvents := make([]kubermaticapiv1.Event, 0)
+	kubermaticEvents := make([]apiv1.Event, 0)
 	for _, event := range events.Items {
 		kubermaticEvent := ConvertInternalEventToExternal(event)
 		kubermaticEvents = append(kubermaticEvents, kubermaticEvent)

--- a/pkg/handler/v1/common/event_test.go
+++ b/pkg/handler/v1/common/event_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,17 +32,17 @@ func TestFilterEventsByType(t *testing.T) {
 	testcases := []struct {
 		Name           string
 		Filter         string
-		ExpectedEvents []v1.Event
-		InputEvents    []v1.Event
+		ExpectedEvents []apiv1.Event
+		InputEvents    []apiv1.Event
 	}{
 		{
 			Name:   "scenario 1, filter out warning event types",
 			Filter: corev1.EventTypeWarning,
-			ExpectedEvents: []v1.Event{
+			ExpectedEvents: []apiv1.Event{
 				genEvent("test1", corev1.EventTypeWarning),
 				genEvent("test2", corev1.EventTypeWarning),
 			},
-			InputEvents: []v1.Event{
+			InputEvents: []apiv1.Event{
 				genEvent("test1", corev1.EventTypeWarning),
 				genEvent("test2", corev1.EventTypeWarning),
 				genEvent("test3", corev1.EventTypeNormal),
@@ -52,11 +52,11 @@ func TestFilterEventsByType(t *testing.T) {
 		{
 			Name:   "scenario 2, filter out normal event types",
 			Filter: corev1.EventTypeNormal,
-			ExpectedEvents: []v1.Event{
+			ExpectedEvents: []apiv1.Event{
 				genEvent("test3", corev1.EventTypeNormal),
 				genEvent("test4", corev1.EventTypeNormal),
 			},
-			InputEvents: []v1.Event{
+			InputEvents: []apiv1.Event{
 				genEvent("test1", corev1.EventTypeWarning),
 				genEvent("test2", corev1.EventTypeWarning),
 				genEvent("test3", corev1.EventTypeNormal),
@@ -76,7 +76,7 @@ func TestFilterEventsByType(t *testing.T) {
 
 // equal tells whether a and b contain the same elements.
 // A nil argument is equivalent to an empty slice.
-func equal(a, b []v1.Event) bool {
+func equal(a, b []apiv1.Event) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -88,8 +88,8 @@ func equal(a, b []v1.Event) bool {
 	return true
 }
 
-func genEvent(message, eventType string) v1.Event {
-	return v1.Event{
+func genEvent(message, eventType string) apiv1.Event {
+	return apiv1.Event{
 		Type:    eventType,
 		Message: message,
 	}

--- a/pkg/handler/v1/common/version_skew.go
+++ b/pkg/handler/v1/common/version_skew.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -51,7 +51,7 @@ func CheckClusterVersionSkew(ctx context.Context, userInfoGetter provider.UserIn
 
 	clusterVersion := cluster.Spec.Version.Semver()
 	for _, ver := range kubeletVersions {
-		kubeletVersion, parseErr := semver.NewVersion(ver)
+		kubeletVersion, parseErr := semverlib.NewVersion(ver)
 		if parseErr != nil {
 			return nil, fmt.Errorf("failed to parse kubelet version: %w", parseErr)
 		}

--- a/pkg/handler/v1/dc/datacenter.go
+++ b/pkg/handler/v1/dc/datacenter.go
@@ -37,7 +37,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/email"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ListEndpoint an HTTP endpoint that returns a list of apiv1.Datacenter.
@@ -253,7 +253,7 @@ func getAPIDCsFromSeed(seed *kubermaticv1.Seed) []apiv1.Datacenter {
 }
 
 // CreateEndpoint an HTTP endpoint that creates the specified apiv1.Datacenter.
-func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter, masterClient client.Client) endpoint.Endpoint {
+func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(createDCReq)
 		if !ok {
@@ -305,7 +305,7 @@ func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 
 // UpdateEndpoint an HTTP endpoint that updates the specified apiv1.Datacenter.
 func UpdateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter,
-	masterClient client.Client) endpoint.Endpoint {
+	masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(updateDCReq)
 		if !ok {
@@ -365,7 +365,7 @@ func UpdateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 
 // PatchEndpoint an HTTP endpoint that patches the specified apiv1.Datacenter.
 func PatchEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter,
-	masterClient client.Client) endpoint.Endpoint {
+	masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(patchDCReq)
 		if !ok {
@@ -458,7 +458,7 @@ func PatchEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Use
 
 // DeleteEndpoint an HTTP endpoint that deletes the specified apiv1.Datacenter.
 func DeleteEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter,
-	masterClient client.Client) endpoint.Endpoint {
+	masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(deleteDCReq)
 		if !ok {

--- a/pkg/handler/v1/dc/datacenter.go
+++ b/pkg/handler/v1/dc/datacenter.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/email"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -45,7 +45,7 @@ func ListEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.User
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -58,7 +58,7 @@ func ListEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.User
 		if !userInfo.IsAdmin {
 			dcs, err = filterDCsByEmail(userInfo, dcs)
 			if err != nil {
-				return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError,
+				return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError,
 					fmt.Sprintf("failed to filter datacenters by email: %v", err))
 			}
 		}
@@ -77,12 +77,12 @@ func ListEndpointForProvider(seedsGetter provider.SeedsGetter, userInfoGetter pr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(forProviderDCListReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -97,7 +97,7 @@ func ListEndpointForProvider(seedsGetter provider.SeedsGetter, userInfoGetter pr
 		if !userInfo.IsAdmin {
 			dcs, err = filterDCsByEmail(userInfo, dcs)
 			if err != nil {
-				return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError,
+				return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError,
 					fmt.Sprintf("failed to filter datacenters by email: %v", err))
 			}
 		}
@@ -140,7 +140,7 @@ func GetEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.UserI
 func GetDatacenter(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, datacenterToGet string) (apiv1.Datacenter, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
-		return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+		return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
 
 	// Get the DCs and immediately filter out the ones restricted by e-mail domain if user is not admin
@@ -148,7 +148,7 @@ func GetDatacenter(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter
 	if !userInfo.IsAdmin {
 		dcs, err = filterDCsByEmail(userInfo, dcs)
 		if err != nil {
-			return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError,
+			return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError,
 				fmt.Sprintf("failed to filter datacenters by email: %v", err))
 		}
 	}
@@ -161,12 +161,12 @@ func GetEndpointForProvider(seedsGetter provider.SeedsGetter, userInfoGetter pro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(forProviderDCGetReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -181,7 +181,7 @@ func GetEndpointForProvider(seedsGetter provider.SeedsGetter, userInfoGetter pro
 		if !userInfo.IsAdmin {
 			dcs, err = filterDCsByEmail(userInfo, dcs)
 			if err != nil {
-				return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError,
+				return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError,
 					fmt.Sprintf("failed to filter datacenters by email: %v", err))
 			}
 		}
@@ -202,7 +202,7 @@ func filterDCsByName(dcs []apiv1.Datacenter, dcName string) (apiv1.Datacenter, e
 		return apiv1.Datacenter{}, fmt.Errorf("did not find one but %d datacenters for name %q", n, dcName)
 	}
 	if len(foundDCs) == 0 {
-		return apiv1.Datacenter{}, errors.NewNotFound("datacenter", dcName)
+		return apiv1.Datacenter{}, utilerrors.NewNotFound("datacenter", dcName)
 	}
 
 	return foundDCs[0], nil
@@ -257,12 +257,12 @@ func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(createDCReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		err := req.validate()
 		if err != nil {
-			return nil, errors.New(http.StatusBadRequest, fmt.Sprintf("Validation error: %v", err))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("Validation error: %v", err))
 		}
 
 		if err := validateUser(ctx, userInfoGetter); err != nil {
@@ -272,17 +272,17 @@ func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 		// Get the seed in which the dc should be created
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 		seed, ok := seeds[req.Body.Spec.Seed]
 		if !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: seed %q does not exist", req.Body.Spec.Seed))
 		}
 
 		// Check if dc already exists
 		if _, ok = seed.Spec.Datacenters[req.Body.Name]; ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: datacenter %q already exists", req.Body.Name))
 		}
 
@@ -290,7 +290,7 @@ func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 		seed.Spec.Datacenters[req.Body.Name] = convertExternalDCToInternal(&req.Body.Spec)
 
 		if err = masterClient.Update(ctx, seed); err != nil {
-			return nil, errors.New(http.StatusInternalServerError,
+			return nil, utilerrors.New(http.StatusInternalServerError,
 				fmt.Sprintf("failed to update seed %q datacenter %q: %v", seed.Name, req.Body.Name, err))
 		}
 
@@ -309,12 +309,12 @@ func UpdateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(updateDCReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		err := req.validate()
 		if err != nil {
-			return nil, errors.New(http.StatusBadRequest, fmt.Sprintf("Validation error: %v", err))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("Validation error: %v", err))
 		}
 
 		if err := validateUser(ctx, userInfoGetter); err != nil {
@@ -324,24 +324,24 @@ func UpdateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 		// Get the seed in which the dc should be updated
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 		seed, ok := seeds[req.Body.Spec.Seed]
 		if !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: seed %q does not exist", req.Body.Spec.Seed))
 		}
 
 		// get the dc to update
 		if _, ok := seed.Spec.Datacenters[req.DCToUpdate]; !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: datacenter %q does not exists", req.DCToUpdate))
 		}
 
 		// Do an extra check if name changed and remove old dc
 		if !strings.EqualFold(req.DCToUpdate, req.Body.Name) {
 			if _, ok := seed.Spec.Datacenters[req.Body.Name]; ok {
-				return nil, errors.New(http.StatusBadRequest,
+				return nil, utilerrors.New(http.StatusBadRequest,
 					fmt.Sprintf("Bad request: cannot change %q datacenter name to %q as it already exists",
 						req.DCToUpdate, req.Body.Name))
 			}
@@ -350,7 +350,7 @@ func UpdateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 		seed.Spec.Datacenters[req.Body.Name] = convertExternalDCToInternal(&req.Body.Spec)
 
 		if err = masterClient.Update(ctx, seed); err != nil {
-			return nil, errors.New(http.StatusInternalServerError,
+			return nil, utilerrors.New(http.StatusInternalServerError,
 				fmt.Sprintf("failed to update seed %q datacenter %q: %v", seed.Name, req.DCToUpdate, err))
 		}
 
@@ -369,7 +369,7 @@ func PatchEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Use
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(patchDCReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		if err := req.validate(); err != nil {
@@ -383,53 +383,53 @@ func PatchEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Use
 		// Get the seed in which the dc should be updated
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 		seed, ok := seeds[req.Seed]
 		if !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: seed %q does not exist", req.Seed))
 		}
 
 		// get the dc to update
 		currentDC, ok := seed.Spec.Datacenters[req.DCToPatch]
 		if !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: datacenter %q does not exists", req.DCToPatch))
 		}
 
 		// patch
 		currentAPIDC, err := convertInternalDCToExternal(&currentDC, req.DCToPatch, req.Seed)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to convert current dc: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to convert current dc: %v", err))
 		}
 
 		currentDCJSON, err := json.Marshal(currentAPIDC)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to marshal current dc: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to marshal current dc: %v", err))
 		}
 
 		patchedJSON, err := jsonpatch.MergePatch(currentDCJSON, req.Patch)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to merge patch dc: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to merge patch dc: %v", err))
 		}
 
 		var patched apiv1.Datacenter
 		err = json.Unmarshal(patchedJSON, &patched)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal patched dc: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal patched dc: %v", err))
 		}
 
 		// validate patched spec
 		if err := validateProvider(&patched.Spec); err != nil {
-			return nil, errors.New(http.StatusBadRequest, fmt.Sprintf("patched dc validation failed: %v", err))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("patched dc validation failed: %v", err))
 		}
 		kubermaticPatched := convertExternalDCToInternal(&patched.Spec)
 
 		// As provider field is extracted from providers, we need to make sure its set properly
 		providerName, err := provider.DatacenterCloudProviderName(kubermaticPatched.Spec.DeepCopy())
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed extracting provider name from dc: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed extracting provider name from dc: %v", err))
 		}
 		patched.Spec.Provider = providerName
 
@@ -437,7 +437,7 @@ func PatchEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Use
 		// Do an extra check if name changed and remove old dc
 		if !strings.EqualFold(req.DCToPatch, patched.Metadata.Name) {
 			if _, ok := seed.Spec.Datacenters[patched.Metadata.Name]; ok {
-				return nil, errors.New(http.StatusBadRequest,
+				return nil, utilerrors.New(http.StatusBadRequest,
 					fmt.Sprintf("Bad request: cannot change %q datacenter name to %q as it already exists",
 						req.DCToPatch, patched.Metadata.Name))
 			}
@@ -448,7 +448,7 @@ func PatchEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Use
 		seed.Spec.Datacenters[dcName] = kubermaticPatched
 
 		if err = masterClient.Update(ctx, seed); err != nil {
-			return nil, errors.New(http.StatusInternalServerError,
+			return nil, utilerrors.New(http.StatusInternalServerError,
 				fmt.Sprintf("failed to update seed %q datacenter %q: %v", seed.Name, req.DCToPatch, err))
 		}
 
@@ -462,7 +462,7 @@ func DeleteEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(deleteDCReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		if err := validateUser(ctx, userInfoGetter); err != nil {
@@ -472,23 +472,23 @@ func DeleteEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 		// Get the seed in which the dc should be deleted
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 		seed, ok := seeds[req.Seed]
 		if !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: seed %q does not exist", req.Seed))
 		}
 
 		// get the dc to delete
 		if _, ok := seed.Spec.Datacenters[req.DC]; !ok {
-			return nil, errors.New(http.StatusBadRequest,
+			return nil, utilerrors.New(http.StatusBadRequest,
 				fmt.Sprintf("Bad request: datacenter %q does not exists", req.DC))
 		}
 		delete(seed.Spec.Datacenters, req.DC)
 
 		if err = masterClient.Update(ctx, seed); err != nil {
-			return nil, errors.New(http.StatusInternalServerError,
+			return nil, utilerrors.New(http.StatusInternalServerError,
 				fmt.Sprintf("failed to delete seed %q datacenter %q: %v", seed.Name, req.DC, err))
 		}
 
@@ -501,12 +501,12 @@ func ListEndpointForSeed(seedsGetter provider.SeedsGetter, userInfoGetter provid
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(listDCForSeedReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -516,7 +516,7 @@ func ListEndpointForSeed(seedsGetter provider.SeedsGetter, userInfoGetter provid
 
 		seed, ok := seeds[req.Seed]
 		if !ok {
-			return nil, errors.NewNotFound("seed", req.Seed)
+			return nil, utilerrors.NewNotFound("seed", req.Seed)
 		}
 
 		// Get the DCs and immediately filter out the ones restricted by e-mail domain if user is not admin
@@ -524,7 +524,7 @@ func ListEndpointForSeed(seedsGetter provider.SeedsGetter, userInfoGetter provid
 		if !userInfo.IsAdmin {
 			dcs, err = filterDCsByEmail(userInfo, dcs)
 			if err != nil {
-				return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError,
+				return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError,
 					fmt.Sprintf("failed to filter datacenters by email: %v", err))
 			}
 		}
@@ -543,12 +543,12 @@ func GetEndpointForSeed(seedsGetter provider.SeedsGetter, userInfoGetter provide
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(getDCForSeedReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		seeds, err := seedsGetter()
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -558,7 +558,7 @@ func GetEndpointForSeed(seedsGetter provider.SeedsGetter, userInfoGetter provide
 
 		seed, ok := seeds[req.Seed]
 		if !ok {
-			return nil, errors.NewNotFound("seed", req.Seed)
+			return nil, utilerrors.NewNotFound("seed", req.Seed)
 		}
 
 		// Get the DCs and immediately filter out the ones restricted by e-mail domain if user is not admin
@@ -566,7 +566,7 @@ func GetEndpointForSeed(seedsGetter provider.SeedsGetter, userInfoGetter provide
 		if !userInfo.IsAdmin {
 			dcs, err = filterDCsByEmail(userInfo, dcs)
 			if err != nil {
-				return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError,
+				return apiv1.Datacenter{}, utilerrors.New(http.StatusInternalServerError,
 					fmt.Sprintf("failed to filter datacenters by email: %v", err))
 			}
 		}
@@ -582,7 +582,7 @@ func validateUser(ctx context.Context, userInfoGetter provider.UserInfoGetter) e
 	}
 
 	if !userInfo.IsAdmin {
-		return errors.New(http.StatusForbidden,
+		return utilerrors.New(http.StatusForbidden,
 			fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", userInfo.Email))
 	}
 	return nil
@@ -868,11 +868,11 @@ func (req patchDCReq) validate() error {
 
 	err := json.Unmarshal(req.Patch, &seedValidator)
 	if err != nil {
-		return errors.New(http.StatusBadRequest, fmt.Sprintf("failed to validate patch body seed: %v", err))
+		return utilerrors.New(http.StatusBadRequest, fmt.Sprintf("failed to validate patch body seed: %v", err))
 	}
 
 	if seedValidator.Spec.Seed != "" && !strings.EqualFold(seedValidator.Spec.Seed, req.Seed) {
-		return errors.New(http.StatusBadRequest,
+		return utilerrors.New(http.StatusBadRequest,
 			fmt.Sprintf("patched dc validation failed: path seed name %q has to be equal to patch seed name %q",
 				req.Seed, seedValidator.Spec.Seed))
 	}

--- a/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/resources/kubernetes-dashboard"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // Minimal wrapper to implement the http.Handler interface.
@@ -57,18 +57,18 @@ func ProxyEndpoint(
 
 		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
-			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "could not read global settings"))
+			common.WriteHTTPError(log, w, utilerrors.New(http.StatusInternalServerError, "could not read global settings"))
 			return
 		}
 
 		if !settings.Spec.EnableDashboard {
-			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusForbidden, "Kubernetes Dashboard access is disabled by the global settings"))
+			common.WriteHTTPError(log, w, utilerrors.New(http.StatusForbidden, "Kubernetes Dashboard access is disabled by the global settings"))
 			return
 		}
 
 		request, err := common.DecodeGetClusterReq(ctx, r)
 		if err != nil {
-			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
+			common.WriteHTTPError(log, w, utilerrors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -88,18 +88,18 @@ func ProxyEndpoint(
 			}
 			req, ok := request.(common.GetClusterReq)
 			if !ok {
-				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, "invalid request"))
+				common.WriteHTTPError(log, w, utilerrors.New(http.StatusBadRequest, "invalid request"))
 				return nil, nil
 			}
 			userInfo, err := userInfoGetter(ctx, req.ProjectID)
 			if err != nil {
-				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
+				common.WriteHTTPError(log, w, utilerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
 				return nil, nil
 			}
 
 			token, err := clusterProvider.GetTokenForCustomerCluster(ctx, userInfo, userCluster)
 			if err != nil {
-				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("error getting token for user %q: %v", userInfo.Email, err)))
+				common.WriteHTTPError(log, w, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("error getting token for user %q: %v", userInfo.Email, err)))
 				return nil, nil
 			}
 

--- a/pkg/handler/v1/presets/credentials.go
+++ b/pkg/handler/v1/presets/credentials.go
@@ -28,7 +28,7 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // providerNames holds a list of providers. They must stay in this order.
@@ -62,11 +62,11 @@ func CredentialEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(providerReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -80,7 +80,7 @@ func CredentialEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 		providerN := parseProvider(req.ProviderName)
 		presets, err := presetProvider.GetPresets(ctx, userInfo)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, err.Error())
+			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 		}
 
 		for _, preset := range presets {

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -44,11 +44,11 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		projectRq, ok := request.(projectReq)
 		if !ok {
-			return nil, kubermaticerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		if len(projectRq.Body.Name) == 0 {
-			return nil, kubermaticerrors.NewBadRequest("the name of the project cannot be empty")
+			return nil, utilerrors.NewBadRequest("the name of the project cannot be empty")
 		}
 
 		settings, err := settingsProvider.GetGlobalSettings(ctx)
@@ -105,11 +105,11 @@ func createProjectByServiceAccount(ctx context.Context, saEmail string, projectR
 	}
 
 	if len(bindings) == 0 {
-		return nil, kubermaticerrors.New(http.StatusInternalServerError, fmt.Sprintf("no bindings for service account user %s", saEmail))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("no bindings for service account user %s", saEmail))
 	}
 	saBinding := bindings[0]
 	if !strings.HasPrefix(saBinding.Spec.Group, rbac.ProjectManagerGroupNamePrefix) {
-		return nil, kubermaticerrors.New(http.StatusForbidden, "the Service Account is not allowed to create a project")
+		return nil, utilerrors.New(http.StatusForbidden, "the Service Account is not allowed to create a project")
 	}
 
 	// determine regular (human) users that will own the project
@@ -117,7 +117,7 @@ func createProjectByServiceAccount(ctx context.Context, saEmail string, projectR
 
 	for _, userEmail := range projectReq.Body.Users {
 		if kubermaticv1helper.IsProjectServiceAccount(userEmail) {
-			return nil, kubermaticerrors.New(http.StatusBadRequest, "user email list should contain only human users")
+			return nil, utilerrors.New(http.StatusBadRequest, "user email list should contain only human users")
 		}
 		humanUserOwner, err := userProvider.UserByEmail(ctx, userEmail)
 		if err != nil {
@@ -127,7 +127,7 @@ func createProjectByServiceAccount(ctx context.Context, saEmail string, projectR
 	}
 
 	if len(humanUserOwnerList) == 0 {
-		return nil, kubermaticerrors.New(http.StatusBadRequest, "owner user email list required for project creation by Service Account")
+		return nil, utilerrors.New(http.StatusBadRequest, "owner user email list required for project creation by Service Account")
 	}
 
 	// create the project
@@ -170,7 +170,7 @@ func checkProjectRestriction(user *kubermaticv1.User, settings *kubermaticv1.Kub
 		return nil
 	}
 	if settings.Spec.RestrictProjectCreation {
-		return kubermaticerrors.New(http.StatusForbidden, "project creation is restricted")
+		return utilerrors.New(http.StatusForbidden, "project creation is restricted")
 	}
 	return nil
 }
@@ -218,11 +218,11 @@ func validateUserProjectsLimit(ctx context.Context, user *kubermaticv1.User, set
 		}
 	}
 	if len(errorList) > 0 {
-		return kubermaticerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some projects, please examine details field for more info", errorList)
+		return utilerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some projects, please examine details field for more info", errorList)
 	}
 
 	if projectsCounter >= settings.Spec.UserProjectsLimit {
-		return kubermaticerrors.New(http.StatusForbidden, "reached maximum number of projects")
+		return utilerrors.New(http.StatusForbidden, "reached maximum number of projects")
 	}
 	return nil
 }
@@ -232,7 +232,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(ListReq)
 		if !ok {
-			return nil, kubermaticerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -281,7 +281,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 		}
 
 		if len(errorList) > 0 {
-			return nil, kubermaticerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some projects, please examine details field for more info", errorList)
+			return nil, utilerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some projects, please examine details field for more info", errorList)
 		}
 		return projects, nil
 	}
@@ -321,10 +321,10 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(deleteRq)
 		if !ok {
-			return nil, kubermaticerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		if len(req.ProjectID) == 0 {
-			return nil, kubermaticerrors.NewBadRequest("the id of the project cannot be empty")
+			return nil, utilerrors.NewBadRequest("the id of the project cannot be empty")
 		}
 
 		// check if admin user
@@ -357,11 +357,11 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(updateRq)
 		if !ok {
-			return nil, kubermaticerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.validate()
 		if err != nil {
-			return nil, kubermaticerrors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -414,10 +414,10 @@ func GetEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(common.GetProjectRq)
 		if !ok {
-			return nil, kubermaticerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		if len(req.ProjectID) == 0 {
-			return nil, kubermaticerrors.NewBadRequest("the id of the project cannot be empty")
+			return nil, utilerrors.NewBadRequest("the id of the project cannot be empty")
 		}
 
 		adminUserInfo, err := userInfoGetter(ctx, "")
@@ -545,13 +545,13 @@ func getNumberOfClustersForProject(ctx context.Context, clusterProviderGetter pr
 	var clustersNumber int
 	seeds, err := seedsGetter()
 	if err != nil {
-		return clustersNumber, kubermaticerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+		return clustersNumber, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
 
 	for datacenter, seed := range seeds {
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
-			return clustersNumber, kubermaticerrors.NewNotFound("cluster-provider", datacenter)
+			return clustersNumber, utilerrors.NewNotFound("cluster-provider", datacenter)
 		}
 		clusters, err := clusterProvider.List(ctx, project, nil)
 		if err != nil {
@@ -567,13 +567,13 @@ func getNumberOfClusters(ctx context.Context, clusterProviderGetter provider.Clu
 	clustersNumber := map[string]int{}
 	seeds, err := seedsGetter()
 	if err != nil {
-		return nil, kubermaticerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
 
 	for datacenter, seed := range seeds {
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
-			return nil, kubermaticerrors.NewNotFound("cluster-provider", datacenter)
+			return nil, utilerrors.NewNotFound("cluster-provider", datacenter)
 		}
 		clusters, err := clusterProvider.ListAll(ctx, nil)
 		if err != nil {

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // CreateEndpoint defines an HTTP endpoint that creates a new project in the system.
@@ -311,7 +311,7 @@ func getAllProjectsForAdmin(ctx context.Context, userInfo *provider.UserInfo, pr
 }
 
 func isStatus(err error, status int32) bool {
-	var statusErr *kerrors.StatusError
+	var statusErr *apierrors.StatusError
 
 	return errors.As(err, &statusErr) && status == statusErr.Status().Code
 }

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
@@ -520,7 +520,7 @@ func TestListProjectMethod(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error")
 				}
-				var kubermaticError kubermaticerrors.HTTPError
+				var kubermaticError utilerrors.HTTPError
 				if !errors.As(err, &kubermaticError) {
 					t.Fatal("expected HTTPError")
 				}

--- a/pkg/handler/v1/provider/alibaba.go
+++ b/pkg/handler/v1/provider/alibaba.go
@@ -26,7 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // AlibabaCommonReq represent a request with common parameters for Alibaba.
@@ -111,7 +111,7 @@ func AlibabaInstanceTypesEndpoint(presetProvider provider.PresetProvider, userIn
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Alibaba; credentials != nil {
 				accessKeyID = credentials.AccessKeyID
@@ -149,7 +149,7 @@ func AlibabaZonesEndpoint(presetProvider provider.PresetProvider, userInfoGetter
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Alibaba; credentials != nil {
 				accessKeyID = credentials.AccessKeyID
@@ -174,7 +174,7 @@ func AlibabaVSwitchesEndpoint(presetProvider provider.PresetProvider, userInfoGe
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Alibaba; credentials != nil {
 				accessKeyID = credentials.AccessKeyID

--- a/pkg/handler/v1/provider/anexia.go
+++ b/pkg/handler/v1/provider/anexia.go
@@ -26,7 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func AnexiaVlanEndpoint(presetProvider provider.PresetProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
@@ -42,7 +42,7 @@ func AnexiaVlanEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Anexia; credentials != nil {
 				token = credentials.Token
@@ -66,7 +66,7 @@ func AnexiaTemplateEndpoint(presetProvider provider.PresetProvider, userInfoGett
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Anexia; credentials != nil {
 				token = credentials.Token

--- a/pkg/handler/v1/provider/aws.go
+++ b/pkg/handler/v1/provider/aws.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	awsprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/aws"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // AWSCommonReq represent a request with common parameters for AWS.
@@ -221,7 +221,7 @@ func AWSSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter provi
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credential := preset.Spec.AWS; credential != nil {
 				accessKeyID = credential.AccessKeyID
@@ -234,7 +234,7 @@ func AWSSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter provi
 
 		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.DC)
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		subnetList, err := providercommon.ListAWSSubnets(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, vpcID, dc)
@@ -274,7 +274,7 @@ func AWSVPCEndpoint(presetProvider provider.PresetProvider, seedsGetter provider
 
 		_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.DC)
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return listAWSVPCS(ctx, credentials.accessKeyID, credentials.secretAccessKey, credentials.assumeRoleARN, credentials.assumeRoleExternalID, datacenter)
@@ -298,7 +298,7 @@ func AWSSecurityGroupsEndpoint(presetProvider provider.PresetProvider, seedsGett
 
 		_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.DC)
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return listSecurityGroup(ctx, credentials.accessKeyID, credentials.secretAccessKey, credentials.assumeRoleARN, credentials.assumeRoleExternalID, datacenter.Spec.AWS.Region, credentials.vpcID)
@@ -310,7 +310,7 @@ func listSecurityGroup(ctx context.Context, accessKeyID, secretAccessKey, assume
 
 	securityGroups, err := awsprovider.GetSecurityGroups(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, vpc)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get Security Groups: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get Security Groups: %v", err))
 	}
 
 	for _, sg := range securityGroups {
@@ -343,7 +343,7 @@ func getAWSCredentialsFromRequest(ctx context.Context, req AWSCommonReq, userInf
 	if len(req.Credential) > 0 {
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}
 		if credential := preset.Spec.AWS; credential != nil {
 			accessKeyID = credential.AccessKeyID
@@ -365,7 +365,7 @@ func getAWSCredentialsFromRequest(ctx context.Context, req AWSCommonReq, userInf
 
 func listAWSVPCS(ctx context.Context, accessKeyID, secretAccessKey string, assumeRoleARN string, assumeRoleExternalID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSVPCList, error) {
 	if datacenter.Spec.AWS == nil {
-		return nil, errors.NewBadRequest("datacenter is not an AWS datacenter")
+		return nil, utilerrors.NewBadRequest("datacenter is not an AWS datacenter")
 	}
 
 	vpcsResults, err := awsprovider.GetVPCS(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, datacenter.Spec.AWS.Region)

--- a/pkg/handler/v1/provider/azure.go
+++ b/pkg/handler/v1/provider/azure.go
@@ -26,7 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func AzureSizeWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -53,7 +53,7 @@ func AzureSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter pr
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Azure; credentials != nil {
 				subscriptionID = credentials.SubscriptionID
@@ -96,7 +96,7 @@ func AzureAvailabilityZonesEndpoint(presetProvider provider.PresetProvider, user
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Azure; credentials != nil {
 				subscriptionID = credentials.SubscriptionID

--- a/pkg/handler/v1/provider/digitalocean.go
+++ b/pkg/handler/v1/provider/digitalocean.go
@@ -26,7 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func DigitaloceanSizeWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -49,7 +49,7 @@ func DigitaloceanSizeEndpoint(presetProvider provider.PresetProvider, userInfoGe
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Digitalocean; credentials != nil {
 				token = credentials.Token

--- a/pkg/handler/v1/provider/gcp.go
+++ b/pkg/handler/v1/provider/gcp.go
@@ -27,7 +27,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // GCPZoneReq represent a request for GCP zones.
@@ -186,7 +186,7 @@ func GCPDiskTypesEndpoint(presetProvider provider.PresetProvider, userInfoGetter
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GCP; credentials != nil {
 				sa = credentials.ServiceAccount
@@ -217,7 +217,7 @@ func GCPSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter prov
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GCP; credentials != nil {
 				sa = credentials.ServiceAccount
@@ -251,7 +251,7 @@ func GCPZoneEndpoint(presetProvider provider.PresetProvider, seedsGetter provide
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GCP; credentials != nil {
 				sa = credentials.ServiceAccount
@@ -281,7 +281,7 @@ func GCPNetworkEndpoint(presetProvider provider.PresetProvider, userInfoGetter p
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GCP; credentials != nil {
 				sa = credentials.ServiceAccount
@@ -311,7 +311,7 @@ func GCPSubnetworkEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GCP; credentials != nil {
 				sa = credentials.ServiceAccount

--- a/pkg/handler/v1/provider/hetzner.go
+++ b/pkg/handler/v1/provider/hetzner.go
@@ -26,7 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func HetznerSizeWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -48,7 +48,7 @@ func HetznerSizeEndpoint(presetProvider provider.PresetProvider, userInfoGetter 
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Hetzner; credentials != nil {
 				token = credentials.Token

--- a/pkg/handler/v1/provider/openstack.go
+++ b/pkg/handler/v1/provider/openstack.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func getAuthInfo(ctx context.Context, req OpenstackReq, userInfoGetter provider.UserInfoGetter, presetProvider provider.PresetProvider) (*provider.UserInfo, *resources.OpenstackCredentials, error) {
@@ -43,7 +43,7 @@ func getAuthInfo(ctx context.Context, req OpenstackReq, userInfoGetter provider.
 	t := ctx.Value(middleware.RawTokenContextKey)
 	token, ok := t.(string)
 	if !ok || token == "" {
-		return nil, nil, k8cerrors.NewNotAuthorized()
+		return nil, nil, utilerrors.NewNotAuthorized()
 	}
 
 	// No preset is used

--- a/pkg/handler/v1/provider/packet.go
+++ b/pkg/handler/v1/provider/packet.go
@@ -26,7 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // PacketSizesReq represent a request for Packet sizes.
@@ -85,7 +85,7 @@ func PacketSizesEndpoint(presetProvider provider.PresetProvider, userInfoGetter 
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Packet; credentials != nil {
 				projectID = credentials.ProjectID

--- a/pkg/handler/v1/provider/vsphere.go
+++ b/pkg/handler/v1/provider/vsphere.go
@@ -27,7 +27,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func VsphereNetworksEndpoint(seedsGetter provider.SeedsGetter, presetProvider provider.PresetProvider,
@@ -47,7 +47,7 @@ func VsphereNetworksEndpoint(seedsGetter provider.SeedsGetter, presetProvider pr
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.VSphere; credentials != nil {
 				username = credentials.Username
@@ -86,7 +86,7 @@ func VsphereFoldersEndpoint(seedsGetter provider.SeedsGetter, presetProvider pro
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.VSphere; credentials != nil {
 				username = credentials.Username

--- a/pkg/handler/v1/serviceaccount/sa.go
+++ b/pkg/handler/v1/serviceaccount/sa.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	serviceaccount "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // serviceAccountGroupsPrefixes holds a list of groups with prefixes that we will generate RBAC Roles/Binding for service account.
@@ -47,7 +47,7 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		req := request.(addReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		saFromRequest := req.Body
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -62,7 +62,7 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		}
 
 		if len(existingSAList) > 0 {
-			return nil, errors.NewAlreadyExists("service account", saFromRequest.Name)
+			return nil, utilerrors.NewAlreadyExists("service account", saFromRequest.Name)
 		}
 
 		sa, err := createSA(ctx, serviceAccountProvider, privilegedServiceAccount, userInfoGetter, project, saFromRequest)
@@ -119,11 +119,11 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(common.GetProjectRq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		if len(req.ProjectID) == 0 {
-			return nil, errors.NewBadRequest("the name of the project cannot be empty")
+			return nil, utilerrors.NewBadRequest("the name of the project cannot be empty")
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -153,7 +153,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			}
 		}
 		if len(errorList) > 0 {
-			return response, errors.NewWithDetails(http.StatusInternalServerError, "failed to get some service accounts, please examine details field for more info", errorList)
+			return response, utilerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some service accounts, please examine details field for more info", errorList)
 		}
 
 		return response, nil
@@ -165,11 +165,11 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(updateReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		saFromRequest := req.Body
 
@@ -192,7 +192,7 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			}
 
 			if len(existingSAList) > 0 {
-				return nil, errors.NewAlreadyExists("service account", saFromRequest.Name)
+				return nil, utilerrors.NewAlreadyExists("service account", saFromRequest.Name)
 			}
 			sa.Spec.Name = saFromRequest.Name
 		}
@@ -260,11 +260,11 @@ func DeleteEndpoint(serviceAccountProvider provider.ServiceAccountProvider, priv
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(deleteReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		// check if project exist

--- a/pkg/handler/v1/serviceaccount/token.go
+++ b/pkg/handler/v1/serviceaccount/token.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
@@ -106,7 +106,7 @@ func listSAToken(ctx context.Context, userInfoGetter provider.UserInfoGetter, se
 		options.LabelSelector = labelSelector
 		options.ServiceAccountID = sa.Name
 		tokens, err := privilegedServiceAccountTokenProvider.ListUnsecured(ctx, options)
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return make([]*corev1.Secret, 0), nil
 		}
 		return tokens, err

--- a/pkg/handler/v1/serviceaccount/token.go
+++ b/pkg/handler/v1/serviceaccount/token.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +46,7 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 		req := request.(addTokenReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
@@ -64,14 +64,14 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(existingTokenList) > 0 {
-			return nil, errors.NewAlreadyExists("token", req.Body.Name)
+			return nil, utilerrors.NewAlreadyExists("token", req.Body.Name)
 		}
 
 		tokenID := rand.String(10)
 
 		token, err := tokenGenerator.Generate(serviceaccount.Claims(sa.Spec.Email, project.Name, tokenID))
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, "can not generate token data")
+			return nil, utilerrors.New(http.StatusInternalServerError, "can not generate token data")
 		}
 
 		secret, err := createSAToken(ctx, userInfoGetter, serviceAccountTokenProvider, privilegedServiceAccountTokenProvider, sa, project.Name, req.Body.Name, tokenID, token)
@@ -81,7 +81,7 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 
 		externalToken, err := convertInternalTokenToPrivateExternal(secret, tokenAuthenticator)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, err.Error())
+			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 		}
 
 		return externalToken, nil
@@ -142,7 +142,7 @@ func ListTokenEndpoint(projectProvider provider.ProjectProvider, privilegedProje
 		req := request.(commonTokenReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -171,7 +171,7 @@ func ListTokenEndpoint(projectProvider provider.ProjectProvider, privilegedProje
 		}
 
 		if len(errorList) > 0 {
-			return nil, errors.NewWithDetails(http.StatusInternalServerError, "failed to get some service account tokens, please examine details field for more info", errorList)
+			return nil, utilerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some service account tokens, please examine details field for more info", errorList)
 		}
 
 		return resultList, nil
@@ -184,7 +184,7 @@ func UpdateTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 		req := request.(updateTokenReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		secret, err := updateEndpoint(ctx, projectProvider, privilegedProjectProvider, serviceAccountProvider, privilegedServiceAccount, serviceAccountTokenProvider, privilegedServiceAccountTokenProvider, userInfoGetter, tokenGenerator, req.ProjectID, req.ServiceAccountID, req.TokenID, req.Body.Name, true)
@@ -194,7 +194,7 @@ func UpdateTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 
 		externalToken, err := convertInternalTokenToPrivateExternal(secret, tokenAuthenticator)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, err.Error())
+			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 		}
 
 		return externalToken, nil
@@ -207,15 +207,15 @@ func PatchTokenEndpoint(projectProvider provider.ProjectProvider, privilegedProj
 		req := request.(patchTokenReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		tokenReq := &apiv1.PublicServiceAccountToken{}
 		if err := json.Unmarshal(req.Body, tokenReq); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		if len(tokenReq.Name) == 0 {
-			return nil, errors.NewBadRequest("new name can not be empty")
+			return nil, utilerrors.NewBadRequest("new name can not be empty")
 		}
 
 		secret, err := updateEndpoint(ctx, projectProvider, privilegedProjectProvider, serviceAccountProvider, privilegedServiceAccount, serviceAccountTokenProvider, privilegedServiceAccountTokenProvider, userInfoGetter, tokenGenerator, req.ProjectID, req.ServiceAccountID, req.TokenID, tokenReq.Name, false)
@@ -225,7 +225,7 @@ func PatchTokenEndpoint(projectProvider provider.ProjectProvider, privilegedProj
 
 		externalToken, err := convertInternalTokenToPublicExternal(secret, tokenAuthenticator)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, err.Error())
+			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 		}
 
 		return externalToken, nil
@@ -238,7 +238,7 @@ func DeleteTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 		req := request.(deleteTokenReq)
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -324,7 +324,7 @@ func updateEndpoint(ctx context.Context, projectProvider provider.ProjectProvide
 			return nil, err
 		}
 		if len(existingTokenList) > 0 {
-			return nil, errors.NewAlreadyExists("token", newName)
+			return nil, utilerrors.NewAlreadyExists("token", newName)
 		}
 		existingSecret.Labels["name"] = newName
 	}

--- a/pkg/handler/v1/ssh/ssh.go
+++ b/pkg/handler/v1/ssh/ssh.go
@@ -29,14 +29,14 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func CreateEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvider provider.PrivilegedSSHKeyProvider, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(CreateReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -49,7 +49,7 @@ func CreateEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(existingKeys) > 0 {
-			return nil, errors.NewAlreadyExists("ssh key", req.Key.Name)
+			return nil, utilerrors.NewAlreadyExists("ssh key", req.Key.Name)
 		}
 
 		key, err := createUserSSHKey(ctx, userInfoGetter, keyProvider, privilegedSSHKeyProvider, project, req.Key.Name, req.Key.Spec.PublicKey)
@@ -91,7 +91,7 @@ func DeleteEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvide
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(DeleteReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
@@ -123,10 +123,10 @@ func ListEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(ListReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		if len(req.ProjectID) == 0 {
-			return nil, errors.NewBadRequest("the name of the project to delete cannot be empty")
+			return nil, utilerrors.NewBadRequest("the name of the project to delete cannot be empty")
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -203,7 +203,7 @@ func DecodeCreateReq(c context.Context, r *http.Request) (interface{}, error) {
 
 	req.Key = apiv1.SSHKey{}
 	if err := json.NewDecoder(r.Body).Decode(&req.Key); err != nil {
-		return nil, errors.NewBadRequest("unable to parse the input: %v", err)
+		return nil, utilerrors.NewBadRequest("unable to parse the input: %v", err)
 	}
 
 	if len(req.Key.Name) == 0 {

--- a/pkg/handler/v1/user/user.go
+++ b/pkg/handler/v1/user/user.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // DeleteEndpoint deletes the given user/member from the given project.
@@ -351,18 +351,18 @@ func PatchSettingsEndpoint(userProvider provider.UserProvider) endpoint.Endpoint
 
 		existingSettingsJSON, err := json.Marshal(existingSettings)
 		if err != nil {
-			return nil, kerrors.NewBadRequest(fmt.Sprintf("cannot decode existing user settings: %v", err))
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot decode existing user settings: %v", err))
 		}
 
 		patchedSettingsJSON, err := jsonpatch.MergePatch(existingSettingsJSON, req.Patch)
 		if err != nil {
-			return nil, kerrors.NewBadRequest(fmt.Sprintf("cannot patch user settings: %v", err))
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot patch user settings: %v", err))
 		}
 
 		var patchedSettings *kubermaticv1.UserSettings
 		err = json.Unmarshal(patchedSettingsJSON, &patchedSettings)
 		if err != nil {
-			return nil, kerrors.NewBadRequest(fmt.Sprintf("cannot decode patched user settings: %v", err))
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot decode patched user settings: %v", err))
 		}
 
 		existingUser.Spec.Settings = patchedSettings

--- a/pkg/handler/v1/user/user.go
+++ b/pkg/handler/v1/user/user.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -46,10 +46,10 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(DeleteReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		if len(req.UserID) == 0 {
-			return nil, k8cerrors.NewBadRequest("the user ID cannot be empty")
+			return nil, utilerrors.NewBadRequest("the user ID cannot be empty")
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -66,10 +66,10 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(memberList) == 0 {
-			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot delete the user %s from the project %s because the user is not a member of the project", user.Spec.Email, req.ProjectID))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot delete the user %s from the project %s because the user is not a member of the project", user.Spec.Email, req.ProjectID))
 		}
 		if len(memberList) != 1 {
-			return nil, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot delete the user user %s from the project, inconsistent state in database", user.Spec.Email))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot delete the user user %s from the project, inconsistent state in database", user.Spec.Email))
 		}
 
 		userInfo, err := userInfoGetter(ctx, "")
@@ -78,7 +78,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		}
 		bindingForRequestedMember := memberList[0]
 		if strings.EqualFold(bindingForRequestedMember.Spec.UserEmail, userInfo.Email) {
-			return nil, k8cerrors.New(http.StatusForbidden, "you cannot delete yourself from the project")
+			return nil, utilerrors.New(http.StatusForbidden, "you cannot delete yourself from the project")
 		}
 
 		if err = deleteBinding(ctx, userInfoGetter, memberProvider, privilegedMemberProvider, req.ProjectID, bindingForRequestedMember.Name); err != nil {
@@ -134,7 +134,7 @@ func EditEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(EditReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -153,7 +153,7 @@ func EditEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 		}
 		memberToUpdate, err := userProvider.UserByEmail(ctx, currentMemberFromRequest.Email)
 		if err != nil && errors.Is(err, provider.ErrNotFound) {
-			return nil, k8cerrors.NewBadRequest("cannot add the user %s to the project %s because the user doesn't exist.", currentMemberFromRequest.Email, projectFromRequest.ID)
+			return nil, utilerrors.NewBadRequest("cannot add the user %s to the project %s because the user doesn't exist.", currentMemberFromRequest.Email, projectFromRequest.ID)
 		} else if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -163,10 +163,10 @@ func EditEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(memberList) == 0 {
-			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot change the membership of the user %s for the project %s because the user is not a member of the project", currentMemberFromRequest.Email, req.ProjectID))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot change the membership of the user %s for the project %s because the user is not a member of the project", currentMemberFromRequest.Email, req.ProjectID))
 		}
 		if len(memberList) != 1 {
-			return nil, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot change the membershp of the user %s, inconsistent state in database", currentMemberFromRequest.Email))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot change the membershp of the user %s, inconsistent state in database", currentMemberFromRequest.Email))
 		}
 
 		currentMemberBinding := memberList[0]
@@ -204,10 +204,10 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(common.GetProjectRq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		if len(req.ProjectID) == 0 {
-			return nil, k8cerrors.NewBadRequest("the name of the project cannot be empty")
+			return nil, utilerrors.NewBadRequest("the name of the project cannot be empty")
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -252,7 +252,7 @@ func AddEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 
 		userToInvite, err := userProvider.UserByEmail(ctx, apiUserFromRequest.Email)
 		if err != nil && errors.Is(err, provider.ErrNotFound) {
-			return nil, k8cerrors.NewBadRequest("cannot add the user %s to the project %s because the user doesn't exist.", apiUserFromRequest.Email, projectFromRequest.ID)
+			return nil, utilerrors.NewBadRequest("cannot add the user %s to the project %s because the user doesn't exist.", apiUserFromRequest.Email, projectFromRequest.ID)
 		} else if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -266,7 +266,7 @@ func AddEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if len(memberList) > 0 {
-			return nil, k8cerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot add the user %s to the project %s because user is already in the project", req.Body.Email, req.ProjectID))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("cannot add the user %s to the project %s because user is already in the project", req.Body.Email, req.ProjectID))
 		}
 
 		generatedGroupName := rbac.GenerateActualGroupNameFor(project.Name, projectFromRequest.GroupPrefix)
@@ -289,12 +289,12 @@ func LogoutEndpoint(userProvider provider.UserProvider) endpoint.Endpoint {
 		t := ctx.Value(middleware.RawTokenContextKey)
 		token, ok := t.(string)
 		if !ok || token == "" {
-			return nil, k8cerrors.NewNotAuthorized()
+			return nil, utilerrors.NewNotAuthorized()
 		}
 		e := ctx.Value(middleware.TokenExpiryContextKey)
 		expiry, ok := e.(apiv1.Time)
 		if !ok {
-			return nil, k8cerrors.NewNotAuthorized()
+			return nil, utilerrors.NewNotAuthorized()
 		}
 		return nil, userProvider.InvalidateToken(ctx, authenticatedUser, token, expiry)
 	}
@@ -398,27 +398,27 @@ type AddReq struct {
 // Validate validates AddReq request.
 func (r AddReq) Validate(authenticatesUserInfo *provider.UserInfo) error {
 	if len(r.ProjectID) == 0 {
-		return k8cerrors.NewBadRequest("the name of the project cannot be empty")
+		return utilerrors.NewBadRequest("the name of the project cannot be empty")
 	}
 	apiUserFromRequest := r.Body
 	if len(apiUserFromRequest.Email) == 0 {
-		return k8cerrors.NewBadRequest("the email address cannot be empty")
+		return utilerrors.NewBadRequest("the email address cannot be empty")
 	}
 	if _, err := mail.ParseAddress(apiUserFromRequest.Email); err != nil {
-		return k8cerrors.NewBadRequest("incorrect email format: %v", err)
+		return utilerrors.NewBadRequest("incorrect email format: %v", err)
 	}
 	if len(r.Body.Projects) != 1 {
-		return k8cerrors.NewBadRequest("expected exactly one entry in \"Projects\" field, but received %d", len(apiUserFromRequest.Projects))
+		return utilerrors.NewBadRequest("expected exactly one entry in \"Projects\" field, but received %d", len(apiUserFromRequest.Projects))
 	}
 	projectFromRequest := apiUserFromRequest.Projects[0]
 	if len(projectFromRequest.ID) == 0 || len(projectFromRequest.GroupPrefix) == 0 {
-		return k8cerrors.NewBadRequest("both the project name and the group name fields are required")
+		return utilerrors.NewBadRequest("both the project name and the group name fields are required")
 	}
 	if projectFromRequest.ID != r.ProjectID {
-		return k8cerrors.New(http.StatusForbidden, fmt.Sprintf("you can only assign the user to %s project", r.ProjectID))
+		return utilerrors.New(http.StatusForbidden, fmt.Sprintf("you can only assign the user to %s project", r.ProjectID))
 	}
 	if strings.EqualFold(apiUserFromRequest.Email, authenticatesUserInfo.Email) {
-		return k8cerrors.New(http.StatusForbidden, "you cannot assign yourself to a different group")
+		return utilerrors.New(http.StatusForbidden, "you cannot assign yourself to a different group")
 	}
 	isRequestedGroupPrefixValid := false
 	for _, existingGroupPrefix := range rbac.AllGroupsPrefixes {
@@ -428,7 +428,7 @@ func (r AddReq) Validate(authenticatesUserInfo *provider.UserInfo) error {
 		}
 	}
 	if !isRequestedGroupPrefixValid {
-		return k8cerrors.NewBadRequest("invalid group name %s", projectFromRequest.GroupPrefix)
+		return utilerrors.NewBadRequest("invalid group name %s", projectFromRequest.GroupPrefix)
 	}
 	return nil
 }
@@ -482,7 +482,7 @@ func (r EditReq) Validate(authenticatesUserInfo *provider.UserInfo) error {
 		return err
 	}
 	if r.UserID != r.Body.ID {
-		return k8cerrors.NewBadRequest(fmt.Sprintf("userID mismatch, you requested to update user %q but body contains user %q", r.UserID, r.Body.ID))
+		return utilerrors.NewBadRequest(fmt.Sprintf("userID mismatch, you requested to update user %q but body contains user %q", r.UserID, r.Body.ID))
 	}
 	return nil
 }

--- a/pkg/handler/v2/allowed_registry/allowed_registry.go
+++ b/pkg/handler/v2/allowed_registry/allowed_registry.go
@@ -31,7 +31,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,7 +45,7 @@ func CreateEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvi
 			return nil, err
 		}
 		if !adminUserInfo.IsAdmin {
-			return nil, errors.New(http.StatusForbidden,
+			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
@@ -98,7 +98,7 @@ func GetEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvider
 			return nil, err
 		}
 		if !adminUserInfo.IsAdmin {
-			return nil, errors.New(http.StatusForbidden,
+			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
@@ -138,7 +138,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvide
 			return nil, err
 		}
 		if !adminUserInfo.IsAdmin {
-			return nil, errors.New(http.StatusForbidden,
+			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
@@ -172,7 +172,7 @@ func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvi
 			return nil, err
 		}
 		if !adminUserInfo.IsAdmin {
-			return nil, errors.New(http.StatusForbidden,
+			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
@@ -219,7 +219,7 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvid
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		if !adminUserInfo.IsAdmin {
-			return nil, errors.New(http.StatusForbidden,
+			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", adminUserInfo.Email))
 		}
 
@@ -234,23 +234,23 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, allowedRegistryProvid
 		// patch
 		originalJSON, err := json.Marshal(originalAPIAR)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to convert current allowedRegistry: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to convert current allowedRegistry: %v", err))
 		}
 
 		patchedJSON, err := jsonpatch.MergePatch(originalJSON, req.Patch)
 		if err != nil {
-			return nil, errors.New(http.StatusBadRequest, fmt.Sprintf("failed to merge patch alloweddRegistry: %v", err))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("failed to merge patch alloweddRegistry: %v", err))
 		}
 
 		var patched *apiv2.AllowedRegistry
 		err = json.Unmarshal(patchedJSON, &patched)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal patch allowedRegistry: %v", err))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal patch allowedRegistry: %v", err))
 		}
 
 		// validate
 		if patched.Name != allowedRegistry.Name {
-			return nil, errors.New(http.StatusBadRequest, fmt.Sprintf("Changing allowedRegistry name is not allowed: %q to %q", allowedRegistry.Name, patched.Name))
+			return nil, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("Changing allowedRegistry name is not allowed: %q to %q", allowedRegistry.Name, patched.Name))
 		}
 
 		allowedRegistry.Spec = patched.Spec

--- a/pkg/handler/v2/backupcredentials/backupcredentials.go
+++ b/pkg/handler/v2/backupcredentials/backupcredentials.go
@@ -27,7 +27,7 @@ import (
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
-	v1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -137,7 +137,7 @@ func DecodeBackupCredentialsReq(c context.Context, r *http.Request) (interface{}
 	return req, nil
 }
 
-func convertAPIToInternalBackupCredentials(bc *apiv2.BackupCredentials, backupDest *v1.BackupDestination) *corev1.Secret {
+func convertAPIToInternalBackupCredentials(bc *apiv2.BackupCredentials, backupDest *kubermaticv1.BackupDestination) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GenBackupCredentialsSecretName(bc.Destination, backupDest),
@@ -151,7 +151,7 @@ func convertAPIToInternalBackupCredentials(bc *apiv2.BackupCredentials, backupDe
 }
 
 // GenBackupCredentialsSecretName generates etcd backup credentials secret name. If backup destination is not set, then use the legacy credentials secret.
-func GenBackupCredentialsSecretName(destinationName string, backupDestination *v1.BackupDestination) string {
+func GenBackupCredentialsSecretName(destinationName string, backupDestination *kubermaticv1.BackupDestination) string {
 	if backupDestination.Credentials != nil {
 		return backupDestination.Credentials.Name
 	}

--- a/pkg/handler/v2/backupdestinations/backupdestinations.go
+++ b/pkg/handler/v2/backupdestinations/backupdestinations.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	errors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func GetEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider,
@@ -77,7 +77,7 @@ func getSeed(ctx context.Context, userInfoGetter provider.UserInfoGetter, projec
 ) (*kubermaticv1.Seed, error) {
 	clusterProvider, ok := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, "no cluster in request")
+		return nil, utilerrors.New(http.StatusInternalServerError, "no cluster in request")
 	}
 	privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 
@@ -98,7 +98,7 @@ func getSeed(ctx context.Context, userInfoGetter provider.UserInfoGetter, projec
 
 	seed, ok := seeds[clusterProvider.GetSeedName()]
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("Seed %q not found", clusterProvider.GetSeedName()))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("Seed %q not found", clusterProvider.GetSeedName()))
 	}
 	return seed, nil
 }

--- a/pkg/handler/v2/backupdestinations/backupdestinations.go
+++ b/pkg/handler/v2/backupdestinations/backupdestinations.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 
-	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
@@ -43,7 +43,7 @@ func GetEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 			return nil, err
 		}
 
-		var destinations v2.BackupDestinationNames
+		var destinations apiv2.BackupDestinationNames
 		if seed.Spec.EtcdBackupRestore == nil {
 			return destinations, nil
 		}

--- a/pkg/handler/v2/cluster/binding.go
+++ b/pkg/handler/v2/cluster/binding.go
@@ -29,7 +29,7 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func BindUserToRoleEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
@@ -37,7 +37,7 @@ func BindUserToRoleEndpoint(projectProvider provider.ProjectProvider, privileged
 		req := request.(roleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.BindUserToRoleEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID, req.Namespace)
@@ -49,7 +49,7 @@ func UnbindUserFromRoleBindingEndpoint(projectProvider provider.ProjectProvider,
 		req := request.(roleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.UnbindUserFromRoleBindingEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID, req.Namespace)
@@ -68,7 +68,7 @@ func BindUserToClusterRoleEndpoint(projectProvider provider.ProjectProvider, pri
 		req := request.(clusterRoleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.BindUserToClusterRoleEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID)
@@ -80,7 +80,7 @@ func UnbindUserFromClusterRoleBindingEndpoint(projectProvider provider.ProjectPr
 		req := request.(clusterRoleUserReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest("invalid request: %v", err)
+			return nil, utilerrors.NewBadRequest("invalid request: %v", err)
 		}
 
 		return handlercommon.UnbindUserFromClusterRoleBindingEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.Body, req.ProjectID, req.ClusterID, req.RoleID)

--- a/pkg/handler/v2/cluster/cluster.go
+++ b/pkg/handler/v2/cluster/cluster.go
@@ -38,8 +38,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
 )
 
@@ -65,7 +64,7 @@ func CreateEndpoint(
 
 		err = req.Validate(version.NewFromConfiguration(config))
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return handlercommon.CreateEndpoint(ctx, req.ProjectID, req.Body, projectProvider, privilegedProjectProvider,
@@ -598,21 +597,21 @@ func GetClusterProviderFromRequest(
 ) (*kubermaticv1.Cluster, *kubernetesprovider.ClusterProvider, error) {
 	req, ok := request.(GetClusterReq)
 	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusBadRequest, "invalid request")
+		return nil, nil, utilerrors.New(http.StatusBadRequest, "invalid request")
 	}
 
 	cluster, err := handlercommon.GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, req.ProjectID, req.ClusterID, nil)
 	if err != nil {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
 
 	rawClusterProvider, ok := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, "no clusterProvider in request")
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, "no clusterProvider in request")
 	}
 	clusterProvider, ok := rawClusterProvider.(*kubernetesprovider.ClusterProvider)
 	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 	}
 	return cluster, clusterProvider, nil
 }

--- a/pkg/handler/v2/cluster/upgrade.go
+++ b/pkg/handler/v2/cluster/upgrade.go
@@ -27,14 +27,14 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func GetUpgradesEndpoint(configGetter provider.KubermaticConfigurationGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(GetClusterReq)
 		if !ok {
-			return nil, errors.NewWrongMethod(request, common.GetClusterReq{})
+			return nil, utilerrors.NewWrongMethod(request, common.GetClusterReq{})
 		}
 		return handlercommon.GetUpgradesEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, projectProvider, privilegedProjectProvider, configGetter)
 	}
@@ -44,7 +44,7 @@ func UpgradeNodeDeploymentsEndpoint(projectProvider provider.ProjectProvider, pr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(UpgradeNodeDeploymentsReq)
 		if !ok {
-			return nil, errors.NewWrongMethod(request, common.GetClusterReq{})
+			return nil, utilerrors.NewWrongMethod(request, common.GetClusterReq{})
 		}
 		return handlercommon.UpgradeNodeDeploymentsEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, req.Body, projectProvider, privilegedProjectProvider)
 	}

--- a/pkg/handler/v2/cluster/upgrade_test.go
+++ b/pkg/handler/v2/cluster/upgrade_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -68,10 +68,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser:                    *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version: semver.MustParse("1.7.0"),
+					Version: semverlib.MustParse("1.7.0"),
 				},
 			},
 			versions: []k8csemver.Semver{
@@ -111,10 +111,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser: *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version:                    semver.MustParse("1.7.0"),
+					Version:                    semverlib.MustParse("1.7.0"),
 					RestrictedByKubeletVersion: true,
 				},
 			},
@@ -151,7 +151,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser: *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.21.1"),
+					Version: semverlib.MustParse("1.21.1"),
 				},
 			},
 			versions: []k8csemver.Semver{
@@ -218,10 +218,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			apiUser:                    *test.GenAPIUser("John", "john@acme.com"),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.6.1"),
+					Version: semverlib.MustParse("1.6.1"),
 				},
 				{
-					Version: semver.MustParse("1.7.0"),
+					Version: semverlib.MustParse("1.7.0"),
 				},
 			},
 			versions: []k8csemver.Semver{

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -38,10 +38,10 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	kerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -81,7 +81,7 @@ func CreateEndpoint(
 
 		err = req.Validate(version.NewFromConfiguration(config))
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 
 		return createClusterTemplate(ctx, userInfoGetter, seedsGetter, projectProvider, privilegedProjectProvider, sshKeyProvider, credentialManager, exposeStrategy, caBundle, configGetter, features, clusterTemplateProvider, req.Body.CreateClusterSpec, req.ProjectID, req.Body.Name, req.Body.Scope, req.Body.UserSSHKeys)
@@ -160,7 +160,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listClusterTemplatesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
 		if err != nil {
@@ -188,7 +188,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			result = append(result, *externalClusterTemplate)
 		}
 		if len(errorList) > 0 {
-			return nil, kerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some cluster templates, please examine details field for more info", errorList)
+			return nil, kubermaticerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some cluster templates, please examine details field for more info", errorList)
 		}
 		return result, nil
 	}
@@ -225,7 +225,7 @@ func GetEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(getClusterTemplatesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 
 		return getClusterTemplate(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, clusterTemplateProvider, req.ProjectID, req.ClusterTemplateID)
@@ -255,7 +255,7 @@ func ExportEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(exportClusterTemplatesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 
 		clusterTemplate, err := getClusterTemplate(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, clusterTemplateProvider, req.ProjectID, req.ClusterTemplateID)
@@ -301,7 +301,7 @@ func ImportEndpoint(
 
 		err = req.Validate(version.NewFromConfiguration(config))
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 
 		var nd *apiv1.NodeDeployment
@@ -426,7 +426,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(getClusterTemplatesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
 		if err != nil {
@@ -449,7 +449,7 @@ func CreateInstanceEndpoint(projectProvider provider.ProjectProvider, privileged
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(createInstanceReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, apierrors.NewBadRequest(err.Error())
 		}
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
 		if err != nil {

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -38,7 +38,7 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -188,7 +188,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			result = append(result, *externalClusterTemplate)
 		}
 		if len(errorList) > 0 {
-			return nil, kubermaticerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some cluster templates, please examine details field for more info", errorList)
+			return nil, utilerrors.NewWithDetails(http.StatusInternalServerError, "failed to get some cluster templates, please examine details field for more info", errorList)
 		}
 		return result, nil
 	}

--- a/pkg/handler/v2/cniversion/cniversion.go
+++ b/pkg/handler/v2/cniversion/cniversion.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
-	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
@@ -50,7 +50,7 @@ func ListVersions() endpoint.Endpoint {
 			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
-		return v2.CNIVersions{
+		return apiv2.CNIVersions{
 			CNIPluginType: req.CNIPluginType,
 			Versions:      versions.List(),
 		}, nil
@@ -103,7 +103,7 @@ func ListVersionsForCluster(userInfoGetter provider.UserInfoGetter, projectProvi
 			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
-		return v2.CNIVersions{
+		return apiv2.CNIVersions{
 			CNIPluginType: c.Spec.CNIPlugin.Type.String(),
 			Versions:      versions.List(),
 		}, nil

--- a/pkg/handler/v2/cniversion/cniversion.go
+++ b/pkg/handler/v2/cniversion/cniversion.go
@@ -29,7 +29,7 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 )
 
@@ -38,16 +38,16 @@ func ListVersions() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(listCNIPluginVersionsReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		versions, err := cni.GetSupportedCNIPluginVersions(kubermaticv1.CNIPluginType(req.CNIPluginType))
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return v2.CNIVersions{
@@ -90,7 +90,7 @@ func ListVersionsForCluster(userInfoGetter provider.UserInfoGetter, projectProvi
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(listCNIPluginVersionsForClusterReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		c, err := handlercommon.GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, req.ProjectID, req.ClusterID, nil)
@@ -100,7 +100,7 @@ func ListVersionsForCluster(userInfoGetter provider.UserInfoGetter, projectProvi
 
 		versions, err := cni.GetSupportedCNIPluginVersions(c.Spec.CNIPlugin.Type)
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return v2.CNIVersions{

--- a/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
+++ b/pkg/handler/v2/etcdbackupconfig/etcdbackupconfig.go
@@ -35,7 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -326,7 +326,7 @@ func (r *listProjectEtcdBackupConfigReq) validate() error {
 		if r.Type == automaticBackup || r.Type == snapshot {
 			return nil
 		}
-		return errors.NewBadRequest("wrong query parameter, unsupported type: %s", r.Type)
+		return utilerrors.NewBadRequest("wrong query parameter, unsupported type: %s", r.Type)
 	}
 	return nil
 }
@@ -438,7 +438,7 @@ func convertInternalToAPIEtcdBackupConfig(ebc *kubermaticv1.EtcdBackupConfig) *a
 func convertAPIToInternalEtcdBackupConfig(name string, ebcSpec *apiv2.EtcdBackupConfigSpec, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdBackupConfig, error) {
 	clusterObjectRef, err := reference.GetReference(scheme.Scheme, cluster)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("error getting cluster object reference: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("error getting cluster object reference: %v", err))
 	}
 
 	return &kubermaticv1.EtcdBackupConfig{
@@ -515,7 +515,7 @@ func listEtcdBackupConfig(ctx context.Context, userInfoGetter provider.UserInfoG
 func listProjectEtcdBackupConfig(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdBackupConfigList, error) {
 	privilegedEtcdBackupConfigProjectProvider := ctx.Value(middleware.PrivilegedEtcdBackupConfigProjectProviderContextKey).(provider.PrivilegedEtcdBackupConfigProjectProvider)
 	if privilegedEtcdBackupConfigProjectProvider == nil {
-		return nil, errors.New(http.StatusInternalServerError, "error getting privileged provider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "error getting privileged provider")
 	}
 	return privilegedEtcdBackupConfigProjectProvider.ListUnsecured(ctx, projectID)
 }

--- a/pkg/handler/v2/etcdrestore/etcdrestore.go
+++ b/pkg/handler/v2/etcdrestore/etcdrestore.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -96,7 +96,7 @@ type erBody struct {
 
 func (r *createEtcdRestoreReq) validate() error {
 	if r.Body.Spec.BackupName == "" {
-		return errors.NewBadRequest("backup name cannot be empty")
+		return utilerrors.NewBadRequest("backup name cannot be empty")
 	}
 	// NOTE we can check if the backup really exists on S3 or if the backup secret exists (if set), but the restore status will give this info as well
 	return nil
@@ -220,7 +220,7 @@ func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 		}
 
 		if er.Status.Phase != kubermaticv1.EtcdRestorePhaseCompleted && er.Status.Phase != "" {
-			return nil, errors.New(http.StatusConflict, fmt.Sprintf("Restore is in progress (phase: %q), cannot delete at this moment", er.Status.Phase))
+			return nil, utilerrors.New(http.StatusConflict, fmt.Sprintf("Restore is in progress (phase: %q), cannot delete at this moment", er.Status.Phase))
 		}
 
 		err = deleteEtcdRestore(ctx, userInfoGetter, c, req.ProjectID, req.EtcdRestoreName)
@@ -311,7 +311,7 @@ func convertInternalToAPIEtcdRestore(er *kubermaticv1.EtcdRestore) *apiv2.EtcdRe
 func convertAPIToInternalEtcdRestore(name string, erSpec *apiv2.EtcdRestoreSpec, cluster *kubermaticv1.Cluster) (*kubermaticv1.EtcdRestore, error) {
 	clusterObjectRef, err := reference.GetReference(scheme.Scheme, cluster)
 	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("error getting cluster object reference: %v", err))
+		return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("error getting cluster object reference: %v", err))
 	}
 
 	return &kubermaticv1.EtcdRestore{
@@ -377,7 +377,7 @@ func listEtcdRestore(ctx context.Context, userInfoGetter provider.UserInfoGetter
 func listProjectEtcdRestore(ctx context.Context, projectID string) ([]*kubermaticv1.EtcdRestoreList, error) {
 	privilegedEtcdRestoreProjectProvider := ctx.Value(middleware.PrivilegedEtcdRestoreProjectProviderContextKey).(provider.PrivilegedEtcdRestoreProjectProvider)
 	if privilegedEtcdRestoreProjectProvider == nil {
-		return nil, errors.New(http.StatusInternalServerError, "error getting privileged provider")
+		return nil, utilerrors.New(http.StatusInternalServerError, "error getting privileged provider")
 	}
 	return privilegedEtcdRestoreProjectProvider.ListUnsecured(ctx, projectID)
 }

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/aks"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/eks"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gke"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,7 +103,7 @@ func DecodeManifestFromKubeOneReq(encodedManifest string) (*kubeonev1beta2.KubeO
 
 	manifest, err := base64.StdEncoding.DecodeString(encodedManifest)
 	if err != nil {
-		return nil, errors.NewBadRequest(err.Error())
+		return nil, utilerrors.NewBadRequest(err.Error())
 	}
 	if err := yaml.UnmarshalStrict(manifest, kubeOneCluster); err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func validatKubeOneReq(kubeOne *apiv2.KubeOneSpec) error {
 		}
 
 		if manifest.APIVersion == "" || manifest.Kind == "" {
-			return errors.NewBadRequest("apiVersion and kind must be present in the manifest")
+			return utilerrors.NewBadRequest("apiVersion and kind must be present in the manifest")
 		}
 	}
 	// validate sshKey
@@ -148,12 +148,12 @@ func CreateEndpoint(
 ) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(createClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -169,7 +169,7 @@ func CreateEndpoint(
 		if len(req.Credential) > 0 {
 			preset, err = presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 		}
 
@@ -182,7 +182,7 @@ func CreateEndpoint(
 			kuberneteshelper.AddFinalizer(newCluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
 			config, err := base64.StdEncoding.DecodeString(req.Body.Kubeconfig)
 			if err != nil {
-				return nil, errors.NewBadRequest(err.Error())
+				return nil, utilerrors.NewBadRequest(err.Error())
 			}
 			if err := clusterProvider.ValidateKubeconfig(ctx, config); err != nil {
 				return nil, err
@@ -255,7 +255,7 @@ func CreateEndpoint(
 		// import KubeOne cluster
 		if cloud.KubeOne != nil {
 			if err := validatKubeOneReq(cloud.KubeOne); err != nil {
-				return nil, errors.NewBadRequest(err.Error())
+				return nil, utilerrors.NewBadRequest(err.Error())
 			}
 			createdCluster, err := importKubeOneCluster(ctx, req.Body.Name, userInfoGetter, project, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
@@ -266,19 +266,19 @@ func CreateEndpoint(
 			apiCluster.Status = apiv2.ExternalClusterStatus{State: apiv2.PROVISIONING}
 			return apiCluster, nil
 		}
-		return nil, errors.NewBadRequest("kubeconfig or cloud provider structure missing")
+		return nil, utilerrors.NewBadRequest("kubeconfig or cloud provider structure missing")
 	}
 }
 
 func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(deleteClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -336,12 +336,12 @@ func (req deleteClusterReq) Validate() error {
 func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(listClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -392,12 +392,12 @@ func (req listClusterReq) Validate() error {
 func GetEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -490,12 +490,12 @@ func (req GetClusterReq) Validate() error {
 func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(updateClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -510,7 +510,7 @@ func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 		if req.Body.Kubeconfig != "" {
 			config, err := base64.StdEncoding.DecodeString(req.Body.Kubeconfig)
 			if err != nil {
-				return nil, errors.NewBadRequest(err.Error())
+				return nil, utilerrors.NewBadRequest(err.Error())
 			}
 			if err := clusterProvider.ValidateKubeconfig(ctx, config); err != nil {
 				return nil, err
@@ -524,7 +524,7 @@ func UpdateEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			cluster.Spec.HumanReadableName = req.Body.Name
 			cluster, err = updateCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, project.Name, cluster)
 			if err != nil {
-				return nil, errors.NewBadRequest(err.Error())
+				return nil, utilerrors.NewBadRequest(err.Error())
 			}
 		}
 
@@ -540,12 +540,12 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provi
 ) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(patchClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -608,15 +608,15 @@ func PatchEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provi
 func patchCluster(clusterToPatch, patchedCluster *apiv2.ExternalCluster, patchJson json.RawMessage) error {
 	existingClusterJSON, err := json.Marshal(clusterToPatch)
 	if err != nil {
-		return errors.NewBadRequest("cannot decode existing cluster: %v", err)
+		return utilerrors.NewBadRequest("cannot decode existing cluster: %v", err)
 	}
 	patchedClusterJSON, err := jsonpatch.MergePatch(existingClusterJSON, patchJson)
 	if err != nil {
-		return errors.NewBadRequest("cannot patch cluster: %v, %v", err, patchJson)
+		return utilerrors.NewBadRequest("cannot patch cluster: %v, %v", err, patchJson)
 	}
 	err = json.Unmarshal(patchedClusterJSON, &patchedCluster)
 	if err != nil {
-		return errors.NewBadRequest("cannot decode patched cluster: %v", err)
+		return utilerrors.NewBadRequest("cannot decode patched cluster: %v", err)
 	}
 	return nil
 }
@@ -717,12 +717,12 @@ func (req updateClusterReq) Validate() error {
 func GetMetricsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -777,12 +777,12 @@ func GetMetricsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider 
 func ListEventsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(listEventsReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -1097,12 +1097,12 @@ func AreExternalClustersEnabled(ctx context.Context, provider provider.SettingsP
 func GetKubeconfigEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gke"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -48,12 +48,12 @@ const GKENodepoolNameLabel = "cloud.google.com/gke-nodepool"
 func GKEImagesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -97,12 +97,12 @@ func GKEImagesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGet
 func GKEZonesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -154,12 +154,12 @@ func GKEZonesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 func GKESizesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -189,12 +189,12 @@ func GKESizesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 func GKEDiskTypesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -244,7 +244,7 @@ func listGKEDiskTypes(ctx context.Context, sa string, zone string) (apiv1.GCPDis
 
 func createOrImportGKECluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, spec *apiv2.ExternalClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	if cloud.GKE.Name == "" || cloud.GKE.Zone == "" || cloud.GKE.ServiceAccount == "" {
-		return nil, errors.NewBadRequest("the GKE cluster name, zone or service account can not be empty")
+		return nil, utilerrors.NewBadRequest("the GKE cluster name, zone or service account can not be empty")
 	}
 
 	if spec != nil && spec.GKEClusterSpec != nil {

--- a/pkg/handler/v2/external_cluster/kubeone.go
+++ b/pkg/handler/v2/external_cluster/kubeone.go
@@ -28,7 +28,6 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	v1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -236,7 +235,7 @@ func createAPIMachineDeployment(md clusterv1alpha1.MachineDeployment) apiv2.Exte
 	return apimd
 }
 
-func getKubeOneMachineDeployment(ctx context.Context, mdName string, cluster *v1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*clusterv1alpha1.MachineDeployment, error) {
+func getKubeOneMachineDeployment(ctx context.Context, mdName string, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*clusterv1alpha1.MachineDeployment, error) {
 	machineDeployment := &clusterv1alpha1.MachineDeployment{}
 	userClusterClient, err := clusterProvider.GetClient(ctx, cluster)
 	if err != nil {
@@ -248,7 +247,7 @@ func getKubeOneMachineDeployment(ctx context.Context, mdName string, cluster *v1
 	return machineDeployment, nil
 }
 
-func getKubeOneMachineDeployments(ctx context.Context, cluster *v1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*clusterv1alpha1.MachineDeploymentList, error) {
+func getKubeOneMachineDeployments(ctx context.Context, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*clusterv1alpha1.MachineDeploymentList, error) {
 	mdList := &clusterv1alpha1.MachineDeploymentList{}
 	userClusterClient, err := clusterProvider.GetClient(ctx, cluster)
 	if err != nil {
@@ -260,7 +259,7 @@ func getKubeOneMachineDeployments(ctx context.Context, cluster *v1.ExternalClust
 	return mdList, nil
 }
 
-func patchKubeOneMachineDeployment(ctx context.Context, machineDeployment *v1alpha1.MachineDeployment, oldmd, newmd *apiv2.ExternalClusterMachineDeployment, cluster *v1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
+func patchKubeOneMachineDeployment(ctx context.Context, machineDeployment *v1alpha1.MachineDeployment, oldmd, newmd *apiv2.ExternalClusterMachineDeployment, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
 	currentVersion := oldmd.NodeDeployment.Spec.Template.Versions.Kubelet
 	desiredVersion := newmd.NodeDeployment.Spec.Template.Versions.Kubelet
 	if desiredVersion != currentVersion {

--- a/pkg/handler/v2/external_cluster/kubeone.go
+++ b/pkg/handler/v2/external_cluster/kubeone.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -259,7 +258,7 @@ func getKubeOneMachineDeployments(ctx context.Context, cluster *kubermaticv1.Ext
 	return mdList, nil
 }
 
-func patchKubeOneMachineDeployment(ctx context.Context, machineDeployment *v1alpha1.MachineDeployment, oldmd, newmd *apiv2.ExternalClusterMachineDeployment, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
+func patchKubeOneMachineDeployment(ctx context.Context, machineDeployment *clusterv1alpha1.MachineDeployment, oldmd, newmd *apiv2.ExternalClusterMachineDeployment, cluster *kubermaticv1.ExternalCluster, clusterProvider provider.ExternalClusterProvider) (*apiv2.ExternalClusterMachineDeployment, error) {
 	currentVersion := oldmd.NodeDeployment.Spec.Template.Versions.Kubelet
 	desiredVersion := newmd.NodeDeployment.Spec.Template.Versions.Kubelet
 	if desiredVersion != currentVersion {

--- a/pkg/handler/v2/external_cluster/node.go
+++ b/pkg/handler/v2/external_cluster/node.go
@@ -33,7 +33,7 @@ import (
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -45,7 +45,7 @@ func ListNodesEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider p
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listNodesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -83,12 +83,12 @@ func ListNodesEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider p
 func ListNodesMetricsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(listNodesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		return getClusterNodesMetrics(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, clusterProvider, privilegedClusterProvider, req.ProjectID, req.ClusterID)
 	}
@@ -190,7 +190,7 @@ func GetNodeEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider pro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(getNodeReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -215,7 +215,7 @@ func ListMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, proje
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listMachineDeploymentsReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -275,7 +275,7 @@ func ListMachineDeploymentNodesEndpoint(userInfoGetter provider.UserInfoGetter, 
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listMachineDeploymentNodesReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		return getMachineDeploymentNodes(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, clusterProvider, privilegedClusterProvider, req.ProjectID, req.ClusterID, req.MachineDeploymentID)
@@ -339,7 +339,7 @@ func DeleteMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, pro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(machineDeploymentReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -383,7 +383,7 @@ func ListMachineDeploymentMetricsEndpoint(userInfoGetter provider.UserInfoGetter
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(machineDeploymentReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		nodeMetrics := make([]apiv1.NodeMetric, 0)
 
@@ -626,7 +626,7 @@ func GetMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projec
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(machineDeploymentReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -681,13 +681,13 @@ func GetMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projec
 func PatchMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(patchMachineDeploymentReq)
 
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -759,7 +759,7 @@ func CreateMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, pro
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(createMachineDeploymentsReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})
@@ -793,15 +793,15 @@ func CreateMachineDeploymentEndpoint(userInfoGetter provider.UserInfoGetter, pro
 func patchMD(mdToPatch, patchedMD *apiv2.ExternalClusterMachineDeployment, patchJson json.RawMessage) error {
 	existingMDJSON, err := json.Marshal(mdToPatch)
 	if err != nil {
-		return errors.NewBadRequest("cannot decode existing md: %v", err)
+		return utilerrors.NewBadRequest("cannot decode existing md: %v", err)
 	}
 	patchedMDJSON, err := jsonpatch.MergePatch(existingMDJSON, patchJson)
 	if err != nil {
-		return errors.NewBadRequest("cannot patch md: %v, %v", err, patchJson)
+		return utilerrors.NewBadRequest("cannot patch md: %v, %v", err, patchJson)
 	}
 	err = json.Unmarshal(patchedMDJSON, &patchedMD)
 	if err != nil {
-		return errors.NewBadRequest("cannot decode patched md: %v", err)
+		return utilerrors.NewBadRequest("cannot decode patched md: %v", err)
 	}
 	return nil
 }

--- a/pkg/handler/v2/external_cluster/upgrade.go
+++ b/pkg/handler/v2/external_cluster/upgrade.go
@@ -32,18 +32,18 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/aks"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gke"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func GetUpgradesEndpoint(configGetter provider.KubermaticConfigurationGetter, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
-			return nil, errors.New(http.StatusForbidden, "external cluster functionality is disabled")
+			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
 		}
 
 		req := request.(GetClusterReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
@@ -97,7 +97,7 @@ func GetMachineDeploymentUpgradesEndpoint(userInfoGetter provider.UserInfoGetter
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(machineDeploymentReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: false})

--- a/pkg/handler/v2/feature_gates/feature_gates_test.go
+++ b/pkg/handler/v2/feature_gates/feature_gates_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
-	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -44,7 +44,7 @@ func TestFeatureGatesEndpoint(t *testing.T) {
 		Name                      string
 		ExistingKubermaticObjects []ctrlruntimeclient.Object
 		ExistingAPIUser           *apiv1.User
-		ExpectedResponse          v2.FeatureGates
+		ExpectedResponse          apiv2.FeatureGates
 		ExpectedHTTPStatusCode    int
 	}{
 		{
@@ -52,7 +52,7 @@ func TestFeatureGatesEndpoint(t *testing.T) {
 			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(),
 			ExistingAPIUser:           test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode:    http.StatusOK,
-			ExpectedResponse: v2.FeatureGates{
+			ExpectedResponse: apiv2.FeatureGates{
 				KonnectivityService: &valTrue,
 			},
 		},
@@ -88,7 +88,7 @@ func TestFeatureGatesEndpoint(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatusCode, resp.Code, resp.Body.String())
 			}
 			if resp.Code == http.StatusOK {
-				var featureGates v2.FeatureGates
+				var featureGates apiv2.FeatureGates
 				if err := json.Unmarshal(resp.Body.Bytes(), &featureGates); err != nil {
 					t.Fatalf("failed to unmarshal response: %v", err)
 				}

--- a/pkg/handler/v2/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v2/kubernetes-dashboard/dashboard.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/resources/kubernetes-dashboard"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // Minimal wrapper to implement the http.Handler interface.
@@ -57,18 +57,18 @@ func ProxyEndpoint(
 
 		settings, err := settingsProvider.GetGlobalSettings(ctx)
 		if err != nil {
-			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "could not read global settings"))
+			common.WriteHTTPError(log, w, utilerrors.New(http.StatusInternalServerError, "could not read global settings"))
 			return
 		}
 
 		if !settings.Spec.EnableDashboard {
-			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusForbidden, "Kubernetes Dashboard access is disabled by the global settings"))
+			common.WriteHTTPError(log, w, utilerrors.New(http.StatusForbidden, "Kubernetes Dashboard access is disabled by the global settings"))
 			return
 		}
 
 		request, err := cluster.DecodeGetClusterReq(ctx, r)
 		if err != nil {
-			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
+			common.WriteHTTPError(log, w, utilerrors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -88,18 +88,18 @@ func ProxyEndpoint(
 			}
 			req, ok := request.(cluster.GetClusterReq)
 			if !ok {
-				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, "invalid request"))
+				common.WriteHTTPError(log, w, utilerrors.New(http.StatusBadRequest, "invalid request"))
 				return nil, nil
 			}
 			userInfo, err := userInfoGetter(ctx, req.ProjectID)
 			if err != nil {
-				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
+				common.WriteHTTPError(log, w, utilerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
 				return nil, nil
 			}
 
 			token, err := clusterProvider.GetTokenForCustomerCluster(ctx, userInfo, userCluster)
 			if err != nil {
-				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("error getting token for user %q: %v", userInfo.Email, err)))
+				common.WriteHTTPError(log, w, utilerrors.New(http.StatusBadRequest, fmt.Sprintf("error getting token for user %q: %v", userInfo.Email, err)))
 				return nil, nil
 			}
 

--- a/pkg/handler/v2/networkdefaults/networkdefaults.go
+++ b/pkg/handler/v2/networkdefaults/networkdefaults.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
-	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
@@ -81,14 +81,14 @@ func GetNetworkDefaultsEndpoint() endpoint.Endpoint {
 		provider := kubermaticv1.ProviderType(req.ProviderName)
 		cni := kubermaticv1.CNIPluginType(req.CNIPluginType)
 
-		return v2.NetworkDefaults{
-			IPv4: &v2.NetworkDefaultsIPFamily{
+		return apiv2.NetworkDefaults{
+			IPv4: &apiv2.NetworkDefaultsIPFamily{
 				PodsCIDR:                resources.GetDefaultPodCIDRIPv4(provider),
 				ServicesCIDR:            resources.GetDefaultServicesCIDRIPv4(provider),
 				NodeCIDRMaskSize:        resources.DefaultNodeCIDRMaskSizeIPv4,
 				NodePortsAllowedIPRange: resources.IPv4MatchAnyCIDR,
 			},
-			IPv6: &v2.NetworkDefaultsIPFamily{
+			IPv6: &apiv2.NetworkDefaultsIPFamily{
 				PodsCIDR:                resources.DefaultClusterPodsCIDRIPv6,
 				ServicesCIDR:            resources.DefaultClusterServicesCIDRIPv6,
 				NodeCIDRMaskSize:        resources.DefaultNodeCIDRMaskSizeIPv6,

--- a/pkg/handler/v2/networkdefaults/networkdefaults.go
+++ b/pkg/handler/v2/networkdefaults/networkdefaults.go
@@ -27,7 +27,7 @@ import (
 	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 )
 
@@ -71,11 +71,11 @@ func GetNetworkDefaultsEndpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(getNetworkDefaultsReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		provider := kubermaticv1.ProviderType(req.ProviderName)

--- a/pkg/handler/v2/preset/preset.go
+++ b/pkg/handler/v2/preset/preset.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -341,11 +341,11 @@ func CreatePreset(presetProvider provider.PresetProvider, userInfoGetter provide
 		}
 
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Body.Name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return presetProvider.CreatePreset(ctx, convertAPIToInternalPreset(req.Body))
 		}
 
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
@@ -473,11 +473,11 @@ func DeletePreset(presetProvider provider.PresetProvider, userInfoGetter provide
 		}
 
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.PresetName)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, errors.NewNotFound("Preset", "preset was not found.")
 		}
 
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
@@ -546,11 +546,11 @@ func DeletePresetProvider(presetProvider provider.PresetProvider, userInfoGetter
 		}
 
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.PresetName)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, errors.NewNotFound("Preset", "preset was not found.")
 		}
 
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, errors.New(http.StatusInternalServerError, err.Error())
 		}
 
@@ -626,11 +626,11 @@ func DeleteProviderPreset(presetProvider provider.PresetProvider, userInfoGetter
 		}
 
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.PresetName)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, errors.NewBadRequest("preset was not found.")
 		}
 
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
@@ -700,7 +700,7 @@ func GetPresetStats(presetProvider provider.PresetProvider, userInfoGetter provi
 
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.PresetName)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil, errors.NewBadRequest("preset was not found.")
 			}
 			return nil, common.KubernetesErrorToHTTPError(err)

--- a/pkg/handler/v2/preset/preset.go
+++ b/pkg/handler/v2/preset/preset.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
-	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
@@ -65,7 +65,7 @@ func ListPresets(presetProvider provider.PresetProvider, userInfoGetter provider
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		presetList := &v2.PresetList{Items: make([]v2.Preset, 0)}
+		presetList := &apiv2.PresetList{Items: make([]apiv2.Preset, 0)}
 		presets, err := presetProvider.GetPresets(ctx, userInfo)
 		if err != nil {
 			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
@@ -227,7 +227,7 @@ func ListProviderPresets(presetProvider provider.PresetProvider, userInfoGetter 
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		presetList := &v2.PresetList{Items: make([]v2.Preset, 0)}
+		presetList := &apiv2.PresetList{Items: make([]apiv2.Preset, 0)}
 		presets, err := presetProvider.GetPresets(ctx, userInfo)
 		if err != nil {
 			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
@@ -268,7 +268,7 @@ type createPresetReq struct {
 	ProviderName string `json:"provider_name"`
 	// in: body
 	// required: true
-	Body v2.PresetBody
+	Body apiv2.PresetBody
 }
 
 // Validate validates createPresetReq request.
@@ -706,7 +706,7 @@ func GetPresetStats(presetProvider provider.PresetProvider, userInfoGetter provi
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		stats := v2.PresetStats{}
+		stats := apiv2.PresetStats{}
 
 		seeds, err := seedsGetter()
 		if err != nil {
@@ -757,21 +757,21 @@ func mergePresets(oldPreset *kubermaticv1.Preset, newPreset *kubermaticv1.Preset
 	return oldPreset
 }
 
-func newAPIPreset(preset *kubermaticv1.Preset, enabled bool) v2.Preset {
-	providers := make([]v2.PresetProvider, 0)
+func newAPIPreset(preset *kubermaticv1.Preset, enabled bool) apiv2.Preset {
+	providers := make([]apiv2.PresetProvider, 0)
 	for _, providerType := range kubermaticv1.SupportedProviders {
 		if hasProvider, _ := kubermaticv1helper.HasProvider(preset, providerType); hasProvider {
-			providers = append(providers, v2.PresetProvider{
+			providers = append(providers, apiv2.PresetProvider{
 				Name:    providerType,
 				Enabled: kubermaticv1helper.IsProviderEnabled(preset, providerType),
 			})
 		}
 	}
 
-	return v2.Preset{Name: preset.Name, Enabled: enabled, Providers: providers}
+	return apiv2.Preset{Name: preset.Name, Enabled: enabled, Providers: providers}
 }
 
-func convertAPIToInternalPreset(preset v2.PresetBody) *kubermaticv1.Preset {
+func convertAPIToInternalPreset(preset apiv2.PresetBody) *kubermaticv1.Preset {
 	return &kubermaticv1.Preset{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: preset.Name,

--- a/pkg/handler/v2/preset/preset_test.go
+++ b/pkg/handler/v2/preset/preset_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
-	v2 "k8c.io/kubermatic/v2/pkg/api/v2"
+	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
@@ -136,7 +136,7 @@ func genPresets() []ctrlruntimeclient.Object {
 	}
 }
 
-func sortPresets(presets []v2.Preset) {
+func sortPresets(presets []apiv2.Preset) {
 	sort.Slice(presets, func(i, j int) bool {
 		return strings.Compare(presets[i].Name, presets[j].Name) < 1
 	})
@@ -147,7 +147,7 @@ func TestListPresets(t *testing.T) {
 	testcases := []struct {
 		Name                   string
 		Disabled               bool
-		ExpectedResponse       *v2.PresetList
+		ExpectedResponse       *apiv2.PresetList
 		HTTPStatus             int
 		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []ctrlruntimeclient.Object
@@ -156,15 +156,15 @@ func TestListPresets(t *testing.T) {
 		{
 			Name:     "scenario 1: list enabled presets",
 			Disabled: false,
-			ExpectedResponse: &v2.PresetList{
-				Items: []v2.Preset{
-					{Name: "enabled", Enabled: true, Providers: []v2.PresetProvider{}},
-					{Name: "enabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "disabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-					{Name: "enabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "disabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{
+				Items: []apiv2.Preset{
+					{Name: "enabled", Enabled: true, Providers: []apiv2.PresetProvider{}},
+					{Name: "enabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "disabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+					{Name: "enabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "disabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 				},
 			},
 			HTTPStatus:             http.StatusOK,
@@ -176,16 +176,16 @@ func TestListPresets(t *testing.T) {
 		{
 			Name:     "scenario 2: list all presets",
 			Disabled: true,
-			ExpectedResponse: &v2.PresetList{
-				Items: []v2.Preset{
-					{Name: "enabled", Enabled: true, Providers: []v2.PresetProvider{}},
-					{Name: "disabled", Providers: []v2.PresetProvider{}},
-					{Name: "enabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "disabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-					{Name: "enabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "disabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{
+				Items: []apiv2.Preset{
+					{Name: "enabled", Enabled: true, Providers: []apiv2.PresetProvider{}},
+					{Name: "disabled", Providers: []apiv2.PresetProvider{}},
+					{Name: "enabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "disabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+					{Name: "enabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "disabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 				},
 			},
 			HTTPStatus:             http.StatusOK,
@@ -210,7 +210,7 @@ func TestListPresets(t *testing.T) {
 
 			assert.Equal(t, tc.HTTPStatus, res.Code)
 
-			response := &v2.PresetList{}
+			response := &apiv2.PresetList{}
 			err = json.Unmarshal(res.Body.Bytes(), response)
 			if err != nil {
 				t.Fatal(err)
@@ -232,7 +232,7 @@ func TestListProviderPresets(t *testing.T) {
 		Disabled               bool
 		Provider               string
 		Datacenter             string
-		ExpectedResponse       *v2.PresetList
+		ExpectedResponse       *apiv2.PresetList
 		HTTPStatus             int
 		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []ctrlruntimeclient.Object
@@ -242,12 +242,12 @@ func TestListProviderPresets(t *testing.T) {
 			Name:     "scenario 1: list enabled digitalocean presets",
 			Disabled: false,
 			Provider: string(kubermaticv1.DigitaloceanCloudProvider),
-			ExpectedResponse: &v2.PresetList{
-				Items: []v2.Preset{
-					{Name: "enabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "enabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{
+				Items: []apiv2.Preset{
+					{Name: "enabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "enabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 				},
 			},
 			HTTPStatus:             http.StatusOK,
@@ -260,14 +260,14 @@ func TestListProviderPresets(t *testing.T) {
 			Name:     "scenario 2: list all digitalocean presets",
 			Disabled: true,
 			Provider: string(kubermaticv1.DigitaloceanCloudProvider),
-			ExpectedResponse: &v2.PresetList{
-				Items: []v2.Preset{
-					{Name: "enabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "enabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "disabled-do-with-dc", Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-					{Name: "disabled-do", Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-					{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{
+				Items: []apiv2.Preset{
+					{Name: "enabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "enabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "disabled-do-with-dc", Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+					{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+					{Name: "disabled-do", Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+					{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 				},
 			},
 			HTTPStatus:             http.StatusOK,
@@ -281,11 +281,11 @@ func TestListProviderPresets(t *testing.T) {
 			Disabled:   false,
 			Provider:   string(kubermaticv1.DigitaloceanCloudProvider),
 			Datacenter: "a",
-			ExpectedResponse: &v2.PresetList{Items: []v2.Preset{
-				{Name: "enabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-				{Name: "enabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-				{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-				{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{Items: []apiv2.Preset{
+				{Name: "enabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+				{Name: "enabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+				{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+				{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 			}},
 			HTTPStatus:             http.StatusOK,
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
@@ -298,13 +298,13 @@ func TestListProviderPresets(t *testing.T) {
 			Disabled:   true,
 			Provider:   string(kubermaticv1.DigitaloceanCloudProvider),
 			Datacenter: "a",
-			ExpectedResponse: &v2.PresetList{Items: []v2.Preset{
-				{Name: "enabled-do", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-				{Name: "disabled-do", Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-				{Name: "enabled-do-with-dc", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-				{Name: "disabled-do-with-dc", Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
-				{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
-				{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{Items: []apiv2.Preset{
+				{Name: "enabled-do", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+				{Name: "disabled-do", Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+				{Name: "enabled-do-with-dc", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+				{Name: "disabled-do-with-dc", Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider}}},
+				{Name: "enabled-do-with-acme-email", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+				{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 			}},
 			HTTPStatus:             http.StatusOK,
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
@@ -316,8 +316,8 @@ func TestListProviderPresets(t *testing.T) {
 			Name:     "scenario 5: list enabled anexia provider",
 			Disabled: false,
 			Provider: string(kubermaticv1.AnexiaCloudProvider),
-			ExpectedResponse: &v2.PresetList{Items: []v2.Preset{
-				{Name: "enabled-multi-provider", Enabled: true, Providers: []v2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
+			ExpectedResponse: &apiv2.PresetList{Items: []apiv2.Preset{
+				{Name: "enabled-multi-provider", Enabled: true, Providers: []apiv2.PresetProvider{{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true}, {Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true}}},
 			}},
 			HTTPStatus:             http.StatusOK,
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
@@ -329,7 +329,7 @@ func TestListProviderPresets(t *testing.T) {
 			Name:                   "scenario 6: invalid provider name",
 			Disabled:               true,
 			Provider:               "invalid",
-			ExpectedResponse:       &v2.PresetList{Items: []v2.Preset{}},
+			ExpectedResponse:       &apiv2.PresetList{Items: []apiv2.Preset{}},
 			HTTPStatus:             http.StatusBadRequest,
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingKubermaticObjs: genPresets(),
@@ -352,7 +352,7 @@ func TestListProviderPresets(t *testing.T) {
 
 			assert.Equal(t, tc.HTTPStatus, res.Code)
 
-			response := &v2.PresetList{}
+			response := &apiv2.PresetList{}
 			err = json.Unmarshal(res.Body.Bytes(), response)
 			if err != nil {
 				t.Fatal(err)
@@ -373,7 +373,7 @@ func TestUpdatePresetStatus(t *testing.T) {
 		Name            string
 		PresetName      string
 		Enabled         bool
-		Provider        v2.PresetProvider
+		Provider        apiv2.PresetProvider
 		ExistingPreset  *kubermaticv1.Preset
 		ExpectedPreset  *kubermaticv1.Preset
 		HTTPStatus      int
@@ -447,7 +447,7 @@ func TestUpdatePresetStatus(t *testing.T) {
 		{
 			Name:       "scenario 4: enable disabled digitalocean preset",
 			PresetName: "disabled-do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Enabled:    true,
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "disabled-do-preset"},
@@ -474,7 +474,7 @@ func TestUpdatePresetStatus(t *testing.T) {
 		{
 			Name:       "scenario 5: disable enabled digitalocean preset",
 			PresetName: "enabled-do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Enabled:    false,
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "enabled-do-preset"},
@@ -501,7 +501,7 @@ func TestUpdatePresetStatus(t *testing.T) {
 		{
 			Name:       "scenario 6: disable enabled digitalocean preset with no enabled status set",
 			PresetName: "enabled-do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Enabled:    false,
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "enabled-do-preset"},
@@ -535,7 +535,7 @@ func TestUpdatePresetStatus(t *testing.T) {
 		{
 			Name:       "scenario 6: block status update when provider configuration missing",
 			PresetName: "preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Enabled:    false,
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "preset"},
@@ -592,7 +592,7 @@ func TestCreatePreset(t *testing.T) {
 	testcases := []struct {
 		Name            string
 		PresetName      string
-		Provider        v2.PresetProvider
+		Provider        apiv2.PresetProvider
 		Body            string
 		ExistingPreset  *kubermaticv1.Preset
 		ExpectedPreset  *kubermaticv1.Preset
@@ -603,7 +603,7 @@ func TestCreatePreset(t *testing.T) {
 		{
 			Name:       "scenario 1: create digitalocean preset",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "do-preset"
@@ -629,7 +629,7 @@ func TestCreatePreset(t *testing.T) {
 		{
 			Name:       "scenario 2: create disabled digitalocean preset",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "do-preset"
@@ -659,7 +659,7 @@ func TestCreatePreset(t *testing.T) {
 		{
 			Name:       "scenario 3: add new anexia provider to existing preset",
 			PresetName: "multi-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.AnexiaCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "multi-preset"
@@ -698,7 +698,7 @@ func TestCreatePreset(t *testing.T) {
 		// scenario 4
 		{
 			Name:     "scenario 4: block overriding existing preset provider configuration",
-			Provider: v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider: apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					 "metadata": {
 						"name": "do-preset"
@@ -725,7 +725,7 @@ func TestCreatePreset(t *testing.T) {
 		// scenario 5
 		{
 			Name:            "scenario 5: provided invalid provider name",
-			Provider:        v2.PresetProvider{Name: "xyz", Enabled: true},
+			Provider:        apiv2.PresetProvider{Name: "xyz", Enabled: true},
 			Body:            "{}",
 			HTTPStatus:      http.StatusBadRequest,
 			ExistingAPIUser: test.GenDefaultAdminAPIUser(),
@@ -734,7 +734,7 @@ func TestCreatePreset(t *testing.T) {
 		// scenario 6
 		{
 			Name:     "scenario 6: missing provider configuration",
-			Provider: v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider: apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					 "metadata": {
 						"name": "do-preset"
@@ -748,7 +748,7 @@ func TestCreatePreset(t *testing.T) {
 		// scenario 7
 		{
 			Name:     "scenario 7: missing required token field for digitalocean provider",
-			Provider: v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider: apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					 "metadata": {
 						"name": "do-preset"
@@ -762,7 +762,7 @@ func TestCreatePreset(t *testing.T) {
 		// scenario 8
 		{
 			Name:     "scenario 8: unexpected provider configuration when creating digitalocean preset",
-			Provider: v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider: apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					 "metadata": {
 						"name": "do-preset"
@@ -779,7 +779,7 @@ func TestCreatePreset(t *testing.T) {
 		// scenario 9
 		{
 			Name:     "scenario 9: block preset creation for regular user",
-			Provider: v2.PresetProvider{Name: kubermaticv1.FakeCloudProvider, Enabled: true},
+			Provider: apiv2.PresetProvider{Name: kubermaticv1.FakeCloudProvider, Enabled: true},
 			Body: `{
 					 "metadata": {
 						"name": "fake-preset"
@@ -836,7 +836,7 @@ func TestUpdatePreset(t *testing.T) {
 	testcases := []struct {
 		Name            string
 		PresetName      string
-		Provider        v2.PresetProvider
+		Provider        apiv2.PresetProvider
 		Body            string
 		ExistingPreset  *kubermaticv1.Preset
 		ExpectedPreset  *kubermaticv1.Preset
@@ -847,7 +847,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 1: update digitalocean preset token and disable it",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "do-preset"
@@ -886,7 +886,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 2: update alibaba credentials",
 			PresetName: "alibaba-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.AlibabaCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.AlibabaCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "alibaba-preset"
@@ -926,7 +926,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 3: omit optional openstack fields to remove them",
 			PresetName: "openstack-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "openstack-preset"
@@ -980,7 +980,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 4: block user from updating multiple providers at once",
 			PresetName: "openstack-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "openstack-preset"
@@ -1018,7 +1018,7 @@ func TestUpdatePreset(t *testing.T) {
 		// scenario 5
 		{
 			Name:     "scenario 5: block preset update for regular user",
-			Provider: v2.PresetProvider{Name: kubermaticv1.FakeCloudProvider, Enabled: true},
+			Provider: apiv2.PresetProvider{Name: kubermaticv1.FakeCloudProvider, Enabled: true},
 			Body: `{
 					 "metadata": {
 						"name": "fake-preset"
@@ -1037,7 +1037,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 6: add requiredEmails",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "do-preset"
@@ -1077,7 +1077,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 7: update requiredEmails",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "do-preset"
@@ -1118,7 +1118,7 @@ func TestUpdatePreset(t *testing.T) {
 		{
 			Name:       "scenario 8: remove requiredEmails",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			Body: `{
 					  "metadata": {
 						"name": "do-preset"
@@ -1193,7 +1193,7 @@ func TestDeleteProviderPreset(t *testing.T) {
 	testcases := []struct {
 		Name            string
 		PresetName      string
-		Provider        v2.PresetProvider
+		Provider        apiv2.PresetProvider
 		Body            string
 		ExistingPreset  *kubermaticv1.Preset
 		ExpectedPreset  *kubermaticv1.Preset
@@ -1205,7 +1205,7 @@ func TestDeleteProviderPreset(t *testing.T) {
 		{
 			Name:       "scenario 1: delete digitalocean preset",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "do-preset"},
 				TypeMeta:   metav1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8c.io/v1"},
@@ -1224,7 +1224,7 @@ func TestDeleteProviderPreset(t *testing.T) {
 		{
 			Name:       "scenario 2: delete digitalocean preset but keep the preset",
 			PresetName: "do-os-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.DigitaloceanCloudProvider, Enabled: true},
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "do-os-preset"},
 				TypeMeta:   metav1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8c.io/v1"},
@@ -1297,7 +1297,7 @@ func TestDeletePresetProvider(t *testing.T) {
 	testcases := []struct {
 		Name            string
 		PresetName      string
-		Provider        v2.PresetProvider
+		Provider        apiv2.PresetProvider
 		Body            string
 		ExistingPreset  *kubermaticv1.Preset
 		ExpectedPreset  *kubermaticv1.Preset
@@ -1308,7 +1308,7 @@ func TestDeletePresetProvider(t *testing.T) {
 		{
 			Name:       "scenario 1: delete aws provider",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.AWSCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.AWSCloudProvider, Enabled: true},
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "do-preset"},
 				TypeMeta:   metav1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8c.io/v1"},
@@ -1332,7 +1332,7 @@ func TestDeletePresetProvider(t *testing.T) {
 		{
 			Name:            "scenario 2: delete aws provider as non admin",
 			PresetName:      test.TestFakeCredential,
-			Provider:        v2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
+			Provider:        apiv2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
 			ExistingPreset:  test.GenDefaultPreset(),
 			HTTPStatus:      http.StatusForbidden,
 			ExistingAPIUser: test.GenDefaultAPIUser(),
@@ -1341,7 +1341,7 @@ func TestDeletePresetProvider(t *testing.T) {
 		{
 			Name:       "scenario 3: delete non-existing provider",
 			PresetName: "do-preset",
-			Provider:   v2.PresetProvider{Name: kubermaticv1.AWSCloudProvider, Enabled: true},
+			Provider:   apiv2.PresetProvider{Name: kubermaticv1.AWSCloudProvider, Enabled: true},
 			ExistingPreset: &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{Name: "do-preset"},
 				TypeMeta:   metav1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8c.io/v1"},
@@ -1354,7 +1354,7 @@ func TestDeletePresetProvider(t *testing.T) {
 		{
 			Name:            "scenario 4: delete provider from non-existing preset",
 			PresetName:      "non-existing-preset",
-			Provider:        v2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
+			Provider:        apiv2.PresetProvider{Name: kubermaticv1.OpenstackCloudProvider, Enabled: true},
 			ExistingPreset:  test.GenDefaultPreset(),
 			HTTPStatus:      http.StatusNotFound,
 			ExistingAPIUser: test.GenDefaultAdminAPIUser(),

--- a/pkg/handler/v2/provider/aks.go
+++ b/pkg/handler/v2/provider/aks.go
@@ -30,7 +30,6 @@ import (
 	externalcluster "k8c.io/kubermatic/v2/pkg/handler/v2/external_cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
@@ -244,7 +243,7 @@ func getAKSCredentialsFromReq(ctx context.Context, req AKSCommonReq, userInfoGet
 	if len(req.Credential) > 0 {
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}
 		if credentials := preset.Spec.AKS; credentials != nil {
 			subscriptionID = credentials.SubscriptionID
@@ -266,7 +265,7 @@ func AKSSizesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGett
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(aksNoCredentialReq)
 		if err := req.Validate(); err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 		return externalcluster.AKSSizesWithClusterCredentialsEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, clusterProvider, privilegedClusterProvider, settingsProvider, req.ProjectID, req.ClusterID, req.Location)
 	}

--- a/pkg/handler/v2/provider/azure.go
+++ b/pkg/handler/v2/provider/azure.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func AzureSizeWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -121,7 +121,7 @@ func getAzureCredentialsFromReq(ctx context.Context, req azureCommonReq, userInf
 	if len(req.Credential) > 0 {
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}
 		if credentials := preset.Spec.Azure; credentials != nil {
 			subscriptionID = credentials.SubscriptionID

--- a/pkg/handler/v2/provider/gcp.go
+++ b/pkg/handler/v2/provider/gcp.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gke"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // gcpTypesNoCredentialReq represent a request for GCP machine or disk types.
@@ -218,7 +218,7 @@ func GKEClustersEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GKE; credentials != nil {
 				sa = credentials.ServiceAccount
@@ -240,7 +240,7 @@ func GKEImagesEndpoint(presetProvider provider.PresetProvider, userInfoGetter pr
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GKE; credentials != nil {
 				sa = credentials.ServiceAccount
@@ -262,7 +262,7 @@ func GKEValidateCredentialsEndpoint(presetProvider provider.PresetProvider, user
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.GKE; credentials != nil {
 				sa = credentials.ServiceAccount

--- a/pkg/handler/v2/provider/kubevirt.go
+++ b/pkg/handler/v2/provider/kubevirt.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // KubeVirtGenericReq represent a request with common parameters for KubeVirt.
@@ -60,7 +60,7 @@ func KubeVirtVMIPresetsEndpoint(presetsProvider provider.PresetProvider, userInf
 		if len(req.Credential) > 0 {
 			preset, err := presetsProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Kubevirt; credentials != nil {
 				kubeconfig = credentials.Kubeconfig
@@ -91,7 +91,7 @@ func KubeVirtStorageClassesEndpoint(presetsProvider provider.PresetProvider, use
 		if len(req.Credential) > 0 {
 			preset, err := presetsProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.Kubevirt; credentials != nil {
 				kubeconfig = credentials.Kubeconfig

--- a/pkg/handler/v2/provider/nutanix.go
+++ b/pkg/handler/v2/provider/nutanix.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 type NutanixCommonReq struct {
@@ -216,7 +216,7 @@ func NutanixClusterEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 
 		clusters, err := client.ListNutanixClusters(ctx)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list clusters: %s", err.Error()))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list clusters: %s", err.Error()))
 		}
 
 		return clusters, nil
@@ -235,7 +235,7 @@ func NutanixProjectEndpoint(presetProvider provider.PresetProvider, seedsGetter 
 
 		projects, err := client.ListNutanixProjects(ctx)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list projects: %s", err.Error()))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list projects: %s", err.Error()))
 		}
 
 		return projects, nil
@@ -262,7 +262,7 @@ func NutanixSubnetEndpoint(presetProvider provider.PresetProvider, seedsGetter p
 
 		subnets, err := client.ListNutanixSubnets(ctx, cluster, project)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list subnets: %s", err.Error()))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list subnets: %s", err.Error()))
 		}
 
 		return subnets, nil
@@ -280,7 +280,7 @@ func NutanixCategoryEndpoint(presetProvider provider.PresetProvider, seedsGetter
 
 		categories, err := client.ListNutanixCategories(ctx)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list categories: %s", err.Error()))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list categories: %s", err.Error()))
 		}
 
 		return categories, nil
@@ -298,7 +298,7 @@ func NutanixCategoryValuesEndpoint(presetProvider provider.PresetProvider, seeds
 
 		categories, err := client.ListNutanixCategoryValues(ctx, req.Category)
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list category values for '%s': %s", req.Category, err.Error()))
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot list category values for '%s': %s", req.Category, err.Error()))
 		}
 
 		return categories, nil
@@ -322,7 +322,7 @@ func getNutanixClient(ctx context.Context, req NutanixCommonReq, presetProvider 
 	if len(req.Credential) > 0 {
 		preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 		if err != nil {
-			return nil, nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+			return nil, nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 		}
 		if credential = preset.Spec.Nutanix; credential != nil {
 			creds.ProxyURL = credential.ProxyURL
@@ -332,15 +332,15 @@ func getNutanixClient(ctx context.Context, req NutanixCommonReq, presetProvider 
 	}
 
 	if creds.Username == "" || creds.Password == "" {
-		return nil, nil, errors.NewBadRequest("no valid credentials found")
+		return nil, nil, utilerrors.NewBadRequest("no valid credentials found")
 	}
 
 	_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.DC)
 	if err != nil {
-		return nil, nil, errors.NewBadRequest(err.Error())
+		return nil, nil, utilerrors.NewBadRequest(err.Error())
 	}
 	if dc.Spec.Nutanix == nil {
-		return nil, nil, errors.NewBadRequest("datacenter '%s' is not a Nutanix datacenter", req.DC)
+		return nil, nil, utilerrors.NewBadRequest("datacenter '%s' is not a Nutanix datacenter", req.DC)
 	}
 
 	client := providercommon.NewNutanixClient(dc.Spec.Nutanix, &creds)

--- a/pkg/handler/v2/provider/nutanix.go
+++ b/pkg/handler/v2/provider/nutanix.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
-	v1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
@@ -305,14 +305,14 @@ func NutanixCategoryValuesEndpoint(presetProvider provider.PresetProvider, seeds
 	}
 }
 
-func getNutanixClient(ctx context.Context, req NutanixCommonReq, presetProvider provider.PresetProvider, seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter) (providercommon.NutanixClientSet, *v1.Nutanix, error) {
+func getNutanixClient(ctx context.Context, req NutanixCommonReq, presetProvider provider.PresetProvider, seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter) (providercommon.NutanixClientSet, *kubermaticv1.Nutanix, error) {
 	creds := providercommon.NutanixCredentials{
 		ProxyURL: req.NutanixProxyURL,
 		Username: req.NutanixUsername,
 		Password: req.NutanixPassword,
 	}
 
-	var credential *v1.Nutanix
+	var credential *kubermaticv1.Nutanix
 
 	userInfo, err := userInfoGetter(ctx, "")
 	if err != nil {

--- a/pkg/handler/v2/provider/vsphere.go
+++ b/pkg/handler/v2/provider/vsphere.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func VsphereNetworksWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider,
@@ -69,7 +69,7 @@ func VsphereDatastoreEndpoint(seedsGetter provider.SeedsGetter, presetProvider p
 		if len(req.Credential) > 0 {
 			preset, err := presetProvider.GetPreset(ctx, userInfo, req.Credential)
 			if err != nil {
-				return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
+				return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", req.Credential, userInfo.Email))
 			}
 			if credentials := preset.Spec.VSphere; credentials != nil {
 				username = credentials.Username

--- a/pkg/handler/v2/seedsettings/seedsettings.go
+++ b/pkg/handler/v2/seedsettings/seedsettings.go
@@ -28,7 +28,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	k8cerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // getSeedSettingsReq defines HTTP request for getSeedSettings
@@ -54,7 +54,7 @@ func GetSeedSettingsEndpoint(seedsGetter provider.SeedsGetter) endpoint.Endpoint
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(getSeedSettingsReq)
 		if !ok {
-			return nil, k8cerrors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
 		seedMap, err := seedsGetter()
@@ -63,7 +63,7 @@ func GetSeedSettingsEndpoint(seedsGetter provider.SeedsGetter) endpoint.Endpoint
 		}
 		seed, ok := seedMap[req.Name]
 		if !ok {
-			return nil, k8cerrors.NewNotFound("Seed", req.Name)
+			return nil, utilerrors.NewNotFound("Seed", req.Name)
 		}
 		return convertSeedToSeedSettings(seed), nil
 	}

--- a/pkg/handler/v2/user/user.go
+++ b/pkg/handler/v2/user/user.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
@@ -46,9 +46,9 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, userProvider provider.
 			return nil, err
 		}
 
-		result := make([]v1.User, 0)
+		result := make([]apiv1.User, 0)
 		for _, crdUser := range list {
-			apiUser := v1.ConvertInternalUserToExternal(&crdUser, false)
+			apiUser := apiv1.ConvertInternalUserToExternal(&crdUser, false)
 			result = append(result, *apiUser)
 		}
 

--- a/pkg/handler/v2/user/user.go
+++ b/pkg/handler/v2/user/user.go
@@ -26,7 +26,7 @@ import (
 	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 func ListEndpoint(userInfoGetter provider.UserInfoGetter, userProvider provider.UserProvider) endpoint.Endpoint {
@@ -37,7 +37,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, userProvider provider.
 		}
 
 		if !userInfo.IsAdmin {
-			return nil, errors.New(http.StatusForbidden,
+			return nil, utilerrors.New(http.StatusForbidden,
 				fmt.Sprintf("forbidden: \"%s\" doesn't have admin rights", userInfo.Email))
 		}
 

--- a/pkg/handler/v2/version/version.go
+++ b/pkg/handler/v2/version/version.go
@@ -27,7 +27,7 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version"
 )
 
@@ -74,11 +74,11 @@ func ListVersions(configGetter provider.KubermaticConfigurationGetter) endpoint.
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(listProviderVersionsReq)
 		if !ok {
-			return nil, errors.NewBadRequest("invalid request")
+			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 		err := req.Validate()
 		if err != nil {
-			return nil, errors.NewBadRequest(err.Error())
+			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		config, err := configGetter(ctx)
@@ -88,7 +88,7 @@ func ListVersions(configGetter provider.KubermaticConfigurationGetter) endpoint.
 
 		versions, err := version.NewFromConfiguration(config).GetVersionsForProvider(kubermaticv1.ProviderType(req.ProviderName))
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, err.Error())
+			return nil, utilerrors.New(http.StatusInternalServerError, err.Error())
 		}
 
 		masterVersions := make([]*apiv1.MasterVersion, len(versions))

--- a/pkg/handler/v2/version/version_test.go
+++ b/pkg/handler/v2/version/version_test.go
@@ -23,7 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -57,16 +57,16 @@ func TestGetClusterUpgrades(t *testing.T) {
 			provider: kubermaticv1.AWSCloudProvider,
 			wantVersions: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 				},
 				{
-					Version: semver.MustParse("1.21.1"),
+					Version: semverlib.MustParse("1.21.1"),
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 				},
 				{
-					Version: semver.MustParse("1.22.1"),
+					Version: semverlib.MustParse("1.22.1"),
 				},
 			},
 			versions: []k8csemver.Semver{
@@ -107,10 +107,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 			provider: kubermaticv1.VSphereCloudProvider,
 			wantVersions: []*apiv1.MasterVersion{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 				},
 				{
-					Version: semver.MustParse("1.21.1"),
+					Version: semverlib.MustParse("1.21.1"),
 				},
 			},
 			versions: []k8csemver.Semver{

--- a/pkg/handler/websocket/settings.go
+++ b/pkg/handler/websocket/settings.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	api "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/watcher"
@@ -36,7 +36,7 @@ func WriteSettings(ctx context.Context, providers watcher.Providers, ws *websock
 		return
 	}
 
-	initialResponse, err := json.Marshal(api.GlobalSettings(initialSettings.Spec))
+	initialResponse, err := json.Marshal(apiv1.GlobalSettings(initialSettings.Spec))
 	if err != nil {
 		log.Logger.Debug(err)
 		return
@@ -50,10 +50,10 @@ func WriteSettings(ctx context.Context, providers watcher.Providers, ws *websock
 	unSub := providers.SettingsWatcher.Subscribe(func(settings interface{}) {
 		var response []byte
 		if settings != nil {
-			var externalSettings api.GlobalSettings
+			var externalSettings apiv1.GlobalSettings
 			internalSettings, ok := settings.(*kubermaticv1.KubermaticSetting)
 			if ok {
-				externalSettings = api.GlobalSettings(internalSettings.Spec)
+				externalSettings = apiv1.GlobalSettings(internalSettings.Spec)
 			} else {
 				log.Logger.Debug("cannot convert settings: %v", settings)
 			}

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/watcher"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -143,7 +143,7 @@ func startProcess(k8sClient kubernetes.Interface, cfg *rest.Config, namespace, p
 		Namespace(namespace).
 		SubResource("exec")
 
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Command: cmd,
 		Stdin:   true,
 		Stdout:  true,

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
@@ -161,7 +161,7 @@ func (c *cli) ListReleases(namespace string) ([]Release, error) {
 	return releases, nil
 }
 
-func guessChartName(fullChart string) (*semver.Version, string, error) {
+func guessChartName(fullChart string) (*semverlib.Version, string, error) {
 	parts := strings.Split(fullChart, "-")
 	if len(parts) == 1 {
 		return nil, "", fmt.Errorf("%q is too short to be <chart>-<version>", fullChart)
@@ -174,7 +174,7 @@ func guessChartName(fullChart string) (*semver.Version, string, error) {
 		versionString := strings.Join(parts, "-")
 
 		// have we found a valid version?
-		version, err := semver.NewVersion(versionString)
+		version, err := semverlib.NewVersion(versionString)
 		if err == nil {
 			return version, chartName, nil
 		}
@@ -217,7 +217,7 @@ func (c *cli) GetValues(namespace string, releaseName string) (*yamled.Document,
 	return yamled.Load(bytes.NewReader(output))
 }
 
-func (c *cli) Version() (*semver.Version, error) {
+func (c *cli) Version() (*semverlib.Version, error) {
 	// add --client to gracefully handle Helm 2 (Helm 3 ignores the flag, thankfully);
 	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
 	// Helm-2-style templating string "{{ .Client.SemVer }}"
@@ -231,7 +231,7 @@ func (c *cli) Version() (*semver.Version, error) {
 		out = "v2.99.99"
 	}
 
-	return semver.NewVersion(out)
+	return semverlib.NewVersion(out)
 }
 
 func (c *cli) run(namespace string, args ...string) ([]byte, error) {

--- a/pkg/install/helm/cli_test.go
+++ b/pkg/install/helm/cli_test.go
@@ -19,13 +19,13 @@ package helm
 import (
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 )
 
 func TestGuessReleaseVersion(t *testing.T) {
 	testcases := []struct {
 		input           string
-		expectedVersion *semver.Version
+		expectedVersion *semverlib.Version
 		expectedChart   string
 	}{
 		{
@@ -40,22 +40,22 @@ func TestGuessReleaseVersion(t *testing.T) {
 		},
 		{
 			input:           "foo-1.2.3",
-			expectedVersion: semver.MustParse("1.2.3"),
+			expectedVersion: semverlib.MustParse("1.2.3"),
 			expectedChart:   "foo",
 		},
 		{
 			input:           "foo-bar-1.2.3",
-			expectedVersion: semver.MustParse("1.2.3"),
+			expectedVersion: semverlib.MustParse("1.2.3"),
 			expectedChart:   "foo-bar",
 		},
 		{
 			input:           "foo-bar-super-long-release-name-1.2.3",
-			expectedVersion: semver.MustParse("1.2.3"),
+			expectedVersion: semverlib.MustParse("1.2.3"),
 			expectedChart:   "foo-bar-super-long-release-name",
 		},
 		{
 			input:           "foo-bar-super-long-release-name-1.2.3-suffix-really-long",
-			expectedVersion: semver.MustParse("1.2.3-suffix-really-long"),
+			expectedVersion: semverlib.MustParse("1.2.3-suffix-really-long"),
 			expectedChart:   "foo-bar-super-long-release-name",
 		},
 		{

--- a/pkg/install/helm/interface.go
+++ b/pkg/install/helm/interface.go
@@ -17,7 +17,7 @@ limitations under the License.
 package helm
 
 import (
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
@@ -26,7 +26,7 @@ import (
 // the installer. This is the minimum set of operations required to
 // perform a Kubermatic installation.
 type Client interface {
-	Version() (*semver.Version, error)
+	Version() (*semverlib.Version, error)
 	BuildChartDependencies(chartDirectory string, flags []string) error
 	InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error
 	GetRelease(namespace string, name string) (*Release, error)

--- a/pkg/install/helm/types.go
+++ b/pkg/install/helm/types.go
@@ -21,16 +21,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v2"
 )
 
 type Release struct {
-	Name      string          `json:"name"`
-	Namespace string          `json:"namespace"`
-	Chart     string          `json:"chart"`
-	Revision  string          `json:"revision"`
-	Version   *semver.Version `json:"-"`
+	Name      string             `json:"name"`
+	Namespace string             `json:"namespace"`
+	Chart     string             `json:"chart"`
+	Revision  string             `json:"revision"`
+	Version   *semverlib.Version `json:"-"`
 	// AppVersion is not a semver, for example Minio has date-based versions.
 	AppVersion string        `json:"app_version"`
 	Status     ReleaseStatus `json:"status"`
@@ -38,15 +38,15 @@ type Release struct {
 
 func (r *Release) Clone() Release {
 	releaseCopy := *r
-	releaseCopy.Version = semver.MustParse(r.Version.Original())
+	releaseCopy.Version = semverlib.MustParse(r.Version.Original())
 
 	return releaseCopy
 }
 
 type Chart struct {
-	Name       string          `yaml:"name"`
-	Version    *semver.Version `yaml:"-"`
-	VersionRaw string          `yaml:"version"`
+	Name       string             `yaml:"name"`
+	Version    *semverlib.Version `yaml:"-"`
+	VersionRaw string             `yaml:"version"`
 	// AppVersion is not a semver, for example Minio has date-based versions.
 	AppVersion   string `yaml:"appVersion"`
 	Directory    string
@@ -55,7 +55,7 @@ type Chart struct {
 
 func (c *Chart) Clone() Chart {
 	chartCopy := *c
-	chartCopy.Version = semver.MustParse(c.Version.Original())
+	chartCopy.Version = semverlib.MustParse(c.Version.Original())
 
 	return chartCopy
 }
@@ -72,7 +72,7 @@ func LoadChart(directory string) (*Chart, error) {
 		return nil, fmt.Errorf("failed to read Chart.yaml: %w", err)
 	}
 
-	version, err := semver.NewVersion(chart.VersionRaw)
+	version, err := semverlib.NewVersion(chart.VersionRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %q: %w", chart.VersionRaw, err)
 	}

--- a/pkg/install/stack/common/validation.go
+++ b/pkg/install/stack/common/validation.go
@@ -22,7 +22,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -53,7 +53,7 @@ func ValidateAllUserClustersAreCompatible(ctx context.Context, seed *kubermaticv
 	}
 
 	configuredVersions := defaulted.Spec.Versions
-	upgradeConstraints := []*semver.Constraints{}
+	upgradeConstraints := []*semverlib.Constraints{}
 
 	// do not parse and check the validity of constraints for each usercluster, but just once
 	for i, update := range configuredVersions.Updates {
@@ -63,7 +63,7 @@ func ValidateAllUserClustersAreCompatible(ctx context.Context, seed *kubermaticv
 			continue
 		}
 
-		from, err := semver.NewConstraint(update.From)
+		from, err := semverlib.NewConstraint(update.From)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("`from` constraint %q for update rule %d is invalid: %w", update.From, i, err))
 			continue

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/sirupsen/logrus"
@@ -80,8 +80,8 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 	// if a pre-2.0 version of the chart is installed, we must perform a
 	// larger migration to bring the cluster from cert-manager 0.16 to 1.x
 	// (and its CRD from v1alpha2 to v1)
-	v2 := semver.MustParse("2.0.0")  // New CRDs - migration required
-	v21 := semver.MustParse("2.1.0") // Updated to use upstream chart - different label selectors
+	v2 := semverlib.MustParse("2.0.0")  // New CRDs - migration required
+	v21 := semverlib.MustParse("2.1.0") // Updated to use upstream chart - different label selectors
 
 	if release != nil && release.Version.LessThan(v2) && !chart.Version.LessThan(v2) {
 		if !opt.EnableCertManagerV2Migration {

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -495,11 +494,11 @@ func preparePreV21CertManagerDeployment(
 		Version: "v1",
 	})
 
-	certManagerObjectsSelector := client.MatchingLabels{
+	certManagerObjectsSelector := ctrlruntimeclient.MatchingLabels{
 		"app.kubernetes.io/managed-by": "Helm",
 	}
 
-	if err := kubeClient.List(ctx, clusterIssuersList, client.InNamespace(CertManagerNamespace), certManagerObjectsSelector); err != nil {
+	if err := kubeClient.List(ctx, clusterIssuersList, ctrlruntimeclient.InNamespace(CertManagerNamespace), certManagerObjectsSelector); err != nil {
 		return fmt.Errorf("failed to query kubernetes API: %w", err)
 	}
 

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -38,7 +38,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -214,7 +214,7 @@ func migrateCertManagerV2(
 		crd.Name = crdName(crdGVK)
 
 		if err := kubeClient.Delete(ctx, &crd); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 
@@ -260,7 +260,7 @@ func migrateCertManagerV2(
 		// only log errors, but continue, as the user can easily fix
 		// problems by using the YAML backup files
 		if err := kubeClient.Create(ctx, &object); err != nil {
-			if kerrors.IsAlreadyExists(err) {
+			if apierrors.IsAlreadyExists(err) {
 				logger.Warn("  already exists, please compare to backup")
 			} else {
 				logger.Errorf("  failed: %v", err)
@@ -359,7 +359,7 @@ func getSecretForCertificate(ctx context.Context, kubeClient ctrlruntimeclient.C
 		Name:      cert.Spec.SecretName,
 		Namespace: cert.Namespace,
 	}, secret); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 
@@ -460,7 +460,7 @@ func deleteCertificate(ctx context.Context, kubeClient ctrlruntimeclient.Client,
 	}
 
 	if err := kubeClient.Get(ctx, key, cert); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -130,12 +129,12 @@ func upgradeNginxIngress(
 		Version: "v1",
 	})
 
-	nginxMatcher := client.MatchingLabels{
+	nginxMatcher := ctrlruntimeclient.MatchingLabels{
 		"app.kubernetes.io/name":       "ingress-nginx",
 		"app.kubernetes.io/managed-by": "Helm",
 		"app.kubernetes.io/instance":   release.Name,
 	}
-	if err := kubeClient.List(ctx, deploymentsList, client.InNamespace(NginxIngressControllerNamespace), nginxMatcher); err != nil {
+	if err := kubeClient.List(ctx, deploymentsList, ctrlruntimeclient.InNamespace(NginxIngressControllerNamespace), nginxMatcher); err != nil {
 		return fmt.Errorf("Error querying API for the existing Deployment object, aborting upgrade process.")
 	}
 	// 2: store the deployment for backup

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -225,7 +225,7 @@ func deleteIngress(ctx context.Context, kubeClient ctrlruntimeclient.Client, nam
 	}
 
 	if err := kubeClient.Get(ctx, key, ingress); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
 	"k8c.io/kubermatic/v2/pkg/features"
@@ -66,7 +66,7 @@ func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kub
 
 	// if version older than 1.3.0 is installed, we must perform a migration
 	// by deleting the old deployment object for the controller
-	v13 := semver.MustParse("1.3.0")
+	v13 := semverlib.MustParse("1.3.0")
 	backupTS := time.Now().Format("2006-01-02T150405")
 
 	isUpgrading := false

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -36,7 +36,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,7 +167,7 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 		return nil
 	}
 
-	if !kerrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to check for StorageClass %s: %w", StorageClassName, err)
 	}
 
@@ -304,7 +304,7 @@ func applyKubermaticConfiguration(ctx context.Context, logger *logrus.Entry, kub
 	}
 
 	err := kubeClient.Get(ctx, name, existingConfig)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to check for existing KubermaticConfiguration: %w", err)
 	}
 

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
@@ -102,10 +102,10 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 	return errs
 }
 
-func getAutoUpdateConstraints(defaultedConfig *kubermaticv1.KubermaticConfiguration) ([]*semver.Constraints, []error) {
+func getAutoUpdateConstraints(defaultedConfig *kubermaticv1.KubermaticConfiguration) ([]*semverlib.Constraints, []error) {
 	var errs []error
 
-	upgradeConstraints := []*semver.Constraints{}
+	upgradeConstraints := []*semverlib.Constraints{}
 
 	for i, update := range defaultedConfig.Spec.Versions.Updates {
 		// only consider automated updates, otherwise we might accept an unsupported
@@ -114,7 +114,7 @@ func getAutoUpdateConstraints(defaultedConfig *kubermaticv1.KubermaticConfigurat
 			continue
 		}
 
-		from, err := semver.NewConstraint(update.From)
+		from, err := semverlib.NewConstraint(update.From)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("`from` constraint %q for update rule %d is invalid: %w", update.From, i, err))
 			continue
@@ -126,7 +126,7 @@ func getAutoUpdateConstraints(defaultedConfig *kubermaticv1.KubermaticConfigurat
 	return upgradeConstraints, errs
 }
 
-func clusterVersionIsConfigured(version k8csemver.Semver, defaultedConfig *kubermaticv1.KubermaticConfiguration, constraints []*semver.Constraints) bool {
+func clusterVersionIsConfigured(version k8csemver.Semver, defaultedConfig *kubermaticv1.KubermaticConfiguration, constraints []*semverlib.Constraints) bool {
 	// is this version still straight up supported?
 	for _, configured := range defaultedConfig.Spec.Versions.Versions {
 		if configured.Equal(&version) {

--- a/pkg/install/stack/kubermatic-seed/migrations.go
+++ b/pkg/install/stack/kubermatic-seed/migrations.go
@@ -28,7 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -77,7 +77,7 @@ func deleteCSIDriver(ctx context.Context, kubeClient ctrlruntimeclient.Client, n
 	drv := storagev1.CSIDriver{}
 
 	err := kubeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: name}, &drv)
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {
@@ -108,7 +108,7 @@ func deleteLogrotateAddon(ctx context.Context, kubeClient ctrlruntimeclient.Clie
 	addon := kubermaticv1.Addon{}
 
 	err := kubeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: name, Namespace: namespace}, &addon)
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -34,7 +34,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -109,7 +109,7 @@ func (s *SeedStack) deployKubermatic(ctx context.Context, logger *logrus.Entry, 
 		},
 	}
 
-	if err := kubeClient.Create(ctx, ns); err != nil && !kerrors.IsAlreadyExists(err) {
+	if err := kubeClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create Namespace %s: %w", ns.Name, err)
 	}
 
@@ -142,7 +142,7 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 		return nil
 	}
 
-	if !kerrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to check for StorageClass %s: %w", common.StorageClassName, err)
 	}
 

--- a/pkg/install/util/crd.go
+++ b/pkg/install/util/crd.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/crd"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,7 +63,7 @@ func DeployCRD(ctx context.Context, kubeClient ctrlruntimeclient.Client, crd ctr
 	}
 
 	// CRD does not exist already, but creating failed for another reason
-	if !kerrors.IsAlreadyExists(err) {
+	if !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -107,7 +107,7 @@ func HasReadyCRD(ctx context.Context, kubeClient ctrlruntimeclient.Client, crdNa
 	if err := kubeClient.Get(ctx, name, retrievedCRD); err != nil {
 		// in theory this should never happen after the .Create() call above
 		// has succeeded, but it can happen temporarily
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 
@@ -135,7 +135,7 @@ func WaitForCRDGone(ctx context.Context, kubeClient ctrlruntimeclient.Client, cr
 		name := types.NamespacedName{Name: crdName}
 
 		if err := kubeClient.Get(ctx, name, retrievedCRD); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return true, nil
 			}
 

--- a/pkg/install/util/kubernetes.go
+++ b/pkg/install/util/kubernetes.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -36,7 +36,7 @@ func EnsureNamespace(ctx context.Context, log logrus.FieldLogger, kubeClient ctr
 		},
 	}
 
-	if err := kubeClient.Create(ctx, &ns); err != nil && !kerrors.IsAlreadyExists(err) {
+	if err := kubeClient.Create(ctx, &ns); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 

--- a/pkg/install/util/migrations.go
+++ b/pkg/install/util/migrations.go
@@ -28,7 +28,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
@@ -44,7 +44,7 @@ func ShutdownDeployment(ctx context.Context, logger logrus.FieldLogger, client c
 	key := types.NamespacedName{Name: name, Namespace: namespace}
 
 	if err := client.Get(ctx, key, &deployment); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			depLogger.Debug("Deployment not found.")
 			return nil
 		}
@@ -126,7 +126,7 @@ func removeWebhook(ctx context.Context, logger logrus.FieldLogger, client ctrlru
 	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(obj), obj); err != nil {
 		// not all webhooks need to exist in all clusters / maybe we already cleaned up
 		// because the user ran the "shutdown" command twice
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debug("Webhook not found.")
 			return nil
 		}

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -31,7 +31,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,7 +81,7 @@ func TryRemoveFinalizer(ctx context.Context, client ctrlruntimeclient.Client, ob
 		if err := client.Get(ctx, key, obj); err != nil {
 			// finalizer removal normally happens during object cleanup, so if
 			// the object is gone already, that is absolutely fine
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil
 			}
 			return err

--- a/pkg/provider/cloud/aws/api.go
+++ b/pkg/provider/cloud/aws/api.go
@@ -28,7 +28,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	httperror "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // The functions in this file are used throughout KKP, mostly in our REST API.
@@ -73,7 +73,7 @@ func GetVPCS(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, a
 
 	if err != nil {
 		if ok, msg := isAuthFailure(err); ok {
-			return nil, httperror.New(401, fmt.Sprintf("failed to list VPCs: %s", msg))
+			return nil, utilerrors.New(401, fmt.Sprintf("failed to list VPCs: %s", msg))
 		}
 
 		return nil, fmt.Errorf("failed to list VPCs: %w", err)
@@ -92,7 +92,7 @@ func GetSecurityGroupsByVPC(ctx context.Context, accessKeyID, secretAccessKey, a
 
 	if err != nil {
 		if ok, msg := isAuthFailure(err); ok {
-			return nil, httperror.New(401, fmt.Sprintf("failed to list security groups: %s", msg))
+			return nil, utilerrors.New(401, fmt.Sprintf("failed to list security groups: %s", msg))
 		}
 
 		return nil, fmt.Errorf("failed to list security groups: %w", err)
@@ -131,7 +131,7 @@ func getSecurityGroupsWithClient(ctx context.Context, client ec2iface.EC2API) ([
 
 	if err != nil {
 		if ok, msg := isAuthFailure(err); ok {
-			return nil, httperror.New(401, fmt.Sprintf("failed to list security groups: %s", msg))
+			return nil, utilerrors.New(401, fmt.Sprintf("failed to list security groups: %s", msg))
 		}
 
 		return nil, fmt.Errorf("failed to list security groups: %w", err)

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,7 +121,7 @@ func (k *kubevirt) CleanUpCloudProvider(ctx context.Context, cluster *kubermatic
 	}
 
 	if kuberneteshelper.HasFinalizer(cluster, FinalizerNamespace) {
-		if err := deleteNamespace(ctx, cluster.Status.NamespaceName, client); err != nil && !kerrors.IsNotFound(err) {
+		if err := deleteNamespace(ctx, cluster.Status.NamespaceName, client); err != nil && !apierrors.IsNotFound(err) {
 			return cluster, fmt.Errorf("failed to delete namespace %s: %w", cluster.Status.NamespaceName, err)
 		}
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {

--- a/pkg/provider/conversions.go
+++ b/pkg/provider/conversions.go
@@ -22,7 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/util/email"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // DatacenterFromSeedMap returns datacenter from the seed:datacenter map.
@@ -35,7 +35,7 @@ import (
 func DatacenterFromSeedMap(userInfo *UserInfo, seedsGetter SeedsGetter, datacenterName string) (*kubermaticv1.Seed, *kubermaticv1.Datacenter, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
-		return nil, nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
 
 	var matchingDatacenters []kubermaticv1.Datacenter
@@ -48,11 +48,11 @@ func DatacenterFromSeedMap(userInfo *UserInfo, seedsGetter SeedsGetter, datacent
 	}
 
 	if len(matchingDatacenters) == 0 {
-		return nil, nil, errors.New(http.StatusNotFound, fmt.Sprintf("datacenter %q not found", datacenterName))
+		return nil, nil, utilerrors.New(http.StatusNotFound, fmt.Sprintf("datacenter %q not found", datacenterName))
 	}
 
 	if count := len(matchingDatacenters); count > 1 {
-		return nil, nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("expected to find exactly one datacenter with name %q, got %d", datacenterName, count))
+		return nil, nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("expected to find exactly one datacenter with name %q, got %d", datacenterName, count))
 	}
 
 	matchingDatacenter := matchingDatacenters[0]
@@ -60,7 +60,7 @@ func DatacenterFromSeedMap(userInfo *UserInfo, seedsGetter SeedsGetter, datacent
 
 	if !userInfo.IsAdmin {
 		if !canAccessDatacenter(matchingDatacenter, userInfo.Email) {
-			return nil, nil, errors.New(http.StatusForbidden, fmt.Sprintf("cannot access %s datacenter due to email requirements", datacenterName))
+			return nil, nil, utilerrors.New(http.StatusForbidden, fmt.Sprintf("cannot access %s datacenter due to email requirements", datacenterName))
 		}
 	}
 

--- a/pkg/provider/kubernetes/addon.go
+++ b/pkg/provider/kubernetes/addon.go
@@ -24,7 +24,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,7 +76,7 @@ func (p *AddonProvider) checkAddonAccessible(ctx context.Context, addonName stri
 	}
 
 	if !accessible.Has(addonName) {
-		return kerrors.NewUnauthorized(fmt.Sprintf("addon not accessible: %v", addonName))
+		return apierrors.NewUnauthorized(fmt.Sprintf("addon not accessible: %v", addonName))
 	}
 
 	return nil

--- a/pkg/provider/kubernetes/admin.go
+++ b/pkg/provider/kubernetes/admin.go
@@ -24,7 +24,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,7 +47,7 @@ var _ provider.AdminProvider = &AdminProvider{}
 func (a *AdminProvider) GetAdmins(ctx context.Context, userInfo *provider.UserInfo) ([]kubermaticv1.User, error) {
 	var adminList []kubermaticv1.User
 	if !userInfo.IsAdmin {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+		return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 	}
 	users := &kubermaticv1.UserList{}
 	if err := a.client.List(ctx, users); err != nil {
@@ -66,10 +66,10 @@ func (a *AdminProvider) GetAdmins(ctx context.Context, userInfo *provider.UserIn
 // SetAdmin set/clear admin rights.
 func (a *AdminProvider) SetAdmin(ctx context.Context, userInfo *provider.UserInfo, email string, isAdmin bool) (*kubermaticv1.User, error) {
 	if !userInfo.IsAdmin {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+		return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 	}
 	if strings.EqualFold(userInfo.Email, email) {
-		return nil, kerrors.NewBadRequest("can not change own privileges")
+		return nil, apierrors.NewBadRequest("can not change own privileges")
 	}
 	userList := &kubermaticv1.UserList{}
 	if err := a.client.List(ctx, userList); err != nil {

--- a/pkg/provider/kubernetes/admission_plugin.go
+++ b/pkg/provider/kubernetes/admission_plugin.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -63,7 +63,7 @@ func (p *AdmissionPluginsProvider) ListPluginNamesFromVersion(ctx context.Contex
 	}
 
 	plugins := []string{}
-	v, err := semver.NewVersion(fromVersion)
+	v, err := semverlib.NewVersion(fromVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/kubernetes/admission_plugin.go
+++ b/pkg/provider/kubernetes/admission_plugin.go
@@ -25,7 +25,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -83,7 +83,7 @@ func (p *AdmissionPluginsProvider) ListPluginNamesFromVersion(ctx context.Contex
 
 func (p *AdmissionPluginsProvider) List(ctx context.Context, userInfo *provider.UserInfo) ([]kubermaticv1.AdmissionPlugin, error) {
 	if !userInfo.IsAdmin {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+		return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 	}
 	admissionPluginList, err := p.admissionPluginsGetter(ctx)
 	if err != nil {
@@ -94,7 +94,7 @@ func (p *AdmissionPluginsProvider) List(ctx context.Context, userInfo *provider.
 
 func (p *AdmissionPluginsProvider) Get(ctx context.Context, userInfo *provider.UserInfo, name string) (*kubermaticv1.AdmissionPlugin, error) {
 	if !userInfo.IsAdmin {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+		return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 	}
 	admissionPluginList, err := p.admissionPluginsGetter(ctx)
 	if err != nil {
@@ -105,7 +105,7 @@ func (p *AdmissionPluginsProvider) Get(ctx context.Context, userInfo *provider.U
 			return &plugin, nil
 		}
 	}
-	return nil, kerrors.NewNotFound(schema.GroupResource{}, name)
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
 }
 
 func (p *AdmissionPluginsProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, name string) error {

--- a/pkg/provider/kubernetes/alertmanager_test.go
+++ b/pkg/provider/kubernetes/alertmanager_test.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -287,7 +287,7 @@ func TestResetAlertmanager(t *testing.T) {
 					Name:      alertmanager.Spec.ConfigSecret.Name,
 					Namespace: alertmanager.Namespace,
 				}, configSecret)
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 				assert.Equal(t, tc.expectedAlertmanager, alertmanager)
 			} else {
 				if err == nil {

--- a/pkg/provider/kubernetes/cluster.go
+++ b/pkg/provider/kubernetes/cluster.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -279,7 +279,7 @@ func (p *ClusterProvider) Get(ctx context.Context, userInfo *provider.UserInfo, 
 	}
 	if options.CheckInitStatus {
 		if !cluster.Status.ExtendedHealth.AllHealthy() {
-			return nil, kerrors.NewServiceUnavailable("Cluster components are not ready yet")
+			return nil, apierrors.NewServiceUnavailable("Cluster components are not ready yet")
 		}
 	}
 
@@ -457,13 +457,13 @@ func (p *ClusterProvider) GetUnsecured(ctx context.Context, project *kubermaticv
 	if cluster.Labels[kubermaticv1.ProjectIDLabelKey] == project.Name {
 		if options.CheckInitStatus {
 			if !cluster.Status.ExtendedHealth.AllHealthy() {
-				return nil, kerrors.NewServiceUnavailable("Cluster components are not ready yet")
+				return nil, apierrors.NewServiceUnavailable("Cluster components are not ready yet")
 			}
 		}
 		return cluster, nil
 	}
 
-	return nil, kerrors.NewNotFound(schema.GroupResource{}, clusterName)
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, clusterName)
 }
 
 // UpdateUnsecured updates a cluster.

--- a/pkg/provider/kubernetes/cluster_template.go
+++ b/pkg/provider/kubernetes/cluster_template.go
@@ -25,7 +25,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	kubermaticerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/labels"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -131,10 +131,10 @@ func (p *ClusterTemplateProvider) Get(ctx context.Context, userInfo *provider.Us
 	}
 
 	if result.Labels[kubermaticv1.ClusterTemplateScopeLabelKey] == kubermaticv1.UserClusterTemplateScope && !strings.EqualFold(result.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey], userInfo.Email) {
-		return nil, kubermaticerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't access template %s", userInfo.Email, templateID))
+		return nil, utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't access template %s", userInfo.Email, templateID))
 	}
 	if projectID != "" && result.Labels[kubermaticv1.ProjectIDLabelKey] != projectID && result.Labels[kubermaticv1.ClusterTemplateScopeLabelKey] == kubermaticv1.ProjectClusterTemplateScope {
-		return nil, kubermaticerrors.New(http.StatusForbidden, fmt.Sprintf("cluster template doesn't belong to the project %s", projectID))
+		return nil, utilerrors.New(http.StatusForbidden, fmt.Sprintf("cluster template doesn't belong to the project %s", projectID))
 	}
 
 	return result, nil
@@ -155,7 +155,7 @@ func (p *ClusterTemplateProvider) Delete(ctx context.Context, userInfo *provider
 
 	// only admin can delete global templates
 	if !userInfo.IsAdmin && result.Labels[kubermaticv1.ClusterTemplateScopeLabelKey] == kubermaticv1.GlobalClusterTemplateScope {
-		return kubermaticerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't delete template %s", userInfo.Email, templateID))
+		return utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't delete template %s", userInfo.Email, templateID))
 	}
 
 	return p.clientPrivileged.Delete(ctx, result)

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -45,7 +45,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,7 +112,7 @@ func ensureCredentialSecret(ctx context.Context, seedClient ctrlruntimeclient.Cl
 
 	namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: name}
 	existingSecret := &corev1.Secret{}
-	if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil && !kerrors.IsNotFound(err) {
+	if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to probe for secret %q: %w", name, err)
 	}
 
@@ -657,7 +657,7 @@ func ensureCredentialKubeOneSecret(ctx context.Context, masterClient ctrlruntime
 	kubeOneNamespaceName := GetKubeOneNamespaceName(externalcluster.Name)
 	namespacedName := types.NamespacedName{Namespace: kubeOneNamespaceName, Name: secretName}
 	existingSecret := &corev1.Secret{}
-	if err := masterClient.Get(ctx, namespacedName, existingSecret); err != nil && !kerrors.IsNotFound(err) {
+	if err := masterClient.Get(ctx, namespacedName, existingSecret); err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to probe for secret %q: %w", secretName, err)
 	}
 

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -42,7 +42,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/packet"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/vsphere"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/util/errors"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -757,7 +757,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateKubeOneCredentialSecret(ctx cont
 
 func createOrUpdateKubeOneAWSSecret(ctx context.Context, cloud apiv2.KubeOneCloudSpec, masterClient ctrlruntimeclient.Client, secretName string, externalcluster *kubermaticv1.ExternalCluster) error {
 	if cloud.AWS.AccessKeyID == "" || cloud.AWS.SecretAccessKey == "" {
-		return errors.NewBadRequest("kubeone aws credentials missing")
+		return utilerrors.NewBadRequest("kubeone aws credentials missing")
 	}
 
 	if err := awsprovider.ValidateCredentials(cloud.AWS.AccessKeyID, cloud.AWS.SecretAccessKey); err != nil {
@@ -782,7 +782,7 @@ func createOrUpdateKubeOneAWSSecret(ctx context.Context, cloud apiv2.KubeOneClou
 func createOrUpdateKubeOneGCPSecret(ctx context.Context, cloud apiv2.KubeOneCloudSpec, masterClient ctrlruntimeclient.Client, secretName string, externalCluster *kubermaticv1.ExternalCluster) error {
 	encodedServiceAccount := cloud.GCP.ServiceAccount
 	if encodedServiceAccount == "" {
-		return errors.NewBadRequest("kubeone gcp credentials missing")
+		return utilerrors.NewBadRequest("kubeone gcp credentials missing")
 	}
 
 	if err := gcp.ValidateCredentials(ctx, encodedServiceAccount); err != nil {
@@ -814,7 +814,7 @@ func createOrUpdateKubeOneAzureSecret(ctx context.Context, cloud apiv2.KubeOneCl
 	clientSecret := cloud.Azure.ClientSecret
 
 	if tenantID == "" || subscriptionID == "" || clientID == "" || clientSecret == "" {
-		return errors.NewBadRequest("kubeone azure credentials missing")
+		return utilerrors.NewBadRequest("kubeone azure credentials missing")
 	}
 
 	if err := azure.ValidateCredentials(ctx, azure.Credentials{
@@ -847,7 +847,7 @@ func createOrUpdateKubeOneDigitaloceanSecret(ctx context.Context, cloud apiv2.Ku
 	token := cloud.DigitalOcean.Token
 
 	if token == "" {
-		return errors.NewBadRequest("kubeone DigitalOcean credentials missing")
+		return utilerrors.NewBadRequest("kubeone DigitalOcean credentials missing")
 	}
 
 	if err := digitalocean.ValidateCredentials(ctx, token); err != nil {
@@ -878,7 +878,7 @@ func createOrUpdateKubeOneOpenstackSecret(ctx context.Context, cloud apiv2.KubeO
 	region := cloud.OpenStack.Region
 
 	if username == "" || password == "" || domain == "" || authUrl == "" || project == "" || projectID == "" || region == "" {
-		return errors.NewBadRequest("kubeone Openstack credentials missing")
+		return utilerrors.NewBadRequest("kubeone Openstack credentials missing")
 	}
 
 	// move credentials into dedicated Secret
@@ -907,7 +907,7 @@ func createOrUpdateKubeOneVSphereSecret(ctx context.Context, cloud apiv2.KubeOne
 	server := cloud.VSphere.Server
 
 	if username == "" || password == "" || server == "" {
-		return errors.NewBadRequest("kubeone VSphere credentials missing")
+		return utilerrors.NewBadRequest("kubeone VSphere credentials missing")
 	}
 
 	// move credentials into dedicated Secret
@@ -931,7 +931,7 @@ func createOrUpdateKubeOneEquinixSecret(ctx context.Context, cloud apiv2.KubeOne
 	projectID := cloud.Equinix.ProjectID
 
 	if apiKey == "" || projectID == "" {
-		return errors.NewBadRequest("kubeone Packet credentials missing")
+		return utilerrors.NewBadRequest("kubeone Packet credentials missing")
 	}
 
 	if err := packet.ValidateCredentials(apiKey, projectID); err != nil {
@@ -957,7 +957,7 @@ func createOrUpdateKubeOneHetznerSecret(ctx context.Context, cloud apiv2.KubeOne
 	token := cloud.Hetzner.Token
 
 	if token == "" {
-		return errors.NewBadRequest("kubeone Hetzner credentials missing")
+		return utilerrors.NewBadRequest("kubeone Hetzner credentials missing")
 	}
 
 	if err := hetzner.ValidateCredentials(ctx, token); err != nil {
@@ -991,7 +991,7 @@ func createOrUpdateKubeOneNutanixSecret(ctx context.Context, cloud apiv2.KubeOne
 	allowInsecure := cloud.Nutanix.AllowInsecure
 
 	if endpoint == "" || port == "" || username == "" || password == "" || peEndpoint == "" || peUsername == "" || pePassword == "" {
-		return errors.NewBadRequest("kubeone Nutanix credentials missing")
+		return utilerrors.NewBadRequest("kubeone Nutanix credentials missing")
 	}
 
 	secretData := map[string][]byte{

--- a/pkg/provider/kubernetes/event.go
+++ b/pkg/provider/kubernetes/event.go
@@ -19,10 +19,10 @@ package kubernetes
 import (
 	"sync"
 
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	kubecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -59,8 +59,8 @@ func (e *EventRecorder) getRecorderForClient(client kubernetes.Interface) record
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: coreV1Client.Events("")})
-	recorder = eventBroadcaster.NewRecorder(scheme.Scheme, apicorev1.EventSource{Component: componentName})
+	eventBroadcaster.StartRecordingToSink(&kubecorev1.EventSinkImpl{Interface: coreV1Client.Events("")})
+	recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: componentName})
 	e.seedClusterRecorderMap[host] = recorder
 
 	return recorder

--- a/pkg/provider/kubernetes/external_cluster.go
+++ b/pkg/provider/kubernetes/external_cluster.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -340,7 +340,7 @@ func (p *ExternalClusterProvider) ensureKubeconfigSecret(ctx context.Context, cl
 	existingSecret := &corev1.Secret{}
 
 	if err := p.clientPrivileged.Get(ctx, namespacedName, existingSecret); err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to probe for secret %q: %w", name, err)
 		}
 		return createKubeconfigSecret(ctx, p.clientPrivileged, name, projectID, secretData)

--- a/pkg/provider/kubernetes/member.go
+++ b/pkg/provider/kubernetes/member.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -58,7 +58,7 @@ var _ provider.ProjectMemberProvider = &ProjectMemberProvider{}
 // Create creates a binding for the given member and the given project.
 func (p *ProjectMemberProvider) Create(ctx context.Context, userInfo *provider.UserInfo, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error) {
 	if kubermaticv1helper.IsProjectServiceAccount(memberEmail) {
-		return nil, kerrors.NewBadRequest(fmt.Sprintf("cannot add the given member %s to the project %s because the email indicates a service account", memberEmail, project.Spec.Name))
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot add the given member %s to the project %s because the email indicates a service account", memberEmail, project.Spec.Name))
 	}
 
 	binding := genBinding(project, memberEmail, group)
@@ -167,7 +167,7 @@ func (p *ProjectMemberProvider) MapUserToGroup(ctx context.Context, userEmail st
 		}
 	}
 
-	return "", kerrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("%q doesn't belong to project %s", userEmail, projectID))
+	return "", apierrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("%q doesn't belong to project %s", userEmail, projectID))
 }
 
 // MappingsFor returns the list of projects (bindings) for the given user
@@ -192,7 +192,7 @@ func (p *ProjectMemberProvider) MappingsFor(ctx context.Context, userEmail strin
 // This function is unsafe in a sense that it uses privileged account to create the resource.
 func (p *ProjectMemberProvider) CreateUnsecured(ctx context.Context, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error) {
 	if kubermaticv1helper.IsProjectServiceAccount(memberEmail) {
-		return nil, kerrors.NewBadRequest(fmt.Sprintf("cannot add the given member %s to the project %s because the email indicates a service account", memberEmail, project.Spec.Name))
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot add the given member %s to the project %s because the email indicates a service account", memberEmail, project.Spec.Name))
 	}
 
 	binding := genBinding(project, memberEmail, group)
@@ -207,7 +207,7 @@ func (p *ProjectMemberProvider) CreateUnsecured(ctx context.Context, project *ku
 // This function is unsafe in a sense that it uses privileged account to create the resource.
 func (p *ProjectMemberProvider) CreateUnsecuredForServiceAccount(ctx context.Context, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error) {
 	if kubermaticv1helper.IsProjectServiceAccount(memberEmail) && !strings.HasPrefix(group, rbac.ProjectManagerGroupNamePrefix) {
-		return nil, kerrors.NewBadRequest(fmt.Sprintf("cannot add the given member %s to the project %s because the email indicates a service account", memberEmail, project.Spec.Name))
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("cannot add the given member %s to the project %s because the email indicates a service account", memberEmail, project.Spec.Name))
 	}
 
 	binding := genBinding(project, memberEmail, group)

--- a/pkg/provider/kubernetes/mla_admin_setting_test.go
+++ b/pkg/provider/kubernetes/mla_admin_setting_test.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -238,7 +238,7 @@ func TestDeleteMLAAdminSetting(t *testing.T) {
 					t.Fatal(err)
 				}
 				_, err = mlaAdminSettingProvider.GetUnsecured(context.Background(), tc.cluster)
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			} else {
 				if err == nil {
 					t.Fatalf("expected error message")

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -24,7 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/util/email"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -138,7 +138,7 @@ func (m *PresetProvider) GetPreset(ctx context.Context, userInfo *provider.UserI
 		}
 	}
 
-	return nil, errors.NewNotFound(kubermaticv1.Resource("preset"), name)
+	return nil, apierrors.NewNotFound(kubermaticv1.Resource("preset"), name)
 }
 
 // DeletePreset delete Preset.

--- a/pkg/provider/kubernetes/project.go
+++ b/pkg/provider/kubernetes/project.go
@@ -24,7 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/label"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -134,7 +134,7 @@ func (p *ProjectProvider) Get(ctx context.Context, userInfo *provider.UserInfo, 
 		return nil, err
 	}
 	if !options.IncludeUninitialized && existingProject.Status.Phase != kubermaticv1.ProjectActive {
-		return nil, kerrors.NewServiceUnavailable("Project is not initialized yet")
+		return nil, apierrors.NewServiceUnavailable("Project is not initialized yet")
 	}
 
 	return existingProject, nil
@@ -151,7 +151,7 @@ func (p *PrivilegedProjectProvider) GetUnsecured(ctx context.Context, projectInt
 		return nil, err
 	}
 	if !options.IncludeUninitialized && project.Status.Phase != kubermaticv1.ProjectActive {
-		return nil, kerrors.NewServiceUnavailable("Project is not initialized yet")
+		return nil, apierrors.NewServiceUnavailable("Project is not initialized yet")
 	}
 	return project, nil
 }

--- a/pkg/provider/kubernetes/rulegroup_test.go
+++ b/pkg/provider/kubernetes/rulegroup_test.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -376,7 +376,7 @@ func TestDeleteRuleGroup(t *testing.T) {
 					t.Fatal(err)
 				}
 				_, err = ruleGroupProvider.Get(context.Background(), tc.userInfo, tc.cluster, tc.ruleGroupName)
-				assert.True(t, errors.IsNotFound(err))
+				assert.True(t, apierrors.IsNotFound(err))
 			} else {
 				if err == nil {
 					t.Fatalf("expected error message")

--- a/pkg/provider/kubernetes/sa.go
+++ b/pkg/provider/kubernetes/sa.go
@@ -24,7 +24,7 @@ import (
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,10 +61,10 @@ var _ provider.PrivilegedServiceAccountProvider = &ServiceAccountProvider{}
 // CreateProjectServiceAccount creates a new service account for the project.
 func (p *ServiceAccountProvider) CreateProjectServiceAccount(ctx context.Context, userInfo *provider.UserInfo, project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error) {
 	if project == nil {
-		return nil, kerrors.NewBadRequest("Project cannot be nil")
+		return nil, apierrors.NewBadRequest("Project cannot be nil")
 	}
 	if len(name) == 0 || len(group) == 0 {
-		return nil, kerrors.NewBadRequest("Service account name and group cannot be empty when creating a new SA resource")
+		return nil, apierrors.NewBadRequest("Service account name and group cannot be empty when creating a new SA resource")
 	}
 
 	sa := genProjectServiceAccount(project, name, group, p.domain)
@@ -87,10 +87,10 @@ func (p *ServiceAccountProvider) CreateProjectServiceAccount(ctx context.Context
 // is unsafe in a sense that it uses privileged account to create the resources.
 func (p *ServiceAccountProvider) CreateUnsecuredProjectServiceAccount(ctx context.Context, project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error) {
 	if project == nil {
-		return nil, kerrors.NewBadRequest("Project cannot be nil")
+		return nil, apierrors.NewBadRequest("Project cannot be nil")
 	}
 	if len(name) == 0 || len(group) == 0 {
-		return nil, kerrors.NewBadRequest("Service account name and group cannot be empty when creating a new SA resource")
+		return nil, apierrors.NewBadRequest("Service account name and group cannot be empty when creating a new SA resource")
 	}
 
 	sa := genProjectServiceAccount(project, name, group, p.domain)
@@ -120,10 +120,10 @@ func genProjectServiceAccount(project *kubermaticv1.Project, name, group, domain
 // ListProjectServiceAccount gets service accounts for the project.
 func (p *ServiceAccountProvider) ListProjectServiceAccount(ctx context.Context, userInfo *provider.UserInfo, project *kubermaticv1.Project, options *provider.ServiceAccountListOptions) ([]*kubermaticv1.User, error) {
 	if userInfo == nil {
-		return nil, kerrors.NewBadRequest("userInfo cannot be nil")
+		return nil, apierrors.NewBadRequest("userInfo cannot be nil")
 	}
 	if project == nil {
-		return nil, kerrors.NewBadRequest("project cannot be nil")
+		return nil, apierrors.NewBadRequest("project cannot be nil")
 	}
 	if options == nil {
 		options = &provider.ServiceAccountListOptions{}
@@ -175,7 +175,7 @@ func (p *ServiceAccountProvider) ListProjectServiceAccount(ctx context.Context, 
 // is unsafe in a sense that it uses privileged account to get the resources.
 func (p *ServiceAccountProvider) ListUnsecuredProjectServiceAccount(ctx context.Context, project *kubermaticv1.Project, options *provider.ServiceAccountListOptions) ([]*kubermaticv1.User, error) {
 	if project == nil {
-		return nil, kerrors.NewBadRequest("project cannot be nil")
+		return nil, apierrors.NewBadRequest("project cannot be nil")
 	}
 	if options == nil {
 		options = &provider.ServiceAccountListOptions{}
@@ -224,10 +224,10 @@ func (p *ServiceAccountProvider) listProjectSA(ctx context.Context, project *kub
 // GetProjectServiceAccount method returns project service account with given name.
 func (p *ServiceAccountProvider) GetProjectServiceAccount(ctx context.Context, userInfo *provider.UserInfo, name string, options *provider.ServiceAccountGetOptions) (*kubermaticv1.User, error) {
 	if userInfo == nil {
-		return nil, kerrors.NewBadRequest("userInfo cannot be nil")
+		return nil, apierrors.NewBadRequest("userInfo cannot be nil")
 	}
 	if len(name) == 0 {
-		return nil, kerrors.NewBadRequest("service account name cannot be empty")
+		return nil, apierrors.NewBadRequest("service account name cannot be empty")
 	}
 	if options == nil {
 		options = &provider.ServiceAccountGetOptions{RemovePrefix: true}
@@ -256,7 +256,7 @@ func (p *ServiceAccountProvider) GetProjectServiceAccount(ctx context.Context, u
 // is unsafe in a sense that it uses privileged account to get the resource.
 func (p *ServiceAccountProvider) GetUnsecuredProjectServiceAccount(ctx context.Context, name string, options *provider.ServiceAccountGetOptions) (*kubermaticv1.User, error) {
 	if len(name) == 0 {
-		return nil, kerrors.NewBadRequest("service account name cannot be empty")
+		return nil, apierrors.NewBadRequest("service account name cannot be empty")
 	}
 	if options == nil {
 		options = &provider.ServiceAccountGetOptions{RemovePrefix: true}
@@ -277,10 +277,10 @@ func (p *ServiceAccountProvider) GetUnsecuredProjectServiceAccount(ctx context.C
 // UpdateProjectServiceAccount simply updates the given project service account.
 func (p *ServiceAccountProvider) UpdateProjectServiceAccount(ctx context.Context, userInfo *provider.UserInfo, serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error) {
 	if userInfo == nil {
-		return nil, kerrors.NewBadRequest("userInfo cannot be nil")
+		return nil, apierrors.NewBadRequest("userInfo cannot be nil")
 	}
 	if serviceAccount == nil {
-		return nil, kerrors.NewBadRequest("service account name cannot be nil")
+		return nil, apierrors.NewBadRequest("service account name cannot be nil")
 	}
 
 	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
@@ -303,7 +303,7 @@ func (p *ServiceAccountProvider) UpdateProjectServiceAccount(ctx context.Context
 // is unsafe in a sense that it uses privileged account to update the resource.
 func (p *ServiceAccountProvider) UpdateUnsecuredProjectServiceAccount(ctx context.Context, serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error) {
 	if serviceAccount == nil {
-		return nil, kerrors.NewBadRequest("service account name cannot be nil")
+		return nil, apierrors.NewBadRequest("service account name cannot be nil")
 	}
 
 	serviceAccount.Name = kubermaticv1helper.EnsureProjectServiceAccountPrefix(serviceAccount.Name)
@@ -318,10 +318,10 @@ func (p *ServiceAccountProvider) UpdateUnsecuredProjectServiceAccount(ctx contex
 // DeleteProjectServiceAccount simply deletes the given project service account.
 func (p *ServiceAccountProvider) DeleteProjectServiceAccount(ctx context.Context, userInfo *provider.UserInfo, name string) error {
 	if userInfo == nil {
-		return kerrors.NewBadRequest("userInfo cannot be nil")
+		return apierrors.NewBadRequest("userInfo cannot be nil")
 	}
 	if len(name) == 0 {
-		return kerrors.NewBadRequest("service account name cannot be empty")
+		return apierrors.NewBadRequest("service account name cannot be empty")
 	}
 
 	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
@@ -339,7 +339,7 @@ func (p *ServiceAccountProvider) DeleteProjectServiceAccount(ctx context.Context
 // is unsafe in a sense that it uses privileged account to delete the resource.
 func (p *ServiceAccountProvider) DeleteUnsecuredProjectServiceAccount(ctx context.Context, name string) error {
 	if len(name) == 0 {
-		return kerrors.NewBadRequest("service account name cannot be empty")
+		return apierrors.NewBadRequest("service account name cannot be empty")
 	}
 
 	name = kubermaticv1helper.EnsureProjectServiceAccountPrefix(name)

--- a/pkg/provider/kubernetes/sa_token_test.go
+++ b/pkg/provider/kubernetes/sa_token_test.go
@@ -30,7 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -419,7 +419,7 @@ func TestDeleteToken(t *testing.T) {
 
 			// validate
 			_, err = target.Get(context.Background(), tc.userInfo, tc.tokenToDelete)
-			if !errors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				t.Fatalf("expected not found error")
 			}
 		})

--- a/pkg/provider/kubernetes/settings.go
+++ b/pkg/provider/kubernetes/settings.go
@@ -23,7 +23,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +47,7 @@ func (s *SettingsProvider) GetGlobalSettings(ctx context.Context) (*kubermaticv1
 	settings := &kubermaticv1.KubermaticSetting{}
 	err := s.runtimeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: kubermaticv1.GlobalSettingsName}, settings)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return s.createDefaultGlobalSettings(ctx)
 		}
 		return nil, err
@@ -57,7 +57,7 @@ func (s *SettingsProvider) GetGlobalSettings(ctx context.Context) (*kubermaticv1
 
 func (s *SettingsProvider) UpdateGlobalSettings(ctx context.Context, userInfo *provider.UserInfo, settings *kubermaticv1.KubermaticSetting) (*kubermaticv1.KubermaticSetting, error) {
 	if !userInfo.IsAdmin {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
+		return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 	}
 	if err := s.runtimeClient.Update(ctx, settings); err != nil {
 		return nil, err

--- a/pkg/provider/seed.go
+++ b/pkg/provider/seed.go
@@ -24,7 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -96,7 +96,7 @@ func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Reader, see
 		seed := &kubermaticv1.Seed{}
 		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: seedName}, seed); err != nil {
 			// allow callers to handle this gracefully
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil, err
 			}
 
@@ -113,7 +113,7 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, na
 	return func() (map[string]*kubermaticv1.Seed, error) {
 		seed := &kubermaticv1.Seed{}
 		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: DefaultSeedName}, seed); err != nil {
-			if kerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// We should not fail if no seed exists and just return an
 				// empty map.
 				return emptySeedMap, nil

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	semver "github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -248,7 +248,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 	}
 }
 
-func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, enableOIDCAuthentication, auditLogEnabled bool, version *semver.Version) ([]string, error) {
+func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, enableOIDCAuthentication, auditLogEnabled bool, version *semverlib.Version) ([]string, error) {
 	overrideFlags, err := getApiserverOverrideFlags(data)
 	if err != nil {
 		return nil, fmt.Errorf("could not get components override flags: %w", err)

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -208,7 +208,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 	}
 }
 
-func getFlags(data *resources.TemplateData, version *semver.Version) ([]string, error) {
+func getFlags(data *resources.TemplateData, version *semverlib.Version) ([]string, error) {
 	cluster := data.Cluster()
 	controllers := []string{"*", "bootstrapsigner", "tokencleaner"}
 
@@ -259,7 +259,7 @@ func getFlags(data *resources.TemplateData, version *semver.Version) ([]string, 
 
 	featureGates := []string{"RotateKubeletServerCertificate=true"}
 	// starting with k8s 1.21, this is always true and cannot be toggled anymore
-	if version.LessThan(semver.MustParse("1.21.0")) {
+	if version.LessThan(semverlib.MustParse("1.21.0")) {
 		featureGates = append(featureGates, "RotateKubeletClientCertificate=true")
 	}
 

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/distribution/distribution/v3/reference"
 	"go.uber.org/zap"
 
@@ -609,7 +609,7 @@ func ExternalCloudProviderEnabled(cluster *kubermaticv1.Cluster) bool {
 
 func GetCSIMigrationFeatureGates(cluster *kubermaticv1.Cluster) []string {
 	var featureFlags []string
-	gte23, _ := semver.NewConstraint(">= 1.23.0")
+	gte23, _ := semverlib.NewConstraint(">= 1.23.0")
 	ccm := cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]
 
 	curVersion := cluster.Status.Versions.ControlPlane
@@ -633,7 +633,7 @@ func GetCSIMigrationFeatureGates(cluster *kubermaticv1.Cluster) []string {
 		// The CSIMigrationNeededAnnotation is removed when all kubelets have
 		// been migrated.
 		if cluster.Status.Conditions[kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted].Status == corev1.ConditionTrue {
-			lessThan21, _ := semver.NewConstraint("< 1.21.0")
+			lessThan21, _ := semverlib.NewConstraint("< 1.21.0")
 			if cluster.Spec.Cloud.Openstack != nil {
 				if lessThan21.Check(curVersion.Semver()) {
 					featureFlags = append(featureFlags, "CSIMigrationOpenStackComplete=true")

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -19,7 +19,7 @@ package dns
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -48,7 +48,7 @@ var (
 )
 
 // source: https://github.com/kubernetes/kubernetes/blob/vX.YY.0/cmd/kubeadm/app/constants/constants.go
-func GetCoreDNSImage(kubernetesVersion *semver.Version) string {
+func GetCoreDNSImage(kubernetesVersion *semverlib.Version) string {
 	switch fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor()) {
 	case "1.20":
 		return "coredns/coredns:v1.7.0"

--- a/pkg/resources/health.go
+++ b/pkg/resources/health.go
@@ -22,7 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -31,7 +31,7 @@ import (
 func HealthyDeployment(ctx context.Context, client ctrlruntimeclient.Client, nn types.NamespacedName, minReady int32) (kubermaticv1.HealthStatus, error) {
 	deployment := &appsv1.Deployment{}
 	if err := client.Get(ctx, nn, deployment); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return kubermaticv1.HealthStatusDown, nil
 		}
 		return kubermaticv1.HealthStatusDown, err
@@ -51,7 +51,7 @@ func HealthyDeployment(ctx context.Context, client ctrlruntimeclient.Client, nn 
 func HealthyStatefulSet(ctx context.Context, client ctrlruntimeclient.Client, nn types.NamespacedName, minReady int32) (kubermaticv1.HealthStatus, error) {
 	statefulSet := &appsv1.StatefulSet{}
 	if err := client.Get(ctx, nn, statefulSet); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return kubermaticv1.HealthStatusDown, nil
 		}
 		return kubermaticv1.HealthStatusDown, err
@@ -70,7 +70,7 @@ func HealthyStatefulSet(ctx context.Context, client ctrlruntimeclient.Client, nn
 func HealthyDaemonSet(ctx context.Context, client ctrlruntimeclient.Client, nn types.NamespacedName, minReady int32) (kubermaticv1.HealthStatus, error) {
 	daemonSet := &appsv1.DaemonSet{}
 	if err := client.Get(ctx, nn, daemonSet); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return kubermaticv1.HealthStatusDown, nil
 		}
 		return kubermaticv1.HealthStatusDown, err

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
@@ -90,7 +90,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
 
 	if nd.Spec.DynamicConfig != nil && *nd.Spec.DynamicConfig {
-		kubeletVersion, err := semver.NewVersion(nd.Spec.Template.Versions.Kubelet)
+		kubeletVersion, err := semverlib.NewVersion(nd.Spec.Template.Versions.Kubelet)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse kubelet version: %w", err)
 		}
@@ -310,7 +310,7 @@ func getProviderOS(config *providerconfig.Config, nd *apiv1.NodeDeployment) erro
 
 // Validate if the node deployment structure fulfills certain requirements. It returns node deployment with updated
 // kubelet version if it wasn't specified.
-func Validate(nd *apiv1.NodeDeployment, controlPlaneVersion *semver.Version) (*apiv1.NodeDeployment, error) {
+func Validate(nd *apiv1.NodeDeployment, controlPlaneVersion *semverlib.Version) (*apiv1.NodeDeployment, error) {
 	if nd.Spec.Template.Cloud.Openstack == nil &&
 		nd.Spec.Template.Cloud.Digitalocean == nil &&
 		nd.Spec.Template.Cloud.AWS == nil &&
@@ -327,7 +327,7 @@ func Validate(nd *apiv1.NodeDeployment, controlPlaneVersion *semver.Version) (*a
 	}
 
 	if nd.Spec.Template.Versions.Kubelet != "" {
-		kubeletVersion, err := semver.NewVersion(nd.Spec.Template.Versions.Kubelet)
+		kubeletVersion, err := semverlib.NewVersion(nd.Spec.Template.Versions.Kubelet)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse kubelet version: %w", err)
 		}

--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -27,7 +27,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
 	appsv1 "k8s.io/api/apps/v1"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -84,7 +84,7 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 	exists := true
 	existingObject := emptyObject.DeepCopyObject().(ctrlruntimeclient.Object)
 	if err := client.Get(ctx, namespacedName, existingObject); err != nil {
-		if !kubeerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get Object(%T): %w", existingObject, err)
 		}
 		exists = false
@@ -197,7 +197,7 @@ func WaitUntilObjectExistsInCacheConditionFunc(
 	return func() (bool, error) {
 		newObj := obj.DeepCopyObject().(ctrlruntimeclient.Object)
 		if err := client.Get(ctx, namespacedName, newObj); err != nil {
-			if kubeerrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 

--- a/pkg/resources/reconciling/wrapper_test.go
+++ b/pkg/resources/reconciling/wrapper_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	utilpointer "k8s.io/utils/pointer"
-	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	controllerruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -508,7 +508,7 @@ func TestDefaultDeployment(t *testing.T) {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
-	key := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	key := ctrlruntimeclient.ObjectKeyFromObject(expectedObject)
 
 	actualDeployment := &appsv1.Deployment{}
 	if err := client.Get(context.Background(), key, actualDeployment); err != nil {
@@ -581,7 +581,7 @@ func TestDefaultStatefulSet(t *testing.T) {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
-	key := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	key := ctrlruntimeclient.ObjectKeyFromObject(expectedObject)
 
 	actualStatefulSet := &appsv1.StatefulSet{}
 	if err := client.Get(context.Background(), key, actualStatefulSet); err != nil {
@@ -654,7 +654,7 @@ func TestDefaultDaemonSet(t *testing.T) {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
-	key := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	key := ctrlruntimeclient.ObjectKeyFromObject(expectedObject)
 
 	actualDaemonSet := &appsv1.DaemonSet{}
 	if err := client.Get(context.Background(), key, actualDaemonSet); err != nil {
@@ -735,7 +735,7 @@ func TestDefaultCronJob(t *testing.T) {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
-	key := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	key := ctrlruntimeclient.ObjectKeyFromObject(expectedObject)
 
 	actualCronJob := &batchv1beta1.CronJob{}
 	if err := client.Get(context.Background(), key, actualCronJob); err != nil {
@@ -863,7 +863,7 @@ func TestImagePullSecretsWrapper(t *testing.T) {
 	tests := []struct {
 		name            string
 		secretNames     []string
-		inputObj        controllerruntimeclient.Object
+		inputObj        ctrlruntimeclient.Object
 		wantSecretNames []string
 		wantErr         bool
 	}{
@@ -937,6 +937,6 @@ func TestImagePullSecretsWrapper(t *testing.T) {
 // identityCreator is an ObjectModifier that returns the input object
 // untouched.
 // TODO May be useful to move this in a test package?
-func identityCreator(obj controllerruntimeclient.Object) (controllerruntimeclient.Object, error) {
+func identityCreator(obj ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 	return obj, nil
 }

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -9,7 +9,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatekeeperv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1288,28 +1288,28 @@ func ReconcileKubermaticV1RuleGroups(ctx context.Context, namedGetters []NamedKu
 	return nil
 }
 
-// AppKubermaticV1ApplicationDefinitionCreator defines an interface to create/update ApplicationDefinitions
-type AppKubermaticV1ApplicationDefinitionCreator = func(existing *appkubermaticv1.ApplicationDefinition) (*appkubermaticv1.ApplicationDefinition, error)
+// AppsKubermaticV1ApplicationDefinitionCreator defines an interface to create/update ApplicationDefinitions
+type AppsKubermaticV1ApplicationDefinitionCreator = func(existing *appskubermaticv1.ApplicationDefinition) (*appskubermaticv1.ApplicationDefinition, error)
 
-// NamedAppKubermaticV1ApplicationDefinitionCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedAppKubermaticV1ApplicationDefinitionCreatorGetter = func() (name string, create AppKubermaticV1ApplicationDefinitionCreator)
+// NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter returns the name of the resource and the corresponding creator function
+type NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter = func() (name string, create AppsKubermaticV1ApplicationDefinitionCreator)
 
-// AppKubermaticV1ApplicationDefinitionObjectWrapper adds a wrapper so the AppKubermaticV1ApplicationDefinitionCreator matches ObjectCreator.
+// AppsKubermaticV1ApplicationDefinitionObjectWrapper adds a wrapper so the AppsKubermaticV1ApplicationDefinitionCreator matches ObjectCreator.
 // This is needed as Go does not support function interface matching.
-func AppKubermaticV1ApplicationDefinitionObjectWrapper(create AppKubermaticV1ApplicationDefinitionCreator) ObjectCreator {
+func AppsKubermaticV1ApplicationDefinitionObjectWrapper(create AppsKubermaticV1ApplicationDefinitionCreator) ObjectCreator {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return create(existing.(*appkubermaticv1.ApplicationDefinition))
+			return create(existing.(*appskubermaticv1.ApplicationDefinition))
 		}
-		return create(&appkubermaticv1.ApplicationDefinition{})
+		return create(&appskubermaticv1.ApplicationDefinition{})
 	}
 }
 
-// ReconcileAppKubermaticV1ApplicationDefinitions will create and update the AppKubermaticV1ApplicationDefinitions coming from the passed AppKubermaticV1ApplicationDefinitionCreator slice
-func ReconcileAppKubermaticV1ApplicationDefinitions(ctx context.Context, namedGetters []NamedAppKubermaticV1ApplicationDefinitionCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
+// ReconcileAppsKubermaticV1ApplicationDefinitions will create and update the AppsKubermaticV1ApplicationDefinitions coming from the passed AppsKubermaticV1ApplicationDefinitionCreator slice
+func ReconcileAppsKubermaticV1ApplicationDefinitions(ctx context.Context, namedGetters []NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		createObject := AppKubermaticV1ApplicationDefinitionObjectWrapper(create)
+		createObject := AppsKubermaticV1ApplicationDefinitionObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
 
@@ -1317,7 +1317,7 @@ func ReconcileAppKubermaticV1ApplicationDefinitions(ctx context.Context, namedGe
 			createObject = objectModifier(createObject)
 		}
 
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appkubermaticv1.ApplicationDefinition{}, false); err != nil {
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appskubermaticv1.ApplicationDefinition{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ApplicationDefinition %s/%s: %w", namespace, name, err)
 		}
 	}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/pmezard/go-difflib/difflib"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -108,7 +108,7 @@ func checkTestResult(t *testing.T, resFile string, testObj interface{}) {
 
 type testCase struct {
 	provider string
-	version  semver.Version
+	version  semverlib.Version
 	features map[string]bool
 }
 
@@ -150,13 +150,13 @@ func (tc testCase) fixturePath(resType, resName string) string {
 func TestLoadFiles(t *testing.T) {
 	versions := []*version.Version{
 		{
-			Version: semver.MustParse("1.21.0"),
+			Version: semverlib.MustParse("1.21.0"),
 		},
 		{
-			Version: semver.MustParse("1.22.1"),
+			Version: semverlib.MustParse("1.22.1"),
 		},
 		{
-			Version: semver.MustParse("1.23.5"),
+			Version: semverlib.MustParse("1.23.5"),
 		},
 	}
 

--- a/pkg/resources/user-cluster-webhook/rbac.go
+++ b/pkg/resources/user-cluster-webhook/rbac.go
@@ -19,7 +19,7 @@ package webhook
 import (
 	"fmt"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +44,7 @@ func ClusterRole() reconciling.NamedClusterRoleCreatorGetter {
 		return roleName, func(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			r.Rules = []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{appkubermaticv1.GroupName},
+					APIGroups: []string{appskubermaticv1.GroupName},
 					Resources: []string{"applicationdefinitions", "applicationdefinitions/status"},
 					Verbs: []string{
 						"get",

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -19,7 +19,7 @@ package usercluster
 import (
 	"fmt"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -119,8 +119,8 @@ func ClusterRole() reconciling.NamedClusterRoleCreatorGetter {
 					},
 				},
 				{
-					APIGroups: []string{appkubermaticv1.GroupName},
-					Resources: []string{appkubermaticv1.ApplicationDefinitionResourceName},
+					APIGroups: []string{appskubermaticv1.GroupName},
+					Resources: []string{appskubermaticv1.ApplicationDefinitionResourceName},
 					Verbs: []string{
 						"get",
 						"list",

--- a/pkg/test/clusterexposer/controller/controller.go
+++ b/pkg/test/clusterexposer/controller/controller.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -130,7 +130,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
 	innerService := &corev1.Service{}
 	if err := r.innerClient.Get(ctx, request.NamespacedName, innerService); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Debug("Got request for service that doesn't exist, returning")
 			return nil
 		}

--- a/pkg/test/e2e/api/hetzner_test.go
+++ b/pkg/test/e2e/api/hetzner_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"testing"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -124,7 +124,7 @@ func TestDeleteClusterBeforeIsUp(t *testing.T) {
 	}
 }
 
-func createProjectWithCluster(t *testing.T, testClient *utils.TestClient, dc, credential, version, location string, replicas int32) (*v1.Project, *v1.Cluster) {
+func createProjectWithCluster(t *testing.T, testClient *utils.TestClient, dc, credential, version, location string, replicas int32) (*apiv1.Project, *apiv1.Cluster) {
 	project, err := testClient.CreateProject(rand.String(10))
 	if err != nil {
 		t.Fatalf("failed to create project %v", err)

--- a/pkg/test/e2e/api/kubevirt_test.go
+++ b/pkg/test/e2e/api/kubevirt_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"testing"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -124,7 +124,7 @@ func TestDeleteKubevirtClusterBeforeIsUp(t *testing.T) {
 	}
 }
 
-func createKubevirtProjectWithCluster(t *testing.T, testClient *utils.TestClient, dc, credential, version, location string, replicas int32) (*v1.Project, *v1.Cluster) {
+func createKubevirtProjectWithCluster(t *testing.T, testClient *utils.TestClient, dc, credential, version, location string, replicas int32) (*apiv1.Project, *apiv1.Cluster) {
 	project, err := testClient.CreateProject(rand.String(10))
 	if err != nil {
 		t.Fatalf("failed to create project %v", err)

--- a/pkg/test/e2e/api/util.go
+++ b/pkg/test/e2e/api/util.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -70,7 +70,7 @@ func getErrorResponse(err error) string {
 	return string(rawData)
 }
 
-func testCluster(ctx context.Context, project *v1.Project, cluster *v1.Cluster, testClient *utils.TestClient, tc createCluster, t *testing.T) {
+func testCluster(ctx context.Context, project *apiv1.Project, cluster *apiv1.Cluster, testClient *utils.TestClient, tc createCluster, t *testing.T) {
 	sshKey, err := testClient.CreateUserSSHKey(project.ID, tc.sshKeyName, tc.publicKey)
 	if err != nil {
 		t.Fatalf("failed to get create SSH key: %v", err)
@@ -109,7 +109,7 @@ func testCluster(ctx context.Context, project *v1.Project, cluster *v1.Cluster, 
 
 	// wait for controller to provision the roles
 	var roleErr error
-	roleNameList := []v1.RoleName{}
+	roleNameList := []apiv1.RoleName{}
 	if err := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		roleNameList, roleErr = testClient.GetRoles(project.ID, tc.dc, cluster.ID)
 		return len(roleNameList) >= len(tc.expectedRoleNames), nil
@@ -128,7 +128,7 @@ func testCluster(ctx context.Context, project *v1.Project, cluster *v1.Cluster, 
 
 	// wait for controller to provision the cluster roles
 	var clusterRoleErr error
-	clusterRoleNameList := []v1.ClusterRoleName{}
+	clusterRoleNameList := []apiv1.ClusterRoleName{}
 	if err := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		clusterRoleNameList, clusterRoleErr = testClient.GetClusterRoles(project.ID, tc.dc, cluster.ID)
 		return len(clusterRoleNameList) >= len(tc.expectedClusterRoleNames), nil

--- a/pkg/test/e2e/ccm-migration/cluster.go
+++ b/pkg/test/e2e/ccm-migration/cluster.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -301,7 +301,7 @@ func (c *ClusterJig) CleanUp(ctx context.Context) error {
 				return false, fmt.Errorf("failed to delete user cluster machinedeployment: %w", err)
 			}
 			return false, nil
-		} else if err != nil && !k8serrors.IsNotFound(err) {
+		} else if err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("failed to get user cluster machinedeployment: %w", err)
 		}
 

--- a/pkg/test/e2e/ccm-migration/providers/cluster.go
+++ b/pkg/test/e2e/ccm-migration/providers/cluster.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -143,7 +143,7 @@ func (ccj *CommonClusterJig) cleanUp(ctx context.Context, userClient ctrlruntime
 	return wait.PollImmediate(utils.UserClusterPollInterval, utils.CustomTestTimeout, func() (bool, error) {
 		cluster := &kubermaticv1.Cluster{}
 		var err error
-		if err = ccj.SeedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: ccj.name, Namespace: ""}, cluster); kerrors.IsNotFound(err) {
+		if err = ccj.SeedClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: ccj.name, Namespace: ""}, cluster); apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		if err != nil {

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -30,7 +30,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -722,7 +722,7 @@ func forceDeleteEtcdPV(ctx context.Context, client ctrlruntimeclient.Client, clu
 
 	// make sure it's gone
 	return wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
-		if err := client.Get(ctx, typedName, pv); kerrors.IsNotFound(err) {
+		if err := client.Get(ctx, typedName, pv); apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, nil

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -257,7 +257,7 @@ func waitForCTSync(ctx context.Context, userClient ctrlruntimeclient.Client, ctN
 		err := userClient.Get(ctx, types.NamespacedName{Name: ctName}, gatekeeperCT)
 
 		if deleted {
-			return kerrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}
 		return err == nil
 	}) {
@@ -271,7 +271,7 @@ func waitForConstraintSync(ctx context.Context, client ctrlruntimeclient.Client,
 		constraint := &kubermaticv1.Constraint{}
 		err := client.Get(ctx, types.NamespacedName{Name: cName, Namespace: namespace}, constraint)
 		if deleted {
-			return kerrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}
 		return err == nil
 	}) {

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -786,7 +786,7 @@ func (r *TestClient) GetClusterNodeDeployments(projectID, dc, clusterID string) 
 		apiNd := apiv1.NodeDeployment{}
 		apiNd.Name = nd.Name
 		apiNd.ID = nd.ID
-		apiNd.Status = v1alpha1.MachineDeploymentStatus{
+		apiNd.Status = clusterv1alpha1.MachineDeploymentStatus{
 			Replicas:          nd.Status.Replicas,
 			AvailableReplicas: nd.Status.AvailableReplicas,
 		}

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 
@@ -431,7 +431,7 @@ func (r *TestClient) ListCredentials(providerName, datacenter string) ([]string,
 
 // CreateAWSCluster creates cluster for AWS provider.
 func (r *TestClient) CreateAWSCluster(projectID, dc, name, secretAccessKey, accessKeyID, version, location, availabilityZone, proxyMode string, replicas int32, konnectivityEnabled bool, cniSettings *models.CNIPluginSettings) (*apiv1.Cluster, error) {
-	_, err := semver.NewVersion(version)
+	_, err := semverlib.NewVersion(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
 	}
@@ -506,7 +506,7 @@ func (r *TestClient) CreateAWSCluster(projectID, dc, name, secretAccessKey, acce
 
 // CreateKubevirtCluster creates cluster for Kubevirt provider.
 func (r *TestClient) CreateKubevirtCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
-	_, err := semver.NewVersion(version)
+	_, err := semverlib.NewVersion(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
 	}
@@ -576,7 +576,7 @@ func (r *TestClient) CreateKubevirtCluster(projectID, dc, name, credential, vers
 
 // CreateHetznerCluster creates cluster for Hetzner provider.
 func (r *TestClient) CreateHetznerCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
-	_, err := semver.NewVersion(version)
+	_, err := semverlib.NewVersion(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
 	}
@@ -1680,7 +1680,7 @@ func (r *TestClient) DeleteConstraint(name string) error {
 
 // CreateClusterTemplate method creates cluster template object.
 func (r *TestClient) CreateClusterTemplate(projectID, name, scope, credential, version, location string) (*apiv2.ClusterTemplate, error) {
-	_, err := semver.NewVersion(version)
+	_, err := semverlib.NewVersion(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
 	}

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 )
 
 // BinaryForClusterVersion returns the full path to a kubectl binary
@@ -28,7 +28,7 @@ import (
 // returned if no suitable kubectl can be determined.
 // We take advantage of version skew policy for kubectl, v1.1.1 would support v1.2.x and v1.0.x, to ship
 // only mandatory variants for kubectl.
-func BinaryForClusterVersion(version *semver.Version) (string, error) {
+func BinaryForClusterVersion(version *semverlib.Version) (string, error) {
 	var binary string
 
 	switch version.Minor() {

--- a/pkg/validation/applicationdefinition.go
+++ b/pkg/validation/applicationdefinition.go
@@ -21,14 +21,14 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/validation/openapi"
 
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func ValidateApplicationDefinition(ad appkubermaticv1.ApplicationDefinition) field.ErrorList {
+func ValidateApplicationDefinition(ad appskubermaticv1.ApplicationDefinition) field.ErrorList {
 	var parentFieldPath *field.Path = nil
 	allErrs := field.ErrorList{}
 
@@ -39,7 +39,7 @@ func ValidateApplicationDefinition(ad appkubermaticv1.ApplicationDefinition) fie
 	return allErrs
 }
 
-func ValidateApplicationVersions(vs []appkubermaticv1.ApplicationVersion, parentFieldPath *field.Path) []*field.Error {
+func ValidateApplicationVersions(vs []appskubermaticv1.ApplicationVersion, parentFieldPath *field.Path) []*field.Error {
 	allErrs := field.ErrorList{}
 
 	lookup := make(map[string]struct{}, len(vs))
@@ -69,7 +69,7 @@ func validateSemverRange(v string, f *field.Path) *field.Error {
 	return nil
 }
 
-func ValidateApplicationDefinitionWithOpenAPI(ad appkubermaticv1.ApplicationDefinition, parentFieldPath *field.Path) field.ErrorList {
+func ValidateApplicationDefinitionWithOpenAPI(ad appskubermaticv1.ApplicationDefinition, parentFieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	v, err := openapi.NewValidatorForType(&ad.TypeMeta)

--- a/pkg/validation/applicationdefinition_test.go
+++ b/pkg/validation/applicationdefinition_test.go
@@ -19,45 +19,45 @@ package validation
 import (
 	"testing"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestValidateApplicationDefinition(t *testing.T) {
 	tm := metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
-	cs := appkubermaticv1.ApplicationConstraints{K8sVersion: ">1.0.0", KKPVersion: ">1.0.0"}
-	helmv := appkubermaticv1.ApplicationVersion{Version: "v1", Constraints: cs, Template: appkubermaticv1.ApplicationTemplate{Method: "helm"}}
-	gitv := appkubermaticv1.ApplicationVersion{Version: "v2", Constraints: cs, Template: appkubermaticv1.ApplicationTemplate{Method: "helm"}}
-	spec := appkubermaticv1.ApplicationDefinitionSpec{Versions: []appkubermaticv1.ApplicationVersion{helmv, gitv}}
+	cs := appskubermaticv1.ApplicationConstraints{K8sVersion: ">1.0.0", KKPVersion: ">1.0.0"}
+	helmv := appskubermaticv1.ApplicationVersion{Version: "v1", Constraints: cs, Template: appskubermaticv1.ApplicationTemplate{Method: "helm"}}
+	gitv := appskubermaticv1.ApplicationVersion{Version: "v2", Constraints: cs, Template: appskubermaticv1.ApplicationTemplate{Method: "helm"}}
+	spec := appskubermaticv1.ApplicationDefinitionSpec{Versions: []appskubermaticv1.ApplicationVersion{helmv, gitv}}
 
 	tt := map[string]struct {
-		ad        appkubermaticv1.ApplicationDefinition
+		ad        appskubermaticv1.ApplicationDefinition
 		expErrLen int
 	}{
 		"valid source helm": {
-			appkubermaticv1.ApplicationDefinition{
-				Spec: func() appkubermaticv1.ApplicationDefinitionSpec {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Source = appkubermaticv1.ApplicationSource{Helm: &appkubermaticv1.HelmSource{URL: "kubermatic.io", ChartName: "test", ChartVersion: "1.0.0"}}
+					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{URL: "kubermatic.io", ChartName: "test", ChartVersion: "1.0.0"}}
 					return *s
 				}(),
 			},
 			0,
 		},
 		"valid source git": {
-			appkubermaticv1.ApplicationDefinition{
-				Spec: func() appkubermaticv1.ApplicationDefinitionSpec {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Source = appkubermaticv1.ApplicationSource{Git: &appkubermaticv1.GitSource{}}
+					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{}}
 					return *s
 				}(),
 			},
 			0,
 		},
 		"mixed sources": {
-			appkubermaticv1.ApplicationDefinition{
-				Spec: func() appkubermaticv1.ApplicationDefinitionSpec {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
 					s.Versions[0].Template.Source = gitv.Template.Source
 					s.Versions[1].Template.Source = helmv.Template.Source
@@ -67,8 +67,8 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			0,
 		},
 		"invalid method": {
-			appkubermaticv1.ApplicationDefinition{
-				Spec: func() appkubermaticv1.ApplicationDefinitionSpec {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
 					s.Versions[0].Template.Method = "invalid"
 					return *s
@@ -77,8 +77,8 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			1,
 		},
 		"valid method": {
-			appkubermaticv1.ApplicationDefinition{
-				Spec: func() appkubermaticv1.ApplicationDefinitionSpec {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
 					s.Versions[0].Template.Method = "helm"
 					return *s
@@ -102,25 +102,25 @@ func TestValidateApplicationDefinition(t *testing.T) {
 
 func TestValidateApplicationVersions(t *testing.T) {
 	tt := map[string]struct {
-		vs        []appkubermaticv1.ApplicationVersion
+		vs        []appskubermaticv1.ApplicationVersion
 		expErrLen int
 	}{
 		"duplicate version": {
-			[]appkubermaticv1.ApplicationVersion{
-				{Version: "v1", Constraints: appkubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}},
-				{Version: "v1", Constraints: appkubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}},
+			[]appskubermaticv1.ApplicationVersion{
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}},
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}},
 			},
 			1,
 		},
 		"invalid kkp version": {
-			[]appkubermaticv1.ApplicationVersion{
-				{Version: "v1", Constraints: appkubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "not-semver"}},
+			[]appskubermaticv1.ApplicationVersion{
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "not-semver"}},
 			},
 			1,
 		},
 		"invalid k8s version": {
-			[]appkubermaticv1.ApplicationVersion{
-				{Version: "v1", Constraints: appkubermaticv1.ApplicationConstraints{K8sVersion: "not-semver", KKPVersion: "1"}},
+			[]appskubermaticv1.ApplicationVersion{
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "not-semver", KKPVersion: "1"}},
 			},
 			1,
 		},

--- a/pkg/validation/applicationdefinition_test.go
+++ b/pkg/validation/applicationdefinition_test.go
@@ -21,11 +21,11 @@ import (
 
 	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestValidateApplicationDefinition(t *testing.T) {
-	tm := v1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
+	tm := metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
 	cs := appkubermaticv1.ApplicationConstraints{K8sVersion: ">1.0.0", KKPVersion: ">1.0.0"}
 	helmv := appkubermaticv1.ApplicationVersion{Version: "v1", Constraints: cs, Template: appkubermaticv1.ApplicationTemplate{Method: "helm"}}
 	gitv := appkubermaticv1.ApplicationVersion{Version: "v2", Constraints: cs, Template: appkubermaticv1.ApplicationTemplate{Method: "helm"}}

--- a/pkg/validation/applicationinstallation.go
+++ b/pkg/validation/applicationinstallation.go
@@ -21,7 +21,7 @@ import (
 
 	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -37,7 +37,7 @@ func ValidateApplicationInstallationSpec(ctx context.Context, client ctrlruntime
 	ad := &appkubermaticv1.ApplicationDefinition{}
 	err := client.Get(ctx, types.NamespacedName{Name: spec.ApplicationRef.Name}, ad)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			allErrs = append(allErrs, field.NotFound(specPath.Child("applicationRef", "name"), spec.ApplicationRef.Name))
 		} else {
 			allErrs = append(allErrs, field.InternalError(specPath.Child("applicationRef", "name"), err))

--- a/pkg/validation/applicationinstallation.go
+++ b/pkg/validation/applicationinstallation.go
@@ -19,7 +19,7 @@ package validation
 import (
 	"context"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -29,12 +29,12 @@ import (
 )
 
 // ValidateApplicationInstallationSpec validates the ApplicationInstallation Spec.
-func ValidateApplicationInstallationSpec(ctx context.Context, client ctrlruntimeclient.Client, spec appkubermaticv1.ApplicationInstallationSpec) field.ErrorList {
+func ValidateApplicationInstallationSpec(ctx context.Context, client ctrlruntimeclient.Client, spec appskubermaticv1.ApplicationInstallationSpec) field.ErrorList {
 	specPath := field.NewPath("spec")
 	allErrs := field.ErrorList{}
 
 	// Ensure that the referenced ApplicationDefinition exists
-	ad := &appkubermaticv1.ApplicationDefinition{}
+	ad := &appskubermaticv1.ApplicationDefinition{}
 	err := client.Get(ctx, types.NamespacedName{Name: spec.ApplicationRef.Name}, ad)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -62,7 +62,7 @@ func ValidateApplicationInstallationSpec(ctx context.Context, client ctrlruntime
 }
 
 // ValidateApplicationInstallationUpdate validates the new ApplicationInstallation for immutable fields.
-func ValidateApplicationInstallationUpdate(ctx context.Context, client ctrlruntimeclient.Client, newAI, oldAI appkubermaticv1.ApplicationInstallation) field.ErrorList {
+func ValidateApplicationInstallationUpdate(ctx context.Context, client ctrlruntimeclient.Client, newAI, oldAI appskubermaticv1.ApplicationInstallation) field.ErrorList {
 	specPath := field.NewPath("spec")
 	allErrs := field.ErrorList{}
 

--- a/pkg/validation/applicationinstallation_test.go
+++ b/pkg/validation/applicationinstallation_test.go
@@ -23,7 +23,7 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +42,7 @@ var (
 )
 
 func init() {
-	_ = appkubermaticv1.AddToScheme(testScheme)
+	_ = appskubermaticv1.AddToScheme(testScheme)
 }
 
 // TestValidateApplicationInstallationSpec tests the validation for ApplicationInstallation creation.
@@ -58,7 +58,7 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		ai            *appkubermaticv1.ApplicationInstallation
+		ai            *appskubermaticv1.ApplicationInstallation
 		expectedError string
 	}{
 		{
@@ -68,8 +68,8 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 		},
 		{
 			name: "Create ApplicationInstallation Failure - ApplicationDefinitation doesn't exist",
-			ai: &appkubermaticv1.ApplicationInstallation{
-				Spec: func() appkubermaticv1.ApplicationInstallationSpec {
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
 					spec.ApplicationRef.Name = invalidResource
 					return *spec
@@ -78,10 +78,10 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 		},
 		{
 			name: "Create ApplicationInstallation Failure - Invalid Version",
-			ai: &appkubermaticv1.ApplicationInstallation{
-				Spec: func() appkubermaticv1.ApplicationInstallationSpec {
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
-					spec.ApplicationRef.Version = appkubermaticv1.Version{Version: *semverlib.MustParse("3.2.3")}
+					spec.ApplicationRef.Version = appskubermaticv1.Version{Version: *semverlib.MustParse("3.2.3")}
 					return *spec
 				}(),
 			}, expectedError: `[spec.applicationRef.version: Not found: 3.2.3]`,
@@ -115,15 +115,15 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		ai            *appkubermaticv1.ApplicationInstallation
-		updatedAI     *appkubermaticv1.ApplicationInstallation
+		ai            *appskubermaticv1.ApplicationInstallation
+		updatedAI     *appskubermaticv1.ApplicationInstallation
 		expectedError string
 	}{
 		{
 			name: "Update ApplicationInstallation Success",
 			ai:   ai,
-			updatedAI: &appkubermaticv1.ApplicationInstallation{
-				Spec: func() appkubermaticv1.ApplicationInstallationSpec {
+			updatedAI: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
 					spec.Namespace.Labels = map[string]string{"key": "value"}
 					return *spec
@@ -134,8 +134,8 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 		{
 			name: "Update ApplicationInstallation Failure - .Namespace.Name is immutable",
 			ai:   ai,
-			updatedAI: &appkubermaticv1.ApplicationInstallation{
-				Spec: func() appkubermaticv1.ApplicationInstallationSpec {
+			updatedAI: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
 					spec.Namespace.Name = invalidResource
 					return *spec
@@ -146,8 +146,8 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 		{
 			name: "Update ApplicationInstallation Failure - .ApplicationRef.Name is immutable",
 			ai:   ai,
-			updatedAI: &appkubermaticv1.ApplicationInstallation{
-				Spec: func() appkubermaticv1.ApplicationInstallationSpec {
+			updatedAI: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
 					spec.ApplicationRef.Name = "updated-app"
 					return *spec
@@ -158,10 +158,10 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 		{
 			name: "Update ApplicationInstallation Failure - .ApplicationRef.Version is immutable",
 			ai:   ai,
-			updatedAI: &appkubermaticv1.ApplicationInstallation{
-				Spec: func() appkubermaticv1.ApplicationInstallationSpec {
+			updatedAI: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
-					spec.ApplicationRef.Version = appkubermaticv1.Version{Version: *semverlib.MustParse(defaultAppSecondaryVersion)}
+					spec.ApplicationRef.Version = appskubermaticv1.Version{Version: *semverlib.MustParse(defaultAppSecondaryVersion)}
 					return *spec
 				}(),
 			},
@@ -182,14 +182,14 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 	}
 }
 
-func getApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinition {
-	return &appkubermaticv1.ApplicationDefinition{
+func getApplicationDefinition(name string) *appskubermaticv1.ApplicationDefinition {
+	return &appskubermaticv1.ApplicationDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: appkubermaticv1.ApplicationDefinitionSpec{
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
 			Description: "Description",
-			Versions: []appkubermaticv1.ApplicationVersion{
+			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: defaultAppVersion,
 				},
@@ -201,20 +201,20 @@ func getApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinitio
 	}
 }
 
-func getApplicationInstallation(name string, appName string, appVersion string) *appkubermaticv1.ApplicationInstallation {
-	return &appkubermaticv1.ApplicationInstallation{
+func getApplicationInstallation(name string, appName string, appVersion string) *appskubermaticv1.ApplicationInstallation {
+	return &appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "kube-system",
 		},
-		Spec: appkubermaticv1.ApplicationInstallationSpec{
-			Namespace: appkubermaticv1.NamespaceSpec{
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
+			Namespace: appskubermaticv1.NamespaceSpec{
 				Name:   "default",
 				Create: true,
 			},
-			ApplicationRef: appkubermaticv1.ApplicationRef{
+			ApplicationRef: appskubermaticv1.ApplicationRef{
 				Name:    appName,
-				Version: appkubermaticv1.Version{Version: *semverlib.MustParse(appVersion)},
+				Version: appskubermaticv1.Version{Version: *semverlib.MustParse(appVersion)},
 			},
 		},
 	}

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/coreos/locksmith/pkg/timeutil"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -80,8 +80,8 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 
 		// Dual-stack is not supported on Canal < v3.22
 		if spec.ClusterNetwork.IPFamily == kubermaticv1.IPFamilyDualStack && spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal {
-			gte322Constraint, _ := semver.NewConstraint(">= 3.22")
-			cniVer, _ := semver.NewVersion(spec.CNIPlugin.Version)
+			gte322Constraint, _ := semverlib.NewConstraint(">= 3.22")
+			cniVer, _ := semverlib.NewVersion(spec.CNIPlugin.Version)
 			if cniVer != nil && !gte322Constraint.Check(cniVer) {
 				allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("cniPlugin"), "dual-stack not allowed on Canal CNI version lower than 3.22"))
 			}
@@ -847,7 +847,7 @@ func ValidateContainerRuntime(spec *kubermaticv1.ClusterSpec) error {
 	}
 
 	// Docker is supported until 1.24.0, excluding 1.24.0
-	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
+	gteKube124Condition, _ := semverlib.NewConstraint(">= 1.24")
 	if spec.ContainerRuntime == "docker" && gteKube124Condition.Check(spec.Version.Semver()) {
 		return fmt.Errorf("docker not supported from version 1.24: %s", spec.ContainerRuntime)
 	}
@@ -978,12 +978,12 @@ func validateCNIUpdate(newCni *kubermaticv1.CNIPluginSettings, oldCni *kubermati
 			return nil // allowed for automated migration from deprecated CNI
 		}
 
-		newV, err := semver.NewVersion(newCni.Version)
+		newV, err := semverlib.NewVersion(newCni.Version)
 		if err != nil {
 			return field.Invalid(basePath.Child("version"), newCni.Version, fmt.Sprintf("couldn't parse CNI version `%s`: %v", newCni.Version, err))
 		}
 
-		oldV, err := semver.NewVersion(oldCni.Version)
+		oldV, err := semverlib.NewVersion(oldCni.Version)
 		if err != nil {
 			return field.Invalid(basePath.Child("version"), oldCni.Version, fmt.Sprintf("couldn't parse CNI version `%s`: %v", oldCni.Version, err))
 		}

--- a/pkg/validation/metering.go
+++ b/pkg/validation/metering.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 
-	v1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
 
 var MeteringReportNameValidator = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
@@ -31,7 +31,7 @@ func GetCronExpressionParser() cron.Parser {
 	return cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 }
 
-func ValidateMeteringConfiguration(configuration *v1.MeteringConfiguration) error {
+func ValidateMeteringConfiguration(configuration *kubermaticv1.MeteringConfiguration) error {
 	if configuration != nil && len(configuration.ReportConfigurations) > 0 {
 		parser := GetCronExpressionParser()
 		for reportName, reportConfig := range configuration.ReportConfigurations {

--- a/pkg/validation/nodeupdate/nodeupdate.go
+++ b/pkg/validation/nodeupdate/nodeupdate.go
@@ -20,13 +20,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 )
 
 // VersionSkewError denotes an error condition where a given kubelet/controlplane version pair is not supported.
 type VersionSkewError struct {
-	ControlPlane *semver.Version
-	Kubelet      *semver.Version
+	ControlPlane *semverlib.Version
+	Kubelet      *semverlib.Version
 }
 
 // Error returns a string representation of the error.
@@ -42,7 +42,7 @@ var _ error = VersionSkewError{}
 
 // EnsureVersionCompatible checks whether the given kubelet version
 // is deemed compatible with the given version of the control plane.
-func EnsureVersionCompatible(controlPlane *semver.Version, kubelet *semver.Version) error {
+func EnsureVersionCompatible(controlPlane *semverlib.Version, kubelet *semverlib.Version) error {
 	if controlPlane == nil {
 		return errors.New("ensureVersionCompatible: controlPlane is nil")
 	}

--- a/pkg/validation/openapi/openapi.go
+++ b/pkg/validation/openapi/openapi.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gobuffalo/flect"
 
 	ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,12 +97,12 @@ func v1beta1Validator(u *unstructured.Unstructured) (*validate.SchemaValidator, 
 }
 
 func v1Validator(u *unstructured.Unstructured, desVer string) (*validate.SchemaValidator, error) {
-	crdv1 := &extv1.CustomResourceDefinition{}
+	crdv1 := &apiextensionsv1.CustomResourceDefinition{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), crdv1); err != nil {
 		return nil, err
 	}
 	crdr := &ext.CustomResourceDefinition{}
-	if err := extv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(crdv1, crdr, nil); err != nil {
+	if err := apiextensionsv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(crdv1, crdr, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/version/helpers.go
+++ b/pkg/version/helpers.go
@@ -19,16 +19,16 @@ package version
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
 
-func IsSupported(version *semver.Version, provider kubermaticv1.ProviderType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
+func IsSupported(version *semverlib.Version, provider kubermaticv1.ProviderType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
 	return checkProviderCompatibility(version, provider, kubermaticv1.SupportOperation, incompatibilities, conditions...)
 }
 
-func checkProviderCompatibility(version *semver.Version, provider kubermaticv1.ProviderType, operation kubermaticv1.OperationType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
+func checkProviderCompatibility(version *semverlib.Version, provider kubermaticv1.ProviderType, operation kubermaticv1.OperationType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
 	var compatible = true
 	var err error
 	for _, pi := range incompatibilities {
@@ -60,8 +60,8 @@ func checkProviderCompatibility(version *semver.Version, provider kubermaticv1.P
 	return compatible, nil
 }
 
-func CheckUnconstrained(baseVersion *semver.Version, version string) (bool, error) {
-	c, err := semver.NewConstraint(version)
+func CheckUnconstrained(baseVersion *semverlib.Version, version string) (bool, error) {
+	c, err := semverlib.NewConstraint(version)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse to constraint %s: %w", c, err)
 	}

--- a/pkg/version/manager.go
+++ b/pkg/version/manager.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -48,8 +48,8 @@ type ProviderIncompatibility struct {
 
 // Version is the object representing a Kubernetes version.
 type Version struct {
-	Version *semver.Version `json:"version"`
-	Default bool            `json:"default,omitempty"`
+	Version *semverlib.Version `json:"version"`
+	Default bool               `json:"default,omitempty"`
 }
 
 // Update represents an update option for a cluster.
@@ -118,7 +118,7 @@ func (m *Manager) GetDefault() (*Version, error) {
 
 // GetVersion returns the Versions for s.
 func (m *Manager) GetVersion(s string) (*Version, error) {
-	sv, err := semver.NewVersion(s)
+	sv, err := semverlib.NewVersion(s)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", s, err)
 	}
@@ -180,7 +180,7 @@ func (m *Manager) AutomaticNodeUpdate(fromVersionRaw, controlPlaneVersion string
 	if err != nil || version == nil {
 		return version, err
 	}
-	controlPlaneSemver, err := semver.NewVersion(controlPlaneVersion)
+	controlPlaneSemver, err := semverlib.NewVersion(controlPlaneVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse controlplane version: %w", err)
 	}
@@ -199,7 +199,7 @@ func (m *Manager) AutomaticControlplaneUpdate(fromVersionRaw string) (*Version, 
 }
 
 func (m *Manager) automaticUpdate(fromVersionRaw string, isForNode bool) (*Version, error) {
-	from, err := semver.NewVersion(fromVersionRaw)
+	from, err := semverlib.NewVersion(fromVersionRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", fromVersionRaw, err)
 	}
@@ -217,7 +217,7 @@ func (m *Manager) automaticUpdate(fromVersionRaw string, isForNode bool) (*Versi
 			continue
 		}
 
-		uFrom, err := semver.NewConstraint(u.From)
+		uFrom, err := semverlib.NewConstraint(u.From)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse from constraint %s: %w", u.From, err)
 		}
@@ -226,7 +226,7 @@ func (m *Manager) automaticUpdate(fromVersionRaw string, isForNode bool) (*Versi
 		}
 
 		// Automatic updates must not be a constraint. They must be version.
-		if _, err = semver.NewVersion(u.To); err != nil {
+		if _, err = semverlib.NewVersion(u.To); err != nil {
 			return nil, fmt.Errorf("failed to parse to version %s: %w", u.To, err)
 		}
 		toVersions = append(toVersions, u.To)
@@ -249,15 +249,15 @@ func (m *Manager) automaticUpdate(fromVersionRaw string, isForNode bool) (*Versi
 
 // GetPossibleUpdates returns possible updates for the version passed in.
 func (m *Manager) GetPossibleUpdates(fromVersionRaw string, provider kubermaticv1.ProviderType, conditions ...kubermaticv1.ConditionType) ([]*Version, error) {
-	from, err := semver.NewVersion(fromVersionRaw)
+	from, err := semverlib.NewVersion(fromVersionRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", fromVersionRaw, err)
 	}
 	var possibleVersions []*Version
 
-	var toConstraints []*semver.Constraints
+	var toConstraints []*semverlib.Constraints
 	for _, u := range m.updates {
-		uFrom, err := semver.NewConstraint(u.From)
+		uFrom, err := semverlib.NewConstraint(u.From)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse from constraint %s: %w", u.From, err)
 		}
@@ -265,7 +265,7 @@ func (m *Manager) GetPossibleUpdates(fromVersionRaw string, provider kubermaticv
 			continue
 		}
 
-		uTo, err := semver.NewConstraint(u.To)
+		uTo, err := semverlib.NewConstraint(u.To)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse to constraint %s: %w", u.To, err)
 		}
@@ -294,15 +294,15 @@ func (m *Manager) GetIncompatibilities() []*ProviderIncompatibility {
 }
 
 func (m *Manager) GetKubeOnePossibleUpdates(fromVersionRaw string, provider kubermaticv1.ProviderType, conditions ...kubermaticv1.ConditionType) ([]*Version, error) {
-	from, err := semver.NewVersion(fromVersionRaw)
+	from, err := semverlib.NewVersion(fromVersionRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", fromVersionRaw, err)
 	}
 	var possibleVersions []*Version
 
-	var toConstraints []*semver.Constraints
+	var toConstraints []*semverlib.Constraints
 	for _, u := range m.updates {
-		uFrom, err := semver.NewConstraint(u.From)
+		uFrom, err := semverlib.NewConstraint(u.From)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse from constraint %s: %w", u.From, err)
 		}
@@ -310,7 +310,7 @@ func (m *Manager) GetKubeOnePossibleUpdates(fromVersionRaw string, provider kube
 			continue
 		}
 
-		uTo, err := semver.NewConstraint(u.To)
+		uTo, err := semverlib.NewConstraint(u.To)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse to constraint %s: %w", u.To, err)
 		}

--- a/pkg/version/manager_test.go
+++ b/pkg/version/manager_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 )
@@ -43,7 +43,7 @@ func TestAutomaticNodeUpdate(t *testing.T) {
 				To:                  "1.6.0",
 				AutomaticNodeUpdate: true,
 			}},
-			expectedVersion: &Version{Version: semver.MustParse("1.6.0")},
+			expectedVersion: &Version{Version: semverlib.MustParse("1.6.0")},
 		},
 		{
 			name:                "Node compatibility check fails, error",
@@ -55,8 +55,8 @@ func TestAutomaticNodeUpdate(t *testing.T) {
 				AutomaticNodeUpdate: true,
 			}},
 			expectedError: nodeupdate.VersionSkewError{
-				ControlPlane: semver.MustParse("1.5.0"),
-				Kubelet:      semver.MustParse("1.6.0"),
+				ControlPlane: semverlib.MustParse("1.5.0"),
+				Kubelet:      semverlib.MustParse("1.6.0"),
 			},
 		},
 	}
@@ -66,7 +66,7 @@ func TestAutomaticNodeUpdate(t *testing.T) {
 			m := &Manager{
 				updates: tc.updates,
 				versions: []*Version{
-					{Version: semver.MustParse(tc.updates[0].To)},
+					{Version: semverlib.MustParse(tc.updates[0].To)},
 				},
 			}
 			version, err := m.AutomaticNodeUpdate(tc.fromVersion, tc.controlPlaneVersion)

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -19,7 +19,7 @@ package version
 import (
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
@@ -40,11 +40,11 @@ func TestAutomaticUpdate(t *testing.T) {
 			expectedVersion: "1.10.1",
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.10.0"),
+					Version: semverlib.MustParse("1.10.0"),
 					Default: false,
 				},
 				{
-					Version: semver.MustParse("1.10.1"),
+					Version: semverlib.MustParse("1.10.1"),
 					Default: true,
 				},
 			}, []*Update{
@@ -61,11 +61,11 @@ func TestAutomaticUpdate(t *testing.T) {
 			expectedVersion: "1.10.1",
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.10.0"),
+					Version: semverlib.MustParse("1.10.0"),
 					Default: false,
 				},
 				{
-					Version: semver.MustParse("1.10.1"),
+					Version: semverlib.MustParse("1.10.1"),
 					Default: true,
 				},
 			}, []*Update{
@@ -115,11 +115,11 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			provider: kubermaticv1.AWSCloudProvider,
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, nil,
@@ -132,10 +132,10 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 				}),
 			expectedVersions: []*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 				},
 			},
 		},
@@ -144,11 +144,11 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			provider: kubermaticv1.VSphereCloudProvider,
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, nil,
@@ -162,7 +162,7 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 				}),
 			expectedVersions: []*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 				},
 			},
 		},
@@ -172,11 +172,11 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			conditions: []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, nil,
@@ -190,7 +190,7 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 				}),
 			expectedVersions: []*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 				},
 			},
 		},
@@ -199,11 +199,11 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 			provider: kubermaticv1.VSphereCloudProvider,
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, nil,
@@ -223,7 +223,7 @@ func TestProviderIncompatibilitiesVersions(t *testing.T) {
 				}),
 			expectedVersions: []*Version{
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 				},
 			},
 		},
@@ -280,11 +280,11 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 			fromVersion: "1.21.0",
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, []*Update{
@@ -303,7 +303,7 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 			}),
 			expectedVersions: []*Version{
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 				},
 			},
 		},
@@ -314,11 +314,11 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 			conditions:  []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, []*Update{
@@ -343,11 +343,11 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 			fromVersion: "1.21.0",
 			manager: New([]*Version{
 				{
-					Version: semver.MustParse("1.21.0"),
+					Version: semverlib.MustParse("1.21.0"),
 					Default: true,
 				},
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 					Default: false,
 				},
 			}, []*Update{
@@ -365,7 +365,7 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 			}),
 			expectedVersions: []*Version{
 				{
-					Version: semver.MustParse("1.22.0"),
+					Version: semverlib.MustParse("1.22.0"),
 				},
 			},
 		},

--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -149,7 +149,7 @@ func (h *AdmissionHandler) ensureClusterReference(ctx context.Context, addon *ku
 		return fmt.Errorf("Cluster %s is in deletion already, cannot create a new addon", cluster.Name)
 	}
 
-	addon.Spec.Cluster = v1.ObjectReference{
+	addon.Spec.Cluster = corev1.ObjectReference{
 		Name:       cluster.Name,
 		Namespace:  "",
 		UID:        cluster.UID,

--- a/pkg/webhook/application/applicationdefinition/validation/validation.go
+++ b/pkg/webhook/application/applicationdefinition/validation/validation.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/validation"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -60,7 +60,7 @@ func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
 
 func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
 	allErrs := field.ErrorList{}
-	ad := &appkubermaticv1.ApplicationDefinition{}
+	ad := &appskubermaticv1.ApplicationDefinition{}
 
 	switch req.Operation {
 	case admissionv1.Create, admissionv1.Update:

--- a/pkg/webhook/application/applicationinstallation/validation/validation.go
+++ b/pkg/webhook/application/applicationinstallation/validation/validation.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/validation"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -65,8 +65,8 @@ func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
 
 func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
 	allErrs := field.ErrorList{}
-	ad := &appkubermaticv1.ApplicationInstallation{}
-	oldAD := &appkubermaticv1.ApplicationInstallation{}
+	ad := &appskubermaticv1.ApplicationInstallation{}
+	oldAD := &appskubermaticv1.ApplicationInstallation{}
 
 	switch req.Operation {
 	case admissionv1.Create:

--- a/pkg/webhook/application/applicationinstallation/validation/validation_test.go
+++ b/pkg/webhook/application/applicationinstallation/validation/validation_test.go
@@ -24,7 +24,7 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 
-	appkubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ var (
 )
 
 func init() {
-	_ = appkubermaticv1.AddToScheme(testScheme)
+	_ = appskubermaticv1.AddToScheme(testScheme)
 }
 
 func TestValidateApplicationInsallation(t *testing.T) {
@@ -76,8 +76,8 @@ func TestValidateApplicationInsallation(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					RequestKind: &metav1.GroupVersionKind{
-						Group:   appkubermaticv1.GroupName,
-						Version: appkubermaticv1.GroupVersion,
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
 						Kind:    "ApplicationInstallation",
 					},
 					Name:   "default",
@@ -92,8 +92,8 @@ func TestValidateApplicationInsallation(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					RequestKind: &metav1.GroupVersionKind{
-						Group:   appkubermaticv1.GroupName,
-						Version: appkubermaticv1.GroupVersion,
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
 						Kind:    "ApplicationInstallation",
 					},
 					Name:   "default",
@@ -108,8 +108,8 @@ func TestValidateApplicationInsallation(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					RequestKind: &metav1.GroupVersionKind{
-						Group:   appkubermaticv1.GroupName,
-						Version: appkubermaticv1.GroupVersion,
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
 						Kind:    "ApplicationInstallation",
 					},
 					Name:   "default",
@@ -124,8 +124,8 @@ func TestValidateApplicationInsallation(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					RequestKind: &metav1.GroupVersionKind{
-						Group:   appkubermaticv1.GroupName,
-						Version: appkubermaticv1.GroupVersion,
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
 						Kind:    "ApplicationInstallation",
 					},
 					Name:      "default",
@@ -158,14 +158,14 @@ func TestValidateApplicationInsallation(t *testing.T) {
 	}
 }
 
-func getApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinition {
-	return &appkubermaticv1.ApplicationDefinition{
+func getApplicationDefinition(name string) *appskubermaticv1.ApplicationDefinition {
+	return &appskubermaticv1.ApplicationDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: appkubermaticv1.ApplicationDefinitionSpec{
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
 			Description: "Description",
-			Versions: []appkubermaticv1.ApplicationVersion{
+			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: defaultAppVersion,
 				},
@@ -174,26 +174,26 @@ func getApplicationDefinition(name string) *appkubermaticv1.ApplicationDefinitio
 	}
 }
 
-func getApplicationInstallation(name string, appName string, appVersion string) *appkubermaticv1.ApplicationInstallation {
-	return &appkubermaticv1.ApplicationInstallation{
+func getApplicationInstallation(name string, appName string, appVersion string) *appskubermaticv1.ApplicationInstallation {
+	return &appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "kube-system",
 		},
-		Spec: appkubermaticv1.ApplicationInstallationSpec{
-			Namespace: appkubermaticv1.NamespaceSpec{
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
+			Namespace: appskubermaticv1.NamespaceSpec{
 				Name:   "default",
 				Create: true,
 			},
-			ApplicationRef: appkubermaticv1.ApplicationRef{
+			ApplicationRef: appskubermaticv1.ApplicationRef{
 				Name:    appName,
-				Version: appkubermaticv1.Version{Version: *semverlib.MustParse(appVersion)},
+				Version: appskubermaticv1.Version{Version: *semverlib.MustParse(appVersion)},
 			},
 		},
 	}
 }
 
-func applicationInstallationToRawExt(ai appkubermaticv1.ApplicationInstallation) runtime.RawExtension {
+func applicationInstallationToRawExt(ai appskubermaticv1.ApplicationInstallation) runtime.RawExtension {
 	s := json.NewSerializer(json.DefaultMetaFactory, testScheme, testScheme, true)
 	buff := bytes.NewBuffer([]byte{})
 	_ = s.Encode(&ai, buff)

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -200,7 +200,7 @@ func (h *AdmissionHandler) mutateUpdate(oldCluster, newCluster *kubermaticv1.Clu
 		// This upgrade is necessary for k8s versions >= 1.22, where v1beta1 CRDs used in old Canal version (v3.8)
 		// are not supported anymore.
 		if newCluster.Spec.CNIPlugin.Version == cni.CanalCNILastUnspecifiedVersion {
-			upgradeConstraint, err := semver.NewConstraint(">= 1.22")
+			upgradeConstraint, err := semverlib.NewConstraint(">= 1.22")
 			if err != nil {
 				return fmt.Errorf("parsing CNI upgrade constraint failed: %w", err)
 			}
@@ -214,15 +214,15 @@ func (h *AdmissionHandler) mutateUpdate(oldCluster, newCluster *kubermaticv1.Clu
 
 		// This part handles Canal version upgrade for clusters with Kubernetes version 1.23 and higher,
 		// where the minimal Canal version is v3.22.
-		cniVersion, err := semver.NewVersion(newCluster.Spec.CNIPlugin.Version)
+		cniVersion, err := semverlib.NewVersion(newCluster.Spec.CNIPlugin.Version)
 		if err != nil {
 			return fmt.Errorf("CNI plugin version parsing failed: %w", err)
 		}
-		lowerThan322, err := semver.NewConstraint("< 3.22")
+		lowerThan322, err := semverlib.NewConstraint("< 3.22")
 		if err != nil {
 			return fmt.Errorf("semver constraint parsing failed: %w", err)
 		}
-		equalOrHigherThan123, err := semver.NewConstraint(">= 1.23")
+		equalOrHigherThan123, err := semverlib.NewConstraint(">= 1.23")
 		if err != nil {
 			return fmt.Errorf("semver constraint parsing failed: %w", err)
 		}

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud"
 	"k8c.io/kubermatic/v2/pkg/validation"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -153,7 +153,7 @@ func (v *validator) validateProjectRelation(ctx context.Context, cluster *kuberm
 
 	project := &kubermaticv1.Project{}
 	if err := v.client.Get(ctx, types.NamespacedName{Name: projectID}, project); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// during cluster creation, we enforce the project label;
 			// during updates we are more relaxed and only require that the label isn't changed,
 			// so that if a project gets removed before the cluster (for whatever reason), then

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,7 +46,7 @@ func NewValidator(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *
 var _ admission.CustomValidator = &validator{}
 
 func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
-	machine, ok := obj.(*v1alpha1.Machine)
+	machine, ok := obj.(*clusterv1alpha1.Machine)
 	if !ok {
 		return errors.New("object is not a Machine")
 	}

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -23,11 +23,11 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ *v1alpha1.Machine) error {
+func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine) error {
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -23,12 +23,12 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *v1alpha1.Machine) error {
+func validateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine) error {
 	return eemachinevalidation.ValidateQuota(ctx, log, seedClient, machine)
 }

--- a/pkg/webhook/util/project.go
+++ b/pkg/webhook/util/project.go
@@ -23,7 +23,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,7 +37,7 @@ func OptimisticallyCheckIfProjectIsValid(ctx context.Context, client ctrlruntime
 	if err := client.Get(ctx, types.NamespacedName{Name: projectName}, project); err != nil {
 		// We rely on eventual consistency; this webhook should only check if the UserSSHKey
 		// object is consistent in itself.
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This enables the `importas` linter and defines a couple of rules to make our code more consistent. No logic was changed.

The aliases for Kubernetes are based on https://github.com/kubernetes-sigs/controller-runtime/blob/master/.golangci.yml#L46-L62 (hence the "renaming" of utilerrors => kerrors and kerrors => apierrors in a few places).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
