### PR TITLE
[release/v2.20] fix S3 exporter (#9769)

### DIFF
--- a/charts/s3-exporter/Chart.yaml
+++ b/charts/s3-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: s3-exporter
 version: v9.9.9-dev
-appVersion: v0.5
+appVersion: v0.6
 keywords:
   - kubermatic
   - prometheus

--- a/charts/s3-exporter/values.yaml
+++ b/charts/s3-exporter/values.yaml
@@ -15,7 +15,7 @@
 s3Exporter:
   image:
     repository: quay.io/kubermatic/s3-exporter
-    tag: v0.5
+    tag: v0.6
   endpoint: http://minio.minio.svc.cluster.local:9000
   bucket: kubermatic-etcd-backups
   # uncomment this and create a ConfigMap with a "cabundle.pem" in it,

--- a/hack/publish-s3-exporter.sh
+++ b/hack/publish-s3-exporter.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 
 REPOSITORY=quay.io/kubermatic/s3-exporter
-TAG=v0.5
+TAG=v0.6
 
 GOOS=linux GOARCH=amd64 make s3-exporter
 

--- a/pkg/exporters/s3/exporter.go
+++ b/pkg/exporters/s3/exporter.go
@@ -87,7 +87,7 @@ func (e *s3Exporter) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (e *s3Exporter) Collect(ch chan<- prometheus.Metric) {
-	var clusterList *kubermaticv1.ClusterList
+	clusterList := &kubermaticv1.ClusterList{}
 	if err := e.client.List(context.Background(), clusterList); err != nil {
 		e.logger.Errorw("Failed to list clusters", zap.Error(err))
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a manual backport of #9769.

**Does this PR introduce a user-facing change?**:
```release-note
Fix S3-Exporter not producing metrics.
```
