### PR TITLE
update Helm in our Docker image to 3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV KUBERMATIC_CHARTS_DIRECTORY=/opt/charts/
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.23.5/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.23
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.21.11/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.21
 
-RUN wget -O- https://get.helm.sh/helm-v3.5.0-linux-amd64.tar.gz | tar xzOf - linux-amd64/helm > /usr/local/bin/helm
+RUN wget -O- https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz | tar xzOf - linux-amd64/helm > /usr/local/bin/helm
 
 # We need the ca-certs so they api doesn't crash because it can't verify the certificate of Dex
 RUN chmod +x /usr/local/bin/kubectl-* /usr/local/bin/helm && apk add ca-certificates


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This bumps to the latest available version.

**Does this PR introduce a user-facing change?**:
```release-note
Update Helm in Docker image to 3.8.1
```
