### PR TITLE
update kubermatic/util image, include yq4

### DIFF
--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -178,7 +178,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.0.0'
+        image: 'quay.io/kubermatic/util:2.1.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -178,7 +178,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.0.0'
+        image: 'quay.io/kubermatic/util:2.1.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -51,7 +51,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.0.0
+      tag: 2.1.0
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -25,7 +25,7 @@ grafana:
     tag: 8.1.2
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 2.0.0
+    tag: 2.1.0
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
     tag: 1.3.1
@@ -120,10 +120,10 @@ grafana:
       # the dashboards.
       viewers_can_edit: false
 
-      # Change this to the URL that will be used to expose 
+      # Change this to the URL that will be used to expose
       # your Grafana installation. This is needed for Grafana to be aware
-      # where it is hosted. This address is used in some redirects 
-      # or for sharing dashboards. 
+      # where it is hosted. This address is used in some redirects
+      # or for sharing dashboards.
       root_url: ""
 
   # If you manage your dashboards via your own configmaps,

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -55,7 +55,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 2.0.0
+      tag: 2.1.0
       pullPolicy: IfNotPresent
   resources:
     karma:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -42,7 +42,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.0.0
+      tag: 2.1.0
     timeout: 60m
 
   # Specify additional external labels which will be added to all

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.0.0
+          image: quay.io/kubermatic/util:2.1.0
           args:
             - /bin/sh
             - -c

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -15,11 +15,12 @@
 FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-ENV MC_VERSION=RELEASE.2021-07-27T06-46-19Z \
-    KUBECTL_VERSION=v1.21.4 \
-    HELM_VERSION=v3.6.3 \
-    VAULT_VERSION=1.8.1 \
-    YQ_VERSION=3.4.1
+ENV MC_VERSION=RELEASE.2022-05-09T04-08-26Z \
+    KUBECTL_VERSION=v1.22.9 \
+    HELM_VERSION=v3.8.1 \
+    VAULT_VERSION=1.10.2 \
+    YQ3_VERSION=3.4.1 \
+    YQ4_VERSION=4.25.1
 
 RUN apk add --no-cache -U \
     bash \
@@ -37,9 +38,14 @@ RUN apk add --no-cache -U \
     unzip \
     tar
 
-RUN curl -Lo /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
-    chmod +x /usr/bin/yq && \
-    yq --version
+RUN curl -Lo /usr/bin/yq3 https://github.com/mikefarah/yq/releases/download/${YQ3_VERSION}/yq_linux_amd64 && \
+    chmod +x /usr/bin/yq3 && \
+    yq3 --version && \
+    ln -s /usr/bin/yq3 /usr/bin/yq
+
+RUN curl -Lo /usr/bin/yq4 https://github.com/mikefarah/yq/releases/download/v${YQ4_VERSION}/yq_linux_amd64 && \
+    chmod +x /usr/bin/yq4 && \
+    yq4 --version
 
 RUN curl -Lo /usr/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} && \
     chmod +x /usr/bin/mc && \

--- a/hack/images/util/release.sh
+++ b/hack/images/util/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/util
-VERSION=2.0.0
+VERSION=2.1.0
 SUFFIX=""
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}${SUFFIX}" .

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -104,7 +104,7 @@ EOF
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.0.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.1.0}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
   local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
   local skip="${NO_CONTAINERIZE:-}"

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -230,7 +230,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret, get
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   getRegistry(resources.RegistryQuay) + "/kubermatic/util:2.0.0",
+					Image:   getRegistry(resources.RegistryQuay) + "/kubermatic/util:2.1.0",
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/util:2.0.0
+        image: quay.io/kubermatic/util:2.1.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/web-terminal/deployment.go
+++ b/pkg/resources/web-terminal/deployment.go
@@ -87,7 +87,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/util:2.0.0",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/util:2.1.0",
 					Command: []string{"/bin/bash", "-c", "--"},
 					Args:    []string{"while true; do sleep 30; done;"},
 					Env: []corev1.EnvVar{{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This updates the included binaries in our util Docker image. Since KKP supports k8s 1.21+, I also updated the kubectl release to allow us to be a bit closer to 1.23/1.24 (soon).

yq4 is now included by default, allowing us to slooooowly migrate our stuff over and then at some point make the switch and remove v3 entirely. The `kubermatic/build` image does the same already, so with this PR we should have `yq4` available everywhere.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
