### PR TITLE
extend cluster metrics, add external cluster metrics

### DIFF
--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/collectors"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
 	"k8c.io/kubermatic/v2/pkg/features"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -189,6 +190,9 @@ func main() {
 	if err != nil {
 		log.Fatalw("failed to construct seedKubeconfigGetter", zap.Error(err))
 	}
+
+	log.Debug("Starting external clusters collector")
+	collectors.MustRegisterExternalClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 
 	if err := createAllControllers(ctrlCtx); err != nil {
 		log.Fatalw("could not create all controllers", zap.Error(err))


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR improves our Prometheus metrics:

* `kubermatic_cluster_info`
  * no `type` label anymore (we removed the notion of clustertypes (kubernetes/openshift) a loooooong time ago)
  * new `phase` label
  * `master_version` => `spec_version`
  * new `current_version` label
* `kubermatic_external_cluster_info`
  * `name`, `display_name`, `provider` and `phase` labels

**Does this PR introduce a user-facing change?**:
```release-note
* `kubermatic_cluster_info` was updated: `type` label was removed, `master_version` renamed to `spec_version` and `current_version` and `phase` labels were added
* `kubermatic_external_cluster_info` metric was added, with `name`, `display_name`, `provider` and `phase` labels (note that external cluster metrics are provided by the master-controller-manager)
```
