### PR TITLE
improve cluster deletion

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -981,11 +981,11 @@ func updateAndDeleteClusterForRegularUser(ctx context.Context, userInfoGetter pr
 	if err != nil {
 		return utilerrors.New(http.StatusInternalServerError, err.Error())
 	}
-	if _, err = clusterProvider.Update(ctx, project, userInfo, cluster); err != nil {
+	if cluster, err = clusterProvider.Update(ctx, project, userInfo, cluster); err != nil {
 		return common.KubernetesErrorToHTTPError(err)
 	}
 
-	err = clusterProvider.Delete(ctx, userInfo, cluster.Name)
+	err = clusterProvider.Delete(ctx, userInfo, cluster)
 	if err != nil {
 		return common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/provider/kubernetes/cluster.go
+++ b/pkg/provider/kubernetes/cluster.go
@@ -295,7 +295,7 @@ func (p *ClusterProvider) IsCluster(ctx context.Context, clusterName string) boo
 }
 
 // Delete deletes the given cluster.
-func (p *ClusterProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, clusterName string) error {
+func (p *ClusterProvider) Delete(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) error {
 	seedImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createSeedImpersonatedClient)
 	if err != nil {
 		return err
@@ -307,7 +307,7 @@ func (p *ClusterProvider) Delete(ctx context.Context, userInfo *provider.UserInf
 	delOpts := &ctrlruntimeclient.DeleteOptions{
 		PropagationPolicy: &policy,
 	}
-	return seedImpersonatedClient.Delete(ctx, &kubermaticv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}, delOpts)
+	return seedImpersonatedClient.Delete(ctx, cluster, delOpts)
 }
 
 // Update updates a cluster.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -180,7 +180,7 @@ type ClusterProvider interface {
 	Update(ctx context.Context, project *kubermaticv1.Project, userInfo *UserInfo, newCluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
 
 	// Delete deletes the given cluster
-	Delete(ctx context.Context, userInfo *UserInfo, clusterName string) error
+	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster) error
 
 	// GetAdminKubeconfigForCustomerCluster returns the admin kubeconfig for the given cluster
 	GetAdminKubeconfigForCustomerCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)


### PR DESCRIPTION
**What does this PR do / Why do we need it**: The cluster deletion throws the error "object has been changed" from time to time. This PR changes the DELETE method and uses the modified cluster instead crating a new cluster object.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

```release-note
NONE
```
