### PR TITLE
enable nosprintfhostport linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,7 @@ linters:
     - misspell
     - noctx
     - nolintlint
+    - nosprintfhostport
     - predeclared
     - promlinter
     - staticcheck

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -91,10 +91,9 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.43.0
+        - image: quay.io/kubermatic/build:go-1.18-node-16-4
           command:
             - make
-          args:
             - lint
           resources:
             requests:

--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -141,7 +141,7 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 	}
 	log.Debug("The Service has an external IP/Name")
 
-	hostURL := fmt.Sprintf("http://%s:80", host)
+	hostURL := fmt.Sprintf("http://%s", net.JoinHostPort(host, "80"))
 	log.Debug("Waiting until the pod is available via the LoadBalancer...")
 	err = wait.Poll(3*time.Second, opts.CustomTestTimeout, func() (done bool, err error) {
 		request, err := http.NewRequestWithContext(ctx, "GET", hostURL, nil)

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -321,12 +322,12 @@ func (e *etcdCluster) updatePeerURLs(log *zap.SugaredLogger) error {
 			// if both plaintext and TLS peer URLs are supposed to be present
 			// update the member to include both plaintext and TLS peer URLs
 			if !e.usePeerTLSOnly && (len(member.PeerURLs) == 1 || peerURL.Scheme != "http") {
-				plainPeerURL, err := url.Parse(fmt.Sprintf("http://%s:2380", peerURL.Hostname()))
+				plainPeerURL, err := url.Parse(fmt.Sprintf("http://%s", net.JoinHostPort(peerURL.Hostname(), "2380")))
 				if err != nil {
 					return err
 				}
 
-				tlsPeerURL, err := url.Parse(fmt.Sprintf("https://%s:2381", peerURL.Hostname()))
+				tlsPeerURL, err := url.Parse(fmt.Sprintf("https://%s", net.JoinHostPort(peerURL.Hostname(), "2381")))
 				if err != nil {
 					return err
 				}
@@ -344,7 +345,7 @@ func (e *etcdCluster) updatePeerURLs(log *zap.SugaredLogger) error {
 			// if we're supposed to run with TLS peer endpoints only, two peer URLs are
 			// not a valid configuration and should be replaced with TLS only
 			if len(member.PeerURLs) == 2 && e.usePeerTLSOnly {
-				tlsPeerURL, err := url.Parse(fmt.Sprintf("https://%s:2381", peerURL.Hostname()))
+				tlsPeerURL, err := url.Parse(fmt.Sprintf("https://%s", net.JoinHostPort(peerURL.Hostname(), "2381")))
 				if err != nil {
 					return err
 				}

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -211,7 +211,7 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 	}
 
 	// URL
-	url := fmt.Sprintf("https://%s:%d", externalName, port)
+	url := fmt.Sprintf("https://%s", net.JoinHostPort(externalName, fmt.Sprintf("%d", port)))
 	if m.cluster.Address.URL != url {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.URL = url

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -144,7 +144,7 @@ func TestSyncClusterAddress(t *testing.T) {
 			expectedExternalName: loadbBalancerHostName,
 			expectedIP:           externalIP,
 			expectedPort:         int32(443),
-			expectedURL:          fmt.Sprintf("https://%s:443", loadbBalancerHostName),
+			expectedURL:          fmt.Sprintf("https://%s", net.JoinHostPort(loadbBalancerHostName, "443")),
 		},
 		{
 			name: "Verify properties for service type NodePort",

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -268,7 +268,7 @@ func testUserCluster(t *testing.T, config *rest.Config) {
 		}
 
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
-			fmt.Sprintf("http://%s:%d", nodeIP, 30007), nil)
+			fmt.Sprintf("http://%s", net.JoinHostPort(nodeIP, "30007")), nil)
 		if err != nil {
 			t.Logf("failed to construct request to hubble ui: %v", err)
 			return false, nil


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This one might be overkill.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
