### PR TITLE
update kubevirt prow preset

### DIFF
--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -17,7 +17,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-kkp-kubevirt: "true"
+      preset-kubevirt: "true"
       preset-vault: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
@@ -60,7 +60,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-kkp-kubevirt: "true"
+      preset-kubevirt: "true"
       preset-vault: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Update the kubevirt prow preset in order to use the new KubeVirt cluster for ci tests.  
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
