### PR TITLE
Add audit logging to presets for Cluster API & Gatekeeper resources

### DIFF
--- a/pkg/resources/apiserver/audit.go
+++ b/pkg/resources/apiserver/audit.go
@@ -37,14 +37,24 @@ kind:  Policy
 omitStages:
   - "RequestReceived"
 rules:
-  # log all changes to workloads (Pods, Deployments, etc) in full, including request and response
   - level: RequestResponse
     verbs: ["create", "delete", "update", "patch"]
     resources:
+      # log all changes to workloads (Pods, Deployments, etc)
       - group: ""
         resources: ["pods"]
       - group: "apps"
         resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+      # log all changes to machines and higher level machine objects
+      - group: "cluster.k8s.io"
+        resources: ["machines", "machinesets", "machinedeployments"]
+      # log all changes to Gatekeeper templates
+      - group: "templates.gatekeeper.sh"
+      # this secret controls SSH access to nodes if user-ssh-keys-agent is enabled
+      # and it is included in audit logging because of that
+      - group: ""
+        resources: ["secrets"]
+        resourceNames: ["usersshkeys"]
   # log extended information for requests that access pods via shell or network proxying
   - level: RequestResponse
     resources:
@@ -61,14 +71,24 @@ kind: Policy
 omitStages:
   - "RequestReceived"
 rules:
-  # log all changes to workloads (Pods, Deployments, etc) in full, including request and response
   - level: RequestResponse
     verbs: ["create", "delete", "update", "patch"]
     resources:
+      # log all changes to workloads (Pods, Deployments, etc)
       - group: ""
         resources: ["pods"]
       - group: "apps"
         resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+      # log all changes to machines and higher level machine objects
+      - group: "cluster.k8s.io"
+        resources: ["machines", "machinesets", "machinedeployments"]
+      # log all changes to Gatekeeper templates
+      - group: "templates.gatekeeper.sh"
+      # this secret controls SSH access to nodes if user-ssh-keys-agent is enabled
+      # and it is included in audit logging because of that
+      - group: ""
+        resources: ["secrets"]
+        resourceNames: ["usersshkeys"]
   # log extended information for requests that access pods in an way (shell or network)
   - level: Request
     resources:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The audit policy presets we offer cover Kubernetes core/default resources, but do not cover custom resources that might be of interest. Obviously we cannot cover what users install onto clusters, but this PR adds logging to the `minimal` and the `recommended` audit logging presets for Cluster API resources and the Gatekeeper template API group. 

It also adds logging for the Kubernetes secret that is used to control SSH access to nodes via `user-ssh-keys-agent`. Quite an important `Secret` that you want to tightly audit, as writing to that secret allows you to access all nodes.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8784

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Audit logging presets `recommended` and `minimal` now include ResponseRequest level logging for `Machine`, `MachineSets` and `MachineDeployments`, any Gatekeeper template resources, and the user-ssh-keys-agent secret for SSH keys
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>