### PR TITLE
Use k8c.io/kubermatic/v2/pkg/semver for some version comparisons

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -418,14 +418,18 @@ func TestController_ensureAddonLabelOnManifests(t *testing.T) {
 
 func TestController_getApplyCommand(t *testing.T) {
 	controller := &Reconciler{}
-	clusterVersion := defaults.DefaultKubernetesVersioning.Default.Semver()
+
+	clusterVersion := defaults.DefaultKubernetesVersioning.Default
+	if clusterVersion == nil {
+		t.Fatalf("Should be able to determine default Kubernetes version, but got nil")
+	}
 
 	binary, err := kubectl.BinaryForClusterVersion(clusterVersion)
 	if err != nil {
 		t.Fatalf("Should be able to determine a kubectl binary for %q, but got %v", clusterVersion, err)
 	}
 
-	cmd, err := controller.getApplyCommand(context.Background(), "/opt/kubeconfig", "/opt/manifest.yaml", labels.SelectorFromSet(map[string]string{"foo": "bar"}), clusterVersion)
+	cmd, err := controller.getApplyCommand(context.Background(), "/opt/kubeconfig", "/opt/manifest.yaml", labels.SelectorFromSet(map[string]string{"foo": "bar"}), *clusterVersion)
 	if err != nil {
 		t.Fatalf("Should be able to determine the command, but got %v", err)
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -421,7 +421,7 @@ func TestController_getApplyCommand(t *testing.T) {
 
 	clusterVersion := defaults.DefaultKubernetesVersioning.Default
 	if clusterVersion == nil {
-		t.Fatalf("Should be able to determine default Kubernetes version, but got nil")
+		t.Fatal("Should be able to determine default Kubernetes version, but got nil")
 	}
 
 	binary, err := kubectl.BinaryForClusterVersion(clusterVersion)

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -170,14 +170,14 @@ func getOSFlags(data *resources.TemplateData) []string {
 }
 
 func getOSVersion(version semver.Semver) (string, error) {
-	switch version.Semver().Minor() {
-	case 20:
+	switch version.MajorMinor() {
+	case "1.20":
 		return "1.20.2", nil
-	case 21:
+	case "1.21":
 		return "1.21.0", nil
-	case 22:
+	case "1.22":
 		return "1.22.0", nil
-	case 23:
+	case "1.23":
 		fallthrough
 	default:
 		return "1.23.1", nil

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -165,12 +165,12 @@ func getCPIContainer(version string, data *resources.TemplateData) corev1.Contai
 }
 
 func getVsphereCPIVersion(version semver.Semver) string {
-	switch version.Semver().Minor() {
-	case 21:
+	switch version.MajorMinor() {
+	case "1.21":
 		return "1.21.3"
-	case 22:
+	case "1.22":
 		return "1.22.6"
-	case 23:
+	case "1.23":
 		fallthrough
 	//	By default return latest version
 	default:

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	semverlib "github.com/Masterminds/semver/v3"
+	"k8c.io/kubermatic/v2/pkg/semver"
 )
 
 // BinaryForClusterVersion returns the full path to a kubectl binary
@@ -28,17 +28,17 @@ import (
 // returned if no suitable kubectl can be determined.
 // We take advantage of version skew policy for kubectl, v1.1.1 would support v1.2.x and v1.0.x, to ship
 // only mandatory variants for kubectl.
-func BinaryForClusterVersion(version *semverlib.Version) (string, error) {
+func BinaryForClusterVersion(version *semver.Semver) (string, error) {
 	var binary string
 
-	switch version.Minor() {
-	case 20:
+	switch version.MajorMinor() {
+	case "1.20":
 		binary = "kubectl-1.21"
-	case 21:
+	case "1.21":
 		binary = "kubectl-1.21"
-	case 22:
+	case "1.22":
 		binary = "kubectl-1.23"
-	case 23:
+	case "1.23":
 		binary = "kubectl-1.23"
 	default:
 		return "", fmt.Errorf("unsupported Kubernetes version %v", version)

--- a/pkg/util/kubectl/kubectl_test.go
+++ b/pkg/util/kubectl/kubectl_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestKubectlForAllSupportedVersions(t *testing.T) {
 	for _, v := range defaults.DefaultKubernetesVersioning.Versions {
-		_, err := BinaryForClusterVersion(v.Semver())
+		_, err := BinaryForClusterVersion(&v)
 		if err != nil {
 			t.Errorf("No kubectl binary found for cluster version %q: %v", v, err)
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a personal pet peeve of me, we have been using `k8c.io/kubermatic/v2/pkg/semver.Semver` in a couple of places, but `semverlib` is also used in some locations. In particular, some of our Kubernetes version checks only ran against the minor version and omitted the major version. While that should never create a problem since we're only supporting a very limited set of versions (and we'll never support Kubernetes `1.20` and a theoretical `2.20` at the same time), I don't feel comfortable discarding that part of the version information.

This moves a couple of places to `semver.Semver` and checks against `MajorMinor()`. Maybe we don't want to merge this, I don't know. WDYT?

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
