### PR TITLE
Enable dual-stack for KKP-managed usercluster services

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -384,17 +384,17 @@ func (r *reconciler) mlaReconcileData(ctx context.Context) (monitoring, logging 
 	return cluster.Spec.MLA.MonitoringResources, cluster.Spec.MLA.LoggingResources, cluster.Spec.MLA.MonitoringReplicas, nil
 }
 
-func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.ClusterAddress, k8sServiceApi *net.IP, reconcileK8sSvcEndpoints bool, err error) {
+func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.ClusterAddress, ipFamily kubermaticv1.IPFamily, k8sServiceApi *net.IP, reconcileK8sSvcEndpoints bool, err error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err = r.seedClient.Get(ctx, types.NamespacedName{
 		Name: r.clusterName,
 	}, cluster); err != nil {
-		return nil, nil, false, fmt.Errorf("failed to get cluster: %w", err)
+		return nil, "", nil, false, fmt.Errorf("failed to get cluster: %w", err)
 	}
 
 	ip, err := resources.InClusterApiserverIP(cluster)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("failed to get Cluster Apiserver IP: %w", err)
+		return nil, "", nil, false, fmt.Errorf("failed to get Cluster Apiserver IP: %w", err)
 	}
 
 	// Reconcile kubernetes service endpoints, unless it is not supported or disabled in the apiserver override settings.
@@ -409,7 +409,7 @@ func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.
 		reconcileK8sSvcEndpoints = false
 	}
 
-	return &cluster.Address, ip, reconcileK8sSvcEndpoints, nil
+	return &cluster.Address, cluster.Spec.ClusterNetwork.IPFamily, ip, reconcileK8sSvcEndpoints, nil
 }
 
 // reconcileDefaultServiceAccount ensures that the Kubernetes default service account has AutomountServiceAccountToken set to false.

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -99,7 +99,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
-	data.clusterAddress, data.k8sServiceApiIP, data.reconcileK8sSvcEndpoints, err = r.networkingData(ctx)
+	data.clusterAddress, data.ipFamily, data.k8sServiceApiIP, data.reconcileK8sSvcEndpoints, err = r.networkingData(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster address: %w", err)
 	}
@@ -672,7 +672,7 @@ func (r *reconciler) reconcileServices(ctx context.Context, data reconcileData) 
 	}
 	if r.isKonnectivityEnabled {
 		// metrics-server running in user cluster - ClusterIP service
-		creatorsKubeSystem = append(creatorsKubeSystem, metricsserver.ServiceCreator())
+		creatorsKubeSystem = append(creatorsKubeSystem, metricsserver.ServiceCreator(data.ipFamily))
 	} else {
 		// metrics-server running in seed cluster - ExternalName service
 		creatorsKubeSystem = append(creatorsKubeSystem, metricsserver.ExternalNameServiceCreator(r.namespace))
@@ -685,7 +685,7 @@ func (r *reconciler) reconcileServices(ctx context.Context, data reconcileData) 
 	// Kubernetes Dashboard and related resources
 	if data.kubernetesDashboardEnabled {
 		creators := []reconciling.NamedServiceCreatorGetter{
-			kubernetesdashboard.ServiceCreator(),
+			kubernetesdashboard.ServiceCreator(data.ipFamily),
 		}
 		if err := reconciling.ReconcileServices(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
 			return fmt.Errorf("failed to reconcile Services in namespace %s: %w", kubernetesdashboard.Namespace, err)
@@ -1077,6 +1077,7 @@ type reconcileData struct {
 	gatekeeperAuditRequirements *corev1.ResourceRequirements
 	monitoringReplicas          *int32
 	clusterAddress              *kubermaticv1.ClusterAddress
+	ipFamily                    kubermaticv1.IPFamily
 	k8sServiceApiIP             *net.IP
 	reconcileK8sSvcEndpoints    bool
 	kubernetesDashboardEnabled  bool

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetesdashboard
 
 import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -25,7 +26,7 @@ import (
 )
 
 // ServiceCreator creates the service for the dashboard-metrics-scraper.
-func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+func ServiceCreator(ipFamily kubermaticv1.IPFamily) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsScraperServiceName, func(s *corev1.Service) (*corev1.Service, error) {
 			s.Name = resources.MetricsScraperServiceName
@@ -37,6 +38,10 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 					Port:       8000,
 					TargetPort: intstr.FromInt(8000),
 				},
+			}
+			if ipFamily == kubermaticv1.IPFamilyDualStack {
+				dsPolicy := corev1.IPFamilyPolicyPreferDualStack
+				s.Spec.IPFamilyPolicy = &dsPolicy
 			}
 			return s, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/service.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metricsserver
 
 import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -25,7 +26,7 @@ import (
 )
 
 // ServiceCreator returns the function to reconcile the user cluster metrics-server service.
-func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+func ServiceCreator(ipFamily kubermaticv1.IPFamily) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsServerServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.MetricsServerServiceName
@@ -40,6 +41,11 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt(443),
 				},
+			}
+
+			if ipFamily == kubermaticv1.IPFamilyDualStack {
+				dsPolicy := corev1.IPFamilyPolicyPreferDualStack
+				se.Spec.IPFamilyPolicy = &dsPolicy
 			}
 
 			return se, nil


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Enables dual-stack for KKP-managed usercluster services. Note that the `kubernetes` and `kube-dns` services are not yet dual-stack enabled, as those need special handling.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9738 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
