### PR TITLE
removed buggy log sync

### DIFF
--- a/cmd/conformance-tester/main.go
+++ b/cmd/conformance-tester/main.go
@@ -68,11 +68,6 @@ func main() {
 	}
 
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	// parse our CLI flags
 	if err := opts.ParseFlags(); err != nil {

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -103,11 +103,6 @@ func main() {
 
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	if (o.configurationFile == "") == (o.versionsFile == "") {
 		log.Fatal("Either -configuration-file or -versions-file must be specified.")

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -80,7 +80,6 @@ type opts struct {
 	helmBinary        string
 }
 
-//nolint:gocritic
 func main() {
 	var err error
 

--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -107,11 +107,6 @@ func main() {
 	}
 	rawLog := kubermaticlog.New(options.log.Debug, options.log.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 	kubermaticlog.Logger = log
 
 	// Set the logger used by sigs.k8s.io/controller-runtime

--- a/cmd/kubermatic-operator/main.go
+++ b/cmd/kubermatic-operator/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -48,7 +47,6 @@ type controllerRunOptions struct {
 	enableLeaderElection bool
 }
 
-//nolint:gocritic
 func main() {
 	ctx := context.Background()
 
@@ -71,11 +69,6 @@ func main() {
 
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format).Named(opt.workerName)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	// update global logger instance
 	kubermaticlog.Logger = log

--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -69,11 +69,6 @@ func main() {
 
 	rawLog := kubermaticlog.New(options.log.Debug, options.log.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	// set the logger used by controller-runtime
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog))

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -107,11 +107,6 @@ func main() {
 	ctrlruntimelog.SetLogger(ctrlruntimezaplog.New(ctrlruntimezaplog.UseDevMode(false)))
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 	kubermaticlog.Logger = log
 	ctrlCtx.log = log
 	ctrlCtx.workerName = runOpts.workerName

--- a/cmd/nodeport-proxy/envoy-manager/main.go
+++ b/cmd/nodeport-proxy/envoy-manager/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 
 	"go.uber.org/zap"
 
@@ -32,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
-//nolint:gocritic
 func main() {
 	logOpts := kubermaticlog.NewDefaultOptions()
 	logOpts.AddFlags(flag.CommandLine)
@@ -55,11 +53,6 @@ func main() {
 	// init logging
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	cli.Hello(log, "Envoy-Manager", logOpts.Debug, nil)
 

--- a/cmd/nodeport-proxy/lb-updater/main.go
+++ b/cmd/nodeport-proxy/lb-updater/main.go
@@ -74,11 +74,6 @@ func main() {
 	// init logging
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	cli.Hello(log, "LoadBalancer Updater", logOpts.Debug, nil)
 

--- a/cmd/s3-exporter/main.go
+++ b/cmd/s3-exporter/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -53,11 +52,6 @@ func main() {
 	// setup logging
 	rawLog := log.New(logOpts.Debug, logOpts.Format)
 	logger := rawLog.Sugar()
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	if *accessKeyID == "" {
 		*accessKeyID = os.Getenv("ACCESS_KEY_ID")

--- a/cmd/s3-storeuploader/main.go
+++ b/cmd/s3-storeuploader/main.go
@@ -77,13 +77,6 @@ func main() {
 			uploader, err = getUploaderFromCtx(logger, opt)
 			return
 		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			if logger != nil {
-				return logger.Sync()
-			}
-
-			return nil
-		},
 	}
 
 	pFlags := rootCmd.PersistentFlags()

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -58,7 +58,6 @@ const (
 	controllerName = "kkp-seed-controller-manager"
 )
 
-//nolint:gocritic
 func main() {
 	klog.InitFlags(nil)
 	pprofOpts := &pprof.Opts{}
@@ -80,11 +79,6 @@ func main() {
 	if options.workerName != "" {
 		log = log.With("worker-name", options.workerName)
 	}
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	// Set the logger used by sigs.k8s.io/controller-runtime
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog))

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -55,11 +55,6 @@ func main() {
 
 	rawLog := kubermaticlog.New(options.log.Debug, options.log.Format)
 	log := rawLog.Sugar()
-	defer func() {
-		if err := log.Sync(); err != nil {
-			fmt.Println(err)
-		}
-	}()
 
 	// set the logger used by controller-runtime
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog))


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Removes the deferred `log.Sync()` which causes:
```
"sync /dev/stderr: invalid argument"
```
on some OS. Its caused by: https://github.com/uber-go/zap/issues/370.%C2%A0, and there are no plans to fix it.
As its not essential, and just causes confusion because it fails on exit, so people think the whole binary failed, lets remove it.


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed `image-loader` and other binaries failing with "sync /dev/stderr: invalid argument", by removing the log.Sync() on command exit.
```
