### PR TITLE
run tagliatelle against all APIs

### DIFF
--- a/.golangci.apis.yml
+++ b/.golangci.apis.yml
@@ -1,0 +1,30 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+run:
+  modules-download-mode: readonly
+  skip-files:
+    - zz_generated.*.go
+
+linters:
+  enable:
+    - tagliatelle
+  disable-all: true
+
+linters-settings:
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
+        yaml: goCamel

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,12 +83,6 @@ issues:
   - singleCaseSwitch # in most cases this is the beginning of a lookup table and should be kept an obvious table
 
 linters-settings:
-  tagliatelle:
-    case:
-      rules:
-        json: goCamel
-        yaml: goCamel
-
   depguard:
     include-go-root: true
     packages:

--- a/Makefile
+++ b/Makefile
@@ -120,13 +120,11 @@ lint: lint-crds
 
 .PHONY: lint-crds
 lint-crds:
-	# we want tagliatelle to check only CRDs
+	@# we want tagliatelle to check only CRDs
 	golangci-lint run \
 		--verbose \
-		--print-resources-usage \
-		--disable-all \
-		--enable tagliatelle \
-		./pkg/apis/kubermatic/...
+		--config .golangci.apis.yml \
+		./pkg/apis/...
 
 .PHONY: shellcheck
 shellcheck:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR ensures that we check the tags for apps.kubermatic.k8c.io as well. Also this makes use of a dedicated config file to actually disable all linters except for `tagliatelle`.

Previously:

```
level=info msg="Memory: 778 samples, avg is 373.2MB, max is 792.5MB"
level=info msg="Execution took 1m17.652418212s"
```

Now:

```
level=info msg="Memory: 32 samples, avg is 45.2MB, max is 49.0MB"
level=info msg="Execution took 3.006100778s"
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
