### PR TITLE
do not reconcile the ClusterAPI Cluster CRD into userclusters anymore

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -610,7 +610,6 @@ func (r *reconciler) reconcileCRDs(ctx context.Context) error {
 		machinecontroller.MachineCRDCreator(),
 		machinecontroller.MachineSetCRDCreator(),
 		machinecontroller.MachineDeploymentCRDCreator(),
-		machinecontroller.ClusterCRDCreator(),
 		applications.CRDCreator(c),
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/crds.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/crds.go
@@ -259,38 +259,3 @@ func MachineDeploymentCRDCreator() reconciling.NamedCustomResourceDefinitionCrea
 		}
 	}
 }
-
-// ClusterCRD returns the cluster crd definition.
-func ClusterCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
-	return func() (string, reconciling.CustomResourceDefinitionCreator) {
-		return resources.ClusterCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			metav1.SetMetaDataAnnotation(&crd.ObjectMeta, "api-approved.kubernetes.io", "unapproved, legacy API")
-
-			crd.Spec.Group = clusterAPIGroup
-			crd.Spec.Scope = apiextensionsv1.NamespaceScoped
-			crd.Spec.Names.Kind = "Cluster"
-			crd.Spec.Names.ListKind = "ClusterList"
-			crd.Spec.Names.Plural = "clusters"
-			crd.Spec.Names.Singular = "cluster"
-			crd.Spec.Names.ShortNames = []string{"cl"}
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    clusterAPIVersion,
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: resources.Bool(true),
-							Type:                   "object",
-						},
-					},
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-					},
-				},
-			}
-
-			return crd, nil
-		}
-	}
-}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
At the latest since https://github.com/kubermatic/machine-controller/pull/649, the machine-controller cannot and does not want to handle Cluster objects anymore. There is absolutely no point anymore in adding this CRD to all userclusters.

**Does this PR introduce a user-facing change?**:
```release-note
The clusters.k8s.io/Cluster CRD is not being reconciled into userclusters anymore, as it served no purpose.
```
