### PR TITLE
Update metrics-server to 0.6.1

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -517,7 +517,6 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileDa
 		machinecontroller.ClusterRoleCreator(),
 		dnatcontroller.ClusterRoleCreator(),
 		metricsserver.ClusterRoleCreator(),
-		metricsserver.AggregatedClusterRoleCreator(),
 		clusterautoscaler.ClusterRoleCreator(),
 		coredns.ClusterRoleCreator(),
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -517,6 +517,7 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileDa
 		machinecontroller.ClusterRoleCreator(),
 		dnatcontroller.ClusterRoleCreator(),
 		metricsserver.ClusterRoleCreator(),
+		metricsserver.AggregatedClusterRoleCreator(),
 		clusterautoscaler.ClusterRoleCreator(),
 		coredns.ClusterRoleCreator(),
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
@@ -23,10 +23,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-const (
-	aggregatedMetricsReaderRoleName = "system:aggregated-metrics-reader"
-)
-
 // ClusterRole returns a cluster role for the metrics server.
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
@@ -45,36 +41,6 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{
-						"pods",
-						"nodes",
-					},
-					Verbs: []string{
-						"get",
-						"list",
-						"watch",
-					},
-				},
-			}
-
-			return cr, nil
-		}
-	}
-}
-
-// AggregatedClusterRoleCreator returns a ClusterRole that can be aggregated by
-// other ClusterRoles, see the discussion in https://github.com/kubernetes-sigs/metrics-server/issues/411
-func AggregatedClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
-	return func() (string, reconciling.ClusterRoleCreator) {
-		return aggregatedMetricsReaderRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabels(Name, nil)
-			cr.Labels["rbac.authorization.k8s.io/aggregate-to-admin"] = "true"
-			cr.Labels["rbac.authorization.k8s.io/aggregate-to-edit"] = "true"
-			cr.Labels["rbac.authorization.k8s.io/aggregate-to-view"] = "true"
-
-			cr.Rules = []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"metrics.k8s.io"},
 					Resources: []string{
 						"pods",
 						"nodes",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
@@ -23,6 +23,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
+const (
+	aggregatedMetricsReaderRoleName = "system:aggregated-metrics-reader"
+)
+
 // ClusterRole returns a cluster role for the metrics server.
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
@@ -33,10 +37,17 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 				{
 					APIGroups: []string{""},
 					Resources: []string{
+						"nodes/metrics",
+					},
+					Verbs: []string{
+						"get",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{
 						"pods",
 						"nodes",
-						"nodes/stats",
-						"namespaces",
 					},
 					Verbs: []string{
 						"get",
@@ -44,14 +55,38 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 						"watch",
 					},
 				},
+			}
+
+			return cr, nil
+		}
+	}
+}
+
+// AggregatedClusterRoleCreator returns a ClusterRole that can be aggregated by
+// other ClusterRoles, see the discussion in https://github.com/kubernetes-sigs/metrics-server/issues/411
+func AggregatedClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return aggregatedMetricsReaderRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Labels = resources.BaseAppLabels(Name, nil)
+			cr.Labels["rbac.authorization.k8s.io/aggregate-to-admin"] = "true"
+			cr.Labels["rbac.authorization.k8s.io/aggregate-to-edit"] = "true"
+			cr.Labels["rbac.authorization.k8s.io/aggregate-to-view"] = "true"
+
+			cr.Rules = []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{"extensions"},
+					APIGroups: []string{"metrics.k8s.io"},
 					Resources: []string{
-						"deployments",
+						"pods",
+						"nodes",
 					},
-					Verbs: []string{"get", "list", "watch"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+					},
 				},
 			}
+
 			return cr, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrolebinding.go
@@ -35,6 +35,7 @@ func ClusterRoleBindingResourceReaderCreator(isKonnectivityEnabled bool) reconci
 				Kind:     "ClusterRole",
 				APIGroup: rbacv1.GroupName,
 			}
+
 			if isKonnectivityEnabled {
 				// metrics server running in the user cluster - ServiceAccount
 				crb.Subjects = []rbacv1.Subject{
@@ -54,6 +55,7 @@ func ClusterRoleBindingResourceReaderCreator(isKonnectivityEnabled bool) reconci
 					},
 				}
 			}
+
 			return crb, nil
 		}
 	}
@@ -65,6 +67,7 @@ func ClusterRoleBindingAuthDelegatorCreator(isKonnectivityEnabled bool) reconcil
 		// metrics server running in the seed cluster
 		return resources.ClusterRoleBindingAuthDelegatorCreator(resources.MetricsServerCertUsername)
 	}
+
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		// metrics server running in the user cluster
 		return "metrics-server:system:auth-delegator", func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -96,6 +96,7 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 					Args: []string{
 						"--kubelet-insecure-tls",
 						"--kubelet-use-node-status-port",
+						"--secure-port", "4443",
 						"--metric-resolution", "15s",
 						"--kubelet-preferred-address-types", "InternalIP,ExternalIP,Hostname",
 						"--v", "1",
@@ -104,7 +105,7 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 					},
 					Ports: []corev1.ContainerPort{
 						{
-							ContainerPort: 443,
+							ContainerPort: 4443,
 							Name:          "https",
 							Protocol:      corev1.ProtocolTCP,
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -118,6 +118,8 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 					LivenessProbe: &corev1.Probe{
 						FailureThreshold: 3,
 						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   1,
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
 								Path:   "/livez",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -110,18 +110,11 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					ReadinessProbe: &corev1.Probe{
-						FailureThreshold:    3,
-						PeriodSeconds:       10,
-						InitialDelaySeconds: 20,
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/readyz",
-								Port:   intstr.FromString("https"),
-								Scheme: corev1.URISchemeHTTPS,
-							},
-						},
-					},
+					// Do not define a readiness probe, as the metrics-server will only get ready
+					// when it has scraped a node or pod at least once, which might never happen in
+					// clusters without nodes. An unready metrics-server would prevent the
+					// SeedResourcesUpToDate condition to become true.
+					// ReadinessProbe: nil,
 					LivenessProbe: &corev1.Probe{
 						FailureThreshold: 3,
 						PeriodSeconds:    10,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/rolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/rolebinding.go
@@ -35,6 +35,7 @@ func RolebindingAuthReaderCreator(isKonnectivityEnabled bool) reconciling.NamedR
 				Kind:     "Role",
 				APIGroup: rbacv1.GroupName,
 			}
+
 			if isKonnectivityEnabled {
 				// metrics server running in the user cluster - ServiceAccount
 				rb.Subjects = []rbacv1.Subject{
@@ -54,6 +55,7 @@ func RolebindingAuthReaderCreator(isKonnectivityEnabled bool) reconciling.NamedR
 					},
 				}
 			}
+
 			return rb, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/service.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/service.go
@@ -36,9 +36,10 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 			se.Spec.Type = corev1.ServiceTypeClusterIP
 			se.Spec.Ports = []corev1.ServicePort{
 				{
+					Name:       "https",
 					Port:       443,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(443),
+					TargetPort: intstr.FromString("https"),
 				},
 			}
 

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -54,7 +55,7 @@ const (
 	ServingCertSecretName  = "metrics-server-serving-cert"
 	servingCertMountFolder = "/etc/serving-cert"
 
-	tag = "v0.5.0"
+	tag = "v0.6.1"
 )
 
 // metricsServerData is the data needed to construct the metrics-server components.
@@ -119,12 +120,43 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 						"--authorization-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 						"--kubelet-insecure-tls",
 						"--kubelet-use-node-status-port",
+						"--secure-port", "4443",
 						"--metric-resolution", "15s",
 						// We use the same as the API server as we use the same dnat-controller
 						"--kubelet-preferred-address-types", "ExternalIP,InternalIP",
 						"--v", "1",
 						"--tls-cert-file", servingCertMountFolder + "/" + resources.ServingCertSecretKey,
 						"--tls-private-key-file", servingCertMountFolder + "/" + resources.ServingCertKeySecretKey,
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 4443,
+							Name:          "https",
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						FailureThreshold:    3,
+						PeriodSeconds:       10,
+						InitialDelaySeconds: 20,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/readyz",
+								Port:   intstr.FromString("https"),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/livez",
+								Port:   intstr.FromString("https"),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -137,6 +169,12 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 							MountPath: servingCertMountFolder,
 							ReadOnly:  true,
 						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: resources.Bool(false),
+						ReadOnlyRootFilesystem:   resources.Bool(true),
+						RunAsNonRoot:             resources.Bool(true),
+						RunAsUser:                resources.Int64(1000),
 					},
 				},
 			}

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -143,6 +143,8 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 					LivenessProbe: &corev1.Probe{
 						FailureThreshold: 3,
 						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   1,
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
 								Path:   "/livez",

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -135,18 +135,11 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					ReadinessProbe: &corev1.Probe{
-						FailureThreshold:    3,
-						PeriodSeconds:       10,
-						InitialDelaySeconds: 20,
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/readyz",
-								Port:   intstr.FromString("https"),
-								Scheme: corev1.URISchemeHTTPS,
-							},
-						},
-					},
+					// Do not define a readiness probe, as the metrics-server will only get ready
+					// when it has scraped a node or pod at least once, which might never happen in
+					// clusters without nodes. An unready metrics-server would prevent the
+					// SeedResourcesUpToDate condition to become true.
+					// ReadinessProbe: nil,
 					LivenessProbe: &corev1.Probe{
 						FailureThreshold: 3,
 						PeriodSeconds:    10,

--- a/pkg/resources/metrics-server/service.go
+++ b/pkg/resources/metrics-server/service.go
@@ -37,7 +37,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 				{
 					Port:       443,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(443),
+					TargetPort: intstr.FromString("https"),
 				},
 			}
 

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
@@ -61,6 +61,8 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: metrics-server
         ports:
         - containerPort: 4443

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
@@ -50,11 +50,22 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: "1"
@@ -62,6 +73,11 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server

--- a/pkg/resources/test/fixtures/service-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.21.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.21.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.21.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.21.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.21.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.21.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Pretty much what it says on the tin. v0.6.x supports k8s 1.19+ according to https://github.com/kubernetes-sigs/metrics-server#compatibility-matrix

This PR is based on https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.1/components.yaml

* Special attention should go to the **ReadinessProbe**, which I purposefully omited. See the code comment.
* I changed the listen-port to 4443, because since v0.5.2, the metrics-server Docker image does not add the
  capabilities for listening on privileged ports anymore (https://github.com/kubernetes-sigs/metrics-server/pull/887)

**Does this PR introduce a user-facing change?**:
```release-note
update metrics-server to 0.6.1
```
