### PR TITLE
update node-local-dns cache to 1.21.1

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -87,7 +87,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           fmt.Sprintf("%s/k8s-dns-node-cache:1.15.7", registryWithOverwrite(resources.RegistryK8SGCR)),
+					Image:           fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.21.1", registryWithOverwrite(resources.RegistryK8SGCR)),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This updates the node-local-dns cache. I could not find a documentation regarding a support matrix and looking at upstream, I don't see any pattern (based on the history of https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml):

* k8s 1.19: **1.15.13**
* k8s 1.20: **1.15.16** (Docker image was moved in 1.15.14+, see release process step 9 in https://github.com/kubernetes/dns)
* k8s 1.21: **1.17.0**
* k8s 1.22: **1.17.0**
* k8s 1.23: **1.21.1**
* k8s 1.24: **1.21.1**

**Does this PR introduce a user-facing change?**:
```release-note
Update dns-node-cache to 1.21.1
```
