### PR TITLE
helm/cli: don't swallow error in BuildChartDependencies

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -76,16 +76,19 @@ func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) (err
 			repoName,
 		}
 
-		defer func() {
-			_, removeErr := c.run("default", repoRemoveFlags...)
-			if err != nil {
-				err = removeErr
-			}
-		}()
-
 		if _, err = c.run("default", repoAddFlags...); err != nil {
 			return err
 		}
+
+		defer func() {
+			_, removeErr := c.run("default", repoRemoveFlags...)
+			if err != nil && removeErr != nil {
+				err = fmt.Errorf("%w; error: clean up resources failed: can not remove remopository: %s", err, removeErr)
+			}
+			if err == nil && removeErr != nil {
+				err = fmt.Errorf("error: clean up resources failed: can not remove remopository: %w", removeErr)
+			}
+		}()
 	}
 
 	command := []string{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

In [BuildChartDependencies](https://github.com/kubermatic/kubermatic/blob/84f408fbbdd1c8ce605ede2cbe824e646fd148c2/pkg/install/helm/cli.go#L58) function, we add the repositories, build the dependencies and thanks to a `defer` function, we remove the repository.

The problem is that if the `helm repo add`  fails, the error is swallowed by the defer function. (doing  `helm repo remove`  with no repository added triggers the following error `Error: no repositories configured. `)

as you can see in this the root cause ( the error from the  `helm repo add` ) is hidden.

```
INFO[10:05:22]    📦 Deploying nginx-ingress-controller…     
INFO[10:05:23]       Deploying Helm chart…                  
ERRO[10:05:23] ❌ Operation failed: failed to deploy nginx-ingress-controller: failed to deploy Helm release: failed to download dependencies: Error: no repositories configured. 
```

This PR moves the `defer` function after the `helm add repo` so we don't try to remove a repository that does not exist. It also combines previous errors (e.g. error from `helm dependency build` ) with error from `helm repo remove` repository.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:
Example of output for the different cases:

**the case where add repo fails**
```
INFO[17:38:35]    📦 Deploying nginx-ingress-controller…     
DEBU[17:38:35]       Ensuring namespace…                     namespace=nginx-ingress-controller
DEBU[17:38:35]       Checking for release…                   name=nginx-ingress-controller namespace=nginx-ingress-controller
DEBU[17:38:35] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace nginx-ingress-controller list --all -o json 
INFO[17:38:35]       Deploying Helm chart…                  
DEBU[17:38:35]       Installing…                            
DEBU[17:38:35] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo add dep-nginx-ingress-controller-0 https://kubernetes.github.io/ingress-nginx 
ERRO[17:38:35] ❌ Operation failed: failed to deploy nginx-ingress-controller: failed to deploy Helm release: failed to download dependencies: Error: open Library/Preferences/helm/repositories.yaml: permission denied. 
Exiting.
```

**the case where build dependencies fails**
```
INFO[17:40:27]    📦 Deploying nginx-ingress-controller…     
DEBU[17:40:27]       Ensuring namespace…                     namespace=nginx-ingress-controller
DEBU[17:40:27]       Checking for release…                   name=nginx-ingress-controller namespace=nginx-ingress-controller
DEBU[17:40:27] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace nginx-ingress-controller list --all -o json 
INFO[17:40:27]       Deploying Helm chart…                  
DEBU[17:40:27]       Installing…                            
DEBU[17:40:27] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo add dep-nginx-ingress-controller-0 https://kubernetes.github.io/ingress-nginx 
DEBU[17:40:35] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default dependency build charts/nginx-ingress-controller 
DEBU[17:40:38] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo remove dep-nginx-ingress-controller-0 
ERRO[17:40:38] ❌ Operation failed: failed to deploy nginx-ingress-controller: failed to deploy Helm release: failed to download dependencies: Error: could not download https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.1.0/ingress-nginx-4.1.0.tgz: Get "https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.1.0/ingress-nginx-4.1.0.tgz": dial tcp: lookup github.com on [::1]:53: read udp [::1]:57345->[::1]:53: read: connection refused. 
Exiting.
```


**the case where build dependencies and remove repo fail**
```
INFO[17:42:17]    📦 Deploying nginx-ingress-controller…     
DEBU[17:42:17]       Ensuring namespace…                     namespace=nginx-ingress-controller
DEBU[17:42:17]       Checking for release…                   name=nginx-ingress-controller namespace=nginx-ingress-controller
DEBU[17:42:17] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace nginx-ingress-controller list --all -o json 
INFO[17:42:17]       Deploying Helm chart…                  
DEBU[17:42:17]       Installing…                            
DEBU[17:42:17] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo add dep-nginx-ingress-controller-0 https://kubernetes.github.io/ingress-nginx 
DEBU[17:42:27] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default dependency build charts/nginx-ingress-controller 
DEBU[17:42:40] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo remove dep-nginx-ingress-controller-0 
ERRO[17:42:47] ❌ Operation failed: failed to deploy nginx-ingress-controller: failed to deploy Helm release: failed to download dependencies: Error: could not download https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.1.0/ingress-nginx-4.1.0.tgz: Get "https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.1.0/ingress-nginx-4.1.0.tgz": dial tcp: lookup github.com on [::1]:53: read udp [::1]:57919->[::1]:53: read: connection refused; error: clean up resources failed: can not remove remopository: Error: open Library/Preferences/helm/repositories.yaml: permission denied. 
Exiting.
```

**the case where remove repo fails**
```
INFO[17:43:36]    📦 Deploying nginx-ingress-controller…     
DEBU[17:43:36]       Ensuring namespace…                     namespace=nginx-ingress-controller
DEBU[17:43:36]       Checking for release…                   name=nginx-ingress-controller namespace=nginx-ingress-controller
DEBU[17:43:36] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace nginx-ingress-controller list --all -o json 
INFO[17:43:36]       Deploying Helm chart…                  
DEBU[17:43:36]       Installing…                            
DEBU[17:43:36] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo add dep-nginx-ingress-controller-0 https://kubernetes.github.io/ingress-nginx 
DEBU[17:43:49] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default dependency build charts/nginx-ingress-controller 
DEBU[17:43:51] $ KUBECONFIG=/Users/vince/.kube/config helm --namespace default repo remove dep-nginx-ingress-controller-0 
ERRO[17:43:51] ❌ Operation failed: failed to deploy nginx-ingress-controller: failed to deploy Helm release: failed to download dependencies: error: clean up resources failed: can not remove remopository: Error: open Library/Preferences/helm/repositories.yaml: permission denied. 
Exiting.
```



**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubermatic-installer: improve error handling when building helm chart dependencies
```
