### PR TITLE
refactor dualstack tester; add tests for GCP, AWS

### DIFF
--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -47,6 +47,8 @@ export AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-$(vault kv get -field=sub
 export AZURE_CLIENT_ID="${AZURE_CLIENT_ID:-$(vault kv get -field=clientID dev/e2e-azure)}"
 export AZURE_CLIENT_SECRET="${AZURE_CLIENT_SECRET:-$(vault kv get -field=clientSecret dev/e2e-azure)}"
 
+export GOOGLE_SERVICE_ACCOUNT="${GOOGLE_SERVICE_ACCOUNT:-$(vault kv get -field=serviceAccount dev/e2e-gce)}"
+
 echodate "Successfully got secrets for dev from Vault"
 
 function print_kubermatic_logs {

--- a/pkg/test/dualstack/cloudProviders.go
+++ b/pkg/test/dualstack/cloudProviders.go
@@ -1,0 +1,265 @@
+package dualstack
+
+import (
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/models"
+	"k8s.io/utils/pointer"
+	"os"
+)
+
+type clusterNetworkingConfig models.ClusterNetworkingConfig
+
+func defaultClusterNetworkingConfig() clusterNetworkingConfig {
+	c := models.ClusterNetworkingConfig{
+		NodeCIDRMaskSizeIPV4: 24,
+		NodeCIDRMaskSizeIPV6: 105,
+		ProxyMode:            "ebpf",
+		IPFamily:             "IPv4+IPv6",
+		Pods: &models.NetworkRanges{
+			CIDRBlocks: []string{"172.25.0.0/16", "fd00::/104"},
+		},
+		Services: &models.NetworkRanges{
+			CIDRBlocks: []string{"10.240.16.0/20", "fd03::/120"},
+		},
+		KonnectivityEnabled: true,
+	}
+
+	return clusterNetworkingConfig(c)
+}
+
+func (c clusterNetworkingConfig) WithProxyMode(proxyMode string) clusterNetworkingConfig {
+	c.ProxyMode = proxyMode
+	return c
+}
+
+type createClusterRequest models.CreateClusterSpec
+
+func defaultClusterRequest() createClusterRequest {
+	netConfig := models.ClusterNetworkingConfig(defaultClusterNetworkingConfig())
+	clusterSpec := models.CreateClusterSpec{}
+	clusterSpec.Cluster = &models.Cluster{
+		Type: "kubernetes",
+		Name: "test-default-azure-cluster",
+		Spec: &models.ClusterSpec{
+			Cloud: &models.CloudSpec{
+				DatacenterName: "azure-westeurope",
+				Azure: &models.AzureCloudSpec{
+					ClientID:        os.Getenv("AZURE_CLIENT_ID"),
+					ClientSecret:    os.Getenv("AZURE_CLIENT_SECRET"),
+					SubscriptionID:  os.Getenv("AZURE_SUBSCRIPTION_ID"),
+					TenantID:        os.Getenv("AZURE_TENANT_ID"),
+					LoadBalancerSKU: "standard",
+				},
+			},
+			CniPlugin: &models.CNIPluginSettings{
+				Version: "v1.11",
+				Type:    "cilium",
+			},
+			ClusterNetwork: &netConfig,
+			Version:        "1.22.7",
+		},
+	}
+
+	clusterSpec.NodeDeployment = &models.NodeDeployment{
+		Spec: &models.NodeDeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Template: &models.NodeSpec{
+				SSHUserName: "root",
+				Cloud: &models.NodeCloudSpec{
+					Azure: &models.AzureNodeSpec{
+						AssignAvailabilitySet: true,
+						AssignPublicIP:        true,
+						DataDiskSize:          int32(30),
+						OSDiskSize:            70,
+						Size:                  pointer.String("Standard_B2s"),
+					},
+				},
+				OperatingSystem: &models.OperatingSystemSpec{
+					Ubuntu: &models.UbuntuSpec{
+						DistUpgradeOnBoot: false,
+					},
+				},
+			},
+		},
+		Status: nil,
+	}
+
+	return createClusterRequest(clusterSpec)
+}
+
+func (c createClusterRequest) WithCNI(cni models.CNIPluginSettings) createClusterRequest {
+	c.Cluster.Spec.CniPlugin = &cni
+	return c
+}
+
+func (c createClusterRequest) WithOS(os models.OperatingSystemSpec) createClusterRequest {
+	c.NodeDeployment.Spec.Template.OperatingSystem = &os
+	return c
+}
+
+func (c createClusterRequest) WithNode(node models.NodeCloudSpec) createClusterRequest {
+	c.NodeDeployment.Spec.Template.Cloud = &node
+	return c
+}
+
+func (c createClusterRequest) WithCloud(cloud models.CloudSpec) createClusterRequest {
+	c.Cluster.Spec.Cloud = &cloud
+	return c
+}
+
+func (c createClusterRequest) WithName(name string) createClusterRequest {
+	c.Cluster.Name = name
+	return c
+}
+
+func (c createClusterRequest) WithNetworkConfig(netConfig models.ClusterNetworkingConfig) createClusterRequest {
+	c.Cluster.Spec.ClusterNetwork = &netConfig
+	return c
+}
+
+// cloud providers
+
+type clusterSpec interface {
+	NodeSpec() models.NodeCloudSpec
+	CloudSpec() models.CloudSpec
+}
+
+type azure struct{}
+
+var _ clusterSpec = azure{}
+
+func (a azure) NodeSpec() models.NodeCloudSpec {
+	return models.NodeCloudSpec{
+		Azure: &models.AzureNodeSpec{
+			AssignAvailabilitySet: true,
+			AssignPublicIP:        true,
+			DataDiskSize:          int32(30),
+			OSDiskSize:            70,
+			Size:                  pointer.String("Standard_B2s"),
+		},
+	}
+}
+
+func (a azure) CloudSpec() models.CloudSpec {
+	return models.CloudSpec{
+		DatacenterName: "azure-westeurope",
+		Azure: &models.AzureCloudSpec{
+			ClientID:        os.Getenv("AZURE_CLIENT_ID"),
+			ClientSecret:    os.Getenv("AZURE_CLIENT_SECRET"),
+			SubscriptionID:  os.Getenv("AZURE_SUBSCRIPTION_ID"),
+			TenantID:        os.Getenv("AZURE_TENANT_ID"),
+			LoadBalancerSKU: "standard",
+		},
+	}
+}
+
+type aws struct{}
+
+var _ clusterSpec = aws{}
+
+func (a aws) NodeSpec() models.NodeCloudSpec {
+	return models.NodeCloudSpec{
+		Aws: &models.AWSNodeSpec{
+			AMI:                           "",
+			AssignPublicIP:                true,
+			AvailabilityZone:              "eu-central-1b",
+			InstanceType:                  pointer.String("t3a.small"),
+			IsSpotInstance:                false,
+			SpotInstanceMaxPrice:          "",
+			SpotInstancePersistentRequest: false,
+			SubnetID:                      "subnet-01d796b6b81cab01c",
+			VolumeSize:                    pointer.Int64(64),
+			VolumeType:                    pointer.String("standard"),
+		},
+	}
+}
+
+func (a aws) CloudSpec() models.CloudSpec {
+	return models.CloudSpec{
+		DatacenterName: "aws-eu-central-1a",
+		Aws: &models.AWSCloudSpec{
+			AccessKeyID:             os.Getenv("AWS_ACCESS_KEY_ID"),
+			ControlPlaneRoleARN:     "",
+			InstanceProfileName:     "",
+			NodePortsAllowedIPRange: "0.0.0.0/0",
+			RouteTableID:            "",
+			SecretAccessKey:         os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			SecurityGroupID:         "",
+			VPCID:                   "vpc-819f62e9",
+		},
+	}
+}
+
+type gcp struct{}
+
+var _ clusterSpec = gcp{}
+
+func (a gcp) NodeSpec() models.NodeCloudSpec {
+	return models.NodeCloudSpec{
+		Gcp: &models.GCPNodeSpec{
+			DiskSize:    25,
+			DiskType:    "pd-standard",
+			MachineType: "e2-highcpu-2",
+			Preemptible: false,
+			Zone:        "europe-west3-a",
+		},
+	}
+}
+
+func (a gcp) CloudSpec() models.CloudSpec {
+	return models.CloudSpec{
+		DatacenterName: "gcp-westeurope",
+		Gcp: &models.GCPCloudSpec{
+			Network:        "global/networks/dualstack",
+			ServiceAccount: os.Getenv("GOOGLE_SERVICE_ACCOUNT"),
+			Subnetwork:     "projects/kubermatic-dev/regions/europe-west3/subnetworks/dualstack-europe-west3",
+		},
+	}
+}
+
+// operating systems
+
+func ubuntu() models.OperatingSystemSpec {
+	return models.OperatingSystemSpec{
+		Ubuntu: &models.UbuntuSpec{},
+	}
+}
+
+func rhel() models.OperatingSystemSpec {
+	return models.OperatingSystemSpec{
+		Rhel: &models.RHELSpec{},
+	}
+}
+
+func sles() models.OperatingSystemSpec {
+	return models.OperatingSystemSpec{
+		Sles: &models.SLESSpec{},
+	}
+}
+
+func centos() models.OperatingSystemSpec {
+	return models.OperatingSystemSpec{
+		Centos: &models.CentOSSpec{},
+	}
+}
+
+func flatcar() models.OperatingSystemSpec {
+	return models.OperatingSystemSpec{
+		Flatcar: &models.FlatcarSpec{},
+	}
+}
+
+// cnis
+
+func cilium() models.CNIPluginSettings {
+	return models.CNIPluginSettings{
+		Version: "v1.11",
+		Type:    "cilium",
+	}
+}
+
+func canal() models.CNIPluginSettings {
+	return models.CNIPluginSettings{
+		Type:    "canal",
+		Version: "v3.22",
+	}
+}

--- a/pkg/test/dualstack/cloudProviders.go
+++ b/pkg/test/dualstack/cloudProviders.go
@@ -2,11 +2,13 @@ package dualstack
 
 import (
 	"context"
-	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/project"
-	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/models"
-	"k8s.io/utils/pointer"
 	"net/http"
 	"os"
+
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/project"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/models"
+
+	"k8s.io/utils/pointer"
 )
 
 type clusterNetworkingConfig models.ClusterNetworkingConfig
@@ -43,21 +45,9 @@ func defaultCreateMachineDeploymentParams() createMachineDeploymentParams {
 			Spec: &models.NodeDeploymentSpec{
 				Replicas: pointer.Int32(1),
 				Template: &models.NodeSpec{
-					SSHUserName: "root",
-					Cloud: &models.NodeCloudSpec{
-						Azure: &models.AzureNodeSpec{
-							AssignAvailabilitySet: true,
-							AssignPublicIP:        true,
-							DataDiskSize:          int32(30),
-							OSDiskSize:            70,
-							Size:                  pointer.String("Standard_B2s"),
-						},
-					},
-					OperatingSystem: &models.OperatingSystemSpec{
-						Ubuntu: &models.UbuntuSpec{
-							DistUpgradeOnBoot: false,
-						},
-					},
+					SSHUserName:     "root",
+					Cloud:           nil, // must fill in later
+					OperatingSystem: nil, // must fill in later
 				},
 			},
 		},

--- a/pkg/test/dualstack/cloudProviders.go
+++ b/pkg/test/dualstack/cloudProviders.go
@@ -15,12 +15,12 @@ type clusterNetworkingConfig models.ClusterNetworkingConfig
 
 func defaultClusterNetworkingConfig() clusterNetworkingConfig {
 	c := models.ClusterNetworkingConfig{
-		NodeCIDRMaskSizeIPV4: 24,
-		NodeCIDRMaskSizeIPV6: 105,
+		NodeCIDRMaskSizeIPV4: 20,
+		NodeCIDRMaskSizeIPV6: 100,
 		ProxyMode:            "ebpf",
 		IPFamily:             "IPv4+IPv6",
 		Pods: &models.NetworkRanges{
-			CIDRBlocks: []string{"172.25.0.0/16", "fd00::/104"},
+			CIDRBlocks: []string{"172.25.0.0/16", "fd00::/99"},
 		},
 		Services: &models.NetworkRanges{
 			CIDRBlocks: []string{"10.240.16.0/20", "fd03::/120"},

--- a/pkg/test/dualstack/cloudProviders.go
+++ b/pkg/test/dualstack/cloudProviders.go
@@ -1,3 +1,21 @@
+//go:build dualstack
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dualstack
 
 import (

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -82,21 +82,23 @@ func TestCloudClusterIPFamily(t *testing.T) {
 
 	apicli := utils.NewTestClient(token, t)
 
-	tests := []struct {
+	type testCase struct {
 		cloudName           string
 		osNames             []string
 		cni                 string
 		ipFamily            util.IPFamily
 		skipNodes           bool
 		skipHostNetworkPods bool
-	}{
+	}
+
+	tests := []testCase{
 		{
 			cloudName: "azure",
 			osNames: []string{
-				//"centos", //  cilium agent crash
-				//"flatcar", // dhcpv6 bug
+				// "centos", // cilium agent crash
+				// "flatcar", // dhcpv6 bug
 				"rhel",
-				//"sles", // unsupported in kkp
+				// "sles", // unsupported in kkp
 				"ubuntu",
 			},
 			cni:                 "cilium",
@@ -108,9 +110,9 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			cloudName: "azure",
 			osNames: []string{
 				"centos",
-				//"flatcar", // dhcpv6 bug
-				//"rhel", // node local dns cache crashing
-				//"sles", // unsupported in kkp
+				// "flatcar", // dhcpv6 bug
+				// "rhel", // node local dns cache crashing
+				// "sles", // unsupported in kkp
 				"ubuntu",
 			},
 			cni:                 "canal",
@@ -118,48 +120,62 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			skipNodes:           true,
 			skipHostNetworkPods: true,
 		},
-		//{
-		//	cloudName: "aws",
-		//	osNames: []string{
-		//		//"centos",
-		//		//"flatcar",
-		//		//"rhel",
-		//		//"sles",
-		//		"ubuntu",
-		//	},
-		//	cni:                 "canal",
-		//	ipFamily:            util.DualStack,
-		//	skipNodes:           false,
-		//	skipHostNetworkPods: false,
-		//},
-		//{
-		//	cloudName: "gcp",
-		//	osNames: []string{
-		//		//"centos",
-		//		//"flatcar",
-		//		//"rhel",
-		//		//"sles",
-		//		"ubuntu",
-		//	},
-		//	cni:                 "cilium",
-		//	ipFamily:            util.DualStack,
-		//	skipNodes:           false,
-		//	skipHostNetworkPods: false,
-		//},
-		//{
-		//	cloudName: "gcp",
-		//	osNames: []string{
-		//		//"centos",
-		//		//"flatcar",
-		//		//"rhel",
-		//		//"sles",
-		//		"ubuntu",
-		//	},
-		//	cni:                 "cilium",
-		//	ipFamily:            util.DualStack,
-		//	skipNodes:           false,
-		//	skipHostNetworkPods: false,
-		//},
+		{
+			cloudName: "aws",
+			osNames: []string{
+				// "centos",
+				// "flatcar",
+				"rhel",
+				// "sles", // unsupported in kkp
+				"ubuntu",
+			},
+			cni:                 "cilium",
+			ipFamily:            util.DualStack,
+			skipNodes:           true,
+			skipHostNetworkPods: true,
+		},
+		{
+			cloudName: "aws",
+			osNames: []string{
+				// "centos",
+				// "flatcar",
+				// "rhel",
+				// "sles",
+				"ubuntu",
+			},
+			cni:                 "canal",
+			ipFamily:            util.DualStack,
+			skipNodes:           true,
+			skipHostNetworkPods: true,
+		},
+		{
+			cloudName: "gcp",
+			osNames: []string{
+				// "centos",
+				// "flatcar",
+				// "rhel",
+				// "sles",
+				"ubuntu",
+			},
+			cni:                 "cilium",
+			ipFamily:            util.DualStack,
+			skipNodes:           true,
+			skipHostNetworkPods: true,
+		},
+		{
+			cloudName: "gcp",
+			osNames:   []string{
+				// "centos",
+				// "flatcar",
+				// "rhel",
+				// "sles",
+				// "ubuntu",
+			},
+			cni:                 "canal",
+			ipFamily:            util.DualStack,
+			skipNodes:           true,
+			skipHostNetworkPods: true,
+		},
 	}
 
 	var mu sync.Mutex

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -137,9 +137,9 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		{
 			cloudName: "aws",
 			osNames: []string{
-				"centos",
+				//"centos", // works
 				// "flatcar",
-				"rhel",
+				//"rhel", // works
 				// "sles",
 				"ubuntu",
 			},

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -84,82 +84,91 @@ func TestCloudClusterIPFamily(t *testing.T) {
 
 	tests := []struct {
 		cloudName           string
-		osName              string
+		osNames             []string
 		cni                 string
 		ipFamily            util.IPFamily
 		skipNodes           bool
 		skipHostNetworkPods bool
-		disabledReason      string
 	}{
 		{
-			cloudName:           "azure",
-			osName:              "centos",
+			cloudName: "azure",
+			osNames: []string{
+				//"centos", //  cilium agent crash
+				//"flatcar", // dhcpv6 bug
+				"rhel",
+				//"sles", // unsupported in kkp
+				"ubuntu",
+			},
 			cni:                 "cilium",
 			ipFamily:            util.DualStack,
 			skipNodes:           true,
 			skipHostNetworkPods: true,
-			disabledReason:      "fails due to https://github.com/kubermatic/kubermatic/issues/9222",
 		},
 		{
-			cloudName:           "azure",
-			osName:              "centos",
+			cloudName: "azure",
+			osNames: []string{
+				"centos",
+				//"flatcar", // dhcpv6 bug
+				//"rhel", // node local dns cache crashing
+				//"sles", // unsupported in kkp
+				"ubuntu",
+			},
 			cni:                 "canal",
 			ipFamily:            util.DualStack,
 			skipNodes:           true,
 			skipHostNetworkPods: true,
-			disabledReason:      "fails -- needs debugging",
 		},
-		{
-			cloudName:           "azure",
-			osName:              "flatcar",
-			cni:                 "cilium",
-			ipFamily:            util.DualStack,
-			skipNodes:           true,
-			skipHostNetworkPods: true,
-			disabledReason:      "fails due to https://github.com/kubermatic/kubermatic/issues/9798",
-		},
-		{
-			cloudName:           "azure",
-			osName:              "rhel",
-			cni:                 "cilium",
-			ipFamily:            util.DualStack,
-			skipNodes:           true,
-			skipHostNetworkPods: true,
-			disabledReason:      "cilium-agent crashing fix in progress https://github.com/kubermatic/machine-controller/pull/1280",
-		},
-		{
-			cloudName:           "azure",
-			osName:              "sles",
-			cni:                 "cilium",
-			ipFamily:            util.DualStack,
-			skipNodes:           true,
-			skipHostNetworkPods: true,
-			disabledReason:      "not supported",
-		},
-		{
-			cloudName:           "azure",
-			osName:              "ubuntu",
-			cni:                 "cilium",
-			ipFamily:            util.DualStack,
-			skipNodes:           true,
-			skipHostNetworkPods: true,
-		},
+		//{
+		//	cloudName: "aws",
+		//	osNames: []string{
+		//		//"centos",
+		//		//"flatcar",
+		//		//"rhel",
+		//		//"sles",
+		//		"ubuntu",
+		//	},
+		//	cni:                 "canal",
+		//	ipFamily:            util.DualStack,
+		//	skipNodes:           false,
+		//	skipHostNetworkPods: false,
+		//},
+		//{
+		//	cloudName: "gcp",
+		//	osNames: []string{
+		//		//"centos",
+		//		//"flatcar",
+		//		//"rhel",
+		//		//"sles",
+		//		"ubuntu",
+		//	},
+		//	cni:                 "cilium",
+		//	ipFamily:            util.DualStack,
+		//	skipNodes:           false,
+		//	skipHostNetworkPods: false,
+		//},
+		//{
+		//	cloudName: "gcp",
+		//	osNames: []string{
+		//		//"centos",
+		//		//"flatcar",
+		//		//"rhel",
+		//		//"sles",
+		//		"ubuntu",
+		//	},
+		//	cni:                 "cilium",
+		//	ipFamily:            util.DualStack,
+		//	skipNodes:           false,
+		//	skipHostNetworkPods: false,
+		//},
 	}
 
 	var mu sync.Mutex
 
 	for _, test := range tests {
-		name := fmt.Sprintf("c-%s-%s-%s-%s", test.cloudName, test.osName, test.cni, test.ipFamily)
-
-		if test.disabledReason != "" {
-			t.Logf("test %q disabled because: %s", name, test.disabledReason)
-			continue
-		}
+		name := fmt.Sprintf("c-%s-%s-%s", test.cloudName, test.cni, test.ipFamily)
 
 		cloud := cloudProviders[test.cloudName]
 		cloudSpec := cloud.CloudSpec()
-		nodeSpec := cloud.NodeSpec()
-		osSpec := operatingSystems[test.osName]
 		clusterSpec := defaultClusterRequest()
 		cniSpec := cnis[test.cni]
 		netConfig := defaultClusterNetworkingConfig()
@@ -173,15 +182,13 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			clusterSpec := clusterSpec.WithName(name).
 				WithCloud(cloudSpec).
-				WithNode(nodeSpec).
-				WithOS(osSpec).
 				WithCNI(cniSpec).
 				WithNetworkConfig(models.ClusterNetworkingConfig(netConfig))
 			spec := models.CreateClusterSpec(clusterSpec)
 
 			mu.Lock()
 			name := fmt.Sprintf("%s-%s", name, rand.String(4))
-			config, _, cleanup, err := createUsercluster(t, apicli, name, spec)
+			config, projectID, clusterID, cleanup, err := createUsercluster(t, apicli, name, spec)
 			mu.Unlock()
 			if err != nil {
 				respErr := new(project.CreateClusterV2Default)
@@ -200,19 +207,32 @@ func TestCloudClusterIPFamily(t *testing.T) {
 				mu.Unlock()
 			}()
 
+			for _, osName := range test.osNames {
+				err := createMachineDeployment(t, apicli, defaultCreateMachineDeploymentParams().
+					WithName(fmt.Sprintf("md-%s", osName)).
+					WithProjectID(projectID).
+					WithClusterID(clusterID).
+					WithOS(operatingSystems[osName]),
+				)
+				if err != nil {
+					t.Fatalf("failed to create machine deployment: %v", err)
+				}
+			}
+
 			userclusterClient, err := kubernetes.NewForConfig(config)
 			if err != nil {
 				t.Fatalf("failed to create usercluster client: %s", err)
 			}
 
 			t.Logf("waiting for nodes to come up")
-			_, err = checkNodeReadiness(t, userclusterClient)
+			err = checkNodeReadiness(t, userclusterClient, len(test.osNames))
 			if err != nil {
 				t.Fatalf("nodes never became ready: %v", err)
 			}
 
-			t.Logf("sleeping for 2m...")
-			time.Sleep(time.Minute * 2)
+			t.Logf("nodes ready")
+			t.Logf("sleeping for 4m...")
+			time.Sleep(time.Minute * 4)
 
 			err = waitForPods(t, userclusterClient, kubeSystem, "app", []string{
 				"coredns", "konnectivity-agent", "kube-proxy", "metrics-server",
@@ -294,11 +314,8 @@ func allPodsHealthy(t *testing.T, pods *corev1.PodList) bool {
 	return allHealthy
 }
 
-func checkNodeReadiness(t *testing.T, userClient *kubernetes.Clientset) (string, error) {
-	expectedNodes := 1
-	var nodeIP string
-
-	err := wait.Poll(30*time.Second, 15*time.Minute, func() (bool, error) {
+func checkNodeReadiness(t *testing.T, userClient *kubernetes.Clientset, expectedNodes int) error {
+	return wait.Poll(30*time.Second, 15*time.Minute, func() (bool, error) {
 		nodes, err := userClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			t.Logf("failed to get nodes list: %s", err)
@@ -324,19 +341,11 @@ func checkNodeReadiness(t *testing.T, userClient *kubernetes.Clientset) (string,
 			return false, nil
 		}
 
-		for _, addr := range nodes.Items[0].Status.Addresses {
-			if addr.Type == corev1.NodeExternalIP {
-				nodeIP = addr.Address
-				break
-			}
-		}
 		return true, nil
 	})
-
-	return nodeIP, err
 }
 
-func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName string, clusterSpec models.CreateClusterSpec) (*rest.Config, string, func(), error) {
+func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName string, clusterSpec models.CreateClusterSpec) (*rest.Config, string, string, func(), error) {
 	var teardowns []func()
 	cleanup := func() {
 		n := len(teardowns)
@@ -348,7 +357,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 	// create a project
 	proj, err := apicli.CreateProject(projectName)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", "", nil, err
 	}
 	teardowns = append(teardowns, func() {
 		err := apicli.DeleteProject(proj.ID)
@@ -365,7 +374,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 		HTTPClient: http.DefaultClient,
 	}, apicli.GetBearerToken())
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", "", nil, err
 	}
 
 	cluster := resp.Payload
@@ -404,7 +413,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 		return true, nil
 	})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", "", nil, err
 	}
 
 	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(userconfig))
@@ -412,5 +421,27 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 		t.Fatalf("failed to build config: %s", err)
 	}
 
-	return config, cluster.ID, cleanup, nil
+	return config, proj.ID, cluster.ID, cleanup, nil
+}
+
+func createMachineDeployment(t *testing.T, apicli *utils.TestClient, params createMachineDeploymentParams) error {
+	mdParams := project.CreateMachineDeploymentParams(params)
+	return wait.Poll(30*time.Second, 2*time.Minute, func() (bool, error) {
+		_, err := apicli.GetKKPAPIClient().Project.CreateMachineDeployment(
+			&mdParams,
+			apicli.GetBearerToken())
+		if err != nil {
+			respErr := new(project.CreateMachineDeploymentDefault)
+			if errors.As(err, &respErr) {
+				errData, err := respErr.GetPayload().MarshalBinary()
+				if err != nil {
+					t.Log("failed to marshal error response")
+				}
+				t.Log(string(errData))
+			}
+			t.Logf("failed to create machine deployment: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
 }

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -212,7 +212,8 @@ func TestCloudClusterIPFamily(t *testing.T) {
 					WithName(fmt.Sprintf("md-%s", osName)).
 					WithProjectID(projectID).
 					WithClusterID(clusterID).
-					WithOS(operatingSystems[osName]),
+					WithOS(operatingSystems[osName]).
+					WithNodeSpec(cloud.NodeSpec()),
 				)
 				if err != nil {
 					t.Fatalf("failed to create machine deployment: %v", err)

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -137,9 +137,9 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		{
 			cloudName: "aws",
 			osNames: []string{
-				// "centos", // works
+				// "centos", // works when instance is crated with ssh keypair
 				// "flatcar",
-				// "rhel", // works
+				// "rhel", // works when instance is crated with ssh keypair
 				// "sles",
 				"ubuntu",
 			},
@@ -181,8 +181,8 @@ func TestCloudClusterIPFamily(t *testing.T) {
 	var mu sync.Mutex
 
 	for _, test := range tests {
+		test := test
 		name := fmt.Sprintf("c-%s-%s-%s", test.cloudName, test.cni, test.ipFamily)
-
 		cloud := cloudProviders[test.cloudName]
 		cloudSpec := cloud.CloudSpec()
 		clusterSpec := defaultClusterRequest()
@@ -196,6 +196,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			clusterSpec := clusterSpec.WithName(name).
 				WithCloud(cloudSpec).
 				WithCNI(cniSpec).

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -137,9 +137,9 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		{
 			cloudName: "aws",
 			osNames: []string{
-				// "centos", // works when instance is crated with ssh keypair
+				// "centos", // works when instance is created with ssh keypair
 				// "flatcar",
-				// "rhel", // works when instance is crated with ssh keypair
+				// "rhel", // works when instance is created with ssh keypair
 				// "sles",
 				"ubuntu",
 			},

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -137,9 +137,9 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		{
 			cloudName: "aws",
 			osNames: []string{
-				//"centos", // works
+				// "centos", // works
 				// "flatcar",
-				//"rhel", // works
+				// "rhel", // works
 				// "sles",
 				"ubuntu",
 			},

--- a/pkg/test/dualstack/cloudProviders_dualstack_test.go
+++ b/pkg/test/dualstack/cloudProviders_dualstack_test.go
@@ -124,7 +124,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			cloudName: "aws",
 			osNames: []string{
 				// "centos",
-				// "flatcar",
+				// "flatcar", //
 				"rhel",
 				// "sles", // unsupported in kkp
 				"ubuntu",
@@ -137,9 +137,9 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		{
 			cloudName: "aws",
 			osNames: []string{
-				// "centos",
+				"centos",
 				// "flatcar",
-				// "rhel",
+				"rhel",
 				// "sles",
 				"ubuntu",
 			},
@@ -155,7 +155,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 				// "flatcar",
 				// "rhel",
 				// "sles",
-				"ubuntu",
+				"ubuntu", //  others are unsupported in kkp
 			},
 			cni:                 "cilium",
 			ipFamily:            util.DualStack,
@@ -164,12 +164,12 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		},
 		{
 			cloudName: "gcp",
-			osNames:   []string{
+			osNames: []string{
 				// "centos",
 				// "flatcar",
 				// "rhel",
 				// "sles",
-				// "ubuntu",
+				"ubuntu", //  others are unsupported in kkp
 			},
 			cni:                 "canal",
 			ipFamily:            util.DualStack,

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -54,6 +54,8 @@ func init() {
 	flag.BoolVar(&skipHostNetworkPods, "skipHostNetworkPods", true, "Set false to test pods in host network")
 }
 
+// TestClusterIPFamily is used to run dualstack test against any cluster. Takes kubeconfig of the cluster as command line
+// argument.
 func TestClusterIPFamily(t *testing.T) {
 	// based on https://kubernetes.io/docs/tasks/network/validate-dual-stack/
 	if userconfig == "" {

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	v1 "k8s.io/api/apps/v1"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -251,9 +251,9 @@ func all(ipFamily util.IPFamily, addrs []string) bool {
 	return true
 }
 
-func egressValidatorDaemonSet(ipVersion int) *v1.DaemonSet {
+func egressValidatorDaemonSet(ipVersion int) *appsv1.DaemonSet {
 	pod := egressValidatorPod(ipVersion)
-	return &v1.DaemonSet{
+	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
 			APIVersion: "apps/v1",
@@ -261,7 +261,7 @@ func egressValidatorDaemonSet(ipVersion int) *v1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("egress-validator-%d", ipVersion),
 		},
-		Spec: v1.DaemonSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": fmt.Sprintf("egress-validator-%d", ipVersion),

--- a/pkg/test/dualstack/egress-validator-daemonset.yaml
+++ b/pkg/test/dualstack/egress-validator-daemonset.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: egress-validator-4
+  labels:
+    name: egress-validator-4
+spec:
+  selector:
+    matchLabels:
+      name: egress-validator-4
+  template:
+    metadata:
+      labels:
+        name: egress-validator-4
+    spec:
+      hostNetwork: false
+      containers:
+        - name: egress-validator-4-container
+          image: docker.io/byrnedo/alpine-curl:0.1.8
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/ash
+            - -c
+            - sleep 1000000000
+          readinessProbe:
+            timeoutSeconds: 7
+            exec:
+              command:
+                - curl
+                - -sS
+                - --ipv4
+                - --fail
+                - --connect-timeout
+                - "5"
+                - -o
+                - /dev/null
+                - v4.ident.me
+          livenessProbe:
+            timeoutSeconds: 7
+            exec:
+              command:
+                - curl
+                - -sS
+                - --ipv4
+                - --fail
+                - --connect-timeout
+                - "5"
+                - -o
+                - /dev/null
+                - v4.ident.me
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: egress-validator-6
+  labels:
+    name: egress-validator-6
+spec:
+  selector:
+    matchLabels:
+      name: egress-validator-6
+  template:
+    metadata:
+      labels:
+        name: egress-validator-6
+    spec:
+      hostNetwork: false
+      containers:
+        - name: egress-validator-6-container
+          image: docker.io/byrnedo/alpine-curl:0.1.8
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/ash
+            - -c
+            - sleep 1000000000
+          readinessProbe:
+            timeoutSeconds: 7
+            exec:
+              command:
+                - curl
+                - -sS
+                - --ipv6
+                - --fail
+                - --connect-timeout
+                - "5"
+                - -o
+                - /dev/null
+                - v6.ident.me
+          livenessProbe:
+            timeoutSeconds: 7
+            exec:
+              command:
+                - curl
+                - -sS
+                - --ipv6
+                - --fail
+                - --connect-timeout
+                - "5"
+                - -o
+                - /dev/null
+                - v6.ident.me

--- a/pkg/test/dualstack/egress-validator-daemonset.yaml
+++ b/pkg/test/dualstack/egress-validator-daemonset.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
- This refactors dualstack tests to use multiple machine deployments with different operating sytems in one cluster. 
Currently we create and teardown one cluster per operating system. 
- Adds tests for GCP.
- Adds tests for AWS. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Implements parts of #9619 #9618 #9617. 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
