### PR TITLE
set the security context for the WEB terminal Pod

### DIFF
--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
@@ -56,6 +58,12 @@ spec:
       dnsPolicy: None
       imagePullSecrets:
       - name: dockercfg
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: web-terminal-kubeconfig
         secret:

--- a/pkg/resources/web-terminal/deployment.go
+++ b/pkg/resources/web-terminal/deployment.go
@@ -95,6 +95,18 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
 					}},
 					VolumeMounts: getVolumeMounts(),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: resources.Bool(false),
+					},
+				},
+			}
+
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsUser:  resources.Int64(1000),
+				RunAsGroup: resources.Int64(3000),
+				FSGroup:    resources.Int64(2000),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**: set the security context for the WEB terminal Pod. It's required to exec pod as a regular user. Add control on whether a process can gain more privileges than its parent process. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9819

```release-note
NONE
```
