### PR TITLE
Fix credential reference for cluster template

### DIFF
--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -355,7 +355,7 @@ func createClusterTemplate(ctx context.Context, userInfoGetter provider.UserInfo
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
-		Credential:             "",
+		Credential:             partialCluster.GetSecretName(),
 		ClusterLabels:          partialCluster.Labels,
 		InheritedClusterLabels: createCluster.Cluster.InheritedLabels,
 		Spec:                   partialCluster.Spec,


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
`credentials` field is used during clean up for cluster templates. https://github.com/kubermatic/kubermatic/pull/8864/files#diff-d4de1dd6a513e65aa7b67b778a7fcb4d607b13d85a9e2fbdf81a8b7d3bd83092R354 mistakenly was setting it to an empty string. 

Due to this missing reference, cluster template deletion was broken. It couldn't delete the secret and then remove the corresponding finalizer `kubermatic.k8c.io/cleanup-credentials-secrets`. Ref https://github.com/kubermatic/kubermatic/blob/master/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go#L149

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing credentials reference for cluster templates.
```
