### PR TITLE
check for cloud provider mismatch between node and datacenter

### DIFF
--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -154,19 +154,19 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 	}
 
 	switch {
-	case nd.Spec.Template.Cloud.AWS != nil:
+	case nd.Spec.Template.Cloud.AWS != nil && dc.Spec.AWS != nil:
 		config.CloudProvider = providerconfig.CloudProviderAWS
 		cloudExt, err = getAWSProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Azure != nil:
+	case nd.Spec.Template.Cloud.Azure != nil && dc.Spec.Azure != nil:
 		config.CloudProvider = providerconfig.CloudProviderAzure
 		cloudExt, err = getAzureProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.VSphere != nil:
+	case nd.Spec.Template.Cloud.VSphere != nil && dc.Spec.VSphere != nil:
 		config.CloudProvider = providerconfig.CloudProviderVsphere
 
 		// We use OverwriteCloudConfig for VSphere to ensure we always use the credentials
@@ -181,7 +181,7 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Openstack != nil:
+	case nd.Spec.Template.Cloud.Openstack != nil && dc.Spec.Openstack != nil:
 		config.CloudProvider = providerconfig.CloudProviderOpenstack
 		if err := validation.ValidateCreateNodeSpec(c, &nd.Spec.Template, dc); err != nil {
 			return nil, err
@@ -191,56 +191,56 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Hetzner != nil:
+	case nd.Spec.Template.Cloud.Hetzner != nil && dc.Spec.Hetzner != nil:
 		config.CloudProvider = providerconfig.CloudProviderHetzner
 		cloudExt, err = getHetznerProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Digitalocean != nil:
+	case nd.Spec.Template.Cloud.Digitalocean != nil && dc.Spec.Digitalocean != nil:
 		config.CloudProvider = providerconfig.CloudProviderDigitalocean
 		cloudExt, err = getDigitaloceanProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Packet != nil:
+	case nd.Spec.Template.Cloud.Packet != nil && dc.Spec.Packet != nil:
 		config.CloudProvider = providerconfig.CloudProviderPacket
 		cloudExt, err = getPacketProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.GCP != nil:
+	case nd.Spec.Template.Cloud.GCP != nil && dc.Spec.GCP != nil:
 		config.CloudProvider = providerconfig.CloudProviderGoogle
 		cloudExt, err = getGCPProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Kubevirt != nil:
+	case nd.Spec.Template.Cloud.Kubevirt != nil && dc.Spec.Kubevirt != nil:
 		config.CloudProvider = providerconfig.CloudProviderKubeVirt
 		cloudExt, err = getKubevirtProviderSpec(nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Alibaba != nil:
+	case nd.Spec.Template.Cloud.Alibaba != nil && dc.Spec.Alibaba != nil:
 		config.CloudProvider = providerconfig.CloudProviderAlibaba
 		cloudExt, err = getAlibabaProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Anexia != nil:
+	case nd.Spec.Template.Cloud.Anexia != nil && dc.Spec.Anexia != nil:
 		config.CloudProvider = providerconfig.CloudProviderAnexia
 		cloudExt, err = getAnexiaProviderSpec(nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
-	case nd.Spec.Template.Cloud.Nutanix != nil:
+	case nd.Spec.Template.Cloud.Nutanix != nil && dc.Spec.Nutanix != nil:
 		config.CloudProvider = providerconfig.CloudProviderNutanix
 		cloudExt, err = getNutanixProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}
 	default:
-		return nil, errors.New("unknown cloud provider")
+		return nil, errors.New("unknown cloud provider or cloud provider mismatch between node and datacenter")
 	}
 	config.CloudProviderSpec = *cloudExt
 

--- a/pkg/resources/machine/machinedeployment_test.go
+++ b/pkg/resources/machine/machinedeployment_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package machine
 
 import (

--- a/pkg/resources/machine/machinedeployment_test.go
+++ b/pkg/resources/machine/machinedeployment_test.go
@@ -1,0 +1,55 @@
+package machine
+
+import (
+	"context"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"testing"
+)
+
+func TestGetProviderConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		nd          *apiv1.NodeDeployment
+		dc          *kubermaticv1.Datacenter
+		expectError bool
+	}{
+		{
+			name: "mismatched cloud provider",
+			nd: &apiv1.NodeDeployment{
+				ObjectMeta: apiv1.ObjectMeta{},
+				Spec: apiv1.NodeDeploymentSpec{
+					Replicas: 0,
+					Template: apiv1.NodeSpec{
+						Cloud: apiv1.NodeCloudSpec{
+							Digitalocean: nil,
+							AWS:          &apiv1.AWSNodeSpec{},
+						},
+						OperatingSystem: apiv1.OperatingSystemSpec{
+							Ubuntu: &apiv1.UbuntuSpec{},
+						},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Azure: &kubermaticv1.DatacenterSpecAzure{},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var c kubermaticv1.Cluster
+			c.Spec.Cloud.Azure = &kubermaticv1.AzureCloudSpec{}
+			_, err := getProviderConfig(&c, test.nd, test.dc, nil,
+				resources.NewCredentialsData(context.Background(), &c, nil))
+			if (err != nil) != test.expectError {
+				t.Fatalf("expected error: %t, got: %v", test.expectError, err)
+			}
+		})
+	}
+}

--- a/pkg/resources/machine/machinedeployment_test.go
+++ b/pkg/resources/machine/machinedeployment_test.go
@@ -2,10 +2,11 @@ package machine
 
 import (
 	"context"
+	"testing"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"testing"
 )
 
 func TestGetProviderConfig(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
If we specify different cloud providers in node deployment and datacenter `getProviderConfig` accepts it. This causes  panic in  the api service. 

This PR adds validation to avoid such panics. 

```
│ kubermatic-api-77bf69c76d-rzdjz 2022/05/18 16:36:07 http: panic serving 10.44.5.19:59360: runtime error: invalid memory address or nil pointer dereference                                                                                                 │
│ kubermatic-api-77bf69c76d-rzdjz goroutine 83497 [running]:                                                                                                                                                                                                 │
│ kubermatic-api-77bf69c76d-rzdjz net/http.(*conn).serve.func1()                                                                                                                                                                                             │
│ kubermatic-api-77bf69c76d-rzdjz     net/http/server.go:1825 +0xbf                                                                                                                                                                                          │
│ kubermatic-api-77bf69c76d-rzdjz panic({0x2e27fc0, 0x6027240})                                                                                                                                                                                              │
│ kubermatic-api-77bf69c76d-rzdjz     runtime/panic.go:844 +0x258                                                                                                                                                                                            │
│ kubermatic-api-77bf69c76d-rzdjz k8c.io/kubermatic/v2/pkg/resources/machine.getAzureProviderSpec(0xc003a9b100, {{0x0, 0x0, 0xc002e4ea20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...}, ...)                                                                     │
│ kubermatic-api-77bf69c76d-rzdjz     k8c.io/kubermatic/v2/pkg/resources/machine/common.go:147 +0x7c                                                                                                                                                         │
│ kubermatic-api-77bf69c76d-rzdjz k8c.io/kubermatic/v2/pkg/resources/machine.getProviderConfig(0xc003a9b100, 0xc002260770, 0xc00300b980, {0x608d500, 0x0, 0xc0022603f8?}, {0x3bdf178, 0xc005118660})                                                         │
│ kubermatic-api-77bf69c76d-rzdjz     k8c.io/kubermatic/v2/pkg/resources/machine/machinedeployment.go:165 +0x348                                                                                                                                             │
│ kubermatic-api-77bf69c76d-rzdjz k8c.io/kubermatic/v2/pkg/resources/machine.Deployment(0xc003a9b100, 0xc002260770, 0xc0046c67c8?, {0x608d500, 0x0, 0x0}, {0x3bdf178, 0xc005118660})                                                                         │
│ kubermatic-api-77bf69c76d-rzdjz     k8c.io/kubermatic/v2/pkg/resources/machine/machinedeployment.go:118 +0x935                                                                                                                                             │
│ kubermatic-api-77bf69c76d-rzdjz k8c.io/kubermatic/v2/pkg/handler/common.CreateMachineDeployment({_, _}, _, {_, _}, {_, _}, {_, _}, 0xc001549f50, ...)                                                                                                      │
│ kubermatic-api-77bf69c76d-rzdjz     k8c.io/kubermatic/v2/pkg/handler/common/machine.go:119 +0x545                                                                                       
```

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
