### PR TITLE
Fail update validation for unsupported cloud spec changes

### DIFF
--- a/pkg/provider/cloud/aws/provider.go
+++ b/pkg/provider/cloud/aws/provider.go
@@ -121,7 +121,31 @@ func (a *AmazonEC2) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (a *AmazonEC2) ValidateCloudSpecUpdate(ctx context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (a *AmazonEC2) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	if oldSpec.AWS == nil || newSpec.AWS == nil {
+		return errors.New("'aws' spec is empty")
+	}
+
+	if oldSpec.AWS.VPCID != "" && oldSpec.AWS.VPCID != newSpec.AWS.VPCID {
+		return fmt.Errorf("updating AWS VPC ID is not supported (was %s, updated to %s)", oldSpec.AWS.VPCID, newSpec.AWS.VPCID)
+	}
+
+	if oldSpec.AWS.RouteTableID != "" && oldSpec.AWS.RouteTableID != newSpec.AWS.RouteTableID {
+		return fmt.Errorf("updating AWS route table ID is not supported (was %s, updated to %s)", oldSpec.AWS.RouteTableID, newSpec.AWS.RouteTableID)
+	}
+
+	if oldSpec.AWS.SecurityGroupID != "" && oldSpec.AWS.SecurityGroupID != newSpec.AWS.SecurityGroupID {
+		return fmt.Errorf("updating AWS security group ID is not supported (was %s, updated to %s)", oldSpec.AWS.SecurityGroupID, newSpec.AWS.SecurityGroupID)
+	}
+
+	if oldSpec.AWS.ControlPlaneRoleARN != "" && oldSpec.AWS.ControlPlaneRoleARN != newSpec.AWS.ControlPlaneRoleARN {
+		return fmt.Errorf("updating AWS control plane ARN is not supported (was %s, updated to %s)", oldSpec.AWS.ControlPlaneRoleARN, newSpec.AWS.ControlPlaneRoleARN)
+	}
+
+	if oldSpec.AWS.InstanceProfileName != "" && oldSpec.AWS.InstanceProfileName != newSpec.AWS.InstanceProfileName {
+		return fmt.Errorf("updating AWS instance profile name is not supported (was %s, updated to %s)", oldSpec.AWS.InstanceProfileName, newSpec.AWS.InstanceProfileName)
+	}
+
 	return nil
 }
 

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -451,7 +451,43 @@ func (a *Azure) AddICMPRulesIfRequired(ctx context.Context, cluster *kubermaticv
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (a *Azure) ValidateCloudSpecUpdate(ctx context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (a *Azure) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	if oldSpec.Azure == nil || newSpec.Azure == nil {
+		return errors.New("'azure' spec is empty")
+	}
+
+	// we validate that a couple of resources are not changed.
+	// the exception being the provider itself updating it in case the field
+	// was left empty to dynamically generate resources.
+
+	if oldSpec.Azure.ResourceGroup != "" && oldSpec.Azure.ResourceGroup != newSpec.Azure.ResourceGroup {
+		return fmt.Errorf("updating Azure resource group is not supported (was %s, updated to %s)", oldSpec.Azure.ResourceGroup, newSpec.Azure.ResourceGroup)
+	}
+
+	if oldSpec.Azure.VNetResourceGroup != "" && oldSpec.Azure.VNetResourceGroup != newSpec.Azure.VNetResourceGroup {
+		return fmt.Errorf("updating Azure vnet resource group is not supported (was %s, updated to %s)", oldSpec.Azure.VNetResourceGroup, newSpec.Azure.VNetResourceGroup)
+	}
+
+	if oldSpec.Azure.VNetName != "" && oldSpec.Azure.VNetName != newSpec.Azure.VNetName {
+		return fmt.Errorf("updating Azure vnet name is not supported (was %s, updated to %s)", oldSpec.Azure.VNetName, newSpec.Azure.VNetName)
+	}
+
+	if oldSpec.Azure.SubnetName != "" && oldSpec.Azure.SubnetName != newSpec.Azure.SubnetName {
+		return fmt.Errorf("updating Azure subnet name is not supported (was %s, updated to %s)", oldSpec.Azure.SubnetName, newSpec.Azure.SubnetName)
+	}
+
+	if oldSpec.Azure.RouteTableName != "" && oldSpec.Azure.RouteTableName != newSpec.Azure.RouteTableName {
+		return fmt.Errorf("updating Azure route table name is not supported (was %s, updated to %s)", oldSpec.Azure.RouteTableName, newSpec.Azure.RouteTableName)
+	}
+
+	if oldSpec.Azure.SecurityGroup != "" && oldSpec.Azure.SecurityGroup != newSpec.Azure.SecurityGroup {
+		return fmt.Errorf("updating Azure security group is not supported (was %s, updated to %s)", oldSpec.Azure.SecurityGroup, newSpec.Azure.SecurityGroup)
+	}
+
+	if oldSpec.Azure.AvailabilitySet != "" && oldSpec.Azure.AvailabilitySet != newSpec.Azure.AvailabilitySet {
+		return fmt.Errorf("updating Azure availability set is not supported (was %s, updated to %s)", oldSpec.Azure.AvailabilitySet, newSpec.Azure.AvailabilitySet)
+	}
+
 	return nil
 }
 

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -136,7 +136,19 @@ func (n *Nutanix) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Cloud
 	return nil
 }
 
-func (n *Nutanix) ValidateCloudSpecUpdate(_ context.Context, _ kubermaticv1.CloudSpec, _ kubermaticv1.CloudSpec) error {
+func (n *Nutanix) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	if oldSpec.Nutanix == nil || newSpec.Nutanix == nil {
+		return errors.New("'nutanix' spec is empty")
+	}
+
+	if oldSpec.Nutanix.ClusterName != newSpec.Nutanix.ClusterName {
+		return fmt.Errorf("updating Nutanix cluster name is not supported (was %s, updated to %s)", oldSpec.Nutanix.ClusterName, newSpec.Nutanix.ClusterName)
+	}
+
+	if oldSpec.Nutanix.ProjectName != newSpec.Nutanix.ProjectName {
+		return fmt.Errorf("updating Nutanix project name is not supported (was %s, updated to %s)", oldSpec.Nutanix.ProjectName, newSpec.Nutanix.ProjectName)
+	}
+
 	return nil
 }
 

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -754,7 +754,31 @@ func addICMPRulesToSecurityGroupIfNecesary(cluster *kubermaticv1.Cluster, secGro
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (os *Provider) ValidateCloudSpecUpdate(ctx context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (os *Provider) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	if oldSpec.Openstack == nil || newSpec.Openstack == nil {
+		return errors.New("'openstack' spec is empty")
+	}
+
+	// we validate that a couple of resources are not changed.
+	// the exception being the provider itself updating it in case the field
+	// was left empty to dynamically generate resources.
+
+	if oldSpec.Openstack.Network != "" && oldSpec.Openstack.Network != newSpec.Openstack.Network {
+		return fmt.Errorf("updating OpenStack network is not supported (was %s, updated to %s)", oldSpec.Openstack.Network, newSpec.Openstack.Network)
+	}
+
+	if oldSpec.Openstack.SubnetID != "" && oldSpec.Openstack.SubnetID != newSpec.Openstack.SubnetID {
+		return fmt.Errorf("updating OpenStack subnet ID is not supported (was %s, updated to %s)", oldSpec.Openstack.SubnetID, newSpec.Openstack.SubnetID)
+	}
+
+	if oldSpec.Openstack.RouterID != "" && oldSpec.Openstack.RouterID != newSpec.Openstack.RouterID {
+		return fmt.Errorf("updating OpenStack router ID is not supported (was %s, updated to %s)", oldSpec.Openstack.RouterID, newSpec.Openstack.RouterID)
+	}
+
+	if oldSpec.Openstack.SecurityGroups != "" && oldSpec.Openstack.SecurityGroups != newSpec.Openstack.SecurityGroups {
+		return fmt.Errorf("updating OpenStack security groups is not supported (was %s, updated to %s)", oldSpec.Openstack.SecurityGroups, newSpec.Openstack.SecurityGroups)
+	}
+
 	return nil
 }
 

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -347,7 +347,15 @@ func (v *Provider) CleanUpCloudProvider(ctx context.Context, cluster *kubermatic
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.
-func (v *Provider) ValidateCloudSpecUpdate(ctx context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+func (v *Provider) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	if oldSpec.VSphere == nil || newSpec.VSphere == nil {
+		return errors.New("'vsphere' spec is empty")
+	}
+
+	if oldSpec.VSphere.Folder != "" && oldSpec.VSphere.Folder != newSpec.VSphere.Folder {
+		return fmt.Errorf("updating vSphere folder is not supported (was %s, updated to %s)", oldSpec.VSphere.Folder, newSpec.VSphere.Folder)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

KKP does not really assume that the cloud provider spec changes. That is especially true for resources generated by KKP if no name is given. This PR tightens the update validation for cloud providers so users can no longer patch the cloud spec in a way that breaks KKP (e.g. if you patch the name of a generated resource with a pre-created resource later on, KKP will try to delete that resource because the finalizer is still there).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9855

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cloud provider spec changes fail validation for fields that are not supported by in-place updates (mostly cloud resources that can be auto-generated by KKP)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
