### PR TITLE
Use newer 'small' instance in Equinix Metal for e2e

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	packetInstanceType = "t1.small.x86"
+	packetInstanceType = "c3.small.x86"
 	packetDatacenter   = "packet-ewr1"
 )
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

As per [Equinix Metal documentation](https://metal.equinix.com/developers/docs/hardware/legacy-servers/), `c3.small.x86` is still considered a legacy instance type, but `t1.small.x86` seems to be effectively gone now, so this is the next best thing (if it stays available).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


Signed-off-by: Marvin Beckers <marvin@kubermatic.com>