### PR TITLE
Load more images in image-loader

### DIFF
--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -37,12 +37,16 @@ import (
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
+	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
 	"k8c.io/kubermatic/v2/pkg/docker"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
+	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
@@ -57,6 +61,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
@@ -277,8 +282,16 @@ func getImagesFromCreators(log *zap.SugaredLogger, templateData *resources.Templ
 	deploymentCreators = append(deploymentCreators, vpa.UpdaterDeploymentCreator(config, kubermaticVersions))
 	deploymentCreators = append(deploymentCreators, mla.GatewayDeploymentCreator(templateData, nil))
 	deploymentCreators = append(deploymentCreators, cloudcontroller.DeploymentCreator(templateData))
+	deploymentCreators = append(deploymentCreators, operatingsystemmanager.DeploymentCreator(templateData))
 
 	cronjobCreators := kubernetescontroller.GetCronJobCreators(templateData)
+
+	var daemonsetCreators []reconciling.NamedDaemonSetCreatorGetter
+	daemonsetCreators = append(daemonsetCreators, usersshkeys.DaemonSetCreator(
+		kubermaticVersions,
+		templateData.ImageRegistry,
+	))
+	daemonsetCreators = append(daemonsetCreators, nodelocaldns.DaemonSetCreator(templateData.ImageRegistry))
 
 	for _, creatorGetter := range statefulsetCreators {
 		_, creator := creatorGetter()
@@ -305,6 +318,15 @@ func getImagesFromCreators(log *zap.SugaredLogger, templateData *resources.Templ
 			return nil, err
 		}
 		images = append(images, getImagesFromPodSpec(cronJob.Spec.JobTemplate.Spec.Template.Spec)...)
+	}
+
+	for _, createFunc := range daemonsetCreators {
+		_, creator := createFunc()
+		daemonset, err := creator(&appsv1.DaemonSet{})
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, getImagesFromPodSpec(daemonset.Spec.Template.Spec)...)
 	}
 
 	return images, nil
@@ -442,6 +464,7 @@ func getTemplateData(clusterVersion *version.Version, cloudSpec kubermaticv1.Clo
 		resources.UserSSHKeys,
 		resources.AdminKubeconfigSecretName,
 		resources.GatekeeperWebhookServerCertSecretName,
+		resources.OperatingSystemManagerKubeconfigSecretName,
 	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{
@@ -465,6 +488,17 @@ func getTemplateData(clusterVersion *version.Version, cloudSpec kubermaticv1.Clo
 	fakeCluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
 	fakeCluster.Spec.ClusterNetwork.DNSDomain = "cluster.local"
 	fakeCluster.Spec.CNIPlugin = cniPlugin
+
+	if fakeCluster.Spec.Cloud.Openstack != nil {
+		if fakeCluster.Spec.Features == nil {
+			fakeCluster.Spec.Features = make(map[string]bool)
+		}
+		fakeCluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] = true
+	}
+
+	fakeCluster.Spec.EnableUserSSHKeyAgent = pointer.Bool(true)
+	fakeCluster.Spec.EnableOperatingSystemManager = true
+
 	fakeCluster.Status.NamespaceName = mockNamespaceName
 	fakeCluster.Status.Versions.ControlPlane = *clusterSemver
 	fakeCluster.Status.Versions.Apiserver = *clusterSemver


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

We were missing images from `image-loader`. Not sure if we cover them all now, but this PR adds more images that were missing before.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`image-loader` loads more images that were missing before (OpenStack CSI, user-ssh-keys-agent, operatingsystem-manager)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>