### PR TITLE
allow for deeper equal comparisions when reconciling

### DIFF
--- a/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
@@ -148,7 +148,7 @@ func (r *Reconciler) updateKubeconfigValidCondition(ctx context.Context, log *za
 }
 
 func (r *Reconciler) updateVersions(ctx context.Context, log *zap.SugaredLogger, seed *kubermaticv1.Seed) {
-	seed.Status.Versions.Kubermatic = r.versions.Kubermatic
+	seed.Status.Versions.Kubermatic = r.versions.KubermaticCommit
 
 	kubeconfig, err := r.seedKubeconfigGetter(seed)
 	if err != nil {

--- a/pkg/resources/reconciling/compare.go
+++ b/pkg/resources/reconciling/compare.go
@@ -32,7 +32,7 @@ import (
 
 func init() {
 	// Kubernetes Objects can be deeper than the default 10 levels.
-	deep.MaxDepth = 30
+	deep.MaxDepth = 50
 	deep.LogErrors = true
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The KKP operator now started to reconcile CRDs (#9748) and we have started seeing

```
2022/05/23 07:30:16 recursed to MaxDepth
2022/05/23 07:30:16 recursed to MaxDepth
2022/05/23 07:30:16 recursed to MaxDepth
2022/05/23 07:30:16 recursed to MaxDepth
2022/05/23 07:30:16 recursed to MaxDepth
2022/05/23 07:30:16 recursed to MaxDepth
2022/05/23 07:30:16 recursed to MaxDepth
```

in the operator logs. This PR therefore increased the max depth a bit.

This PR also changes what KKP version we're putting on the SeedStatus. Using `KubermaticCommit` will give us (also since #9748) a nice git-describe string like "v2.19.0-479-ge36868111". In this particular usecase, so far it was not important to know whether a seed was older or newer, just different. But using `KubermaticCommit` now would allow us to make that distinction, if we ever need it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
