### PR TITLE
Let helm call invoked by installer evaluate env

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -249,7 +250,10 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 	}
 
 	cmd := exec.Command(c.binary, append(globalArgs, args...)...)
-	cmd.Env = append(cmd.Env, "KUBECONFIG="+c.kubeconfig)
+	// "If Env contains duplicate environment keys, only the last
+	// value in the slice for each duplicate key is used."
+	// Source: https://pkg.go.dev/os/exec#Cmd.Env
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+c.kubeconfig)
 
 	c.logger.Debugf("$ KUBECONFIG=%s %s", c.kubeconfig, strings.Join(cmd.Args, " "))
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
`helm` calls invoked by the kubermatic-installer ignore most env variables. This is for example proplematic for systems depending on `http_proxy`.   

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9873 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue where helm invocations by the kubermatic-installer ignored most environment variables
```
