### PR TITLE
Allow upgrading from k8s 1.23 to 1.24

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -501,6 +501,8 @@ spec:
         to: 1.23.*
       - from: 1.23.*
         to: 1.23.*
+      - from: 1.23.*
+        to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
     # Versions lists the available versions.

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -286,6 +286,11 @@ var (
 				From: "1.23.*",
 				To:   "1.23.*",
 			},
+			{
+				// Allow to next minor release
+				From: "1.23.*",
+				To:   "1.24.*",
+			},
 			// ======= 1.24 =======
 			{
 				// Allow to change to any patch version


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This was forgotten in #9736. To upgrade from 1.23 to 1.24, this rule needs to be in place.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
