### PR TITLE
CoreDNS deployment: configurable number of replicas + anti-affinity rules

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -21862,6 +21862,12 @@
       "description": "ClusterNetworkingConfig specifies the different networking\nparameters for a cluster.",
       "type": "object",
       "properties": {
+        "coreDNSReplicas": {
+          "description": "CoreDNSReplicas is the number of desired pods of user cluster coredns deployment.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "CoreDNSReplicas"
+        },
         "dnsDomain": {
           "description": "Domain name for services.",
           "type": "string",

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -775,6 +775,9 @@ type ClusterNetworkingConfig struct {
 	// Defaults to true.
 	NodeLocalDNSCacheEnabled *bool `json:"nodeLocalDNSCacheEnabled,omitempty"`
 
+	// CoreDNSReplicas is the number of desired pods of user cluster coredns deployment.
+	CoreDNSReplicas *int32 `json:"coreDNSReplicas,omitempty"`
+
 	// KonnectivityEnabled enables konnectivity for controlplane to node network communication.
 	KonnectivityEnabled *bool `json:"konnectivityEnabled,omitempty"`
 }

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -1043,6 +1043,11 @@ func (in *ClusterNetworkingConfig) DeepCopyInto(out *ClusterNetworkingConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CoreDNSReplicas != nil {
+		in, out := &in.CoreDNSReplicas, &out.CoreDNSReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.KonnectivityEnabled != nil {
 		in, out := &in.KonnectivityEnabled, &out.KonnectivityEnabled
 		*out = new(bool)

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -384,17 +384,17 @@ func (r *reconciler) mlaReconcileData(ctx context.Context) (monitoring, logging 
 	return cluster.Spec.MLA.MonitoringResources, cluster.Spec.MLA.LoggingResources, cluster.Spec.MLA.MonitoringReplicas, nil
 }
 
-func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.ClusterAddress, ipFamily kubermaticv1.IPFamily, k8sServiceApi *net.IP, reconcileK8sSvcEndpoints bool, err error) {
+func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.ClusterAddress, ipFamily kubermaticv1.IPFamily, k8sServiceApi *net.IP, reconcileK8sSvcEndpoints bool, coreDNSReplicas *int32, err error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err = r.seedClient.Get(ctx, types.NamespacedName{
 		Name: r.clusterName,
 	}, cluster); err != nil {
-		return nil, "", nil, false, fmt.Errorf("failed to get cluster: %w", err)
+		return nil, "", nil, false, nil, fmt.Errorf("failed to get cluster: %w", err)
 	}
 
 	ip, err := resources.InClusterApiserverIP(cluster)
 	if err != nil {
-		return nil, "", nil, false, fmt.Errorf("failed to get Cluster Apiserver IP: %w", err)
+		return nil, "", nil, false, nil, fmt.Errorf("failed to get Cluster Apiserver IP: %w", err)
 	}
 
 	// Reconcile kubernetes service endpoints, unless it is not supported or disabled in the apiserver override settings.
@@ -409,7 +409,7 @@ func (r *reconciler) networkingData(ctx context.Context) (address *kubermaticv1.
 		reconcileK8sSvcEndpoints = false
 	}
 
-	return &cluster.Address, cluster.Spec.ClusterNetwork.IPFamily, ip, reconcileK8sSvcEndpoints, nil
+	return &cluster.Address, cluster.Spec.ClusterNetwork.IPFamily, ip, reconcileK8sSvcEndpoints, cluster.Spec.ClusterNetwork.CoreDNSReplicas, nil
 }
 
 // reconcileDefaultServiceAccount ensures that the Kubernetes default service account has AutomountServiceAccountToken set to false.

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -99,7 +99,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
-	data.clusterAddress, data.ipFamily, data.k8sServiceApiIP, data.reconcileK8sSvcEndpoints, err = r.networkingData(ctx)
+	data.clusterAddress, data.ipFamily, data.k8sServiceApiIP, data.reconcileK8sSvcEndpoints, data.coreDNSReplicas, err = r.networkingData(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster address: %w", err)
 	}
@@ -973,7 +973,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 	}
 
 	kubeSystemCreators := []reconciling.NamedDeploymentCreatorGetter{
-		coredns.DeploymentCreator(r.clusterSemVer, r.overwriteRegistryFunc),
+		coredns.DeploymentCreator(r.clusterSemVer, data.coreDNSReplicas, r.overwriteRegistryFunc),
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, kubeSystemCreators, metav1.NamespaceSystem, r.Client); err != nil {
@@ -1080,6 +1080,7 @@ type reconcileData struct {
 	k8sServiceApiIP             *net.IP
 	reconcileK8sSvcEndpoints    bool
 	kubernetesDashboardEnabled  bool
+	coreDNSReplicas             *int32
 }
 
 func (r *reconciler) ensureOPAIntegrationIsRemoved(ctx context.Context) error {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -112,6 +112,7 @@ func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, re
 				PodAntiAffinity: &corev1.PodAntiAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 						{
+							Weight: 10,
 							PodAffinityTerm: corev1.PodAffinityTerm{
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -112,7 +112,6 @@ func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, re
 				PodAntiAffinity: &corev1.PodAntiAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 						{
-							Weight: 10,
 							PodAffinityTerm: corev1.PodAffinityTerm{
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -108,6 +108,22 @@ func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, re
 
 			dep.Spec.Template.Spec.ServiceAccountName = resources.CoreDNSServiceAccountName
 
+			dep.Spec.Template.Spec.Affinity = &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							Weight: 10,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil),
+								},
+								TopologyKey: resources.TopologyKeyHostname,
+							},
+						},
+					},
+				},
+			}
+
 			return dep, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -51,7 +51,7 @@ var (
 )
 
 // DeploymentCreator returns the function to create and update the CoreDNS deployment.
-func DeploymentCreator(kubernetesVersion *semverlib.Version, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.CoreDNSDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.CoreDNSDeploymentName
@@ -59,6 +59,10 @@ func DeploymentCreator(kubernetesVersion *semverlib.Version, registryWithOverwri
 			dep.Labels = resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil)
 
 			dep.Spec.Replicas = resources.Int32(2)
+			if replicas != nil {
+				dep.Spec.Replicas = replicas
+			}
+
 			// The Selector is immutable, so we don't change it if it's set. This happens in upgrade cases
 			// where coredns is switched from a manifest based addon to a user-cluster-controller-manager resource
 			if dep.Spec.Selector == nil {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1100,6 +1100,11 @@ spec:
                 description: ClusterNetworkingConfig specifies the different networking
                   parameters for a cluster.
                 properties:
+                  coreDNSReplicas:
+                    description: CoreDNSReplicas is the number of desired pods of
+                      user cluster coredns deployment.
+                    format: int32
+                    type: integer
                   dnsDomain:
                     description: Domain name for services.
                     type: string

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1062,6 +1062,11 @@ spec:
                 description: ClusterNetworkingConfig specifies the different networking
                   parameters for a cluster.
                 properties:
+                  coreDNSReplicas:
+                    description: CoreDNSReplicas is the number of desired pods of
+                      user cluster coredns deployment.
+                    format: int32
+                    type: integer
                   dnsDomain:
                     description: Domain name for services.
                     type: string

--- a/pkg/test/e2e/utils/apiclient/models/cluster_networking_config.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster_networking_config.go
@@ -19,6 +19,9 @@ import (
 // swagger:model ClusterNetworkingConfig
 type ClusterNetworkingConfig struct {
 
+	// CoreDNSReplicas is the number of desired pods of user cluster coredns deployment.
+	CoreDNSReplicas int32 `json:"coreDNSReplicas,omitempty"`
+
 	// Domain name for services.
 	DNSDomain string `json:"dnsDomain,omitempty"`
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
- Adding API configuration for number of replicas for CoreDNS deployment.
- Adding anti-affinity rules to CoreDNS deployment to make sure its replicas don't run on the same node.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9396, fixes #9397

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
