### PR TITLE
Block dynamic kubelet config for NodeDeployments with Kubernetes 1.24 and higher

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -26530,6 +26530,7 @@
       ],
       "properties": {
         "dynamicConfig": {
+          "description": "Only supported for nodes with Kubernetes 1.23 or less.",
           "type": "boolean",
           "x-go-name": "DynamicConfig"
         },

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2242,6 +2242,7 @@ type NodeDeploymentSpec struct {
 	Template NodeSpec `json:"template"`
 	// required: false
 	Paused *bool `json:"paused,omitempty"`
+	// Only supported for nodes with Kubernetes 1.23 or less.
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
 }

--- a/pkg/handler/v1/node/node_test.go
+++ b/pkg/handler/v1/node/node_test.go
@@ -289,8 +289,8 @@ func TestCreateNodeDeployment(t *testing.T) {
 		{
 			Name:             "scenario 7: create a node deployment with dynamic config",
 			Body:             `{"spec":{"replicas":1,"dynamicConfig":true,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
-			ExpectedResponse: `{"id":"%s","name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":true},"status":{}}`,
-			HTTPStatus:       http.StatusCreated,
+			ExpectedResponse: `{"error":{"code":400,"message":"node deployment validation failed: dynamic config cannot be configured for Kubernetes 1.24 or higher"}}`,
+			HTTPStatus:       http.StatusBadRequest,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -302,8 +302,8 @@ func TestCreateNodeDeployment(t *testing.T) {
 		// scenario 8
 		{
 			Name:             "scenario 8: create a node deployment with annotations",
-			Body:             `{"annotations":{"test/annotations":"true"},"spec":{"replicas":1,"dynamicConfig":true,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
-			ExpectedResponse: `{"id":"%s","name":"%s","annotations":{"test/annotations":"true"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":true},"status":{}}`,
+			Body:             `{"annotations":{"test/annotations":"true"},"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
+			ExpectedResponse: `{"id":"%s","name":"%s","annotations":{"test/annotations":"true"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false},"status":{}}`,
 			HTTPStatus:       http.StatusCreated,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,

--- a/pkg/handler/v2/machine/machine_test.go
+++ b/pkg/handler/v2/machine/machine_test.go
@@ -148,8 +148,8 @@ func TestCreateMachineDeployment(t *testing.T) {
 		{
 			Name:             "scenario 7: create a machine deployment with dynamic config",
 			Body:             `{"spec":{"replicas":1,"dynamicConfig":true,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
-			ExpectedResponse: `{"id":"%s","name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":true},"status":{}}`,
-			HTTPStatus:       http.StatusCreated,
+			ExpectedResponse: `{"error":{"code":400,"message":"node deployment validation failed: dynamic config cannot be configured for Kubernetes 1.24 or higher"}}`,
+			HTTPStatus:       http.StatusBadRequest,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -162,8 +162,8 @@ func TestCreateMachineDeployment(t *testing.T) {
 		// scenario 8
 		{
 			Name:             "scenario 8: create a machine deployment with annotations",
-			Body:             `{"annotations":{"test/annotations":"true"},"spec":{"replicas":1,"dynamicConfig":true,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
-			ExpectedResponse: `{"id":"%s","name":"%s","annotations":{"test/annotations":"true"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":true},"status":{}}`,
+			Body:             `{"annotations":{"test/annotations":"true"},"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
+			ExpectedResponse: `{"id":"%s","name":"%s","annotations":{"test/annotations":"true"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false},"status":{}}`,
 			HTTPStatus:       http.StatusCreated,
 			ProjectID:        test.GenDefaultProject().Name,
 			ClusterID:        test.GenDefaultCluster().Name,

--- a/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
@@ -19,7 +19,7 @@ import (
 // swagger:model NodeDeploymentSpec
 type NodeDeploymentSpec struct {
 
-	// dynamic config
+	// Only supported for nodes with Kubernetes 1.23 or less.
 	DynamicConfig bool `json:"dynamicConfig,omitempty"`
 
 	// paused


### PR DESCRIPTION
Signed-off-by: Marvin Beckers <marvin@kubermatic.com>

**What does this PR do / Why do we need it**:

Dynamic kubelet configuration is not supported in 1.24 or higher. We should block it at the KKP API level. Blocking it for `MachineDeployments` is pulled in with https://github.com/kubermatic/machine-controller/pull/1312.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Dynamic kubelet configuration is rejected by the KKP API for `NodeDeployments` with Kubernetes 1.24 or higher
```
