### PR TITLE
Ignore conflicting operation on bucket lifecycle update

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -27,6 +27,7 @@ package metering
 import (
 	"context"
 	"fmt"
+
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
 

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -27,6 +27,7 @@ package metering
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
 
@@ -136,6 +137,10 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 		return err
 	}
 	if err := mc.SetBucketLifecycle(ctx, bucket, config); err != nil {
+		// Ignore conflict error in case lock after previous reconciliation process still exists.
+		if strings.HasPrefix(err.Error(), "A conflicting conditional operation") {
+			return nil
+		}
 		return fmt.Errorf("failed to update bucket lifecycle: %w", err)
 	}
 

--- a/pkg/ee/metering/report_config_handler.go
+++ b/pkg/ee/metering/report_config_handler.go
@@ -389,7 +389,9 @@ func updateMeteringReportConfiguration(ctx context.Context, reportCfgReq updateR
 		reportConfiguration.Interval = uint32(*reportCfgReq.Body.Interval)
 	}
 
-	if reportCfgReq.Body.Retention != nil && *reportCfgReq.Body.Retention >= 1 {
+	if reportCfgReq.Body.Retention == nil {
+		reportConfiguration.Retention = nil
+	} else if *reportCfgReq.Body.Retention >= 1 {
 		retention := uint32(*reportCfgReq.Body.Retention)
 		reportConfiguration.Retention = &retention
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
- ignore conflicting operation on the bucket lifecycle update. The problem is that in the seed controller we set watchers for events that we create (e.g. cronjobs). Combined with `MaxConcurrentReconciles` parameter above 1, it leads to the situation where multiple seed reconciliations happen at nearly the same time. In such case trying to update S3 lifecycle fails due to the lock on configuration update operation. 
- fix metering configuration update (allow updating the config with empty value to remove retention)

**Special notes for your reviewer**:
This could be alternatively resolved by fetching existing lifecycle configuration and comparing it with the metering configuration. Initial testing showed that this approach works but I assume it still may fail occasionally as S3 configuration updates are eventually consistent. It was one of reasons why I chose to ignore the error instead. Another benefit of ignoring the error is reduced complexity of solution.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
