### PR TITLE
Makes telemetry uuid optional and generates if not provided

### DIFF
--- a/charts/telemetry/templates/secret.yaml
+++ b/charts/telemetry/templates/secret.yaml
@@ -15,8 +15,17 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-client-uuid
+  {{- $name := printf "%s-client-uuid" .Release.Name  }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  uuid: {{ required "A valid .Values.telemetry.uuid entry required!" .Values.telemetry.uuid | b64enc }}
+  {{- $previous := lookup "v1" "Secret" .Release.Namespace $name }}
+
+  {{- if $previous }}
+  uuid: {{ index $previous.data "uuid" }}
+  {{- else if .Values.telemetry.uuid }}
+  uuid: {{ .Values.telemetry.uuid  | b64enc }}
+  {{- else }}
+  uuid: {{ uuidv4 | b64enc }}
+  {{- end }}

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -16,8 +16,8 @@ telemetry:
   schedule: "0 0 * * *"
 
   # uuid is the unique identifier of the client where the agent is running.
-  # This field is required and will print an error message when that entry is missing.
-  # You can generate uuid using command uuidgen on your linux machine
+  # You can generate uuid using command uuidgen on your linux machine.
+  # This field is optional.
   uuid: ""
 
   kubermaticAgent:


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**: 
- Makes telemetry uuid optional
- Generates it if not provided
- Stores the Generated or Provided UUID in a secret and when the helm chart is upgraded the uuid value is  reused from the secret and not regenerated to make sure the UUID is unique for a installation (unique for a user).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8271 and https://github.com/kubermatic/telemetry-client/issues/4

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Making telemetry UUID field optional
```
