### PR TITLE
add storage for the WEB terminal Pod

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -80,7 +80,7 @@ var upgrader = websocket.Upgrader{
 
 type WebsocketSettingsWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn)
 type WebsocketUserWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string)
-type WebsocketTerminalWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, seedClient kubernetes.Interface, seedCfg *rest.Config, namespace, podName string)
+type WebsocketTerminalWriter func(ws *websocket.Conn, seedClient kubernetes.Interface, seedCfg *rest.Config, namespace, podName string)
 
 func (r Routing) RegisterV1Websocket(mux *mux.Router) {
 	providers := getProviders(r)
@@ -211,7 +211,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			return
 		}
 
-		writer(ctx, providers, ws, k8sClusterProvider.GetSeedClusterAdminClient(), k8sClusterProvider.SeedAdminConfig(), namespace, podName)
+		writer(ws, k8sClusterProvider.GetSeedClusterAdminClient(), k8sClusterProvider.SeedAdminConfig(), namespace, podName)
 	}
 }
 

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -17,7 +17,6 @@ limitations under the License.
 package websocket
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +24,6 @@ import (
 	"github.com/gorilla/websocket"
 
 	"k8c.io/kubermatic/v2/pkg/log"
-	"k8c.io/kubermatic/v2/pkg/watcher"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -171,7 +169,7 @@ func startProcess(k8sClient kubernetes.Interface, cfg *rest.Config, namespace, p
 }
 
 // Terminal is called for any new websocket connection.
-func Terminal(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, seedClient kubernetes.Interface, seedCfg *rest.Config, namespace, podName string) {
+func Terminal(ws *websocket.Conn, seedClient kubernetes.Interface, seedCfg *rest.Config, namespace, podName string) {
 	defer ws.Close()
 
 	err := startProcess(
@@ -179,7 +177,7 @@ func Terminal(ctx context.Context, providers watcher.Providers, ws *websocket.Co
 		seedCfg,
 		namespace,
 		podName,
-		[]string{"bash"},
+		[]string{"bash", "-c", "cd /data/terminal && /bin/bash"},
 		TerminalSession{
 			websocketConn: ws,
 		},

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal.yaml
@@ -35,7 +35,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -45,6 +45,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: web-terminal-kubeconfig
           readOnly: true
+        - mountPath: /data/terminal
+          name: web-terminal-storage
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -68,4 +70,7 @@ spec:
       - name: web-terminal-kubeconfig
         secret:
           secretName: admin-kubeconfig
+      - emptyDir:
+          medium: Memory
+        name: web-terminal-storage
 status: {}

--- a/pkg/resources/web-terminal/deployment.go
+++ b/pkg/resources/web-terminal/deployment.go
@@ -36,7 +36,7 @@ var (
 				corev1.ResourceCPU:    resource.MustParse("100m"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
 				corev1.ResourceCPU:    resource.MustParse("250m"),
 			},
 		},
@@ -44,7 +44,8 @@ var (
 )
 
 const (
-	name = "web-terminal"
+	name               = "web-terminal"
+	webTerminalStorage = "web-terminal-storage"
 )
 
 // DeploymentCreator returns the function to create WEB terminal deployment.
@@ -127,6 +128,11 @@ func getVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/etc/kubernetes/kubeconfig",
 			ReadOnly:  true,
 		},
+		{
+			Name:      webTerminalStorage,
+			ReadOnly:  false,
+			MountPath: "/data/terminal",
+		},
 	}
 }
 
@@ -137,6 +143,14 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.AdminKubeconfigSecretName,
+				},
+			},
+		},
+		{
+			Name: webTerminalStorage,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
 				},
 			},
 		},


### PR DESCRIPTION
**What does this PR do / Why do we need it**: This PR adds storage for the WEB terminal. When the user execs to the pod, the current directory is set for this storage path. The storage size is limited.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9861


```release-note
Extend WEB terminal Pod for dedicated in-memory storage.
```
