### PR TITLE
Add delete propagation policy while removing metering cron jobs

### DIFF
--- a/pkg/ee/metering/handler.go
+++ b/pkg/ee/metering/handler.go
@@ -110,11 +110,12 @@ func CreateOrUpdateConfigurations(ctx context.Context, request interface{}, mast
 }
 
 func updateSeedMeteringConfiguration(ctx context.Context, meteringCfg configurationReq, seed *kubermaticv1.Seed, masterClient ctrlruntimeclient.Client) error {
-	seed.Spec.Metering = &kubermaticv1.MeteringConfiguration{
-		Enabled:          meteringCfg.Enabled,
-		StorageClassName: meteringCfg.StorageClassName,
-		StorageSize:      meteringCfg.StorageSize,
+	if seed.Spec.Metering == nil {
+		seed.Spec.Metering = &kubermaticv1.MeteringConfiguration{}
 	}
+	seed.Spec.Metering.Enabled = meteringCfg.Enabled
+	seed.Spec.Metering.StorageClassName = meteringCfg.StorageClassName
+	seed.Spec.Metering.StorageSize = meteringCfg.StorageSize
 
 	if err := masterClient.Update(ctx, seed); err != nil {
 		return fmt.Errorf("failed to update seed %q: %w", seed.Name, err)

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -39,6 +39,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -160,7 +161,11 @@ func cleanupOrphanedReportingCronJobs(ctx context.Context, client ctrlruntimecli
 
 	for cronJobName, existingCronJob := range existingReportingCronJobNamedMap {
 		if orphanedCronJobNames.Has(cronJobName) {
-			if err := client.Delete(ctx, &existingCronJob); err != nil {
+			policy := metav1.DeletePropagationBackground
+			delOpts := &ctrlruntimeclient.DeleteOptions{
+				PropagationPolicy: &policy,
+			}
+			if err := client.Delete(ctx, &existingCronJob, delOpts); err != nil {
 				return fmt.Errorf("failed to remove an orphaned reporting cronjob (%s): %w", cronJobName, err)
 			}
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
At the moment controller leaves orphaned jobs and pods after deleting cronjob during reconciliation. My initial though was that DeletePropagationBackground is a default option and we do not need to set it explicitly but I guess I was wrong.

Additionally, I included fix for updating metering configuration. It no longer overwrites the whole metering object. 

**Does this PR close any issues?**:
Fixes #9822 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
