### PR TITLE
 run dualstack e2e for Azure in East US region 

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -91,6 +91,12 @@ spec:
       spec:
         azure:
           location: "westeurope"
+    azure-eastus:
+      location: "Azure East US"
+      country: US
+      spec:
+        azure:
+          location: "eastus"
     gcp-westeurope:
       location: "Europe West (Germany)"
       country: DE

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -189,7 +189,7 @@ func (a azure) NodeSpec() models.NodeCloudSpec {
 
 func (a azure) CloudSpec() models.CloudSpec {
 	return models.CloudSpec{
-		DatacenterName: "azure-westeurope",
+		DatacenterName: "azure-eastus",
 		Azure: &models.AzureCloudSpec{
 			ClientID:        os.Getenv("AZURE_CLIENT_ID"),
 			ClientSecret:    os.Getenv("AZURE_CLIENT_SECRET"),

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -444,7 +444,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 
 func createMachineDeployment(t *testing.T, apicli *utils.TestClient, params createMachineDeploymentParams) error {
 	mdParams := project.CreateMachineDeploymentParams(params)
-	return wait.Poll(30*time.Second, 2*time.Minute, func() (bool, error) {
+	return wait.Poll(30*time.Second, 10*time.Minute, func() (bool, error) {
 		_, err := apicli.GetKKPAPIClient().Project.CreateMachineDeployment(
 			&mdParams,
 			apicli.GetBearerToken())


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Dualstack e2e tests were flaky due to hitting quota limits on Azure West Europe region. 
This PR makes the tests run in East US where we don't hit the quota limits (at least right now). 


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
