### PR TITLE
extend the user settings for new flag

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -3924,6 +3924,11 @@
         "parameters": [
           {
             "type": "string",
+            "name": "Region",
+            "in": "header"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -3942,11 +3947,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "name": "Region",
-            "in": "header"
           }
         ],
         "responses": {
@@ -29385,6 +29385,10 @@
         "selectedTheme": {
           "type": "string",
           "x-go-name": "SelectedTheme"
+        },
+        "useClustersView": {
+          "type": "boolean",
+          "x-go-name": "UseClustersView"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -3924,11 +3924,6 @@
         "parameters": [
           {
             "type": "string",
-            "name": "Region",
-            "in": "header"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -3947,6 +3942,11 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "Region",
+            "in": "header"
           }
         ],
         "responses": {

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -88,6 +88,7 @@ type UserSettings struct {
 	CollapseSidenav            bool   `json:"collapseSidenav,omitempty"`
 	DisplayAllProjectsForAdmin bool   `json:"displayAllProjectsForAdmin,omitempty"`
 	LastSeenChangelogVersion   string `json:"lastSeenChangelogVersion,omitempty"`
+	UseClustersView            bool   `json:"useClustersView"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -88,7 +88,7 @@ type UserSettings struct {
 	CollapseSidenav            bool   `json:"collapseSidenav,omitempty"`
 	DisplayAllProjectsForAdmin bool   `json:"displayAllProjectsForAdmin,omitempty"`
 	LastSeenChangelogVersion   string `json:"lastSeenChangelogVersion,omitempty"`
-	UseClustersView            bool   `json:"useClustersView"`
+	UseClustersView            bool   `json:"useClustersView,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -123,6 +123,10 @@ spec:
                     type: string
                   selectedTheme:
                     type: string
+                  useClustersView:
+                    type: boolean
+                required:
+                - useClustersView
                 type: object
             required:
             - admin

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -125,8 +125,6 @@ spec:
                     type: string
                   useClustersView:
                     type: boolean
-                required:
-                - useClustersView
                 type: object
             required:
             - admin

--- a/pkg/test/e2e/utils/apiclient/models/user_settings.go
+++ b/pkg/test/e2e/utils/apiclient/models/user_settings.go
@@ -37,6 +37,9 @@ type UserSettings struct {
 
 	// selected theme
 	SelectedTheme string `json:"selectedTheme,omitempty"`
+
+	// use clusters view
+	UseClustersView bool `json:"useClustersView,omitempty"`
 }
 
 // Validate validates this user settings


### PR DESCRIPTION
**What does this PR do / Why do we need it**: flag to the user settings object that will allow users saving their view preferences

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9915 


```release-note
New flag for the user settings to allow users saving their view preferences
```
