### PR TITLE
Remove telemetry uuid validation

### DIFF
--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -210,13 +210,6 @@ func validateHelmValues(config *kubermaticv1.KubermaticConfiguration, helmValues
 		helmValues.Set(path, config.Spec.ImagePullSecret)
 	}
 
-	if !opt.DisableTelemetry {
-		path = yamled.Path{"telemetry", "uuid"}
-		if value, _ := helmValues.GetString(path); value == "" {
-			failures = append(failures, errors.New("Telemetry is enabled, but no UUID was configured; generate a UUID and set it as telemetry.uuid in your Helm values"))
-		}
-	}
-
 	if !config.Spec.FeatureGates[features.HeadlessInstallation] {
 		path := yamled.Path{"dex", "ingress", "host"}
 		if domain, _ := helmValues.GetString(path); domain == "" {


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**: Remove telemetry UUID validation as UUID is not longer a required value, it can be generated if not provided

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
