### PR TITLE
WIP - add Basic LDAP Client

### DIFF
--- a/cmd/ldap-group-syncer/Dockerfile
+++ b/cmd/ldap-group-syncer/Dockerfile
@@ -15,4 +15,4 @@
 FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY ./_build/ldap-group-syncer /
+COPY ./ldap-group-syncer /usr/local/bin/

--- a/cmd/ldap-group-syncer/Dockerfile
+++ b/cmd/ldap-group-syncer/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.13
+LABEL maintainer="support@kubermatic.com"
+
+COPY ./_build/ldap-group-syncer /

--- a/cmd/ldap-group-syncer/Makefile
+++ b/cmd/ldap-group-syncer/Makefile
@@ -47,4 +47,4 @@ docker-env:
 		-e "LDAP_BINDDN=$${LDAP_BINDDN}" \
 		-e "LDAP_SECRET=$${LDAP_SECRET}" \
 		-v $(realpath testdata/pawnee-grouped):/bootstrap \
-		quay.io/kubermatic-labs/openldap-test:latest
+		quay.io/kubermatic-labs/openldap-test:latest || true

--- a/cmd/ldap-group-syncer/Makefile
+++ b/cmd/ldap-group-syncer/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL := /bin/bash
+
+.PHONY: default
+default: build
+
+.PHONY: build
+build:
+	CGO_ENABLED=0 go build -v
+
+.PHONY: docker
+docker: build
+	docker build -t quay.io/kubermatic/ldap-group-syncer:latest .
+
+.PHONY: docker-env
+docker-env:
+	. testdata/pawnee-grouped/env.sh; \
+	docker run \
+		--rm \
+		-p 10389:10389 \
+		-p 10636:10636 \
+		-e "DATA_DIR=/bootstrap" \
+		-e "LDAP_DOMAIN=$${LDAP_DOMAIN}" \
+		-e "LDAP_BASEDN=$${LDAP_BASEDN}" \
+		-e "LDAP_ORGANISATION=$${LDAP_ORGANISATION}" \
+		-e "LDAP_BINDDN=$${LDAP_BINDDN}" \
+		-e "LDAP_SECRET=$${LDAP_SECRET}" \
+		-v $(realpath testdata/pawnee-grouped):/bootstrap \
+		quay.io/kubermatic-labs/openldap-test:latest

--- a/cmd/ldap-group-syncer/Makefile
+++ b/cmd/ldap-group-syncer/Makefile
@@ -25,11 +25,19 @@ build:
 docker: build
 	docker build -t quay.io/kubermatic/ldap-group-syncer:latest .
 
+.PHONY: integration-tests
+integration-tests: docker-env
+	sleep 10
+	go test -tags ldaptest -v ./...
+	docker stop openldap-test
+
 .PHONY: docker-env
 docker-env:
 	. testdata/pawnee-grouped/env.sh; \
 	docker run \
 		--rm \
+		--detach \
+		--name openldap-test \
 		-p 10389:10389 \
 		-p 10636:10636 \
 		-e "DATA_DIR=/bootstrap" \

--- a/cmd/ldap-group-syncer/config.dist.yaml
+++ b/cmd/ldap-group-syncer/config.dist.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This is an example configuration file, demonstrating all options that
 # can be set. For testing you can use the "grouped" mapping type and
 # start a test Docker container using

--- a/cmd/ldap-group-syncer/config.dist.yaml
+++ b/cmd/ldap-group-syncer/config.dist.yaml
@@ -72,5 +72,5 @@ mapping:
     memberAttribute: member
 
     # the query to use to find all relevant groups (for each group, the list
-    # of members is then fetched indivdually)
+    # of members is then fetched individually)
     query: '(objectClass=Group)'

--- a/cmd/ldap-group-syncer/config.dist.yaml
+++ b/cmd/ldap-group-syncer/config.dist.yaml
@@ -1,0 +1,62 @@
+# This is an example configuration file, demonstrating all options that
+# can be set. For testing you can use the "grouped" mapping type and
+# start a test Docker container using
+#
+#     docker run --rm -p 10389:10389 -p 10636:10636 rroemhild/test-openldap
+#
+
+# the address of the LDAP server, can use ldaps for secure communication
+address: ldap://localhost:10389
+
+# This section defines how the LDAP syncer is reading persons and
+# groups from LDAP. Only one of the two modes must be configured,
+# otherwise an error will be raised.
+mapping:
+  # This is a sample configuration for a setup where each person
+  # in LDAP has a "group" attribute that lists the groups this
+  # person should be assigned to.
+  # tagged:
+  #   # the root node from which to start the search for persons
+  #   baseDN: dc=planetexpress,dc=com
+
+  #   # the attribute in each person that contains the e-mail address
+  #   emailAttribute: mail
+
+  #   # the attribute that contains the group's name
+  #   groupNameAttribute: cn
+
+  #   # the attribute that contains the person's name
+  #   personNameAttribute: cn
+
+  #   # the attribute that contains the KKP group name DNs (each person
+  #   # can have multiple groups assigned)
+  #   groupAttribute: group
+
+  #   # the query to use to find all relevant persons
+  #   query: '(objectClass=person)'
+
+  # This mapping mode is used when a dedicated objectClass exists
+  # to represent KKP groups, and this objectClass has the members
+  # defined as its attributes.
+  # This is for example how the test-ldap-server structures the persons:
+  # https://github.com/rroemhild/docker-test-openldap/blob/master/rootfs/opt/openldap/bootstrap/data/30_groups_crew.ldif
+  grouped:
+    # the root node from which to start the search for persons
+    baseDN: dc=planetexpress,dc=com
+
+    # the attribute in each person that contains the e-mail address
+    emailAttribute: mail
+
+    # the attribute that contains the group's name
+    groupNameAttribute: cn
+
+    # the attribute that contains the person's name
+    personNameAttribute: cn
+
+    # the attribute that contains the DN of persons assigned to this group
+    # (can be used multiple times)
+    memberAttribute: member
+
+    # the query to use to find all relevant groups (for each group, the list
+    # of members is then fetched indivdually)
+    query: '(objectClass=Group)'

--- a/cmd/ldap-group-syncer/config.go
+++ b/cmd/ldap-group-syncer/config.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Address string `yaml:"address"`
+	Mapping struct {
+		Tagged  *TaggedConfig  `yaml:"tagged"`
+		Grouped *GroupedConfig `yaml:"grouped"`
+	} `yaml:"mapping"`
+}
+
+type TaggedConfig struct {
+	BaseDN              string `yaml:"baseDN"`
+	EmailAttribute      string `yaml:"emailAttribute"`
+	GroupNameAttribute  string `yaml:"groupNameAttribute"`
+	PersonNameAttribute string `yaml:"personNameAttribute"`
+	GroupAttribute      string `yaml:"groupAttribute"`
+	Query               string `yaml:"query"`
+}
+
+type GroupedConfig struct {
+	BaseDN              string `yaml:"baseDN"`
+	EmailAttribute      string `yaml:"emailAttribute"`
+	GroupNameAttribute  string `yaml:"groupNameAttribute"`
+	PersonNameAttribute string `yaml:"personNameAttribute"`
+	MemberAttribute     string `yaml:"memberAttribute"`
+	Query               string `yaml:"query"`
+}
+
+func loadConfig(filename string) (*Config, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &Config{}
+	if err := yaml.Unmarshal(content, config); err != nil {
+		return nil, err
+	}
+
+	if config.Mapping.Grouped == nil && config.Mapping.Tagged == nil {
+		return nil, errors.New("either tagged or grouped mapping must be configured")
+	}
+
+	if config.Mapping.Grouped != nil && config.Mapping.Tagged != nil {
+		return nil, errors.New("tagged and grouped mapping must not be configured at the same time")
+	}
+
+	return config, nil
+}

--- a/cmd/ldap-group-syncer/main.go
+++ b/cmd/ldap-group-syncer/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ldap-group-syncer/main.go
+++ b/cmd/ldap-group-syncer/main.go
@@ -39,9 +39,15 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err := runSync(config); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runSync(config *types.Config) error {
 	l, err := ldap.NewClient(config.Address)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer l.Close()
 
@@ -54,13 +60,15 @@ func main() {
 	}
 
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	encoder := yaml.NewEncoder(os.Stdout)
 	encoder.SetIndent(2)
 
 	if err := encoder.Encode(org); err != nil {
-		log.Fatal(err)
+		return err
 	}
+
+	return nil
 }

--- a/cmd/ldap-group-syncer/main.go
+++ b/cmd/ldap-group-syncer/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
 	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/ldap"
 	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
 )

--- a/cmd/ldap-group-syncer/main.go
+++ b/cmd/ldap-group-syncer/main.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sort"
+
+	ldap "github.com/go-ldap/ldap/v3"
+	"gopkg.in/yaml.v3"
+)
+
+type Person struct {
+	DN    string `yaml:"dn"`
+	Name  string `yaml:"name"`
+	Email string `yaml:"email"`
+}
+
+type Group struct {
+	DN      string   `yaml:"dn"`
+	Name    string   `yaml:"name"`
+	Members []Person `yaml:"members"`
+}
+
+type Organization struct {
+	Groups []Group `yaml:"groups"`
+}
+
+func main() {
+	config, err := loadConfig("config.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	l, err := ldap.DialURL(config.Address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	var org *Organization
+
+	if config.Mapping.Grouped != nil {
+		org, err = fetchGroupedData(l, config.Mapping.Grouped)
+	} else {
+		org, err = fetchTaggedData(l, config.Mapping.Tagged)
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	encoder := yaml.NewEncoder(os.Stdout)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(org); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func fetchGroupedData(conn *ldap.Conn, config *GroupedConfig) (*Organization, error) {
+	groupAttributes := []string{
+		"dn",
+		config.GroupNameAttribute,
+		config.MemberAttribute,
+	}
+
+	// step 1, find all relevant groups
+	searchRequest := ldap.NewSearchRequest(
+		config.BaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		config.Query,
+		groupAttributes,
+		nil,
+	)
+
+	log.Println("Fetching groups…")
+
+	groupsResult, err := conn.SearchWithPaging(searchRequest, 50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+
+	// go through all groups and collect the DNs for every member
+	persons := map[string]Person{}
+	for _, group := range groupsResult.Entries {
+		for _, member := range group.GetAttributeValues(config.MemberAttribute) {
+			persons[member] = Person{}
+		}
+	}
+
+	// step2, fetch all the members individually
+	personAttributes := []string{
+		"dn",
+		config.EmailAttribute,
+		config.PersonNameAttribute,
+	}
+
+	for personDN := range persons {
+		searchRequest := ldap.NewSearchRequest(
+			personDN,
+			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
+			"(objectClass=*)",
+			personAttributes,
+			nil,
+		)
+
+		log.Printf("Fetching person %q…", personDN)
+		sr, err := conn.Search(searchRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch person %q: %w", personDN, err)
+		}
+
+		for _, person := range sr.Entries {
+			persons[personDN] = Person{
+				DN:    personDN,
+				Name:  person.GetAttributeValue(config.PersonNameAttribute),
+				Email: person.GetAttributeValue(config.EmailAttribute),
+			}
+		}
+	}
+
+	// step 3, create a nice result structure with org and members
+	org := &Organization{
+		Groups: []Group{},
+	}
+
+	for _, group := range groupsResult.Entries {
+		members := []Person{}
+		for _, member := range group.GetAttributeValues(config.MemberAttribute) {
+			members = append(members, persons[member])
+		}
+
+		sortMembers(members)
+		org.Groups = append(org.Groups, Group{
+			DN:      group.DN,
+			Name:    group.GetAttributeValue(config.GroupNameAttribute),
+			Members: members,
+		})
+	}
+
+	return org, nil
+}
+
+func fetchTaggedData(conn *ldap.Conn, config *TaggedConfig) (*Organization, error) {
+	personAttributes := []string{
+		"dn",
+		config.EmailAttribute,
+		config.PersonNameAttribute,
+	}
+
+	searchRequest := ldap.NewSearchRequest(
+		config.BaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		config.Query,
+		personAttributes,
+		nil,
+	)
+
+	log.Println("Fetching persons…")
+
+	personsResult, err := conn.SearchWithPaging(searchRequest, 50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list persons: %w", err)
+	}
+
+	// go through all persons and collect the DNs for every group
+	groups := map[string]Group{}
+	for _, person := range personsResult.Entries {
+		for _, groupDN := range person.GetAttributeValues(config.GroupAttribute) {
+			groups[groupDN] = Group{}
+		}
+	}
+
+	// step2, fetch all the groups individually
+	groupAttributes := []string{
+		"dn",
+		config.GroupNameAttribute,
+	}
+
+	for groupDN := range groups {
+		searchRequest := ldap.NewSearchRequest(
+			groupDN,
+			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
+			"(objectClass=*)",
+			groupAttributes,
+			nil,
+		)
+
+		log.Printf("Fetching group %q…", groupDN)
+		sr, err := conn.Search(searchRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch group %q: %w", groupDN, err)
+		}
+
+		for _, group := range sr.Entries {
+			groups[groupDN] = Group{
+				DN:      group.DN,
+				Name:    group.GetAttributeValue(config.GroupNameAttribute),
+				Members: []Person{},
+			}
+		}
+	}
+
+	// step 3, create a nice result structure with org and members
+	for _, person := range personsResult.Entries {
+		for _, groupDN := range person.GetAttributeValues(config.GroupAttribute) {
+			group := groups[groupDN]
+			group.Members = append(group.Members, Person{
+				DN:    person.DN,
+				Name:  person.GetAttributeValue(config.PersonNameAttribute),
+				Email: person.GetAttributeValue(config.EmailAttribute),
+			})
+
+			groups[groupDN] = group
+		}
+	}
+
+	org := &Organization{
+		Groups: []Group{},
+	}
+
+	for i := range groups {
+		sortMembers(groups[i].Members)
+		org.Groups = append(org.Groups, groups[i])
+	}
+
+	return org, nil
+}
+
+func sortMembers(persons []Person) {
+	sort.Slice(persons, func(i, j int) bool {
+		return persons[i].Email < persons[j].Email
+	})
+}
+
+// authenticate demonstrate a BIND operation using behera password auth.
+func authenticate() error {
+	// controls := []ldap.Control{}
+	// controls = append(controls, ldap.NewControlBeheraPasswordPolicy())
+	// bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone", controls)
+
+	// r, err := l.SimpleBind(bindRequest)
+	// ppolicyControl := ldap.FindControl(r.Controls, ldap.ControlTypeBeheraPasswordPolicy)
+
+	// var ppolicy *ldap.ControlBeheraPasswordPolicy
+	// if ppolicyControl != nil {
+	// 	ppolicy = ppolicyControl.(*ldap.ControlBeheraPasswordPolicy)
+	// } else {
+	// 	log.Printf("ppolicyControl response not available.\n")
+	// }
+	// if err != nil {
+	// 	errStr := "ERROR: Cannot bind: " + err.Error()
+	// 	if ppolicy != nil && ppolicy.Error >= 0 {
+	// 		errStr += ":" + ppolicy.ErrorString
+	// 	}
+	// 	log.Print(errStr)
+	// } else {
+	// 	logStr := "Login Ok"
+	// 	if ppolicy != nil {
+	// 		if ppolicy.Expire >= 0 {
+	// 			logStr += fmt.Sprintf(". Password expires in %d seconds\n", ppolicy.Expire)
+	// 		} else if ppolicy.Grace >= 0 {
+	// 			logStr += fmt.Sprintf(". Password expired, %d grace logins remain\n", ppolicy.Grace)
+	// 		}
+	// 	}
+	// 	log.Print(logStr)
+	// }
+
+	return nil
+}

--- a/cmd/ldap-group-syncer/main.go
+++ b/cmd/ldap-group-syncer/main.go
@@ -17,49 +17,40 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
+	"flag"
 	"log"
 	"os"
-	"sort"
 
-	ldap "github.com/go-ldap/ldap/v3"
 	"gopkg.in/yaml.v3"
+	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/ldap"
+	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
 )
 
-type Person struct {
-	DN    string `yaml:"dn"`
-	Name  string `yaml:"name"`
-	Email string `yaml:"email"`
-}
-
-type Group struct {
-	DN      string   `yaml:"dn"`
-	Name    string   `yaml:"name"`
-	Members []Person `yaml:"members"`
-}
-
-type Organization struct {
-	Groups []Group `yaml:"groups"`
-}
-
 func main() {
-	config, err := loadConfig("config.yaml")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		log.Fatal("No configuration file given.")
+	}
+
+	config, err := types.LoadConfig(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	l, err := ldap.DialURL(config.Address)
+	l, err := ldap.NewClient(config.Address)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer l.Close()
 
-	var org *Organization
+	var org *types.Organization
 
 	if config.Mapping.Grouped != nil {
-		org, err = fetchGroupedData(l, config.Mapping.Grouped)
+		org, err = l.FetchGroupedData(config.Mapping.Grouped)
 	} else {
-		org, err = fetchTaggedData(l, config.Mapping.Tagged)
+		org, err = l.FetchTaggedData(config.Mapping.Tagged)
 	}
 
 	if err != nil {
@@ -72,216 +63,4 @@ func main() {
 	if err := encoder.Encode(org); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func fetchGroupedData(conn *ldap.Conn, config *GroupedConfig) (*Organization, error) {
-	groupAttributes := []string{
-		"dn",
-		config.GroupNameAttribute,
-		config.MemberAttribute,
-	}
-
-	// step 1, find all relevant groups
-	searchRequest := ldap.NewSearchRequest(
-		config.BaseDN,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		config.Query,
-		groupAttributes,
-		nil,
-	)
-
-	log.Println("Fetching groups…")
-
-	groupsResult, err := conn.SearchWithPaging(searchRequest, 50)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list groups: %w", err)
-	}
-
-	// go through all groups and collect the DNs for every member
-	persons := map[string]Person{}
-	for _, group := range groupsResult.Entries {
-		for _, member := range group.GetAttributeValues(config.MemberAttribute) {
-			persons[member] = Person{}
-		}
-	}
-
-	// step2, fetch all the members individually
-	personAttributes := []string{
-		"dn",
-		config.EmailAttribute,
-		config.PersonNameAttribute,
-	}
-
-	for personDN := range persons {
-		searchRequest := ldap.NewSearchRequest(
-			personDN,
-			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
-			"(objectClass=*)",
-			personAttributes,
-			nil,
-		)
-
-		log.Printf("Fetching person %q…", personDN)
-		sr, err := conn.Search(searchRequest)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch person %q: %w", personDN, err)
-		}
-
-		for _, person := range sr.Entries {
-			persons[personDN] = Person{
-				DN:    personDN,
-				Name:  person.GetAttributeValue(config.PersonNameAttribute),
-				Email: person.GetAttributeValue(config.EmailAttribute),
-			}
-		}
-	}
-
-	// step 3, create a nice result structure with org and members
-	org := &Organization{
-		Groups: []Group{},
-	}
-
-	for _, group := range groupsResult.Entries {
-		members := []Person{}
-		for _, member := range group.GetAttributeValues(config.MemberAttribute) {
-			members = append(members, persons[member])
-		}
-
-		sortMembers(members)
-		org.Groups = append(org.Groups, Group{
-			DN:      group.DN,
-			Name:    group.GetAttributeValue(config.GroupNameAttribute),
-			Members: members,
-		})
-	}
-
-	return org, nil
-}
-
-func fetchTaggedData(conn *ldap.Conn, config *TaggedConfig) (*Organization, error) {
-	personAttributes := []string{
-		"dn",
-		config.EmailAttribute,
-		config.PersonNameAttribute,
-	}
-
-	searchRequest := ldap.NewSearchRequest(
-		config.BaseDN,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		config.Query,
-		personAttributes,
-		nil,
-	)
-
-	log.Println("Fetching persons…")
-
-	personsResult, err := conn.SearchWithPaging(searchRequest, 50)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list persons: %w", err)
-	}
-
-	// go through all persons and collect the DNs for every group
-	groups := map[string]Group{}
-	for _, person := range personsResult.Entries {
-		for _, groupDN := range person.GetAttributeValues(config.GroupAttribute) {
-			groups[groupDN] = Group{}
-		}
-	}
-
-	// step2, fetch all the groups individually
-	groupAttributes := []string{
-		"dn",
-		config.GroupNameAttribute,
-	}
-
-	for groupDN := range groups {
-		searchRequest := ldap.NewSearchRequest(
-			groupDN,
-			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
-			"(objectClass=*)",
-			groupAttributes,
-			nil,
-		)
-
-		log.Printf("Fetching group %q…", groupDN)
-		sr, err := conn.Search(searchRequest)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch group %q: %w", groupDN, err)
-		}
-
-		for _, group := range sr.Entries {
-			groups[groupDN] = Group{
-				DN:      group.DN,
-				Name:    group.GetAttributeValue(config.GroupNameAttribute),
-				Members: []Person{},
-			}
-		}
-	}
-
-	// step 3, create a nice result structure with org and members
-	for _, person := range personsResult.Entries {
-		for _, groupDN := range person.GetAttributeValues(config.GroupAttribute) {
-			group := groups[groupDN]
-			group.Members = append(group.Members, Person{
-				DN:    person.DN,
-				Name:  person.GetAttributeValue(config.PersonNameAttribute),
-				Email: person.GetAttributeValue(config.EmailAttribute),
-			})
-
-			groups[groupDN] = group
-		}
-	}
-
-	org := &Organization{
-		Groups: []Group{},
-	}
-
-	for i := range groups {
-		sortMembers(groups[i].Members)
-		org.Groups = append(org.Groups, groups[i])
-	}
-
-	return org, nil
-}
-
-func sortMembers(persons []Person) {
-	sort.Slice(persons, func(i, j int) bool {
-		return persons[i].Email < persons[j].Email
-	})
-}
-
-// authenticate demonstrate a BIND operation using behera password auth.
-func authenticate() error {
-	// controls := []ldap.Control{}
-	// controls = append(controls, ldap.NewControlBeheraPasswordPolicy())
-	// bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone", controls)
-
-	// r, err := l.SimpleBind(bindRequest)
-	// ppolicyControl := ldap.FindControl(r.Controls, ldap.ControlTypeBeheraPasswordPolicy)
-
-	// var ppolicy *ldap.ControlBeheraPasswordPolicy
-	// if ppolicyControl != nil {
-	// 	ppolicy = ppolicyControl.(*ldap.ControlBeheraPasswordPolicy)
-	// } else {
-	// 	log.Printf("ppolicyControl response not available.\n")
-	// }
-	// if err != nil {
-	// 	errStr := "ERROR: Cannot bind: " + err.Error()
-	// 	if ppolicy != nil && ppolicy.Error >= 0 {
-	// 		errStr += ":" + ppolicy.ErrorString
-	// 	}
-	// 	log.Print(errStr)
-	// } else {
-	// 	logStr := "Login Ok"
-	// 	if ppolicy != nil {
-	// 		if ppolicy.Expire >= 0 {
-	// 			logStr += fmt.Sprintf(". Password expires in %d seconds\n", ppolicy.Expire)
-	// 		} else if ppolicy.Grace >= 0 {
-	// 			logStr += fmt.Sprintf(". Password expired, %d grace logins remain\n", ppolicy.Grace)
-	// 		}
-	// 	}
-	// 	log.Print(logStr)
-	// }
-
-	return nil
 }

--- a/cmd/ldap-group-syncer/pkg/ldap/client.go
+++ b/cmd/ldap-group-syncer/pkg/ldap/client.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"log"
 
-	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
-
 	ldap3 "github.com/go-ldap/ldap/v3"
+
+	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
 )
 
 type Client struct {

--- a/cmd/ldap-group-syncer/pkg/ldap/client.go
+++ b/cmd/ldap-group-syncer/pkg/ldap/client.go
@@ -26,7 +26,7 @@ import (
 )
 
 type Client struct {
-	ldap3.Conn
+	*ldap3.Conn
 }
 
 // NewClient returns a new LDAP client.
@@ -37,45 +37,45 @@ func NewClient(addr string) (*Client, error) {
 	}
 
 	return &Client{
-		Conn: *conn,
+		Conn: conn,
 	}, nil
 }
 
 // authenticate demonstrate a BIND operation using behera password auth.
-func authenticate() error {
-	// controls := []ldap.Control{}
-	// controls = append(controls, ldap.NewControlBeheraPasswordPolicy())
-	// bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone", controls)
+// func authenticate() error {
+// 	controls := []ldap.Control{}
+// 	controls = append(controls, ldap.NewControlBeheraPasswordPolicy())
+// 	bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone", controls)
 
-	// r, err := l.SimpleBind(bindRequest)
-	// ppolicyControl := ldap.FindControl(r.Controls, ldap.ControlTypeBeheraPasswordPolicy)
+// 	r, err := l.SimpleBind(bindRequest)
+// 	ppolicyControl := ldap.FindControl(r.Controls, ldap.ControlTypeBeheraPasswordPolicy)
 
-	// var ppolicy *ldap.ControlBeheraPasswordPolicy
-	// if ppolicyControl != nil {
-	// 	ppolicy = ppolicyControl.(*ldap.ControlBeheraPasswordPolicy)
-	// } else {
-	// 	log.Printf("ppolicyControl response not available.\n")
-	// }
-	// if err != nil {
-	// 	errStr := "ERROR: Cannot bind: " + err.Error()
-	// 	if ppolicy != nil && ppolicy.Error >= 0 {
-	// 		errStr += ":" + ppolicy.ErrorString
-	// 	}
-	// 	log.Print(errStr)
-	// } else {
-	// 	logStr := "Login Ok"
-	// 	if ppolicy != nil {
-	// 		if ppolicy.Expire >= 0 {
-	// 			logStr += fmt.Sprintf(". Password expires in %d seconds\n", ppolicy.Expire)
-	// 		} else if ppolicy.Grace >= 0 {
-	// 			logStr += fmt.Sprintf(". Password expired, %d grace logins remain\n", ppolicy.Grace)
-	// 		}
-	// 	}
-	// 	log.Print(logStr)
-	// }
+// 	var ppolicy *ldap.ControlBeheraPasswordPolicy
+// 	if ppolicyControl != nil {
+// 		ppolicy = ppolicyControl.(*ldap.ControlBeheraPasswordPolicy)
+// 	} else {
+// 		log.Printf("ppolicyControl response not available.\n")
+// 	}
+// 	if err != nil {
+// 		errStr := "ERROR: Cannot bind: " + err.Error()
+// 		if ppolicy != nil && ppolicy.Error >= 0 {
+// 			errStr += ":" + ppolicy.ErrorString
+// 		}
+// 		log.Print(errStr)
+// 	} else {
+// 		logStr := "Login Ok"
+// 		if ppolicy != nil {
+// 			if ppolicy.Expire >= 0 {
+// 				logStr += fmt.Sprintf(". Password expires in %d seconds\n", ppolicy.Expire)
+// 			} else if ppolicy.Grace >= 0 {
+// 				logStr += fmt.Sprintf(". Password expired, %d grace logins remain\n", ppolicy.Grace)
+// 			}
+// 		}
+// 		log.Print(logStr)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 func (c *Client) FetchGroupedData(config *types.GroupedConfig) (*types.Organization, error) {
 	groupAttributes := []string{

--- a/cmd/ldap-group-syncer/pkg/ldap/client.go
+++ b/cmd/ldap-group-syncer/pkg/ldap/client.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ldap
+
+import (
+	"fmt"
+	"log"
+
+	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
+
+	ldap3 "github.com/go-ldap/ldap/v3"
+)
+
+type Client struct {
+	ldap3.Conn
+}
+
+// NewClient returns a new LDAP client.
+func NewClient(addr string) (*Client, error) {
+	conn, err := ldap3.DialURL(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		Conn: *conn,
+	}, nil
+}
+
+// authenticate demonstrate a BIND operation using behera password auth.
+func authenticate() error {
+	// controls := []ldap.Control{}
+	// controls = append(controls, ldap.NewControlBeheraPasswordPolicy())
+	// bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone", controls)
+
+	// r, err := l.SimpleBind(bindRequest)
+	// ppolicyControl := ldap.FindControl(r.Controls, ldap.ControlTypeBeheraPasswordPolicy)
+
+	// var ppolicy *ldap.ControlBeheraPasswordPolicy
+	// if ppolicyControl != nil {
+	// 	ppolicy = ppolicyControl.(*ldap.ControlBeheraPasswordPolicy)
+	// } else {
+	// 	log.Printf("ppolicyControl response not available.\n")
+	// }
+	// if err != nil {
+	// 	errStr := "ERROR: Cannot bind: " + err.Error()
+	// 	if ppolicy != nil && ppolicy.Error >= 0 {
+	// 		errStr += ":" + ppolicy.ErrorString
+	// 	}
+	// 	log.Print(errStr)
+	// } else {
+	// 	logStr := "Login Ok"
+	// 	if ppolicy != nil {
+	// 		if ppolicy.Expire >= 0 {
+	// 			logStr += fmt.Sprintf(". Password expires in %d seconds\n", ppolicy.Expire)
+	// 		} else if ppolicy.Grace >= 0 {
+	// 			logStr += fmt.Sprintf(". Password expired, %d grace logins remain\n", ppolicy.Grace)
+	// 		}
+	// 	}
+	// 	log.Print(logStr)
+	// }
+
+	return nil
+}
+
+func (c *Client) FetchGroupedData(config *types.GroupedConfig) (*types.Organization, error) {
+	groupAttributes := []string{
+		"dn",
+		config.GroupNameAttribute,
+		config.MemberAttribute,
+	}
+
+	// step 1, find all relevant groups
+	searchRequest := ldap3.NewSearchRequest(
+		config.BaseDN,
+		ldap3.ScopeWholeSubtree, ldap3.NeverDerefAliases, 0, 0, false,
+		config.Query,
+		groupAttributes,
+		nil,
+	)
+
+	log.Println("Fetching groups…")
+
+	groupsResult, err := c.SearchWithPaging(searchRequest, 50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+
+	// go through all groups and collect the DNs for every member
+	persons := map[string]types.Person{}
+	for _, group := range groupsResult.Entries {
+		for _, member := range group.GetAttributeValues(config.MemberAttribute) {
+			persons[member] = types.Person{}
+		}
+	}
+
+	// step2, fetch all the members individually
+	personAttributes := []string{
+		"dn",
+		config.EmailAttribute,
+		config.PersonNameAttribute,
+	}
+
+	for personDN := range persons {
+		searchRequest := ldap3.NewSearchRequest(
+			personDN,
+			ldap3.ScopeBaseObject, ldap3.NeverDerefAliases, 0, 0, false,
+			"(objectClass=*)",
+			personAttributes,
+			nil,
+		)
+
+		log.Printf("Fetching person %q…", personDN)
+		sr, err := c.Search(searchRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch person %q: %w", personDN, err)
+		}
+
+		for _, person := range sr.Entries {
+			persons[personDN] = types.Person{
+				DN:    personDN,
+				Name:  person.GetAttributeValue(config.PersonNameAttribute),
+				Email: person.GetAttributeValue(config.EmailAttribute),
+			}
+		}
+	}
+
+	// step 3, create a nice result structure with org and members
+	org := &types.Organization{
+		Groups: []types.Group{},
+	}
+
+	for _, group := range groupsResult.Entries {
+		members := []types.Person{}
+		for _, member := range group.GetAttributeValues(config.MemberAttribute) {
+			members = append(members, persons[member])
+		}
+
+		types.SortPersons(members)
+		org.Groups = append(org.Groups, types.Group{
+			DN:      group.DN,
+			Name:    group.GetAttributeValue(config.GroupNameAttribute),
+			Members: members,
+		})
+	}
+
+	types.SortGroups(org.Groups)
+
+	return org, nil
+}
+
+func (c *Client) FetchTaggedData(config *types.TaggedConfig) (*types.Organization, error) {
+	personAttributes := []string{
+		"dn",
+		config.EmailAttribute,
+		config.PersonNameAttribute,
+	}
+
+	searchRequest := ldap3.NewSearchRequest(
+		config.BaseDN,
+		ldap3.ScopeWholeSubtree, ldap3.NeverDerefAliases, 0, 0, false,
+		config.Query,
+		personAttributes,
+		nil,
+	)
+
+	log.Println("Fetching persons…")
+
+	personsResult, err := c.SearchWithPaging(searchRequest, 50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list persons: %w", err)
+	}
+
+	// go through all persons and collect the DNs for every group
+	groups := map[string]types.Group{}
+	for _, person := range personsResult.Entries {
+		for _, groupDN := range person.GetAttributeValues(config.GroupAttribute) {
+			groups[groupDN] = types.Group{}
+		}
+	}
+
+	// step2, fetch all the groups individually
+	groupAttributes := []string{
+		"dn",
+		config.GroupNameAttribute,
+	}
+
+	for groupDN := range groups {
+		searchRequest := ldap3.NewSearchRequest(
+			groupDN,
+			ldap3.ScopeBaseObject, ldap3.NeverDerefAliases, 0, 0, false,
+			"(objectClass=*)",
+			groupAttributes,
+			nil,
+		)
+
+		log.Printf("Fetching group %q…", groupDN)
+		sr, err := c.Search(searchRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch group %q: %w", groupDN, err)
+		}
+
+		for _, group := range sr.Entries {
+			groups[groupDN] = types.Group{
+				DN:      group.DN,
+				Name:    group.GetAttributeValue(config.GroupNameAttribute),
+				Members: []types.Person{},
+			}
+		}
+	}
+
+	// step 3, create a nice result structure with org and members
+	for _, person := range personsResult.Entries {
+		for _, groupDN := range person.GetAttributeValues(config.GroupAttribute) {
+			group := groups[groupDN]
+			group.Members = append(group.Members, types.Person{
+				DN:    person.DN,
+				Name:  person.GetAttributeValue(config.PersonNameAttribute),
+				Email: person.GetAttributeValue(config.EmailAttribute),
+			})
+
+			groups[groupDN] = group
+		}
+	}
+
+	org := &types.Organization{
+		Groups: []types.Group{},
+	}
+
+	for i := range groups {
+		types.SortPersons(groups[i].Members)
+		org.Groups = append(org.Groups, groups[i])
+	}
+
+	types.SortGroups(org.Groups)
+
+	return org, nil
+}

--- a/cmd/ldap-group-syncer/pkg/ldap/client_test.go
+++ b/cmd/ldap-group-syncer/pkg/ldap/client_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
+
 	"k8s.io/utils/diff"
 )
 

--- a/cmd/ldap-group-syncer/pkg/ldap/client_test.go
+++ b/cmd/ldap-group-syncer/pkg/ldap/client_test.go
@@ -1,0 +1,101 @@
+//go:build ldaptest
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ldap
+
+import (
+	"reflect"
+	"testing"
+
+	"k8c.io/kubermatic/v2/cmd/ldap-group-syncer/pkg/types"
+	"k8s.io/utils/diff"
+)
+
+func TestFetchGroupedData(t *testing.T) {
+	cfg, err := types.LoadConfig("../../testdata/pawnee-grouped/config.yaml")
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	client, err := NewClient("ldap://localhost:10389")
+	if err != nil {
+		t.Fatalf("Failed to create LDAP client: %v", err)
+	}
+
+	org, err := client.FetchGroupedData(cfg.Mapping.Grouped)
+	if err != nil {
+		t.Fatalf("Failed to fetch data: %v", err)
+	}
+
+	expected := &types.Organization{
+		Groups: []types.Group{
+			{
+				DN:   "cn=City Government,ou=people,dc=pawnee,dc=gov",
+				Name: "City Government",
+				Members: []types.Person{
+					{DN: "cn=Ben Wyatt,ou=people,dc=pawnee,dc=gov", Name: "Ben Wyatt", Email: "bwyatt@pawnee.gov"},
+					{DN: "cn=Chris Traeger,ou=people,dc=pawnee,dc=gov", Name: "Chris Traeger", Email: "ctrager@pawnee.gov"},
+					{DN: "cn=Leslie Knope,ou=people,dc=pawnee,dc=gov", Name: "Leslie Knope", Email: "lknope@pawnee.gov"},
+				},
+			},
+			{
+				DN:   "cn=Lot 48 Project,ou=people,dc=pawnee,dc=gov",
+				Name: "Lot 48 Project",
+				Members: []types.Person{
+					{DN: "cn=Andy Dwyer,ou=people,dc=pawnee,dc=gov", Name: "Andy Dwyer", Email: "adwyer@pawnee.gov"},
+					{DN: "cn=Ann Perkins,ou=people,dc=pawnee,dc=gov", Name: "Ann Perkins", Email: "aperkins@pawnee.gov"},
+					{DN: "cn=Leslie Knope,ou=people,dc=pawnee,dc=gov", Name: "Leslie Knope", Email: "lknope@pawnee.gov"},
+					{DN: "cn=Mark Brendanawicz,ou=people,dc=pawnee,dc=gov", Name: "Mark Brendanawicz", Email: "mbrendanawicz@pawnee.gov"},
+				},
+			},
+			{
+				DN:   "cn=Media,ou=people,dc=pawnee,dc=gov",
+				Name: "Media",
+				Members: []types.Person{
+					{DN: "cn=Joan Callamezzo,ou=people,dc=pawnee,dc=gov", Name: "Joan Callamezzo", Email: "jcallamezzo@pawnee.gov"},
+					{DN: "cn=Perd Hapley,ou=people,dc=pawnee,dc=gov", Name: "Perd Hapley", Email: "phapley@pawnee.gov"},
+				},
+			},
+			{
+				DN:   "cn=Parks & Recreation,ou=people,dc=pawnee,dc=gov",
+				Name: "Parks & Recreation",
+				Members: []types.Person{
+					{DN: "cn=April Ludgate,ou=people,dc=pawnee,dc=gov", Name: "April Ludgate", Email: "aludgate@pawnee.gov"},
+					{DN: "cn=Donna Meagle,ou=people,dc=pawnee,dc=gov", Name: "Donna Meagle", Email: "dmeagle@pawnee.gov"},
+					{DN: "cn=Garry Gergich,ou=people,dc=pawnee,dc=gov", Name: "Garry Gergich", Email: "ggergich@pawnee.gov"},
+					{DN: "cn=Leslie Knope,ou=people,dc=pawnee,dc=gov", Name: "Leslie Knope", Email: "lknope@pawnee.gov"},
+					{DN: "cn=Mark Brendanawicz,ou=people,dc=pawnee,dc=gov", Name: "Mark Brendanawicz", Email: "mbrendanawicz@pawnee.gov"},
+					{DN: "cn=Ron Swanson,ou=people,dc=pawnee,dc=gov", Name: "Ron Swanson", Email: "rswanson@pawnee.gov"},
+					{DN: "cn=Tom Haverford,ou=people,dc=pawnee,dc=gov", Name: "Tom Haverford", Email: "thaverford@pawnee.gov"},
+				},
+			},
+			{
+				DN:   "cn=The Dynamic Duo,ou=people,dc=pawnee,dc=gov",
+				Name: "The Dynamic Duo",
+				Members: []types.Person{
+					{DN: "cn=Ben Wyatt,ou=people,dc=pawnee,dc=gov", Name: "Ben Wyatt", Email: "bwyatt@pawnee.gov"},
+					{DN: "cn=Chris Traeger,ou=people,dc=pawnee,dc=gov", Name: "Chris Traeger", Email: "ctrager@pawnee.gov"},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, org) {
+		t.Fatalf("diff: %s", diff.ObjectGoPrintSideBySide(expected, org))
+	}
+}

--- a/cmd/ldap-group-syncer/pkg/types/types.go
+++ b/cmd/ldap-group-syncer/pkg/types/types.go
@@ -14,14 +14,43 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package types
 
 import (
 	"errors"
 	"os"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 )
+
+type Person struct {
+	DN    string `yaml:"dn"`
+	Name  string `yaml:"name"`
+	Email string `yaml:"email"`
+}
+
+func SortPersons(persons []Person) {
+	sort.Slice(persons, func(i, j int) bool {
+		return persons[i].Email < persons[j].Email
+	})
+}
+
+type Group struct {
+	DN      string   `yaml:"dn"`
+	Name    string   `yaml:"name"`
+	Members []Person `yaml:"members"`
+}
+
+func SortGroups(groups []Group) {
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Name < groups[j].Name
+	})
+}
+
+type Organization struct {
+	Groups []Group `yaml:"groups"`
+}
 
 type Config struct {
 	Address string `yaml:"address"`
@@ -49,7 +78,7 @@ type GroupedConfig struct {
 	Query               string `yaml:"query"`
 }
 
-func loadConfig(filename string) (*Config, error) {
+func LoadConfig(filename string) (*Config, error) {
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/00_ou_people.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/00_ou_people.ldif
@@ -1,0 +1,5 @@
+dn: ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: organizationalUnit
+description: Pawnee, Indiana
+ou: people

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_andy.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_andy.ldif
@@ -1,0 +1,11 @@
+dn: cn=Andy Dwyer,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Andy Dwyer
+sn: Dwyer
+givenName: Andy
+mail: adwyer@pawnee.gov
+ou: Mouse Rat Shoeshine Emporium
+uid: adwyer

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_ann.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_ann.ldif
@@ -1,0 +1,11 @@
+dn: cn=Ann Perkins,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Ann Perkins
+sn: Perkins
+givenName: Ann
+mail: aperkins@pawnee.gov
+ou: Health & Safety
+uid: aperkins

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_april.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_april.ldif
@@ -1,0 +1,11 @@
+dn: cn=April Ludgate,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: April Ludgate
+sn: Ludgate
+givenName: April
+mail: aludgate@pawnee.gov
+ou: parksrec
+uid: aludgate

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_ben.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_ben.ldif
@@ -1,0 +1,11 @@
+dn: cn=Ben Wyatt,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Ben Wyatt
+sn: Wyatt
+givenName: Ben
+mail: bwyatt@pawnee.gov
+ou: City Management
+uid: bwyatt

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_chris.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_chris.ldif
@@ -1,0 +1,11 @@
+dn: cn=Chris Traeger,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Chris Traeger
+sn: Traeger
+givenName: Chris
+mail: ctrager@pawnee.gov
+ou: City Management
+uid: ctrager

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_donna.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_donna.ldif
@@ -1,0 +1,11 @@
+dn: cn=Donna Meagle,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Donna Meagle
+sn: Meagle
+givenName: Donna
+mail: dmeagle@pawnee.gov
+ou: Parks & Recreation
+uid: dmeagle

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_garry.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_garry.ldif
@@ -1,0 +1,11 @@
+dn: cn=Garry Gergich,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Garry Gergich
+sn: Gergich
+givenName: Garry
+mail: ggergich@pawnee.gov
+ou: Parks & Recreation
+uid: ggergich

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_joan.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_joan.ldif
@@ -1,0 +1,11 @@
+dn: cn=Joan Callamezzo,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Joan Callamezzo
+sn: Callamezzo
+givenName: Joan
+mail: jcallamezzo@pawnee.gov
+ou: Media Outlets
+uid: jcallamezzo

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_leslie.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_leslie.ldif
@@ -1,0 +1,11 @@
+dn: cn=Leslie Knope,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Leslie Knope
+sn: Knope
+givenName: Leslie
+mail: lknope@pawnee.gov
+ou: Parks & Recreation
+uid: lknope

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_mark.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_mark.ldif
@@ -1,0 +1,11 @@
+dn: cn=Mark Brendanawicz,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Mark Brendanawicz
+sn: Brendanawicz
+givenName: Mark
+mail: mbrendanawicz@pawnee.gov
+ou: Parks & Recreation
+uid: mbrendanawicz

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_perd.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_perd.ldif
@@ -1,0 +1,11 @@
+dn: cn=Perd Hapley,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Perd Hapley
+sn: Hapley
+givenName: Perd
+mail: phapley@pawnee.gov
+ou: Media Outlets
+uid: phapley

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_ron.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_ron.ldif
@@ -1,0 +1,11 @@
+dn: cn=Ron Swanson,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Ron Swanson
+sn: Swanson
+givenName: Ron
+mail: rswanson@pawnee.gov
+ou: Parks & Recreation
+uid: rswanson

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_tammy.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_tammy.ldif
@@ -1,0 +1,11 @@
+dn: cn=Tammy Swanson,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Tammy Swanson
+sn: Swanson
+givenName: Tammy
+mail: tswanson@pawnee.gov
+ou: Library Department
+uid: tswanson

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_tom.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/10_people_tom.ldif
@@ -1,0 +1,11 @@
+dn: cn=Tom Haverford,ou=people,dc=pawnee,dc=gov
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Tom Haverford
+sn: Haverford
+givenName: Tom
+mail: thaverford@pawnee.gov
+ou: Parks & Recreation
+uid: thaverford

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_duo.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_duo.ldif
@@ -1,0 +1,7 @@
+dn: cn=The Dynamic Duo,ou=people,dc=pawnee,dc=gov
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: The Dynamic Duo
+member: cn=Chris Traeger,ou=people,dc=pawnee,dc=gov
+member: cn=Ben Wyatt,ou=people,dc=pawnee,dc=gov

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_government.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_government.ldif
@@ -1,0 +1,8 @@
+dn: cn=City Government,ou=people,dc=pawnee,dc=gov
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: City Government
+member: cn=Chris Traeger,ou=people,dc=pawnee,dc=gov
+member: cn=Ben Wyatt,ou=people,dc=pawnee,dc=gov
+member: cn=Leslie Knope,ou=people,dc=pawnee,dc=gov

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_lot48.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_lot48.ldif
@@ -1,0 +1,9 @@
+dn: cn=Lot 48 Project,ou=people,dc=pawnee,dc=gov
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: Lot 48 Project
+member: cn=Leslie Knope,ou=people,dc=pawnee,dc=gov
+member: cn=Ann Perkins,ou=people,dc=pawnee,dc=gov
+member: cn=Andy Dwyer,ou=people,dc=pawnee,dc=gov
+member: cn=Mark Brendanawicz,ou=people,dc=pawnee,dc=gov

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_media.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_media.ldif
@@ -1,0 +1,7 @@
+dn: cn=Media,ou=people,dc=pawnee,dc=gov
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: Media
+member: cn=Joan Callamezzo,ou=people,dc=pawnee,dc=gov
+member: cn=Perd Hapley,ou=people,dc=pawnee,dc=gov

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_parksrec.ldif
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/30_groups_parksrec.ldif
@@ -1,0 +1,12 @@
+dn: cn=Parks & Recreation,ou=people,dc=pawnee,dc=gov
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: Parks & Recreation
+member: cn=Leslie Knope,ou=people,dc=pawnee,dc=gov
+member: cn=Mark Brendanawicz,ou=people,dc=pawnee,dc=gov
+member: cn=Tom Haverford,ou=people,dc=pawnee,dc=gov
+member: cn=Ron Swanson,ou=people,dc=pawnee,dc=gov
+member: cn=Garry Gergich,ou=people,dc=pawnee,dc=gov
+member: cn=Donna Meagle,ou=people,dc=pawnee,dc=gov
+member: cn=April Ludgate,ou=people,dc=pawnee,dc=gov

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/config.yaml
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # the address of the LDAP server, can use ldaps for secure communication
 address: ldap://localhost:10389
 
@@ -23,5 +37,5 @@ mapping:
     memberAttribute: member
 
     # the query to use to find all relevant groups (for each group, the list
-    # of members is then fetched indivdually)
+    # of members is then fetched individually)
     query: '(objectClass=Group)'

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/config.yaml
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/config.yaml
@@ -1,0 +1,27 @@
+# the address of the LDAP server, can use ldaps for secure communication
+address: ldap://localhost:10389
+
+mapping:
+  # This mapping mode is used when a dedicated objectClass exists
+  # to represent KKP groups, and this objectClass has the members
+  # defined as its attributes.
+  grouped:
+    # the root node from which to start the search for persons
+    baseDN: dc=pawnee,dc=gov
+
+    # the attribute in each person that contains the e-mail address
+    emailAttribute: mail
+
+    # the attribute that contains the group's name
+    groupNameAttribute: cn
+
+    # the attribute that contains the person's name
+    personNameAttribute: cn
+
+    # the attribute that contains the DN of persons assigned to this group
+    # (can be used multiple times)
+    memberAttribute: member
+
+    # the query to use to find all relevant groups (for each group, the list
+    # of members is then fetched indivdually)
+    query: '(objectClass=Group)'

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/env.sh
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/env.sh
@@ -1,0 +1,5 @@
+export LDAP_DOMAIN=pawnee.gov
+export LDAP_BASEDN="dc=pawnee,dc=gov"
+export LDAP_ORGANISATION="Pawnee, Indiana"
+export LDAP_BINDDN="cn=admin,dc=pawnee,dc=gov"
+export LDAP_SECRET=BreakfastFoodIsBestFood

--- a/cmd/ldap-group-syncer/testdata/pawnee-grouped/env.sh
+++ b/cmd/ldap-group-syncer/testdata/pawnee-grouped/env.sh
@@ -1,3 +1,17 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 export LDAP_DOMAIN=pawnee.gov
 export LDAP_BASEDN="dc=pawnee,dc=gov"
 export LDAP_ORGANISATION="Pawnee, Indiana"

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/go-kit/kit v0.12.0
 	github.com/go-kit/log v0.2.0
+	github.com/go-ldap/ldap/v3 v3.4.3
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/go-openapi/errors v0.20.2
@@ -128,6 +129,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -165,6 +167,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/Azure/go-autorest/tracing v0.1.0/go.mod h1:ROEEAFwXycQw7Sn3DXNtEedEvd
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e h1:ZU22z/2YRFLyf/P4ZwUYSdNCWsMEI0VeyrFoI2rAhJQ=
+github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -893,6 +895,8 @@ github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
+github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-bindata/go-bindata/v3 v3.1.3/go.mod h1:1/zrpXsLD8YDIbhZRqXzm1Ghc7NhEvIN9+Z6R5/xH4I=
 github.com/go-critic/go-critic v0.4.1/go.mod h1:7/14rZGnZbY6E38VEGk2kVhoq6itzc1E68facVDK23g=
@@ -915,9 +919,12 @@ github.com/go-kit/kit v0.12.0/go.mod h1:lHd+EkCZPIwYItmGDDRdhinkzX2A1sj+M9biaEai
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-ldap/ldap v3.0.2+incompatible h1:kD5HQcAzlQ7yrhfn+h+MSABeAy/jAJhvIJ/QDllP44g=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-ldap/ldap/v3 v3.1.3/go.mod h1:3rbOH3jRS2u6jg2rJnKAMLE/xQyCKIveG2Sa/Cohzb8=
 github.com/go-ldap/ldap/v3 v3.1.10/go.mod h1:5Zun81jBTabRaI8lzN7E1JjyEl1g6zI6u9pd8luAK4Q=
+github.com/go-ldap/ldap/v3 v3.4.3 h1:JCKUtJPIcyOuG7ctGabLKMgIlKnGumD/iGjuWeEruDI=
+github.com/go-ldap/ldap/v3 v3.4.3/go.mod h1:7LdHfVt6iIOESVEe3Bs4Jp2sHEKgDeduAhgM1/f9qmo=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -2780,6 +2787,7 @@ golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 h1:NvGWuYG8dkDHFSKksI1P9faiVJ9rayE6l0+ouWVIDs8=
 golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -78,3 +78,6 @@ grep --files-with-matches --recursive --extended-regexp '//go:build.+integration
   xargs dirname |
   sort -u |
   xargs -I ^ go test -tags "integration ${KUBERMATIC_EDITION:-ce}" -race ./^
+
+echodate "Running LDAP integration tests..."
+make -C cmd/ldap-group-syncer integration-tests


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is part of the "LDAP Group Epic" (see related issues #9896 and #9897). This PR introduces a very simple LDAP client that is capable of connecting to an LDAP server and query for groups and their members. As LDAPs are usually very, very customized, the syncer tool has a configuration file to tweak most aspects (base DN, filter queries, attribute names, ...).

The goal is to read groups/members from LDAP and use that information to manage/sync KKP Users, Projects and UserProjectBindings. The exact semantics of this sync (e.g. what happens to a group when it's removed in LDAP? Should we nuke the KKP project and all clusters in it?) are not yet fully defined, so for now the LDAP sync tool will only spit out YAML.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
