### PR TITLE
Update Openstack CCM and CSI to 1.24.0

### DIFF
--- a/addons/csi/openstack/controllerplugin-rbac.yaml
+++ b/addons/csi/openstack/controllerplugin-rbac.yaml
@@ -39,6 +39,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -85,6 +88,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -118,10 +127,13 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -177,30 +189,5 @@ roleRef:
   name: csi-resizer-role
   apiGroup: rbac.authorization.k8s.io
 
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: kube-system
-  name: external-resizer-cfg
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-role-cfg
-  namespace: kube-system
-subjects:
-  - kind: ServiceAccount
-    name: csi-cinder-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: Role
-  name: external-resizer-cfg
-  apiGroup: rbac.authorization.k8s.io
 {{ end }}
 {{ end }}

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -33,29 +33,18 @@
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-cinder-controller-service
-  namespace: kube-system
-  labels:
-    app: csi-cinder-controllerplugin
-spec:
-  selector:
-    app: csi-cinder-controllerplugin
-  ports:
-    - name: dummy
-      port: 12345
-
----
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-cinder-controllerplugin
   namespace: kube-system
 spec:
-  serviceName: "csi-cinder-controller-service"
   replicas: 1
+  strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   selector:
     matchLabels:
       app: csi-cinder-controllerplugin
@@ -70,10 +59,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.1.0'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.4.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -82,11 +72,12 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.1.0'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v3.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--default-fstype=ext4"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -95,10 +86,11 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v2.1.3'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v5.0.1'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -107,11 +99,12 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.1.0'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.4.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--handle-volume-inuse-error=false"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -120,7 +113,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.6.0'
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -29,7 +29,7 @@
 {{ $version = "v1.23.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.23.0"}}
+{{ $version = "v1.24.0"}}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 ---

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -57,7 +57,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v1.3.0'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -81,7 +81,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.6.0'
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -29,7 +29,7 @@
 {{ $version = "v1.23.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.23.0"}}
+{{ $version = "v1.24.0"}}
 {{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}

--- a/addons/csi/openstack/snapshot-crds.yaml
+++ b/addons/csi/openstack/snapshot-crds.yaml
@@ -111,7 +111,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -215,7 +215,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'

--- a/addons/csi/openstack/snapshot-crds.yaml
+++ b/addons/csi/openstack/snapshot-crds.yaml
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 # Sourced from
-# https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.2/client/config/crd
-
-{{ if .Cluster.Features.Has "externalCloudProvider" }}
-{{ if eq .Cluster.CloudProviderName "openstack" }}
-
+# https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -34,6 +30,8 @@ spec:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
+    shortNames:
+    - vs
     singular: volumesnapshot
   scope: Namespaced
   versions:
@@ -113,7 +111,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -217,7 +215,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -266,6 +264,9 @@ spec:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
+    shortNames:
+    - vsc
+    - vscs
     singular: volumesnapshotcontent
   scope: Cluster
   versions:
@@ -572,6 +573,9 @@ spec:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
+    shortNames:
+    - vsclass
+    - vsclasses
     singular: volumesnapshotclass
   scope: Cluster
   versions:
@@ -673,5 +677,3 @@ status:
   conditions: []
   storedVersions: []
 
-{{ end }}
-{{ end }}

--- a/addons/csi/openstack/snapshot-crds.yaml
+++ b/addons/csi/openstack/snapshot-crds.yaml
@@ -15,6 +15,10 @@
 # Sourced from
 # https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
+
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -677,3 +681,5 @@ status:
   conditions: []
   storedVersions: []
 
+{{ end }}
+{{ end }}

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -106,6 +106,10 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 				},
 			)
 
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsUser: pointer.Int64(1001),
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    ccmContainerName,
@@ -178,11 +182,11 @@ func getOSVersion(version semver.Semver) (string, error) {
 	case "1.22":
 		return "1.22.0", nil
 	case "1.23":
-		fallthrough
+		return "1.23.1", nil
 	case "1.24":
 		fallthrough
 	default:
-		return "1.23.1", nil
+		return "1.24.0", nil
 	}
 }
 

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -106,10 +106,6 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 				},
 			)
 
-			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-				RunAsUser: pointer.Int64(1001),
-			}
-
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    ccmContainerName,
@@ -134,6 +130,9 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 							ReadOnly:  true,
 						},
 					),
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: pointer.Int64(1001),
+					},
 				},
 			}
 

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -273,7 +273,13 @@ func getFlags(data *resources.TemplateData, version *semverlib.Version) ([]strin
 	if cloudProviderName != "" && cloudProviderName != "external" {
 		flags = append(flags, "--cloud-provider", cloudProviderName)
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		if cloudProviderName == "azure" && version.GreaterThan(semverlib.MustParse("1.15.0")) {
+
+		constraint115, err := semverlib.NewConstraint(">= 1.15.0")
+		if err != nil {
+			return nil, err
+		}
+
+		if cloudProviderName == "azure" && constraint115.Check(version) {
 			// Required so multiple clusters using the same resource group can allocate public IPs.
 			// Ref: https://github.com/kubernetes/kubernetes/pull/77630
 			flags = append(flags, "--cluster-name", cluster.Name)

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -273,7 +273,7 @@ func getFlags(data *resources.TemplateData, version *semverlib.Version) ([]strin
 	if cloudProviderName != "" && cloudProviderName != "external" {
 		flags = append(flags, "--cloud-provider", cloudProviderName)
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		if cloudProviderName == "azure" && version.Minor() >= 15 {
+		if cloudProviderName == "azure" && version.GreaterThan(semverlib.MustParse("1.15.0")) {
 			// Required so multiple clusters using the same resource group can allocate public IPs.
 			// Ref: https://github.com/kubernetes/kubernetes/pull/77630
 			flags = append(flags, "--cluster-name", cluster.Name)

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,6 +111,8 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -46,6 +46,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: cloud-controller-manager-kubeconfig
@@ -111,8 +113,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      securityContext:
-        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,6 +111,8 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -46,6 +46,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: cloud-controller-manager-kubeconfig
@@ -111,8 +113,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      securityContext:
-        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,6 +111,8 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -46,6 +46,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: cloud-controller-manager-kubeconfig
@@ -111,8 +113,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      securityContext:
-        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -46,6 +46,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: cloud-controller-manager-kubeconfig
@@ -111,8 +113,6 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
-      securityContext:
-        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.1
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.0
         name: cloud-controller-manager
         resources:
           limits:
@@ -111,6 +111,8 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        runAsUser: 1001
       volumes:
       - name: cloud-controller-manager-kubeconfig
         secret:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
What it says on the title. Openstack CCM and CSI support 1.24.0 now, so this adds that version to KKP for Kubernetes 1.24+. This PR is mostly based on https://github.com/kubermatic/kubeone/pull/2061 to make sure we offer the same configuration across Kubermatic products.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
xref #9818

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for OpenStack CCM v1.24.0 (for Kubernetes 1.24 clusters)
Add support for OpenStack Cinder CSI driver v1.24.0 (for Kubernetes 1.24 clusters)
Update CSI components in OpenStack Cinder CSI driver
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>