### PR TITLE
wwhrd.yml: add github.com/acomagu/bufpipe to the exeption list

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -28,6 +28,7 @@ exceptions:
   - github.com/ajeddeloh/go-json # Since it's a fork, https://github.com/golang/go/blob/master/LICENSE
   - github.com/cristim/ec2-instances-info # Public domain: https://github.com/cristim/ec2-instances-info/blob/master/LICENSE.
   - github.com/cristim/ec2-instances-info/data # MIT: https://github.com/powdahound/ec2instances.info/blob/master/LICENSE.
+  - github.com/acomagu/bufpipe # MIT: https://github.com/acomagu/bufpipe/blob/master/LICENSE (used by go-git)
   - github.com/embik/nutanix-client-go/internal/utils # MPL-2.0
   - github.com/embik/nutanix-client-go/pkg/client # MPL-2.0
   - github.com/embik/nutanix-client-go/pkg/client/v3 # MPL-2.0


### PR DESCRIPTION
For #8379  we use [go-git](https://github.com/go-git/go-git) to interact with git repositroy. [go-git](https://github.com/go-git/go-git) has a dependency on [acomagu/bufpipe](https://github.com/acomagu/bufpipe) which is under MIT license.
the license is not recognized because it's slightly different from the one provided by SDPX

```
	diff  'SDPX-MIT.txt' 'bufpipe-LICENSE.txt'
	3c3
	< Copyright (c) <year> <copyright holders>
	---
	> Copyright (c) 2019 acomagu
	7c7
	< The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
	---
	> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
```

full license: [https://github.com/acomagu/bufpipe/blob/master/LICENSE](https://github.com/acomagu/bufpipe/blob/master/LICENSE )

/hold
/assign @scheeles 

**What does this PR do / Why do we need it**:

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
