### PR TITLE
Update k8s/dashboard to 2.6.0 for k8s 1.24, metrics-scraper to 1.0.8

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -49,7 +49,7 @@ var (
 const (
 	scraperName      = resources.MetricsScraperDeploymentName
 	scraperImageName = "kubernetesui/metrics-scraper"
-	scraperTag       = "v1.0.7"
+	scraperTag       = "v1.0.8"
 )
 
 // DeploymentCreator returns the function to create and update the dashboard-metrics-scraper deployment.

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -33,10 +33,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const (
-	dashboard250 = "v2.5.0"
-)
-
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
 		resources.KubernetesDashboardDeploymentName: {
@@ -192,11 +188,11 @@ func getDashboardVersion(clusterVersion semver.Semver) (string, error) {
 	case "1.21":
 		return "v2.4.0", nil
 	case "1.22":
-		return dashboard250, nil
+		return "v2.5.0", nil
 	case "1.23":
-		return dashboard250, nil
+		return "v2.5.0", nil
 	case "1.24":
-		return dashboard250, nil
+		return "v2.6.0", nil
 	default:
 		return "", fmt.Errorf("no compatible version defined for Kubernetes %q", clusterVersion.MajorMinor())
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Updates k8s/dashboard to 2.6.0 when using Kubernetes 1.24, also pulls in a newer metrics-scraper version.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
xref #9818

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Kubernetes dashboard to 2.6.0 for Kubernetes 1.24
Update metrics-scraper to 1.0.8
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>