### PR TITLE
update integration-test image to use Go 1.18

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -44,10 +44,9 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/integration-tests:5-1
+        - image: quay.io/kubermatic/integration-tests:6-0
           command:
             - make
-          args:
             - test-integration
           # docker-in-docker (for localstack) needs privileged mode
           securityContext:

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-7
+FROM quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-5
 LABEL maintainer="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating
-ENV KUBE_VERSION=1.23.3
+ENV KUBE_VERSION=1.23.5
 
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \

--- a/hack/images/integration-tests/release.sh
+++ b/hack/images/integration-tests/release.sh
@@ -19,8 +19,8 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/integration-tests
-VERSION=5
-BUILD_SUFFIX=1
+VERSION=6
+BUILD_SUFFIX=0
 
 docker build --no-cache --pull -t "$REPOSITORY:$VERSION-$BUILD_SUFFIX" .
 docker push "$REPOSITORY:$VERSION-$BUILD_SUFFIX"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This will prevent the integration tests from failing to find a gocache. There are no 1.24.x binaries yet available, see https://github.com/kubernetes-sigs/kubebuilder/issues/2559 and related issues.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
