### PR TITLE
Gracefully handle new Seeds that have no CRDs yet in our webhook

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -45,6 +45,7 @@ import (
 	usersshkeyvalidation "k8c.io/kubermatic/v2/pkg/webhook/usersshkey/validation"
 	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -212,6 +213,9 @@ func addAPIs(dst *runtime.Scheme, log *zap.SugaredLogger) {
 	}
 	if err := appskubermaticv1.AddToScheme(dst); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", appskubermaticv1.SchemeGroupVersion), zap.Error(err))
+	}
+	if err := apiextensionsv1.AddToScheme(dst); err != nil {
+		log.Fatalw("Failed to register scheme", zap.Stringer("api", apiextensionsv1.SchemeGroupVersion), zap.Error(err))
 	}
 }
 

--- a/pkg/webhook/seed/validation_test.go
+++ b/pkg/webhook/seed/validation_test.go
@@ -22,9 +22,11 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/crd"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/test"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -475,6 +477,10 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
+	if err := apiextensionsv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to register scheme: %v", err)
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
@@ -482,6 +488,12 @@ func TestValidate(t *testing.T) {
 				err error
 			)
 
+			clusterCRD, err := crd.CRDForGVK(kubermaticv1.SchemeGroupVersion.WithKind("Cluster"))
+			if err != nil {
+				t.Fatalf("Failed to load Cluster CRD: %v", err)
+			}
+
+			obj = append(obj, clusterCRD)
 			for _, c := range tc.existingClusters {
 				obj = append(obj, c)
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Since we now manage CRDs ourselves (via the KKP operator), it's now normal for admins to add new, empty clusters as seeds and expect KKP to set it up. But the KKP webhook would reject new seeds, as it could not query them for clusters, which caused a chicken-egg-problem.

This PR solves that by first probing for the CRD. This should be more stable and reliable than checking the SeedStatus for some flags.

**NOTE:** There is another PR coming to merge the seed-sync controller into the operator and further improve the seed setup experience. I kept this smaller PR standalone to make reviews easier.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9961

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
