### PR TITLE
fix hack/local/run-kubermatic-kind.sh

### DIFF
--- a/hack/local/run-kubermatic-kind.sh
+++ b/hack/local/run-kubermatic-kind.sh
@@ -233,9 +233,9 @@ retry 9 check_all_deployments_ready kube-system
 echodate "VPA is ready."
 
 echodate "Installing metallb"
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
 echodate "Waiting for load balancer to be ready..."
 retry 10 check_all_deployments_ready metallb-system
 echodate "Load balancer is ready."


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

 install MetalLB from tag instead of master.

the master branch has been renamed to `main` and maintainers switch installation from manifest to helm. Moreover, maintainers add a warning to strongly advise users to use a Tag instead of the development branch. Currently, the helm chart seems to be still in development...


**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
