### PR TITLE
Migration for ApplicationInstallations

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const ApplicationInstallationsFQDNName = "applicationinstallations." + GroupName
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -711,7 +711,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 	return nil
 }
 
-// skipCRDInstallation returns true if we want to skip installation of a CRD on the seed cluster
+// skipCRDInstallation returns true if we want to skip installation of a CRD on the seed cluster.
 func skipCRDInstallation(name string) bool {
 	switch name {
 	// ApplicationInstallations are only required on the user-cluster

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
@@ -43,6 +44,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -296,6 +298,11 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *kubermaticv1.K
 		return fmt.Errorf("failed to get CA bundle ConfigMap: %w", err)
 	}
 
+	// Ensure that ApplicationInstallation CRD doesn't exist on the seed cluster.
+	if err := r.removeApplicationInstallationCRD(ctx, client); err != nil {
+		return err
+	}
+
 	if err := r.reconcileCRDs(ctx, cfg, seed, client, log); err != nil {
 		return err
 	}
@@ -376,6 +383,9 @@ func (r *Reconciler) reconcileCRDs(ctx context.Context, cfg *kubermaticv1.Kuberm
 		}
 
 		for i := range crds {
+			if skipCRDInstallation(crds[i].Name) {
+				continue
+			}
 			creators = append(creators, common.CRDCreator(&crds[i], log, r.versions))
 		}
 	}
@@ -698,5 +708,27 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		return fmt.Errorf("failed to reconcile mutating Admission Webhooks: %w", err)
 	}
 
+	return nil
+}
+
+// skipCRDInstallation returns true if we want to skip installation of a CRD on the seed cluster
+func skipCRDInstallation(name string) bool {
+	switch name {
+	// ApplicationInstallations are only required on the user-cluster
+	case appskubermaticv1.ApplicationInstallationsFQDNName:
+		return true
+	default:
+		return false
+	}
+}
+
+// TODO: This should be removed after KKP 2.21 release.
+func (r *Reconciler) removeApplicationInstallationCRD(ctx context.Context, client ctrlruntimeclient.Client) error {
+	crd := apiextensionsv1.CustomResourceDefinition{}
+	crd.Name = appskubermaticv1.ApplicationInstallationsFQDNName
+
+	if err := client.Delete(ctx, &crd); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
+	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
In our [initial implementation](https://github.com/kubermatic/kubermatic/pull/8480), `ApplicationInstallations` were `cluster` scoped but we later [decided to switch](https://github.com/kubermatic/kubermatic/pull/9601/files#diff-60650466b80ab7fc9d7a10d979f7c5958da3348fe965d51a1bd149d2ca7d129bL28) to `namespaced` scope resources.

This CRD was shipped with `KKP 2.19.0` release. And since `scope` is an immutable field, we need a way to migrate this CRD so that we can install the new one. This CRD is a component of an unreleased feature i.e. applications, so it's completely safe to just delete the old CRD and ship the new one.

We don't need this CRD on the seed cluster. In general, it's fine to install all the CRDs on seed but I think even in the future we'll have exceptions like these. So I've handled that with this PR as well.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
