### PR TITLE
Install updated Namespace scoped ApplicationInstallation CRD on seed

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/zap"
 
-	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
@@ -32,6 +31,7 @@ import (
 	kubermaticseed "k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/kubermatic"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/metering"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
+	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	"k8c.io/kubermatic/v2/pkg/crd"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -44,7 +44,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -298,8 +297,8 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *kubermaticv1.K
 		return fmt.Errorf("failed to get CA bundle ConfigMap: %w", err)
 	}
 
-	// Ensure that ApplicationInstallation CRD doesn't exist on the seed cluster.
-	if err := r.removeApplicationInstallationCRD(ctx, client); err != nil {
+	// Ensure that Old version of ApplicationInstallation CRD is removed.
+	if err := controllerutil.RemoveOldApplicationInstallationCRD(ctx, client); err != nil {
 		return err
 	}
 
@@ -383,9 +382,6 @@ func (r *Reconciler) reconcileCRDs(ctx context.Context, cfg *kubermaticv1.Kuberm
 		}
 
 		for i := range crds {
-			if skipCRDInstallation(crds[i].Name) {
-				continue
-			}
 			creators = append(creators, common.CRDCreator(&crds[i], log, r.versions))
 		}
 	}
@@ -708,27 +704,5 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		return fmt.Errorf("failed to reconcile mutating Admission Webhooks: %w", err)
 	}
 
-	return nil
-}
-
-// skipCRDInstallation returns true if we want to skip installation of a CRD on the seed cluster.
-func skipCRDInstallation(name string) bool {
-	switch name {
-	// ApplicationInstallations are only required on the user-cluster
-	case appskubermaticv1.ApplicationInstallationsFQDNName:
-		return true
-	default:
-		return false
-	}
-}
-
-// TODO: This should be removed after KKP 2.21 release.
-func (r *Reconciler) removeApplicationInstallationCRD(ctx context.Context, client ctrlruntimeclient.Client) error {
-	crd := apiextensionsv1.CustomResourceDefinition{}
-	crd.Name = appskubermaticv1.ApplicationInstallationsFQDNName
-
-	if err := client.Delete(ctx, &crd); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
-	}
 	return nil
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -56,6 +56,7 @@ import (
 	systembasicuser "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/system-basic-user"
 	userauth "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/user-auth"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
+	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	"k8c.io/kubermatic/v2/pkg/crd"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -64,7 +65,6 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -184,7 +184,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.removeOldApplicationInstallationCRD(ctx); err != nil {
+	if err := controllerutil.RemoveOldApplicationInstallationCRD(ctx, r.Client); err != nil {
 		return err
 	}
 
@@ -1366,31 +1366,4 @@ func (r *reconciler) cleanUpMLAHealthStatus(ctx context.Context, logging, monito
 			}
 		}
 	})
-}
-
-// removeOldApplicationInstallationCRD handles deletion of ApplicationInstallations CRD
-// if the existing CRD has scope set to `Cluster`. This action is super safe since
-// at the time of writing this method this feature has not been rolled out.
-// We can just delete the CRD and install the new one.
-// TODO: This should be removed after KKP 2.21 release.
-func (r *reconciler) removeOldApplicationInstallationCRD(ctx context.Context) error {
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: appskubermaticv1.ApplicationInstallationsFQDNName}, crd)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get CRD %s: %w", appskubermaticv1.ApplicationInstallationsFQDNName, err)
-	}
-
-	// No action is required
-	if err != nil && apierrors.IsNotFound(err) {
-		return nil
-	}
-
-	// CRD exists, now we need to check if it's cluster scoped
-	if crd.Spec.Scope == apiextensionsv1.ClusterScoped {
-		// We need to delete this CRD
-		if err := r.Client.Delete(ctx, crd); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
-		}
-	}
-	return nil
 }

--- a/pkg/controller/util/applications.go
+++ b/pkg/controller/util/applications.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RemoveOldApplicationInstallationCRD handles deletion of ApplicationInstallations CRD
+// if the existing CRD has scope set to `Cluster`. This action is super safe since
+// at the time of writing this method this feature has not been rolled out.
+// We can just delete the CRD and install the new one.
+// TODO: This should be removed after KKP 2.21 release.
+func RemoveOldApplicationInstallationCRD(ctx context.Context, client ctrlruntimeclient.Client) error {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err := client.Get(ctx, types.NamespacedName{Name: appskubermaticv1.ApplicationInstallationsFQDNName}, crd)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get CRD %s: %w", appskubermaticv1.ApplicationInstallationsFQDNName, err)
+	}
+
+	// No action is required
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	// CRD exists, now we need to check if it's cluster scoped
+	if crd.Spec.Scope == apiextensionsv1.ClusterScoped {
+		// We need to delete this CRD
+		if err := client.Delete(ctx, crd); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
Delete cluster scoped ApplicationInstallation CRD and install updated Namespace scoped CRD for seed.

Previously with https://github.com/kubermatic/kubermatic/pull/9975, we were skipping the installation of ApplicationInstallation CRD completely for the seed. Although the installer was still trying to install and wait for it to become available https://github.com/kubermatic/kubermatic/blob/master/pkg/install/util/crd.go#L62. Installation was failing as a result since `seed-controller` removes it as soon as the `installer` creates it.

```
time="14:56:05" level=error msg="❌ Operation failed: failed to deploy Kubermatic Operator: failed to deploy CRDs: failed to wait for CRD applicationinstallations.apps.kubermatic.k8c.io to have Established=True condition: timed out waiting for the condition."
```

Although this could have been fixed by skipping the CRD during seed installation. I resorted to the old workflow i.e. install all the available CRDs unconditionally for seed. This makes sense for `ApplicationInstallations` since in the future I can imagine us having use cases where we need this CRD in the seed cluster as well. For example, if someone wants to enable a certain application for all the user clusters against a seed/master.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
