### PR TITLE
make konnectivity component settings optional for backwards compatibility

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -675,7 +675,7 @@ type ComponentSettings struct {
 	// strategy is configured.
 	NodePortProxyEnvoy NodeportProxyComponent `json:"nodePortProxyEnvoy"`
 	// KonnectivityProxy configures resources limits/requests for konnectivity-server sidecar.
-	KonnectivityProxy KonnectvityProxySettings `json:"konnectivityProxy"`
+	KonnectivityProxy KonnectvityProxySettings `json:"konnectivityProxy,omitempty"`
 }
 
 type APIServerSettings struct {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1754,7 +1754,6 @@ spec:
                 - apiserver
                 - controllerManager
                 - etcd
-                - konnectivityProxy
                 - nodePortProxyEnvoy
                 - prometheus
                 - scheduler

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1716,7 +1716,6 @@ spec:
                 - apiserver
                 - controllerManager
                 - etcd
-                - konnectivityProxy
                 - nodePortProxyEnvoy
                 - prometheus
                 - scheduler

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1000,7 +1000,6 @@ spec:
                 - apiserver
                 - controllerManager
                 - etcd
-                - konnectivityProxy
                 - nodePortProxyEnvoy
                 - prometheus
                 - scheduler


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Makes Konnectivity component settings optional for backwards compatibility.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
