### PR TITLE
[release/v2.19] make konnectivity component settings optional for backwards compatibility

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.3.47
+version: 0.3.48
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1451,7 +1451,6 @@ spec:
                 - apiserver
                 - controllerManager
                 - etcd
-                - konnectivityProxy
                 - nodePortProxyEnvoy
                 - prometheus
                 - scheduler

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1422,7 +1422,6 @@ spec:
                 - apiserver
                 - controllerManager
                 - etcd
-                - konnectivityProxy
                 - nodePortProxyEnvoy
                 - prometheus
                 - scheduler

--- a/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/charts/kubermatic-operator/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -988,7 +988,6 @@ spec:
                 - apiserver
                 - controllerManager
                 - etcd
-                - konnectivityProxy
                 - nodePortProxyEnvoy
                 - prometheus
                 - scheduler

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -492,7 +492,7 @@ type ComponentSettings struct {
 	// strategy is configured.
 	NodePortProxyEnvoy NodeportProxyComponent `json:"nodePortProxyEnvoy"`
 	// KonnectivityProxy configures resources limits/requests for konnectivity-server sidecar.
-	KonnectivityProxy KonnectvityProxySettings `json:"konnectivityProxy"`
+	KonnectivityProxy KonnectvityProxySettings `json:"konnectivityProxy,omitempty"`
 }
 
 type APIServerSettings struct {

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -471,7 +471,7 @@ type ComponentSettings struct {
 	Etcd               EtcdStatefulSetSettings  `json:"etcd"`
 	Prometheus         StatefulSetSettings      `json:"prometheus"`
 	NodePortProxyEnvoy NodeportProxyComponent   `json:"nodePortProxyEnvoy"`
-	KonnectivityProxy  KonnectvityProxySettings `json:"konnectivityProxy"`
+	KonnectivityProxy  KonnectvityProxySettings `json:"konnectivityProxy,omitempty"`
 }
 
 type APIServerSettings struct {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Makes konnectivity component settings optional for backwards compatibility.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
