### PR TITLE
Return EKS error message instead of full error

### DIFF
--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -369,7 +369,7 @@ func createNewEKSCluster(ctx context.Context, eksClusterSpec *apiv2.EKSClusterSp
 	}
 	_, err = client.EKS.CreateCluster(input)
 
-	return err
+	return decodeAWSError(err)
 }
 
 func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter provider.UserInfoGetter, project *kubermaticv1.Project, spec *apiv2.ExternalClusterSpec, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
@@ -428,26 +428,7 @@ func patchEKSCluster(oldCluster, newCluster *apiv2.ExternalCluster, secretKeySel
 	}
 	_, err = client.EKS.UpdateClusterVersion(&updateInput)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case eks.ErrCodeInvalidParameterException:
-				return nil, errors.New(aerr.Message())
-			case eks.ErrCodeClientException:
-				return nil, errors.New(aerr.Message())
-			case eks.ErrCodeServerException:
-				return nil, errors.New(aerr.Message())
-			case eks.ErrCodeResourceInUseException:
-				return nil, errors.New(aerr.Message())
-			case eks.ErrCodeResourceNotFoundException:
-				return nil, errors.New(aerr.Message())
-			case eks.ErrCodeInvalidRequestException:
-				return nil, errors.New(aerr.Message())
-			default:
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
+		return nil, decodeAWSError(err)
 	}
 
 	return newCluster, nil
@@ -471,7 +452,7 @@ func getEKSNodeGroups(ctx context.Context, cluster *kubermaticv1.ExternalCluster
 	}
 	nodeOutput, err := client.EKS.ListNodegroups(nodeInput)
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 	nodeGroups := nodeOutput.Nodegroups
 
@@ -499,7 +480,7 @@ func getEKSNodeGroups(ctx context.Context, cluster *kubermaticv1.ExternalCluster
 
 		nodeGroupOutput, err := client.EKS.DescribeNodegroup(nodeGroupInput)
 		if err != nil {
-			return nil, err
+			return nil, decodeAWSError(err)
 		}
 		nodeGroup := nodeGroupOutput.Nodegroup
 		machineDeployments = append(machineDeployments, createMachineDeploymentFromEKSNodePoll(nodeGroup, readyReplicas))
@@ -534,7 +515,7 @@ func getEKSMachineDeployment(ctx context.Context, client *awsprovider.ClientSet,
 
 	nodeGroupOutput, err := client.EKS.DescribeNodegroup(nodeGroupInput)
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 	nodeGroup := nodeGroupOutput.Nodegroup
 
@@ -662,7 +643,7 @@ func upgradeEKSNodeGroup(client *awsprovider.ClientSet, clusterName, nodeGroupNa
 
 	updateOutput, err := client.EKS.UpdateNodegroupVersion(&nodeGroupInput)
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 
 	return updateOutput, nil
@@ -676,7 +657,7 @@ func resizeEKSNodeGroup(client *awsprovider.ClientSet, clusterName, nodeGroupNam
 
 	nodeGroupOutput, err := client.EKS.DescribeNodegroup(&nodeGroupInput)
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 
 	nodeGroup := nodeGroupOutput.Nodegroup
@@ -710,7 +691,7 @@ func resizeEKSNodeGroup(client *awsprovider.ClientSet, clusterName, nodeGroupNam
 
 	updateOutput, err := client.EKS.UpdateNodegroupConfig(&configInput)
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 
 	return updateOutput, nil
@@ -757,7 +738,7 @@ func deleteEKSNodeGroup(cluster *kubermaticv1.ExternalCluster, nodeGroupName str
 	}
 	_, err = client.EKS.DeleteNodegroup(&deleteNGInput)
 
-	return err
+	return decodeAWSError(err)
 }
 
 func EKSInstanceTypesWithClusterCredentialsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -883,7 +864,7 @@ func getEKSClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 	}
 	clusterOutput, err := client.EKS.DescribeCluster(&eks.DescribeClusterInput{Name: &cloudSpec.EKS.Name})
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 	eksCluster := clusterOutput.Cluster
 	if eksCluster == nil {
@@ -960,7 +941,7 @@ func createEKSNodePool(cloudSpec *kubermaticv1.ExternalClusterCloudSpec, machine
 	}
 	_, err = client.EKS.CreateNodegroup(createInput)
 	if err != nil {
-		return nil, err
+		return nil, decodeAWSError(err)
 	}
 
 	machineDeployment.Phase = apiv2.ExternalClusterMDPhase{State: apiv2.PROVISIONING}
@@ -1009,8 +990,21 @@ func deleteEKSCluster(ctx context.Context, secretKeySelector provider.SecretKeyS
 
 	_, err = client.EKS.DeleteCluster(&eks.DeleteClusterInput{Name: &cloudSpec.EKS.Name})
 	if err != nil {
-		return err
+		return decodeAWSError(err)
 	}
 
 	return nil
+}
+
+func decodeAWSError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var aerr awserr.Error
+	if errors.As(err, &aerr) {
+		return errors.New(aerr.Message())
+	}
+
+	return err
 }


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**:
Return EKS error message instead of full error i.e. EKS error contains error code, error message.
Returning whole error doesn't make sense from the UI perspective, 
for ex: 
the PR will return error
`"Nodegroups eks-md,nodepool must be updated to match cluster version 1.21 before updating cluster version"`
instead of 
`InvalidParameterException: Nodegroups eks-md,nodepool must be updated to match cluster version 1.21 before updating cluster version
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "19af8993-75e9-4651-a832-968a6c198a2e"
  },
  ClusterName: "eks",
  Message_: "Nodegroups eks-md,nodepool must be updated to match cluster version 1.21 before updating cluster version"
}`

This PR just returns the error message for EKS Upgrade version.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #
its part of fixing this https://github.com/kubermatic/dashboard/issues/4545

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
