### PR TITLE
update cluster mutation webhook

### DIFF
--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -110,16 +110,18 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		// apply defaults to the existing clusters
-		err := h.applyDefaults(ctx, cluster)
-		if err != nil {
-			h.log.Info("cluster mutation failed", "error", err)
-			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
-		}
+		if cluster.DeletionTimestamp == nil {
+			// apply defaults to the existing clusters
+			err := h.applyDefaults(ctx, cluster)
+			if err != nil {
+				h.log.Info("cluster mutation failed", "error", err)
+				return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
+			}
 
-		if err := h.mutateUpdate(oldCluster, cluster); err != nil {
-			h.log.Info("cluster mutation failed", "error", err)
-			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
+			if err := h.mutateUpdate(oldCluster, cluster); err != nil {
+				h.log.Info("cluster mutation failed", "error", err)
+				return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
+			}
 		}
 
 	case admissionv1.Delete:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR introduces skipping applying default to cluster object in case of cluster deletion.

Current issue:
For the KubeVirt Cloud provider, we want to apply`DefaultCloudSpec` to the cluster object and for this, we first fetch the secret `credential-kubevirt-xxx` and then update the spec.
We noticed during cluster deletion when finalizers get removed, `DefaultCloudSpec` gets called from the cluster mutation webhook which again tries to fetch secret `credential-kubevirt-xxx`. As the secret is already deleted, we end up in error state, which then blocks cluster deletion.
To avoid this issue we want to skip applying defaults to cluster during cluster deletion.


**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Sankalp Rangare <sankalprangare786@gmail.com>