### PR TITLE
Set etcd PDB allowed disruptions based on componentsOverride

### DIFF
--- a/pkg/resources/etcd/pdb.go
+++ b/pkg/resources/etcd/pdb.go
@@ -34,7 +34,7 @@ type pdbData interface {
 func PodDisruptionBudgetCreator(data pdbData) reconciling.NamedPodDisruptionBudgetCreatorGetter {
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return resources.EtcdPodDisruptionBudgetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
-			minAvailable := intstr.FromInt((resources.EtcdClusterSize / 2) + 1)
+			minAvailable := intstr.FromInt((int(getClusterSize(data.Cluster().Spec.ComponentsOverride.Etcd)) / 2) + 1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: GetBasePodLabels(data.Cluster()),


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Consider the etcd components override for `pdb.minAvailable`.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9997

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Consider components override for etcd PDB
```
