### PR TITLE
Add validation webhook for ClusterTemplates

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -155,7 +155,7 @@ func main() {
 	// /////////////////////////////////////////
 	// setup ClusterTemplate webhooks
 
-	clusterTemplateValidator := clustertemplatevalidation.NewValidator(mgr.GetClient(), seedGetter, configGetter, options.featureGates, caPool)
+	clusterTemplateValidator := clustertemplatevalidation.NewValidator(mgr.GetClient(), seedGetter, seedClientGetter, configGetter, options.featureGates, caPool)
 	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.ClusterTemplate{}).WithValidator(clusterTemplateValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup cluster validation webhook", zap.Error(err))
 	}

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -77,12 +77,6 @@ func NewSeedGetter(seed *kubermaticv1.Seed) provider.SeedGetter {
 	}
 }
 
-func NewSeedClientGetter(seedClient ctrlruntimeclient.Client) provider.SeedClientGetter {
-	return func(_ *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
-		return seedClient, nil
-	}
-}
-
 func NewConfigGetter(config *kubermaticv1.KubermaticConfiguration) provider.KubermaticConfigurationGetter {
 	defaulted, err := defaults.DefaultConfiguration(config, zap.NewNop().Sugar())
 	return func(_ context.Context) (*kubermaticv1.KubermaticConfiguration, error) {

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -31,6 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -73,6 +74,12 @@ func CompareOutput(t *testing.T, name, output string, update bool, suffix string
 func NewSeedGetter(seed *kubermaticv1.Seed) provider.SeedGetter {
 	return func() (*kubermaticv1.Seed, error) {
 		return seed, nil
+	}
+}
+
+func NewSeedClientGetter(seedClient ctrlruntimeclient.Client) provider.SeedClientGetter {
+	return func(_ *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
+		return seedClient, nil
 	}
 }
 

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -31,7 +31,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/validation/clustertemplate.go
+++ b/pkg/validation/clustertemplate.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/version"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ValidateClusterTemplate(template *kubermaticv1.ClusterTemplate, dc *kubermaticv1.Datacenter, enabledFeatures features.FeatureGate, versions []*version.Version, parentFieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// validate cluster spec passed in ClusterTemplate
+	if errs := ValidateClusterSpec(&template.Spec, dc, enabledFeatures, versions, parentFieldPath.Child("spec")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	return allErrs
+}

--- a/pkg/validation/clustertemplate.go
+++ b/pkg/validation/clustertemplate.go
@@ -27,6 +27,10 @@ import (
 func ValidateClusterTemplate(template *kubermaticv1.ClusterTemplate, dc *kubermaticv1.Datacenter, enabledFeatures features.FeatureGate, versions []*version.Version, parentFieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	// TODO(embik): validate preset reference
+
+	// TODO(embik): validate SSH key presence in project
+
 	// validate cluster spec passed in ClusterTemplate
 	if errs := ValidateClusterSpec(&template.Spec, dc, enabledFeatures, versions, parentFieldPath.Child("spec")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)

--- a/pkg/webhook/clustertemplate/validation/validation.go
+++ b/pkg/webhook/clustertemplate/validation/validation.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/provider/cloud"
+	"k8c.io/kubermatic/v2/pkg/validation"
+	"k8c.io/kubermatic/v2/pkg/version"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ admission.CustomValidator = &validator{}
+
+// validator for validating Kubermatic ClusterTemplate CRs.
+type validator struct {
+	features     features.FeatureGate
+	client       ctrlruntimeclient.Client
+	seedGetter   provider.SeedGetter
+	configGetter provider.KubermaticConfigurationGetter
+	caBundle     *x509.CertPool
+}
+
+// NewValidator returns a new cluster template validator.
+func NewValidator(client ctrlruntimeclient.Client, seedGetter provider.SeedGetter, configGetter provider.KubermaticConfigurationGetter, features features.FeatureGate, caBundle *x509.CertPool) *validator {
+	return &validator{
+		client:       client,
+		features:     features,
+		seedGetter:   seedGetter,
+		configGetter: configGetter,
+		caBundle:     caBundle,
+	}
+}
+
+func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	return v.validate(ctx, obj)
+}
+
+func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	return v.validate(ctx, newObj)
+}
+
+func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
+	cluster, ok := obj.(*kubermaticv1.Cluster)
+	if !ok {
+		return errors.New("object is not a Cluster")
+	}
+
+	datacenter, cloudProvider, err := v.buildValidationDependencies(ctx, cluster)
+	if err != nil {
+		return err
+	}
+
+	config, configErr := v.configGetter(ctx)
+	if configErr != nil {
+		return configErr
+	}
+
+	versionManager := version.NewFromConfiguration(config)
+
+	errs := validation.ValidateNewClusterSpec(ctx, &cluster.Spec, datacenter, cloudProvider, versionManager, v.features, nil)
+
+	return errs.ToAggregate()
+}
+
+func (v *validator) buildValidationDependencies(ctx context.Context, c *kubermaticv1.Cluster) (*kubermaticv1.Datacenter, provider.CloudProvider, *field.Error) {
+	seed, err := v.seedGetter()
+	if err != nil {
+		return nil, nil, field.InternalError(nil, err)
+	}
+	if seed == nil {
+		return nil, nil, field.InternalError(nil, errors.New("webhook is not configured with -seed-name, cannot validate Clusters"))
+	}
+
+	datacenter, fieldErr := defaulting.DatacenterForClusterSpec(&c.Spec, seed)
+	if fieldErr != nil {
+		return nil, nil, fieldErr
+	}
+
+	secretKeySelectorFunc := provider.SecretKeySelectorValueFuncFactory(ctx, v.client)
+	cloudProvider, err := cloud.Provider(datacenter, secretKeySelectorFunc, v.caBundle)
+	if err != nil {
+		return nil, nil, field.InternalError(nil, err)
+	}
+
+	return datacenter, cloudProvider, nil
+}

--- a/pkg/webhook/clustertemplate/validation/validation.go
+++ b/pkg/webhook/clustertemplate/validation/validation.go
@@ -39,12 +39,11 @@ var _ admission.CustomValidator = &validator{}
 
 // validator for validating Kubermatic ClusterTemplate CRs.
 type validator struct {
-	features         features.FeatureGate
-	client           ctrlruntimeclient.Client
-	seedGetter       provider.SeedGetter
-	seedClientGetter provider.SeedClientGetter
-	configGetter     provider.KubermaticConfigurationGetter
-	caBundle         *x509.CertPool
+	features     features.FeatureGate
+	client       ctrlruntimeclient.Client
+	seedGetter   provider.SeedGetter
+	configGetter provider.KubermaticConfigurationGetter
+	caBundle     *x509.CertPool
 
 	// disableProviderValidation is only for unit tests, to ensure no
 	// provide would phone home to validate dummy test credentials
@@ -54,12 +53,11 @@ type validator struct {
 // NewValidator returns a new cluster template validator.
 func NewValidator(client ctrlruntimeclient.Client, seedGetter provider.SeedGetter, seedClientGetter provider.SeedClientGetter, configGetter provider.KubermaticConfigurationGetter, features features.FeatureGate, caBundle *x509.CertPool) *validator {
 	return &validator{
-		client:           client,
-		features:         features,
-		seedGetter:       seedGetter,
-		seedClientGetter: seedClientGetter,
-		configGetter:     configGetter,
-		caBundle:         caBundle,
+		client:       client,
+		features:     features,
+		seedGetter:   seedGetter,
+		configGetter: configGetter,
+		caBundle:     caBundle,
 	}
 }
 
@@ -87,7 +85,7 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
 
 	// we only validate ClusterTemplates that are not labeled as scope=seed
 	if !ok || scope != kubermaticv1.SeedTemplateScope {
-		datacenter, cloudProvider, client, err := v.buildValidationDependencies(ctx, &template.Spec)
+		datacenter, cloudProvider, err := v.buildValidationDependencies(ctx, &template.Spec)
 		if err != nil {
 			return err
 		}
@@ -99,37 +97,35 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
 
 		versionManager := version.NewFromConfiguration(config)
 
-		errs = validation.ValidateClusterTemplate(ctx, template, datacenter, cloudProvider, v.features, versionManager, client, nil)
+		errs = validation.ValidateClusterTemplate(ctx, template, datacenter, cloudProvider, v.features, versionManager, nil)
 	}
 
 	return errs.ToAggregate()
 }
 
-func (v *validator) buildValidationDependencies(ctx context.Context, c *kubermaticv1.ClusterSpec) (*kubermaticv1.Datacenter, provider.CloudProvider, ctrlruntimeclient.Client, *field.Error) {
+func (v *validator) buildValidationDependencies(ctx context.Context, c *kubermaticv1.ClusterSpec) (*kubermaticv1.Datacenter, provider.CloudProvider, *field.Error) {
 	seed, err := v.seedGetter()
 	if err != nil {
-		return nil, nil, nil, field.InternalError(nil, err)
+		return nil, nil, field.InternalError(nil, err)
 	}
 	if seed == nil {
-		return nil, nil, nil, field.InternalError(nil, errors.New("webhook is not configured with -seed-name, cannot validate Clusters"))
+		return nil, nil, field.InternalError(nil, errors.New("webhook is not configured with -seed-name, cannot validate Clusters"))
 	}
 
 	datacenter, fieldErr := defaulting.DatacenterForClusterSpec(c, seed)
 	if fieldErr != nil {
-		return nil, nil, nil, fieldErr
+		return nil, nil, fieldErr
 	}
 
-	seedClient, err := v.seedClientGetter(seed)
-
 	if v.disableProviderValidation {
-		return datacenter, nil, seedClient, nil
+		return datacenter, nil, nil
 	}
 
 	secretKeySelectorFunc := provider.SecretKeySelectorValueFuncFactory(ctx, v.client)
 	cloudProvider, err := cloud.Provider(datacenter, secretKeySelectorFunc, v.caBundle)
 	if err != nil {
-		return nil, nil, nil, field.InternalError(nil, err)
+		return nil, nil, field.InternalError(nil, err)
 	}
 
-	return datacenter, cloudProvider, seedClient, nil
+	return datacenter, cloudProvider, nil
 }

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -688,7 +688,6 @@ func TestHandle(t *testing.T) {
 		Build()
 
 	seedGetter := test.NewSeedGetter(&seed)
-	seedClientGetter := test.NewSeedClientGetter(seedClient)
 	configGetter := test.NewConfigGetter(&config)
 
 	for _, tt := range tests {
@@ -697,7 +696,6 @@ func TestHandle(t *testing.T) {
 				features:                  tt.features,
 				client:                    seedClient,
 				seedGetter:                seedGetter,
-				seedClientGetter:          seedClientGetter,
 				configGetter:              configGetter,
 				disableProviderValidation: true,
 			}

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -1,0 +1,768 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
+	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/semver"
+	"k8c.io/kubermatic/v2/pkg/test"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/utils/pointer"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testScheme     = runtime.NewScheme()
+	datacenterName = "foo"
+)
+
+func init() {
+	_ = kubermaticv1.AddToScheme(testScheme)
+}
+
+// TestHandle tests the admission handler, but with the cloud provider validation
+// disabled (i.e. we do not check if the digitalocean token is valid, which would
+// be done by issuing a HTTP call).
+//
+// ***************** IMPORTANT ***************
+//
+// This tests the admission webhook for ClusterTemplates standalone.
+//
+
+func TestHandle(t *testing.T) {
+	seed := kubermaticv1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubermatic",
+			Namespace: "kubermatic",
+		},
+		Spec: kubermaticv1.SeedSpec{
+			Datacenters: map[string]kubermaticv1.Datacenter{
+				datacenterName: {
+					Spec: kubermaticv1.DatacenterSpec{
+						Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{},
+					},
+				},
+			},
+		},
+	}
+
+	config := kubermaticv1.KubermaticConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubermatic",
+			Namespace: "kubermatic",
+		},
+		Spec: kubermaticv1.KubermaticConfigurationSpec{},
+	}
+
+	project1 := kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "abcd1234",
+		},
+		Spec: kubermaticv1.ProjectSpec{
+			Name: "my project",
+		},
+		Status: kubermaticv1.ProjectStatus{
+			Phase: kubermaticv1.ProjectActive,
+		},
+	}
+
+	project2 := kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "wxyz0987",
+		},
+		Spec: kubermaticv1.ProjectSpec{
+			Name: "my other project",
+		},
+		Status: kubermaticv1.ProjectStatus{
+			Phase: kubermaticv1.ProjectActive,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		op          admissionv1.Operation
+		features    features.FeatureGate
+		template    kubermaticv1.ClusterTemplate
+		wantAllowed bool
+	}{
+		{
+			name: "Delete cluster success",
+			op:   admissionv1.Delete,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: "Tunneling",
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name:     "Create cluster with Tunneling expose strategy succeeds when the FeatureGate is enabled",
+			features: features.FeatureGate{features.TunnelingExposeStrategy: true},
+			op:       admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: "Tunneling",
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name:     "Create cluster with Tunneling expose strategy fails when the FeatureGate is not enabled",
+			features: features.FeatureGate{features.TunnelingExposeStrategy: false},
+			op:       admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: "Tunneling",
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name:     "Create cluster with invalid provider name",
+			features: features.FeatureGate{features.TunnelingExposeStrategy: false},
+			op:       admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: "Tunneling",
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Create cluster expose strategy different from Tunneling should succeed",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: "NodePort",
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Unknown expose strategy",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: "ciao",
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Unsupported CNIPlugin type",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "calium",
+					Version: "v3.19",
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Unsupported CNIPlugin version",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "canal",
+					Version: "v3.5",
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Supported CNIPlugin",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "canal",
+					Version: "v3.19",
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Supported CNIPlugin none",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "none",
+					Version: "",
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Reject unsupported ebpf proxy mode (wrong CNI)",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.EBPFProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+					KonnectivityEnabled:      pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "canal",
+					Version: "v3.19",
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Reject unsupported ebpf proxy mode (Konnectivity not enabled)",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.EBPFProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+					KonnectivityEnabled:      pointer.BoolPtr(false),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "cilium",
+					Version: "v1.11",
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Supported ebpf proxy mode",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.EBPFProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+					KonnectivityEnabled:      pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "cilium",
+					Version: "v1.11",
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Supported CNI for dual-stack",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					IPFamily:                 kubermaticv1.IPFamilyDualStack,
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16", "fd01::/48"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/120"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+					KonnectivityEnabled:      pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "canal",
+					Version: "v3.22",
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Unsupported CNI for dual-stack",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					IPFamily:                 kubermaticv1.IPFamilyDualStack,
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16", "fd01::/48"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/120"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+					KonnectivityEnabled:      pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+				CNIPlugin: &kubermaticv1.CNIPluginSettings{
+					Type:    "canal",
+					Version: "v3.21",
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Accept a cluster template create request with externalCloudProvider disabled",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy:        "NodePort",
+				ExternalCloudProvider: false,
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Accept a cluster template create request with externalCloudProvider enabled",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy:        "NodePort",
+				ExternalCloudProvider: true,
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32768",
+					},
+				},
+			}.Build(),
+			wantAllowed: true,
+		},
+		{
+			name: "Reject empty nodeport range",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.192.0.0/20"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "",
+					},
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Reject malformed nodeport range",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project1.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.192.0.0/20"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "-",
+					},
+				},
+			}.Build(),
+			wantAllowed: false,
+		},
+		{
+			name: "Reject unsupported Kubernetes version",
+			op:   admissionv1.Create,
+			template: rawTemplateGen{
+				Name:      "foo",
+				Namespace: "kubermatic",
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: project2.Name,
+				},
+				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
+				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
+					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"172.192.0.0/20"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
+					DNSDomain:                "cluster.local",
+					ProxyMode:                resources.IPVSProxyMode,
+					NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
+				},
+				ComponentSettings: kubermaticv1.ComponentSettings{
+					Apiserver: kubermaticv1.APIServerSettings{
+						NodePortRange: "30000-32000",
+					},
+				},
+				Version: semver.NewSemverOrDie("1.0.0"),
+			}.Build(),
+			wantAllowed: false,
+		},
+	}
+
+	seedClient := ctrlruntimefakeclient.
+		NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(&seed, &project1, &project2).
+		Build()
+
+	seedGetter := test.NewSeedGetter(&seed)
+	configGetter := test.NewConfigGetter(&config)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templateValidator := validator{
+				features:                  tt.features,
+				client:                    seedClient,
+				seedGetter:                seedGetter,
+				configGetter:              configGetter,
+				disableProviderValidation: true,
+			}
+
+			ctx := context.Background()
+			var err error
+
+			switch tt.op {
+			case admissionv1.Create:
+				err = templateValidator.ValidateCreate(ctx, &tt.template)
+			case admissionv1.Update:
+				err = templateValidator.ValidateUpdate(ctx, nil, &tt.template)
+			case admissionv1.Delete:
+				err = templateValidator.ValidateDelete(ctx, &tt.template)
+			}
+
+			allowed := err == nil
+
+			if allowed != tt.wantAllowed {
+				t.Errorf("Allowed %t, but wanted %t: %v", allowed, tt.wantAllowed, err)
+			}
+		})
+	}
+
+}
+
+type rawTemplateGen struct {
+	Name                  string
+	Namespace             string
+	Labels                map[string]string
+	ExposeStrategy        string
+	EnableUserSSHKey      *bool
+	ExternalCloudProvider bool
+	NetworkConfig         kubermaticv1.ClusterNetworkingConfig
+	ComponentSettings     kubermaticv1.ComponentSettings
+	CNIPlugin             *kubermaticv1.CNIPluginSettings
+	Version               *semver.Semver
+}
+
+func (r rawTemplateGen) BuildPtr() *kubermaticv1.ClusterTemplate {
+	c := r.Build()
+	return &c
+}
+
+func (r rawTemplateGen) Build() kubermaticv1.ClusterTemplate {
+	version := r.Version
+	if version == nil {
+		version = defaults.DefaultKubernetesVersioning.Default
+	}
+
+	c := kubermaticv1.ClusterTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubermatic.k8c.io/v1",
+			Kind:       "ClusterTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Labels:    r.Labels,
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			HumanReadableName: "a-test-cluster",
+			Version:           *version,
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: datacenterName,
+				Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
+					Token: "thisis.reallyreallyfake",
+				},
+			},
+			Features: map[string]bool{
+				"externalCloudProvider": r.ExternalCloudProvider,
+			},
+			ExposeStrategy:        kubermaticv1.ExposeStrategy(r.ExposeStrategy),
+			EnableUserSSHKeyAgent: r.EnableUserSSHKey,
+			ClusterNetwork:        r.NetworkConfig,
+			ComponentsOverride:    r.ComponentSettings,
+			CNIPlugin:             r.CNIPlugin,
+		},
+	}
+
+	return c
+}
+
+func (r rawTemplateGen) Do() []byte {
+	c := r.Build()
+	s := json.NewSerializer(json.DefaultMetaFactory, testScheme, testScheme, true)
+	buff := bytes.NewBuffer([]byte{})
+	_ = s.Encode(&c, buff)
+	return buff.Bytes()
+}

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -118,6 +118,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: "Tunneling",
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -144,6 +145,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: "Tunneling",
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -170,6 +172,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: "Tunneling",
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -196,6 +199,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: "Tunneling",
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -221,6 +225,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: "NodePort",
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -246,6 +251,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: "ciao",
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -271,6 +277,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -300,6 +307,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -329,6 +337,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -358,6 +367,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -387,6 +397,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -417,6 +428,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -447,6 +459,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -477,6 +490,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -508,6 +522,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -539,6 +554,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy:        "NodePort",
 				ExternalCloudProvider: false,
@@ -565,6 +581,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy:        "NodePort",
 				ExternalCloudProvider: true,
@@ -591,6 +608,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -616,6 +634,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -641,6 +660,7 @@ func TestHandle(t *testing.T) {
 				Namespace: "kubermatic",
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project2.Name,
+					"scope":                        "project",
 				},
 				ExposeStrategy: kubermaticv1.ExposeStrategyNodePort.String(),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
@@ -668,6 +688,7 @@ func TestHandle(t *testing.T) {
 		Build()
 
 	seedGetter := test.NewSeedGetter(&seed)
+	seedClientGetter := test.NewSeedClientGetter(seedClient)
 	configGetter := test.NewConfigGetter(&config)
 
 	for _, tt := range tests {
@@ -676,6 +697,7 @@ func TestHandle(t *testing.T) {
 				features:                  tt.features,
 				client:                    seedClient,
 				seedGetter:                seedGetter,
+				seedClientGetter:          seedClientGetter,
 				configGetter:              configGetter,
 				disableProviderValidation: true,
 			}

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -721,7 +721,6 @@ func TestHandle(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 type rawTemplateGen struct {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds a validation webhook for `ClusterTemplates`. Another step towards operating KKP from the Kubernetes API directly. Previously, the Kubermatic API was doing the only validation and as such, invalid `ClusterTemplates` could easily be created via kubectl.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9914

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a validation webhook for `ClusterTemplate` CRs
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>