### PR TITLE
fix addon variables not being persisted

### DIFF
--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -61,6 +61,7 @@ type AddonSpec struct {
 	// Cluster is the reference to the cluster the addon should be installed in
 	Cluster corev1.ObjectReference `json:"cluster"`
 	// Variables is free form data to use for parsing the manifest templates
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Variables *runtime.RawExtension `json:"variables,omitempty"`
 	// RequiredResourceTypes allows to indicate that this addon needs some resource type before it
 	// can be installed. This can be used to indicate that a specific CRD and/or extension

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -105,6 +105,7 @@ spec:
                 description: Variables is free form data to use for parsing the manifest
                   templates
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
             required:
             - cluster
             - name


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We're using RawExtension for the addon variables, which requires us to also allow unknown fields within the variables. Otherwise the kube-apiserver will simply drop and ignore all values in the extension field.

**Does this PR introduce a user-facing change?**:
```release-note
fix addon variables not being persisted
```
