### PR TITLE
Generate valid cluster names where a random name is generated

### DIFF
--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -31,6 +31,7 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -251,7 +251,8 @@ func (r *reconciler) assignSSHKeyToCluster(ctx context.Context, clusterID string
 }
 
 func genNewCluster(template *kubermaticv1.ClusterTemplate, instance *kubermaticv1.ClusterTemplateInstance, workerName string) *kubermaticv1.Cluster {
-	name := rand.String(10)
+	name := utilcluster.MakeClusterName()
+
 	newCluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -44,6 +44,7 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/cluster"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version"
@@ -156,12 +157,6 @@ func CreateEndpoint(
 	return ConvertInternalClusterToExternal(newCluster, dc, true, supportManager.GetIncompatibilities()...), nil
 }
 
-func makeClusterName() string {
-	alpha := "abcdefghijklmnopqrstuvwxyz"
-	r := rand.Intn(len(alpha))
-	return fmt.Sprintf("%c%s", alpha[r], rand.String(9))
-}
-
 func GenerateCluster(
 	ctx context.Context,
 	projectID string,
@@ -235,7 +230,7 @@ func GenerateCluster(
 	}
 
 	// Generate the name here so that it can be used below.
-	partialCluster.Name = makeClusterName()
+	partialCluster.Name = utilcluster.MakeClusterName()
 
 	// Serialize initial machine deployment request into annotation if it is in the body and provider different than
 	// BringYourOwn was selected. The request will be transformed into machine deployment by the controller once cluster

--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -25,9 +25,9 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const (
@@ -55,7 +55,7 @@ func getTestClientSet(t *testing.T) *ClientSet {
 func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {
 	return &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: rand.String(10),
+			Name: utilcluster.MakeClusterName(),
 		},
 		Spec: kubermaticv1.ClusterSpec{
 			Cloud: kubermaticv1.CloudSpec{

--- a/pkg/provider/kubernetes/cluster.go
+++ b/pkg/provider/kubernetes/cluster.go
@@ -33,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubenetutil "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -196,7 +196,7 @@ func genAPICluster(project *kubermaticv1.Project, cluster *kubermaticv1.Cluster,
 	if cluster.Name != "" {
 		name = cluster.Name
 	} else {
-		name = rand.String(10)
+		name = utilcluster.MakeClusterName()
 	}
 
 	return &kubermaticv1.Cluster{

--- a/pkg/test/e2e/ccm-migration/providers/azure.go
+++ b/pkg/test/e2e/ccm-migration/providers/azure.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,7 +46,7 @@ const (
 func NewClusterJigAzure(seedClient ctrlruntimeclient.Client, version semver.Semver, seedDatacenter string, credentials AzureCredentialsType) *AzureClusterJig {
 	return &AzureClusterJig{
 		CommonClusterJig: CommonClusterJig{
-			name:           makeClusterName(),
+			name:           utilcluster.MakeClusterName(),
 			DatacenterName: seedDatacenter,
 			Version:        version,
 			SeedClient:     seedClient,
@@ -178,10 +179,4 @@ func (c *AzureCredentialsType) GenerateProviderSpec(spec *kubermaticv1.AzureClou
 		spec.RouteTableName,
 		spec.SecurityGroup,
 	))
-}
-
-func makeClusterName() string {
-	alpha := "abcdefghijklmnopqrstuvwxyz"
-	r := rand.Intn(len(alpha))
-	return fmt.Sprintf("%c%s", alpha[r], rand.String(9))
 }

--- a/pkg/test/e2e/ccm-migration/providers/openstack.go
+++ b/pkg/test/e2e/ccm-migration/providers/openstack.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ type OpenstackClusterJig struct {
 func NewClusterJigOpenstack(seedClient ctrlruntimeclient.Client, version semver.Semver, seedDatacenter string, credentials OpenstackCredentialsType) *OpenstackClusterJig {
 	return &OpenstackClusterJig{
 		CommonClusterJig: CommonClusterJig{
-			name:           "c" + rand.String(9),
+			name:           utilcluster.MakeClusterName(),
 			DatacenterName: seedDatacenter,
 			Version:        version,
 			SeedClient:     seedClient,

--- a/pkg/test/e2e/ccm-migration/providers/vsphere.go
+++ b/pkg/test/e2e/ccm-migration/providers/vsphere.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ type VsphereClusterJig struct {
 func NewClusterJigVsphere(seedClient ctrlruntimeclient.Client, version semver.Semver, seedDatacenter string, credentials VsphereCredentialsType) *VsphereClusterJig {
 	return &VsphereClusterJig{
 		CommonClusterJig: CommonClusterJig{
-			name:           "c" + rand.String(9),
+			name:           utilcluster.MakeClusterName(),
 			DatacenterName: seedDatacenter,
 			Version:        version,
 			SeedClient:     seedClient,

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func MakeClusterName() string {
+	alpha := "abcdefghijklmnopqrstuvwxyz"
+	r := rand.Intn(len(alpha))
+	return fmt.Sprintf("%c%s", alpha[r], rand.String(9))
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
#9749 introduced more strict checking of cluster names (only rfc1035 is allowed now, no names starting with numbers are forbidden). Unfortunately, the PR missed a couple of places that generate random cluster names, so this is a follow-up to make sure that for example clusters generated from cluster templates are always valid.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
