### PR TITLE
collect logs during CCM tests

### DIFF
--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -37,6 +37,12 @@ echodate "Creating kind cluster"
 export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
 source hack/ci/setup-kind-cluster.sh
 
+if [ -x "$(command -v protokol)" ]; then
+  # gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+  protokol --kubeconfig "${HOME}/.kube/config" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
+  protokol --kubeconfig "${HOME}/.kube/config" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+fi
+
 echodate "Setting up Kubermatic in kind on revision ${KUBERMATIC_VERSION}"
 
 beforeKubermaticSetup=$(nowms)

--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -107,7 +108,7 @@ func setupAndGetUserClient(ctx context.Context, clusterJig providers.ClusterJigI
 		gomega.Expect(clusterJig.Seed().Get(ctx, types.NamespacedName{Name: clusterJig.Name()}, cluster)).NotTo(gomega.HaveOccurred())
 		userClient, err = clusterClientProvider.GetClient(ctx, cluster)
 		if err != nil {
-			clusterJig.Log().Debug("user cluster client get failed: %v", err)
+			clusterJig.Log().Debugw("failed to get usercluster client", zap.Error(err))
 			return false, nil
 		}
 		return true, nil
@@ -118,7 +119,7 @@ func setupAndGetUserClient(ctx context.Context, clusterJig providers.ClusterJigI
 
 	gomega.Expect(wait.Poll(utils.UserClusterPollInterval, utils.CustomTestTimeout, func() (done bool, err error) {
 		if err = clusterJig.CreateMachineDeployment(ctx, userClient); err != nil {
-			clusterJig.Log().Debug("machine deployment creation failed: %v", err)
+			clusterJig.Log().Debugw("machine deployment creation failed", zap.Error(err))
 			return false, nil
 		}
 		return true, nil
@@ -128,7 +129,7 @@ func setupAndGetUserClient(ctx context.Context, clusterJig providers.ClusterJigI
 	gomega.Expect(wait.Poll(utils.UserClusterPollInterval, utils.CustomTestTimeout, func() (done bool, err error) {
 		var ready bool
 		if ready, err = clusterJig.WaitForNodeToBeReady(ctx, userClient); err != nil {
-			clusterJig.Log().Debug("node not ready yet, %v", err)
+			clusterJig.Log().Debugw("node not ready yet", zap.Error(err))
 			return false, nil
 		}
 		return ready, nil
@@ -200,7 +201,7 @@ func testBody(ctx context.Context, clusterJig providers.ClusterJigInterface, clu
 	gomega.Expect(wait.Poll(utils.UserClusterPollInterval, utils.CustomTestTimeout, func() (done bool, err error) {
 		var ready bool
 		if ready, err = clusterJig.WaitForNodeToBeReady(ctx, userClient); err != nil {
-			clusterJig.Log().Debug("node not ready yet, %v", err)
+			clusterJig.Log().Debugw("node not ready yet", zap.Error(err))
 			return false, nil
 		}
 		return ready, nil

--- a/pkg/test/e2e/ccm-migration/providers/openstack.go
+++ b/pkg/test/e2e/ccm-migration/providers/openstack.go
@@ -89,7 +89,7 @@ func (c *OpenstackClusterJig) Setup(ctx context.Context) error {
 	}, projectID); err != nil {
 		return fmt.Errorf("failed to create user cluster: %w", err)
 	}
-	c.log.Debugw("Cluster created", "name", c.Name)
+	c.log.Debugw("Cluster created", "name", c.Name())
 
 	return c.waitForClusterControlPlaneReady(ctx)
 }

--- a/pkg/test/e2e/ccm-migration/providers/vsphere.go
+++ b/pkg/test/e2e/ccm-migration/providers/vsphere.go
@@ -88,7 +88,7 @@ func (c *VsphereClusterJig) Setup(ctx context.Context) error {
 	}, projectID); err != nil {
 		return fmt.Errorf("failed to create user cluster: %w", err)
 	}
-	c.log.Debugw("Cluster created", "name", c.Name)
+	c.log.Debugw("Cluster created", "name", c.Name())
 
 	return c.waitForClusterControlPlaneReady(ctx)
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
CCM migration tests often flake and it would be nice to have their logs available. Since this is not a script in `hack/ci/`, I overlooked it in my original PR that introduced protokol.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
