### PR TITLE
Pin AWS AMI in e2e tests

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -57,6 +57,8 @@ spec:
       spec:
         aws:
           region: eu-central-1
+          images:
+            ubuntu: ami-092f628832a8d22a5 # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523
     hetzner-hel1:
       location: Helsinki 1 DC 6
       country: DE

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -60,6 +60,8 @@ spec:
       spec:
         aws:
           region: eu-central-1
+          images:
+            ubuntu: ami-092f628832a8d22a5 # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523
     hetzner-hel1:
       location: Helsinki 1 DC 6
       country: DE


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The latest Ubuntu image has a kernel bug in it (https://bugs.launchpad.net/ubuntu/+source/linux-aws/+bug/1977919) and this PR makes it so that we pin on the previous AMI (see #10022). This will unblock our e2e tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
