### PR TITLE
[release/v2.20] pin AWS AMI to prevent encountering kernel bug (#10021)

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -53,6 +53,8 @@ spec:
       spec:
         aws:
           region: eu-central-1
+          images:
+            ubuntu: ami-092f628832a8d22a5 # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523
     hetzner-nbg1:
       location: Nuremberg 1 DC 3
       country: DE

--- a/hack/ci/testdata/seed_backup.yaml
+++ b/hack/ci/testdata/seed_backup.yaml
@@ -62,6 +62,8 @@ spec:
       spec:
         aws:
           region: eu-central-1
+          images:
+            ubuntu: ami-092f628832a8d22a5 # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523
     hetzner-nbg1:
       location: Nuremberg 1 DC 3
       country: DE


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Manual backport of #10021.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
