### PR TITLE
Add ImagePullSecret to Cluster

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -138,6 +138,9 @@ type ClusterSpec struct {
 	// ContainerRuntime to use, i.e. `docker` or `containerd`. By default `containerd` will be used.
 	ContainerRuntime string `json:"containerRuntime,omitempty"`
 
+	// Optional: ImagePullSecret references a secret containing container registry credentials that are set on node level.
+	ImagePullSecret *corev1.SecretReference `json:"imagePullSecret,omitempty"`
+
 	CNIPlugin *CNIPluginSettings `json:"cniPlugin,omitempty"`
 
 	ClusterNetwork  ClusterNetworkingConfig   `json:"clusterNetwork"`

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -138,7 +138,7 @@ type ClusterSpec struct {
 	// ContainerRuntime to use, i.e. `docker` or `containerd`. By default `containerd` will be used.
 	ContainerRuntime string `json:"containerRuntime,omitempty"`
 
-	// Optional: ImagePullSecret references a secret containing container registry credentials that are set on node level.
+	// Optional: ImagePullSecret references a secret with container registry credentials. This is passed to the machine-controller which sets the registry credentials on node level.
 	ImagePullSecret *corev1.SecretReference `json:"imagePullSecret,omitempty"`
 
 	CNIPlugin *CNIPluginSettings `json:"cniPlugin,omitempty"`

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -1075,6 +1075,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	*out = *in
 	out.Version = in.Version.DeepCopy()
 	in.Cloud.DeepCopyInto(&out.Cloud)
+	if in.ImagePullSecret != nil {
+		in, out := &in.ImagePullSecret, &out.ImagePullSecret
+		*out = new(corev1.SecretReference)
+		**out = **in
+	}
 	if in.CNIPlugin != nil {
 		in, out := &in.CNIPlugin, &out.CNIPlugin
 		*out = new(CNIPluginSettings)

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1945,6 +1945,19 @@ spec:
                 description: HumanReadableName is the cluster name provided by the
                   user.
                 type: string
+              imagePullSecret:
+                description: 'Optional: ImagePullSecret references a secret containing
+                  container registry credentials that are set on node level.'
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
               kubernetesDashboard:
                 description: KubernetesDashboard holds the configuration for the kubernetes-dashboard
                   component.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1946,8 +1946,9 @@ spec:
                   user.
                 type: string
               imagePullSecret:
-                description: 'Optional: ImagePullSecret references a secret containing
-                  container registry credentials that are set on node level.'
+                description: 'Optional: ImagePullSecret references a secret with container
+                  registry credentials. This is passed to the machine-controller which
+                  sets the registry credentials on node level.'
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1907,6 +1907,19 @@ spec:
                 description: HumanReadableName is the cluster name provided by the
                   user.
                 type: string
+              imagePullSecret:
+                description: 'Optional: ImagePullSecret references a secret containing
+                  container registry credentials that are set on node level.'
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
               kubernetesDashboard:
                 description: KubernetesDashboard holds the configuration for the kubernetes-dashboard
                   component.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1908,8 +1908,9 @@ spec:
                   user.
                 type: string
               imagePullSecret:
-                description: 'Optional: ImagePullSecret references a secret containing
-                  container registry credentials that are set on node level.'
+                description: 'Optional: ImagePullSecret references a secret with container
+                  registry credentials. This is passed to the machine-controller which
+                  sets the registry credentials on node level.'
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -148,7 +148,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 					Name:    Name,
 					Image:   repository + ":" + tag,
 					Command: []string{"/usr/local/bin/machine-controller"},
-					Args:    getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime, data.Cluster().Spec.EnableOperatingSystemManager, data.Cluster().Spec.Features),
+					Args:    getFlags(clusterDNSIP, data.DC().Node, data.Cluster().Spec.ContainerRuntime, data.Cluster().Spec.ImagePullSecret, data.Cluster().Spec.EnableOperatingSystemManager, data.Cluster().Spec.Features),
 					Env: append(envVars, corev1.EnvVar{
 						Name:  "PROBER_KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
@@ -288,7 +288,7 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 	return vars, nil
 }
 
-func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri string, enableOperatingSystemManager bool, features map[string]bool) []string {
+func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri string, imagePullSecret *corev1.SecretReference, enableOperatingSystemManager bool, features map[string]bool) []string {
 	flags := []string{
 		"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 		"-logtostderr",
@@ -325,6 +325,10 @@ func getFlags(clusterDNSIP string, nodeSettings *kubermaticv1.NodeSettings, cri 
 
 	if cri != "" {
 		flags = append(flags, "-node-container-runtime", cri)
+	}
+
+	if imagePullSecret != nil {
+		flags = append(flags, "-node-registry-credentials-secret", fmt.Sprintf("%s/%s", imagePullSecret.Namespace, imagePullSecret.Name))
 	}
 
 	// Machine Controller will use OSM for managing machine's provisioning and bootstrapping configurations


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This adds a new field `ImagePullSecrets` to the `Cluster` CRD. The secret referenced by this  `corev1.SecretReference` is passed to a user cluster's machine-controller as a flag (`-node-registry-credentials-secret`).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9925

**Special notes for your reviewer**:
For context see [Proposal: Container Registry Credentials per User Cluster](https://github.com/kubermatic/kubermatic/blob/c8f0695f4c2b2c443281b4b22a83c7f550d3da9f/docs/proposals/container-registry-credentials-per-usercluster.md)

**Documentation**:
Will follow with the extension of KubermaticConfiguration

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
It's now possible to reference a secret with container registry credentials on Cluster resources. These credentials are implicitly available on every node of the cluster.
```
