### PR TITLE
Add dual-stack support for Hetzner

### DIFF
--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -58,6 +58,7 @@ export OS_PASSWORD="${OS_PASSWORD:-$(vault kv get -field=password dev/syseleven-
 export OS_USER_DOMAIN_NAME="${OS_USER_DOMAIN_NAME:-$(vault kv get -field=OS_USER_DOMAIN_NAME dev/syseleven-openstack)}"
 export OS_PROJECT_NAME="${OS_PROJECT_NAME:-$(vault kv get -field=OS_TENANT_NAME dev/syseleven-openstack)}"
 export OS_FLOATING_IP_POOL="${OS_FLOATING_IP_POOL:-$(vault kv get -field=OS_FLOATING_IP_POOL dev/syseleven-openstack)}"
+export HETZNER_TOKEN="${HETZNER_TOKEN:-$(vault kv get -field=token dev/e2e-hetzner)}"
 
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running dualstack tests..."

--- a/pkg/handler/v1/dc/datacenter.go
+++ b/pkg/handler/v1/dc/datacenter.go
@@ -42,9 +42,10 @@ import (
 
 // providersWithIPv6Enabled configures which providers have IPv6 enabled for all datacenters.
 var providersWithIPv6Enabled = map[kubermaticv1.ProviderType]struct{}{
-	kubermaticv1.AWSCloudProvider:   {},
-	kubermaticv1.AzureCloudProvider: {},
-	kubermaticv1.GCPCloudProvider:   {},
+	kubermaticv1.AWSCloudProvider:     {},
+	kubermaticv1.AzureCloudProvider:   {},
+	kubermaticv1.GCPCloudProvider:     {},
+	kubermaticv1.HetznerCloudProvider: {},
 }
 
 // ListEndpoint an HTTP endpoint that returns a list of apiv1.Datacenter.

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -127,6 +127,14 @@ func hetznerDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 					VolumeMounts: getVolumeMounts(),
 				},
 			}
+
+			if data.Cluster().IsDualStack() {
+				dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  "HCLOUD_INSTANCES_ADDRESS_FAMILY",
+					Value: "dualstack",
+				})
+			}
+
 			defResourceRequirements := map[string]*corev1.ResourceRequirements{
 				ccmContainerName: hetznerResourceRequirements.DeepCopy(),
 			}

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -93,8 +93,8 @@ func hetznerDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 						"--cloud-provider=hcloud",
 						"--allow-untagged-cloud",
-						"--allocate-node-cidrs=true",
-						fmt.Sprintf("--cluster-cidr=%s", data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0]),
+						// "false" as we use IPAM in kube-controller-manager
+						"--allocate-node-cidrs=false",
 					},
 					Env: []corev1.EnvVar{
 						{

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -330,6 +330,27 @@ func (a openstack) CloudSpec() models.CloudSpec {
 	}
 }
 
+type hetzner struct{}
+
+var _ clusterSpec = hetzner{}
+
+func (a hetzner) NodeSpec() models.NodeCloudSpec {
+	return models.NodeCloudSpec{
+		Hetzner: &models.HetznerNodeSpec{
+			Type: "cx21",
+		},
+	}
+}
+
+func (a hetzner) CloudSpec() models.CloudSpec {
+	return models.CloudSpec{
+		DatacenterName: "hetzner-hel1",
+		Hetzner: &models.HetznerCloudSpec{
+			Token: os.Getenv("HETZNER_TOKEN"),
+		},
+	}
+}
+
 // operating systems
 
 func ubuntu() models.OperatingSystemSpec {
@@ -359,6 +380,12 @@ func centos() models.OperatingSystemSpec {
 func flatcar() models.OperatingSystemSpec {
 	return models.OperatingSystemSpec{
 		Flatcar: &models.FlatcarSpec{},
+	}
+}
+
+func rockyLinux() models.OperatingSystemSpec {
+	return models.OperatingSystemSpec{
+		RockyLinux: models.RockyLinuxSpec{},
 	}
 }
 

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -385,7 +385,7 @@ func flatcar() models.OperatingSystemSpec {
 
 func rockyLinux() models.OperatingSystemSpec {
 	return models.OperatingSystemSpec{
-		RockyLinux: models.RockyLinuxSpec{},
+		RockyLinux: &models.RockyLinuxSpec{},
 	}
 }
 

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -337,7 +337,7 @@ var _ clusterSpec = hetzner{}
 func (a hetzner) NodeSpec() models.NodeCloudSpec {
 	return models.NodeCloudSpec{
 		Hetzner: &models.HetznerNodeSpec{
-			Type: "cx21",
+			Type: pointer.String("cx21"),
 		},
 	}
 }

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -46,11 +46,12 @@ import (
 )
 
 var operatingSystems = map[string]models.OperatingSystemSpec{
-	"centos":  centos(),
-	"flatcar": flatcar(),
-	"rhel":    rhel(),
-	"sles":    sles(),
-	"ubuntu":  ubuntu(),
+	"centos":     centos(),
+	"flatcar":    flatcar(),
+	"rhel":       rhel(),
+	"sles":       sles(),
+	"ubuntu":     ubuntu(),
+	"rockylinux": rockyLinux(),
 }
 
 var cloudProviders = map[string]clusterSpec{
@@ -58,6 +59,7 @@ var cloudProviders = map[string]clusterSpec{
 	"gcp":       gcp{},
 	"aws":       aws{},
 	"openstack": openstack{},
+	"hetzner":   hetzner{},
 }
 
 var cnis = map[string]models.CNIPluginSettings{
@@ -175,6 +177,30 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			ipFamily:            util.DualStack,
 			skipNodes:           true,
 			skipHostNetworkPods: true,
+		},
+		{
+			cloudName: "hetzner",
+			osNames: []string{
+				"ubuntu",
+				// "centos", // cilium is not working on centos because of old kernel version
+				"rockylinux",
+			},
+			cni:                 "cilium",
+			ipFamily:            util.DualStack,
+			skipNodes:           false,
+			skipHostNetworkPods: false,
+		},
+		{
+			cloudName: "hetzner",
+			osNames: []string{
+				"ubuntu",
+				"centos",
+				"rockylinux",
+			},
+			cni:                 "canal",
+			ipFamily:            util.DualStack,
+			skipNodes:           false,
+			skipHostNetworkPods: false,
 		},
 	}
 

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -182,7 +182,6 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			cloudName: "hetzner",
 			osNames: []string{
 				"ubuntu",
-				// "centos", // cilium is not working on centos because of old kernel version
 				"rockylinux",
 			},
 			cni:                 "cilium",
@@ -194,7 +193,6 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			cloudName: "hetzner",
 			osNames: []string{
 				"ubuntu",
-				"centos",
 				"rockylinux",
 			},
 			cni:                 "canal",
@@ -516,7 +514,7 @@ func createMachineDeployment(t *testing.T, apicli *utils.TestClient, params crea
 				}
 				t.Log(string(errData))
 			}
-			t.Logf("failed to create machine deployment: %s", err.Error())
+			t.Logf("failed to create machine deployment: %v", err)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -183,7 +183,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			osNames: []string{
 				"ubuntu",
 				// "centos", // cilium is not working on centos because of old kernel version
-				"rockylinux",
+				//"rockylinux",
 			},
 			cni:                 "cilium",
 			ipFamily:            util.DualStack,
@@ -195,7 +195,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			osNames: []string{
 				"ubuntu",
 				"centos",
-				"rockylinux",
+				//"rockylinux",
 			},
 			cni:                 "canal",
 			ipFamily:            util.DualStack,
@@ -516,7 +516,7 @@ func createMachineDeployment(t *testing.T, apicli *utils.TestClient, params crea
 				}
 				t.Log(string(errData))
 			}
-			t.Logf("failed to create machine deployment: %v", err)
+			t.Logf("failed to create machine deployment: %s", err)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -183,7 +183,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			osNames: []string{
 				"ubuntu",
 				// "centos", // cilium is not working on centos because of old kernel version
-				//"rockylinux",
+				"rockylinux",
 			},
 			cni:                 "cilium",
 			ipFamily:            util.DualStack,
@@ -195,7 +195,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			osNames: []string{
 				"ubuntu",
 				"centos",
-				//"rockylinux",
+				"rockylinux",
 			},
 			cni:                 "canal",
 			ipFamily:            util.DualStack,
@@ -516,7 +516,7 @@ func createMachineDeployment(t *testing.T, apicli *utils.TestClient, params crea
 				}
 				t.Log(string(errData))
 			}
-			t.Logf("failed to create machine deployment: %s", err)
+			t.Logf("failed to create machine deployment: %s", err.Error())
 			return false, nil
 		}
 		return true, nil

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -106,7 +106,7 @@ func testUserCluster(t *testing.T, userclusterClient *kubernetes.Clientset, ipFa
 
 		for _, node := range nodes.Items {
 			if len(node.Spec.PodCIDRs) > 0 {
-				// in case of Cilium we have 0 pod CIDRs as Cilium uses its own pod IPAM
+				// in case of Cilium we can have 0 pod CIDRs as Cilium uses its own node IPAM
 				validate(t, fmt.Sprintf("node '%s' pod CIDRs", node.Name), ipFamily, node.Spec.PodCIDRs)
 			}
 		}

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -101,11 +101,14 @@ func testUserCluster(t *testing.T, userclusterClient *kubernetes.Clientset, ipFa
 				}
 				addrs = append(addrs, addr.Address)
 			}
-			validate(t, node.Name, ipFamily, addrs)
+			validate(t, fmt.Sprintf("node '%s' status addresses", node.Name), ipFamily, addrs)
 		}
 
 		for _, node := range nodes.Items {
-			validate(t, node.Name, ipFamily, node.Spec.PodCIDRs)
+			if len(node.Spec.PodCIDRs) > 0 {
+				// in case of Cilium we have 0 pod CIDRs as Cilium uses its own pod IPAM
+				validate(t, fmt.Sprintf("node '%s' pod CIDRs", node.Name), ipFamily, node.Spec.PodCIDRs)
+			}
 		}
 	}
 
@@ -126,7 +129,7 @@ func testUserCluster(t *testing.T, userclusterClient *kubernetes.Clientset, ipFa
 			for _, addr := range pod.Status.PodIPs {
 				podAddrs = append(podAddrs, addr.IP)
 			}
-			validate(t, pod.Name, ipFamily, podAddrs)
+			validate(t, fmt.Sprintf("pod '%s' addresses", pod.Name), ipFamily, podAddrs)
 		}
 	}
 
@@ -153,12 +156,12 @@ func testUserCluster(t *testing.T, userclusterClient *kubernetes.Clientset, ipFa
 
 			switch svc.Spec.Type {
 			case corev1.ServiceTypeClusterIP:
-				validate(t, svc.Name, ipFamily, svc.Spec.ClusterIPs)
+				validate(t, fmt.Sprintf("service '%s' cluster IPs", svc.Name), ipFamily, svc.Spec.ClusterIPs)
 			case corev1.ServiceTypeNodePort:
 			case corev1.ServiceTypeExternalName:
 			case corev1.ServiceTypeLoadBalancer:
-				validate(t, svc.Name, ipFamily, svc.Spec.ClusterIPs)
-				validate(t, svc.Name, ipFamily, svc.Spec.ExternalIPs)
+				validate(t, fmt.Sprintf("service '%s' cluster IPs", svc.Name), ipFamily, svc.Spec.ClusterIPs)
+				validate(t, fmt.Sprintf("service '%s' external IPs", svc.Name), ipFamily, svc.Spec.ExternalIPs)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
Adds dual-stack support for user-cluster at Hetzner.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9353 

**Special notes for your reviewer**:
As part of this PR, we are also switching `--allocate-node-cidrs` to `false` in Hetzner CCM. The reason is that we use IPAM in kube-controller-manager (which takes care of dual-stack IPAM properly), and two controllers should not compete when doing the IPAM.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add dual-stack support for Hetzner.
```
