### PR TITLE
update openstack external snapshotter to version 5.0

### DIFF
--- a/addons/csi/openstack/snapshot-controller.yaml
+++ b/addons/csi/openstack/snapshot-controller.yaml
@@ -13,20 +13,14 @@
 # limitations under the License.
 
 # Sourced from:
-# - https://github.com/kubernetes-csi/external-snapshotter/blob/release-4.2/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-# - https://github.com/kubernetes-csi/external-snapshotter/blob/release-4.2/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+# - https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+# - https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 # Modifications:
 #   - template function to replace base registry
 #   - add seccomp profile
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "openstack" }}
-# RBAC file for the snapshot controller.
-#
-# The snapshot controller implements the control loop for CSI snapshot functionality.
-# It should be installed as part of the base Kubernetes distribution in an appropriate
-# namespace for components implementing base system functionality. For installing with
-# Vanilla Kubernetes, kube-system makes sense for the namespace.
 
 apiVersion: v1
 kind: ServiceAccount
@@ -57,14 +51,20 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
-    verbs: ["update"]
-
+    verbs: ["update", "patch"]
+  # Enable this RBAC rule only when using distributed snapshotting, i.e. when the enable-distributed-snapshotting flag is set to true
+  # - apiGroups: [""]
+  #   resources: ["nodes"]
+  #   verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -103,13 +103,6 @@ roleRef:
   kind: Role
   name: snapshot-controller-leaderelection
   apiGroup: rbac.authorization.k8s.io
----
-# This YAML file shows how to deploy the snapshot controller
-
-# The snapshot controller implements the control loop for CSI snapshot functionality.
-# It should be installed as part of the base Kubernetes distribution in an appropriate
-# namespace for components implementing base system functionality. For installing with
-# Vanilla Kubernetes, kube-system makes sense for the namespace.
 
 ---
 kind: Deployment
@@ -142,7 +135,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-controller:v4.2.1'
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-controller:v5.0.1'
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/addons/csi/openstack/snapshot-webhook.yaml
+++ b/addons/csi/openstack/snapshot-webhook.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from:
-# - https://github.com/kubernetes-csi/external-snapshotter/blob/release-4.2/deploy/kubernetes/webhook-example/webhook.yaml
+# - https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/webhook-example/webhook.yaml
 # Modifications:
 #   - change namespace
 #   - template function to replace base registry
@@ -46,7 +46,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-validation-webhook:v4.2.1' # change the image if you wish to use your own custom validation server image
+          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1' # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
           ports:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

After the recent [update of openstack csi](https://github.com/kubermatic/kubermatic/pull/9935) this PR updates the external snapshotter components

```release-note
NONE
```
