### PR TITLE
Add junit output for tests

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:

--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -111,7 +111,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
@@ -102,7 +102,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
@@ -140,7 +140,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
@@ -179,7 +179,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -213,7 +213,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -241,7 +241,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -275,7 +275,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/embik/kubermatic-build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -199,7 +199,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: "ce"
@@ -243,7 +243,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: "ee"

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/embik/kubermatic-build:go-1.18-node-16-kind-0.14-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -199,7 +199,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: "ce"
@@ -243,7 +243,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: "ee"

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/embik/kubermatic-build:go-1.18-node-16-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-8
           command:
             - make
           args:

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-9
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-9
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-9
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-7
+        - image: quay.io/embik/kubermatic-build:go-1.18-node-16-8
           command:
             - make
           args:

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-8
+        - image: quay.io/kubermatic/build:go-1.18-node-16-9
           command:
             - make
           args:

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/integration-tests:6-0
+        - image: quay.io/kubermatic/integration-tests:6-1
           command:
             - make
             - test-integration

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test: download-gocache run-tests build-tests
 
 .PHONY:  run-tests
 run-tests:
-	CGO_ENABLED=1 go test -tags "unit,$(KUBERMATIC_EDITION)" -race ./pkg/... ./cmd/... ./codegen/...
+	./hack/run-tests.sh
 
 .PHONY: build-tests
 build-tests:

--- a/cmd/conformance-tester/pkg/util/ginkgo.go
+++ b/cmd/conformance-tester/pkg/util/ginkgo.go
@@ -195,6 +195,8 @@ func AppendReport(report, toAppend *reporters.JUnitTestSuite) {
 	report.Errors += toAppend.Errors
 
 	for _, testCase := range toAppend.TestCases {
+		exists := false
+
 		for i, existingCase := range report.TestCases {
 			if testCase.Name == existingCase.Name && testCase.ClassName == existingCase.ClassName {
 				if testCase.Skipped == nil && existingCase.Skipped != nil {
@@ -206,9 +208,11 @@ func AppendReport(report, toAppend *reporters.JUnitTestSuite) {
 				}
 
 				// skip over adding this test case
-				continue
+				exists = true
 			}
+		}
 
+		if !exists {
 			report.TestCases = append(report.TestCases, testCase)
 			if testCase.FailureMessage != nil {
 				report.Failures += 1

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestRetagImageForAllVersions(t *testing.T) {
-	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
+	log := kubermaticlog.New(false, kubermaticlog.FormatConsole).Sugar()
 
 	config, err := defaults.DefaultConfiguration(&kubermaticv1.KubermaticConfiguration{}, log)
 	if err != nil {

--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -140,15 +140,8 @@ retry 2 kubectl apply -f user.yaml
 
 echodate "Running API E2E tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.kubermatic_api_create.xml
-  go test -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.kubermatic_api_e2e.xml
-  go test -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.kubermatic_api_logout.xml
-else
-  go test -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
-  go test -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
-  go test -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
-fi
+go_test kubermatic_api_create -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
+go_test kubermatic_api_e2e -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
+go_test kubermatic_api_logout -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -140,8 +140,15 @@ retry 2 kubectl apply -f user.yaml
 
 echodate "Running API E2E tests..."
 
-go test -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
-go test -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
-go test -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.kubermatic_api_create.xml
+  go test -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.kubermatic_api_e2e.xml
+  go test -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.kubermatic_api_logout.xml
+else
+  go test -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
+  go test -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
+  go test -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
+fi
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-cilium-e2e-test.sh
+++ b/hack/ci/run-cilium-e2e-test.sh
@@ -49,6 +49,11 @@ export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws)
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running cilium tests..."
 
-go test -race -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium/...
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -race -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.cilium_e2e.xml
+else
+  go test -race -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium/...
+fi
 
 echodate "Cilium tests done."

--- a/hack/ci/run-cilium-e2e-test.sh
+++ b/hack/ci/run-cilium-e2e-test.sh
@@ -49,11 +49,6 @@ export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws)
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running cilium tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -race -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.cilium_e2e.xml
-else
-  go test -race -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium/...
-fi
+go_test cilium_e2e -race -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium/...
 
 echodate "Cilium tests done."

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -107,8 +107,8 @@ numVersions=$(echo "${VERSIONS_TO_TEST:-}" | tr "," "\n" | wc -l)
 
 # copy conformance junit into artifacts to process it in Prow
 function copy_junit {
-    echodate "Copying conformance results to ${ARTIFACTS}"
-    cp -r ${ARTIFACTS}/conformance/junit.*.xml ${ARTIFACTS}/
+  echodate "Copying conformance results to ${ARTIFACTS}"
+  cp -r ${ARTIFACTS}/conformance/junit.*.xml ${ARTIFACTS}/
 }
 appendTrap copy_junit EXIT
 

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -108,7 +108,7 @@ numVersions=$(echo "${VERSIONS_TO_TEST:-}" | tr "," "\n" | wc -l)
 # copy conformance junit into artifacts to process it in Prow
 function copy_junit {
     echodate "Copying conformance results to ${ARTIFACTS}"
-    cp -r ${ARTIFACTS}/conformance/**/*.xml ${ARTIFACTS}/
+    cp -r ${ARTIFACTS}/conformance/junit.*.xml ${ARTIFACTS}/
 }
 appendTrap copy_junit EXIT
 

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -108,8 +108,7 @@ numVersions=$(echo "${VERSIONS_TO_TEST:-}" | tr "," "\n" | wc -l)
 # copy conformance junit into artifacts to process it in Prow
 function copy_junit {
     echodate "Copying conformance results to ${ARTIFACTS}"
-    cp -r ${ARTIFACTS}/conformance/*.xml ${ARTIFACTS}/
-    cp -r ${ARTIFACTS}/conformance/*/*/*.xml ${ARTIFACTS}/
+    cp -r ${ARTIFACTS}/conformance/**/*.xml ${ARTIFACTS}/
 }
 appendTrap copy_junit EXIT
 

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -108,7 +108,8 @@ numVersions=$(echo "${VERSIONS_TO_TEST:-}" | tr "," "\n" | wc -l)
 # copy conformance junit into artifacts to process it in Prow
 function copy_junit {
     echodate "Copying conformance results to ${ARTIFACTS}"
-    cp ${ARTIFACTS}/conformance/* ${ARTIFACTS}/
+    cp -r ${ARTIFACTS}/conformance/*.xml ${ARTIFACTS}/
+    cp -r ${ARTIFACTS}/conformance/*/*/*.xml ${ARTIFACTS}/
 }
 appendTrap copy_junit EXIT
 

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -105,6 +105,13 @@ numVersions=$(echo "${VERSIONS_TO_TEST:-}" | tr "," "\n" | wc -l)
 # add a bit of setup time to bring up the project, tear it down again etc.
 ((maxDuration = $maxDuration + 30))
 
+# copy conformance junit into artifacts to process it in Prow
+function copy_junit {
+    echodate "Copying conformance results to ${ARTIFACTS}"
+    cp ${ARTIFACTS}/conformance/* ${ARTIFACTS}/
+}
+appendTrap copy_junit EXIT
+
 timeout -s 9 "${maxDuration}m" ./_build/conformance-tester $EXTRA_ARGS \
   -client="${SETUP_MODE:-api}" \
   -name-prefix=prow-e2e \

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -62,6 +62,11 @@ export OS_FLOATING_IP_POOL="${OS_FLOATING_IP_POOL:-$(vault kv get -field=OS_FLOA
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running dualstack tests..."
 
-go test -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/...
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.dualstack_e2e.xml
+else
+  go test -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/...
+fi
 
 echodate "Dualstack tests done."

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -62,11 +62,6 @@ export OS_FLOATING_IP_POOL="${OS_FLOATING_IP_POOL:-$(vault kv get -field=OS_FLOA
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running dualstack tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.dualstack_e2e.xml
-else
-  go test -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/...
-fi
+go_test dualstack_e2e -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/...
 
 echodate "Dualstack tests done."

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -62,5 +62,12 @@ EOF
 retry 2 kubectl apply -f user.yaml
 
 echodate "Running etcd-launcher tests..."
-go test -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
+
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.etcd_launcher_e2e.xml
+else
+  go test -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
+fi
+
 echodate "Tests completed successfully!"

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -63,11 +63,6 @@ retry 2 kubectl apply -f user.yaml
 
 echodate "Running etcd-launcher tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.etcd_launcher_e2e.xml
-else
-  go test -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
-fi
+go_test etcd_launcher_e2e -timeout 60m -tags e2e -v ./pkg/test/e2e/etcd-launcher -kubeconfig "$KUBECONFIG"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-ipam-e2e-tests.sh
+++ b/hack/ci/run-ipam-e2e-tests.sh
@@ -62,5 +62,5 @@ EOF
 retry 2 kubectl apply -f user.yaml
 
 echodate "Running IPAM tests..."
-go test -timeout 30m -tags ipam -v ./pkg/test/e2e/ipam -kubeconfig "$KUBECONFIG"
+go_test ipam_e2e -timeout 30m -tags ipam -v ./pkg/test/e2e/ipam -kubeconfig "$KUBECONFIG"
 echodate "Tests completed successfully!"

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -48,7 +48,7 @@ echodate "Running konnectivity tests..."
 
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
 if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG} 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.konnectivity_e2e.xml
+  go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG} 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.konnectivity_e2e.xml
 else
   go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG}
 fi

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -46,11 +46,6 @@ echodate "Successfully got secrets for dev from Vault"
 
 echodate "Running konnectivity tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG} 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.konnectivity_e2e.xml
-else
-  go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG}
-fi
+go_test konnectivity_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG}
 
 echodate "Konnectivity tests done."

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -46,6 +46,11 @@ echodate "Successfully got secrets for dev from Vault"
 
 echodate "Running konnectivity tests..."
 
-go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG}
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG} 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.konnectivity_e2e.xml
+else
+  go test -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity/... -args -seedconfig=${KUBECONFIG}
+fi
 
 echodate "Konnectivity tests done."

--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -63,11 +63,6 @@ retry 2 kubectl apply -f user.yaml
 
 echodate "Running mla tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -timeout 30m -tags mla -v ./pkg/test/e2e/mla -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.mla_e2e.xml
-else
-  go test -timeout 30m -tags mla -v ./pkg/test/e2e/mla -kubeconfig "$KUBECONFIG"
-fi
+go_test mla_e2e -timeout 30m -tags mla -v ./pkg/test/e2e/mla -kubeconfig "$KUBECONFIG"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -62,5 +62,12 @@ EOF
 retry 2 kubectl apply -f user.yaml
 
 echodate "Running mla tests..."
-go test -timeout 30m -tags mla -v ./pkg/test/e2e/mla -kubeconfig "$KUBECONFIG"
+
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -timeout 30m -tags mla -v ./pkg/test/e2e/mla -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.mla_e2e.xml
+else
+  go test -timeout 30m -tags mla -v ./pkg/test/e2e/mla -kubeconfig "$KUBECONFIG"
+fi
+
 echodate "Tests completed successfully!"

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -65,9 +65,9 @@ echodate "Running opa tests..."
 
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
 if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-    go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.opa_e2e.xml
+  go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.opa_e2e.xml
 else
-    go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
+  go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
 fi
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -63,11 +63,6 @@ retry 2 kubectl apply -f user.yaml
 
 echodate "Running opa tests..."
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.opa_e2e.xml
-else
-  go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
-fi
+go_test opa_e2e -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -62,5 +62,12 @@ EOF
 retry 2 kubectl apply -f user.yaml
 
 echodate "Running opa tests..."
-go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
+
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+    go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG" 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.opa_e2e.xml
+else
+    go test -timeout 30m -tags e2e -v ./pkg/test/e2e/opa -kubeconfig "$KUBECONFIG"
+fi
+
 echodate "Tests completed successfully!"

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-5
+FROM quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
 LABEL maintainer="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating

--- a/hack/images/integration-tests/release.sh
+++ b/hack/images/integration-tests/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/integration-tests
 VERSION=6
-BUILD_SUFFIX=0
+BUILD_SUFFIX=1
 
 docker build --no-cache --pull -t "$REPOSITORY:$VERSION-$BUILD_SUFFIX" .
 docker push "$REPOSITORY:$VERSION-$BUILD_SUFFIX"

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -98,8 +98,8 @@ if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
     -v \
     -timeout 30m \
     -kubeconfig "${HOME}/.kube/config" \
-    -provider "$PROVIDER_TO_TEST" \
-    | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.ccm_migration_${PROVIDER_TO_TEST}.xml
+    -provider "$PROVIDER_TO_TEST" |
+    go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.ccm_migration_${PROVIDER_TO_TEST}.xml
 else
   go test -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
     -v \

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -90,9 +90,20 @@ echodate "Running CCM tests..."
 
 # for unknown reasons, log output is not shown live when using
 # "/..." in the package expression (the position of the -v flag
-# doesn't make a difference)
-go test -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
-  -v \
-  -timeout 30m \
-  -kubeconfig "${HOME}/.kube/config" \
-  -provider "$PROVIDER_TO_TEST"
+# doesn't make a difference).
+#
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
+    -v \
+    -timeout 30m \
+    -kubeconfig "${HOME}/.kube/config" \
+    -provider "$PROVIDER_TO_TEST" \
+    | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.ccm_migration_${PROVIDER_TO_TEST}.xml
+else
+  go test -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
+    -v \
+    -timeout 30m \
+    -kubeconfig "${HOME}/.kube/config" \
+    -provider "$PROVIDER_TO_TEST"
+fi

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -91,19 +91,9 @@ echodate "Running CCM tests..."
 # for unknown reasons, log output is not shown live when using
 # "/..." in the package expression (the position of the -v flag
 # doesn't make a difference).
-#
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
-    -v \
-    -timeout 30m \
-    -kubeconfig "${HOME}/.kube/config" \
-    -provider "$PROVIDER_TO_TEST" |
-    go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.ccm_migration_${PROVIDER_TO_TEST}.xml
-else
-  go test -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
-    -v \
-    -timeout 30m \
-    -kubeconfig "${HOME}/.kube/config" \
-    -provider "$PROVIDER_TO_TEST"
-fi
+go_test ccm_migration_${PROVIDER_TO_TEST} \
+  -tags=e2e ./pkg/test/e2e/ccm-migration $EXTRA_ARGS \
+  -v \
+  -timeout 30m \
+  -kubeconfig "${HOME}/.kube/config" \
+  -provider "$PROVIDER_TO_TEST"

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -204,20 +204,11 @@ retry 5 patch_kubermatic_domain
 echodate "Kubermatic ingress domain patched."
 
 echodate "Running tests..."
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
-    -kubeconfig "$HOME/.kube/config" \
-    -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
-    -datacenter byo-kubernetes \
-    -log-debug 2>&1 |
-    go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.expose_strategy_e2e.xml
-else
-  go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
-    -kubeconfig "$HOME/.kube/config" \
-    -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
-    -datacenter byo-kubernetes \
-    -log-debug
-fi
-
+go_test expose_strategy_e2e \
+  -tags "$KUBERMATIC_EDITION,e2e" \
+  -v ./pkg/test/e2e/expose-strategy \
+  -kubeconfig "$HOME/.kube/config" \
+  -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
+  -datacenter byo-kubernetes \
+  -log-debug
 echodate "Done."

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -204,10 +204,20 @@ retry 5 patch_kubermatic_domain
 echodate "Kubermatic ingress domain patched."
 
 echodate "Running tests..."
-go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
-  -kubeconfig "$HOME/.kube/config" \
-  -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
-  -datacenter byo-kubernetes \
-  -log-debug
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+  go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
+    -kubeconfig "$HOME/.kube/config" \
+    -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
+    -datacenter byo-kubernetes \
+    -log-debug 2>&1 \
+    | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.expose_strategy_e2e.xml
+else
+  go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
+    -kubeconfig "$HOME/.kube/config" \
+    -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
+    -datacenter byo-kubernetes \
+    -log-debug
+fi
 
 echodate "Done."

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -210,8 +210,8 @@ if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
     -kubeconfig "$HOME/.kube/config" \
     -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
     -datacenter byo-kubernetes \
-    -log-debug 2>&1 \
-    | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.expose_strategy_e2e.xml
+    -log-debug 2>&1 |
+    go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.expose_strategy_e2e.xml
 else
   go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
     -kubeconfig "$HOME/.kube/config" \

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -75,5 +75,5 @@ echodate "Running integration tests..."
 # * Extracting the dirname as the `go test` command doesn't play well with individual files as args
 # * Prefixing them with `./` as that's needed by `go test` as well
 for file in $(grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ | xargs dirname | sort -u); do
-  go_test $(echo $file | sed 's/\//_/g') -tags "integration ${KUBERMATIC_EDITION:-ce}" -race ./${file} -v
+  go_test $(echo $file | sed 's/\//_/g') -tags "integration,${KUBERMATIC_EDITION:-ce}" -race ./${file} -v
 done

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -75,10 +75,5 @@ echodate "Running integration tests..."
 # * Extracting the dirname as the `go test` command doesn't play well with individual files as args
 # * Prefixing them with `./` as that's needed by `go test` as well
 for file in $(grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ | xargs dirname | sort -u); do
-  if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-    junit_name=$(echo $file | sed 's/\//_/g')
-    go test -tags "integration ${KUBERMATIC_EDITION:-ce}" -race ./${file} -v 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.${junit_name}.xml
-  else
-    go test -tags "integration ${KUBERMATIC_EDITION:-ce}" -race ./${file} -v
-  fi
+  go_test $(echo $file | sed 's/\//_/g') -tags "integration ${KUBERMATIC_EDITION:-ce}" -race ./${file} -v
 done

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -59,47 +59,13 @@ time kind create cluster --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "$KIND_CLUSTER_NAME"
 
 # run tests
-#
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set.
-# if we want to generate a junit report, we do not use ginkgo (ginkgo has a junit report functionality,
-# but only in Ginkgo v2).
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
-    --ginkgo.randomizeAllSpecs \
-    --ginkgo.failOnPending \
-    --ginkgo.trace \
-    --ginkgo.progress \
-    --ginkgo.v \
-    --kubeconfig "${HOME}/.kube/config" \
-    --kubermatic-tag "${TAG}" \
-    --log-debug 2>&1 |
-    go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.nodeport_proxy_e2e.xml
-else
-  # use ginkgo binary by preference to have better output:
-  # https://github.com/onsi/ginkgo/issues/633
-  if type ginkgo > /dev/null; then
-    ginkgo --tags=e2e -v pkg/test/e2e/nodeport-proxy/ \
-      -r \
-      --randomizeAllSpecs \
-      --randomizeSuites \
-      --failOnPending \
-      --cover \
-      --trace \
-      --race \
-      --progress \
-      -v \
-      -- --kubeconfig "${HOME}/.kube/config" \
-      --kubermatic-tag "${TAG}" \
-      --log-debug
-  else
-    CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
-      --ginkgo.randomizeAllSpecs \
-      --ginkgo.failOnPending \
-      --ginkgo.trace \
-      --ginkgo.progress \
-      --ginkgo.v \
-      --kubeconfig "${HOME}/.kube/config" \
-      --kubermatic-tag "${TAG}" \
-      --log-debug
-  fi
-fi
+CGO_ENABLED=1 go_test nodeport_proxy_e2e \
+  --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
+  --ginkgo.randomizeAllSpecs \
+  --ginkgo.failOnPending \
+  --ginkgo.trace \
+  --ginkgo.progress \
+  --ginkgo.v \
+  --kubeconfig "${HOME}/.kube/config" \
+  --kubermatic-tag "${TAG}" \
+  --log-debug

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -59,30 +59,47 @@ time kind create cluster --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "$KIND_CLUSTER_NAME"
 
 # run tests
-# use ginkgo binary by preference to have better output:
-# https://github.com/onsi/ginkgo/issues/633
-if type ginkgo > /dev/null; then
-  ginkgo --tags=e2e -v pkg/test/e2e/nodeport-proxy/ \
-    -r \
-    --randomizeAllSpecs \
-    --randomizeSuites \
-    --failOnPending \
-    --cover \
-    --trace \
-    --race \
-    --progress \
-    -v \
-    -- --kubeconfig "${HOME}/.kube/config" \
-    --kubermatic-tag "${TAG}" \
-    --log-debug
+#
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set.
+# if we want to generate a junit report, we do not use ginkgo (ginkgo has a junit report functionality,
+# but only in Ginkgo v2).
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+    CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
+      --ginkgo.randomizeAllSpecs \
+      --ginkgo.failOnPending \
+      --ginkgo.trace \
+      --ginkgo.progress \
+      --ginkgo.v \
+      --kubeconfig "${HOME}/.kube/config" \
+      --kubermatic-tag "${TAG}" \
+      --log-debug 2>&1 |
+      go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.nodeport_proxy_e2e.xml
 else
-  CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
-    --ginkgo.randomizeAllSpecs \
-    --ginkgo.failOnPending \
-    --ginkgo.trace \
-    --ginkgo.progress \
-    --ginkgo.v \
-    --kubeconfig "${HOME}/.kube/config" \
-    --kubermatic-tag "${TAG}" \
-    --log-debug
+  # use ginkgo binary by preference to have better output:
+  # https://github.com/onsi/ginkgo/issues/633
+  if type ginkgo > /dev/null; then
+    ginkgo --tags=e2e -v pkg/test/e2e/nodeport-proxy/ \
+      -r \
+      --randomizeAllSpecs \
+      --randomizeSuites \
+      --failOnPending \
+      --cover \
+      --trace \
+      --race \
+      --progress \
+      -v \
+      -- --kubeconfig "${HOME}/.kube/config" \
+      --kubermatic-tag "${TAG}" \
+      --log-debug
+  else
+    CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
+      --ginkgo.randomizeAllSpecs \
+      --ginkgo.failOnPending \
+      --ginkgo.trace \
+      --ginkgo.progress \
+      --ginkgo.v \
+      --kubeconfig "${HOME}/.kube/config" \
+      --kubermatic-tag "${TAG}" \
+      --log-debug
+  fi
 fi

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -64,16 +64,16 @@ time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "$KIND
 # if we want to generate a junit report, we do not use ginkgo (ginkgo has a junit report functionality,
 # but only in Ginkgo v2).
 if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-    CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
-      --ginkgo.randomizeAllSpecs \
-      --ginkgo.failOnPending \
-      --ginkgo.trace \
-      --ginkgo.progress \
-      --ginkgo.v \
-      --kubeconfig "${HOME}/.kube/config" \
-      --kubermatic-tag "${TAG}" \
-      --log-debug 2>&1 \
-      | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.nodeport_proxy_e2e.xml
+  CGO_ENABLED=1 go test --tags=e2e -v -race ./pkg/test/e2e/nodeport-proxy/... \
+    --ginkgo.randomizeAllSpecs \
+    --ginkgo.failOnPending \
+    --ginkgo.trace \
+    --ginkgo.progress \
+    --ginkgo.v \
+    --kubeconfig "${HOME}/.kube/config" \
+    --kubermatic-tag "${TAG}" \
+    --log-debug 2>&1 |
+    go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.nodeport_proxy_e2e.xml
 else
   # use ginkgo binary by preference to have better output:
   # https://github.com/onsi/ginkgo/issues/633

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -72,8 +72,8 @@ if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
       --ginkgo.v \
       --kubeconfig "${HOME}/.kube/config" \
       --kubermatic-tag "${TAG}" \
-      --log-debug 2>&1 |
-      go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.nodeport_proxy_e2e.xml
+      --log-debug 2>&1 \
+      | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.nodeport_proxy_e2e.xml
 else
   # use ginkgo binary by preference to have better output:
   # https://github.com/onsi/ginkgo/issues/633

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -25,7 +25,8 @@ KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 go install github.com/jstemmer/go-junit-report@v1.0.0
 
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+#if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+if [ ! -z "${ARTIFACTS:-}" ]; then
     CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code > ${ARTIFACTS}/junit.unit_tests.xml
 else
     CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -27,7 +27,7 @@ go install github.com/jstemmer/go-junit-report@v1.0.0
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
 #if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
 if [ ! -z "${ARTIFACTS:-}" ]; then
-    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | $(go env GOPATH)/bin/go-junit-report -set-exit-code > ${ARTIFACTS}/junit.unit_tests.xml
+    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | $(go env GOPATH)/bin/go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.unit_tests.xml
 else
     CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
 fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -23,7 +23,7 @@ KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
 if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.unit_tests.xml
+  CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.unit_tests.xml
 else
-    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
+  CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
 fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -22,7 +22,7 @@ source hack/lib.sh
 KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 
 # TODO(embik): remove this
-go install github.com/jstemmer/go-junit-report@v1.0.0
+go install github.com/jstemmer/go-junit-report/v2@v2.0.0-beta1
 
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
 #if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+source hack/lib.sh
+
+KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
+
+# TODO(embik): remove this
+go install github.com/jstemmer/go-junit-report@v1.0.0
+
+# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code > ${ARTIFACTS}/junit.unit_tests.xml
+else
+    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
+fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -21,13 +21,9 @@ source hack/lib.sh
 
 KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 
-# TODO(embik): remove this
-go install github.com/jstemmer/go-junit-report/v2@v2.0.0-beta1
-
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-#if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-if [ ! -z "${ARTIFACTS:-}" ]; then
-    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | $(go env GOPATH)/bin/go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.unit_tests.xml
+if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
+    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.unit_tests.xml
 else
     CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
 fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -21,5 +21,5 @@ source hack/lib.sh
 
 KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 
-go_test unit_tests \
+CGO_ENABLED=1 go_test unit_tests \
   -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/...

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -21,9 +21,5 @@ source hack/lib.sh
 
 KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
 
-# only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
-if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
-  CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code -iocopy -out ${ARTIFACTS}/junit.unit_tests.xml
-else
-  CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
-fi
+go_test unit_tests \
+  -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/...

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -27,7 +27,7 @@ go install github.com/jstemmer/go-junit-report@v1.0.0
 # only run go-junit-report if binary is present and we're in CI / the ARTIFACTS environment is set
 #if [ -x "$(command -v go-junit-report)" ] && [ ! -z "${ARTIFACTS:-}" ]; then
 if [ ! -z "${ARTIFACTS:-}" ]; then
-    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | go-junit-report -set-exit-code > ${ARTIFACTS}/junit.unit_tests.xml
+    CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -v -race ./pkg/... ./cmd/... ./codegen/... 2>&1 | $(go env GOPATH)/bin/go-junit-report -set-exit-code > ${ARTIFACTS}/junit.unit_tests.xml
 else
     CGO_ENABLED=1 go test -tags "unit,${KUBERMATIC_EDITION}" -race ./pkg/... ./cmd/... ./codegen/...
 fi


### PR DESCRIPTION

**What does this PR do / Why do we need it**:
This PR attempts to capture as many test results in junit files as possible. This is mostly done through `go-junit-report`, which can process `go test -v` output and produces junit files we write to artifacts. conformance tests already produced junit files but needed to be copied to the proper location, apparently.

Prow jobs are decorated with junit results, so this makes it easier to find the failed test results and makes Prow jobs sortable by failed tests, I think.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10065

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
