### PR TITLE
Resource usage controller 

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -387,6 +387,11 @@ func main() {
 	}
 	log.Info("Registered Application Installation controller")
 
+	if err := addResourceUsageController(log, seedMgr, mgr, runOp.clusterName, caBundle, isPausedChecker); err != nil {
+		log.Fatalw("Failed to add user Resource Usage controller to mgr", zap.Error(err))
+	}
+	log.Info("Registered Resource Usage controller")
+
 	if err := mgr.Start(rootCtx); err != nil {
 		log.Fatalw("Failed running manager", zap.Error(err))
 	}

--- a/cmd/user-cluster-controller-manager/wrappers_ce.go
+++ b/cmd/user-cluster-controller-manager/wrappers_ce.go
@@ -1,0 +1,34 @@
+//go:build !ee
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"go.uber.org/zap"
+
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// NOP
+func addResourceUsageController(_ *zap.SugaredLogger, _, _ manager.Manager, _ string, _ *certificates.CABundle,
+	_ userclustercontrollermanager.IsPausedChecker) error {
+	return nil
+}

--- a/cmd/user-cluster-controller-manager/wrappers_ee.go
+++ b/cmd/user-cluster-controller-manager/wrappers_ee.go
@@ -1,0 +1,34 @@
+//go:build ee
+
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"go.uber.org/zap"
+
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
+	resourceusagecontroller "k8c.io/kubermatic/v2/pkg/ee/resource-usage-controller"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func addResourceUsageController(log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterName string, caBundle *certificates.CABundle,
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
+	return resourceusagecontroller.Add(log, seedMgr, userMgr, clusterName, caBundle, clusterIsPaused)
+}

--- a/pkg/apis/kubermatic/v1/resource_quota.go
+++ b/pkg/apis/kubermatic/v1/resource_quota.go
@@ -74,3 +74,11 @@ type ResourceDetails struct {
 	// Storage represents the disk size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
 	Storage *resource.Quantity `json:"storage,omitempty"`
 }
+
+func NewResourceDetails(cpu, memory, storage resource.Quantity) *ResourceDetails {
+	return &ResourceDetails{
+		CPU:     &cpu,
+		Memory:  &memory,
+		Storage: &storage,
+	}
+}

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -102,7 +102,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	log := r.log.With("resource", request)
-	log.Debug("Reconciling")
+	log.Debug("reconciling")
 
 	machines := &clusterv1alpha1.MachineList{}
 	if err := r.userClient.List(ctx, machines); err != nil {

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -1,0 +1,144 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package resource_usage_controller
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
+	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	machinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const controllerName = "resource_usage_controller"
+
+type reconciler struct {
+	log             *zap.SugaredLogger
+	seedClient      ctrlruntimeclient.Client
+	userClient      ctrlruntimeclient.Client
+	clusterName     string
+	caBundle        *certificates.CABundle
+	recorder        record.EventRecorder
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
+}
+
+func Add(log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterName string, caBundle *certificates.CABundle,
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
+	log = log.Named(controllerName)
+
+	r := &reconciler{
+		log:             log,
+		seedClient:      seedMgr.GetClient(),
+		userClient:      userMgr.GetClient(),
+		clusterName:     clusterName,
+		caBundle:        caBundle,
+		recorder:        userMgr.GetEventRecorderFor(controllerName),
+		clusterIsPaused: clusterIsPaused,
+	}
+	c, err := controller.New(controllerName, userMgr, controller.Options{
+		Reconciler: r,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	// Watch for changes to Machines
+	if err = c.Watch(
+		&source.Kind{Type: &v1alpha1.Machine{}}, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(v1.NamespaceSystem)); err != nil {
+		return fmt.Errorf("failed to establish watch for the Constraints: %w", err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
+	log := r.log.With("resource", request)
+	log.Debug("Reconciling")
+
+	machines := &v1alpha1.MachineList{}
+	if err := r.userClient.List(ctx, machines); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get machines: %w", err)
+	}
+
+	cluster := &kubermaticv1.Cluster{}
+	if err = r.seedClient.Get(ctx, types.NamespacedName{
+		Name: r.clusterName,
+	}, cluster); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get cluster: %w", err)
+	}
+
+	err = r.reconcile(ctx, cluster, machines)
+	if err != nil {
+		log.Errorw("Reconciling failed", zap.Error(err))
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ClusterResourceUsageReconcileFailed", err.Error())
+	}
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, machines *v1alpha1.MachineList) error {
+	resourceUsage := &kubermaticv1.ResourceDetails{}
+	for _, machine := range machines.Items {
+		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, &machine, r.caBundle)
+		if err != nil {
+			return fmt.Errorf("error getting machine resource usage for machine %q: %w", machine.Name, err)
+		}
+
+		resourceUsage.CPU.Add(*resourceDetails.Cpu())
+		resourceUsage.Memory.Add(*resourceDetails.Memory())
+		resourceUsage.Storage.Add(*resourceDetails.Storage())
+	}
+
+	cluster.Status.ResourceUsage = resourceUsage
+
+	return kubermaticv1helper.UpdateClusterStatus(ctx, r.seedClient, cluster, func(c *kubermaticv1.Cluster) {
+		c.Status.ResourceUsage = resourceUsage
+	})
+}

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -30,7 +30,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
@@ -40,7 +40,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,7 +85,7 @@ func Add(log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterName s
 
 	// Watch for changes to Machines
 	if err = c.Watch(
-		&source.Kind{Type: &v1alpha1.Machine{}}, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(v1.NamespaceSystem)); err != nil {
+		&source.Kind{Type: &clusterv1alpha1.Machine{}}, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(metav1.NamespaceSystem)); err != nil {
 		return fmt.Errorf("failed to establish watch for Machines: %w", err)
 	}
 
@@ -104,7 +104,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log := r.log.With("resource", request)
 	log.Debug("Reconciling")
 
-	machines := &v1alpha1.MachineList{}
+	machines := &clusterv1alpha1.MachineList{}
 	if err := r.userClient.List(ctx, machines); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get machines: %w", err)
 	}
@@ -124,7 +124,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, machines *v1alpha1.MachineList) error {
+func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, machines *clusterv1alpha1.MachineList) error {
 	resourceUsage := kubermaticv1.NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
 	for _, machine := range machines.Items {
 		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, &machine, r.caBundle)

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -86,7 +86,7 @@ func Add(log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterName s
 	// Watch for changes to Machines
 	if err = c.Watch(
 		&source.Kind{Type: &v1alpha1.Machine{}}, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(v1.NamespaceSystem)); err != nil {
-		return fmt.Errorf("failed to establish watch for the Constraints: %w", err)
+		return fmt.Errorf("failed to establish watch for Machines: %w", err)
 	}
 
 	return nil

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -39,6 +39,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -124,7 +125,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, machines *v1alpha1.MachineList) error {
-	resourceUsage := &kubermaticv1.ResourceDetails{}
+	resourceUsage := kubermaticv1.NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
 	for _, machine := range machines.Items {
 		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, &machine, r.caBundle)
 		if err != nil {

--- a/pkg/ee/resource-usage-controller/controller_test.go
+++ b/pkg/ee/resource-usage-controller/controller_test.go
@@ -76,7 +76,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name:    "scenario 3: set proper resource usage from 2 machines",
+			name:    "scenario 3: calculate proper resource usage from 2 machines",
 			cluster: test.GenDefaultCluster(),
 			machines: []*clusterv1alpha1.Machine{
 				genFakeMachine("m1", "5", "5G", "10G"),

--- a/pkg/ee/resource-usage-controller/controller_test.go
+++ b/pkg/ee/resource-usage-controller/controller_test.go
@@ -1,0 +1,25 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package resource_usage_controller

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	awstypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/types"
 	azuretypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/types"
 	gcptypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce/types"
@@ -46,7 +46,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.Client, machine *v1alpha1.Machine,
+func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine,
 	caBundle *certificates.CABundle) (*ResourceDetails, error) {
 	config, err := types.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -72,7 +72,7 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 		quotaReq, err = getOpenstackResourceRequirements(ctx, userClient, config, caBundle)
 	default:
 		// TODO skip for now, when all providers are added, throw error
-		return nil, fmt.Errorf("provider %q not supported for resource quotas", config.CloudProvider)
+		return NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{}), nil
 	}
 
 	return quotaReq, err

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -53,29 +53,29 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 		return nil, fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)
 	}
 
-	var quotaReq *ResourceDetails
+	var quotaUsage *ResourceDetails
 	// TODO add all providers
 	switch config.CloudProvider {
 	case types.CloudProviderFake:
-		quotaReq, err = getFakeQuotaRequest(config)
+		quotaUsage, err = getFakeQuotaRequest(config)
 	case types.CloudProviderAWS:
-		quotaReq, err = getAWSResourceRequirements(ctx, userClient, config)
+		quotaUsage, err = getAWSResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderGoogle:
-		quotaReq, err = getGCPResourceRequirements(ctx, userClient, config)
+		quotaUsage, err = getGCPResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderAzure:
-		quotaReq, err = getAzureResourceRequirements(ctx, userClient, config)
+		quotaUsage, err = getAzureResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderKubeVirt:
-		quotaReq, err = getKubeVirtResourceRequirements(ctx, userClient, config)
+		quotaUsage, err = getKubeVirtResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderVsphere:
-		quotaReq, err = getVsphereResourceRequirements(config)
+		quotaUsage, err = getVsphereResourceRequirements(config)
 	case types.CloudProviderOpenstack:
-		quotaReq, err = getOpenstackResourceRequirements(ctx, userClient, config, caBundle)
+		quotaUsage, err = getOpenstackResourceRequirements(ctx, userClient, config, caBundle)
 	default:
 		// TODO skip for now, when all providers are added, throw error
 		return NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{}), nil
 	}
 
-	return quotaReq, err
+	return quotaUsage, err
 }
 
 func getAWSResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -40,7 +40,6 @@ import (
 // ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.
 func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client,
 	machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle) error {
-
 	quotaReq, err := GetMachineResourceUsage(ctx, userClient, machine, caBundle)
 	if err != nil {
 		return fmt.Errorf("error getting machine resource request: %w", err)

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -40,7 +40,7 @@ import (
 // ValidateQuota validates if the requested Machine resource consumption fits in the quota of the clusters project.
 func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, userClient ctrlruntimeclient.Client,
 	machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle) error {
-	quotaReq, err := GetMachineResourceUsage(ctx, userClient, machine, caBundle)
+	machineResourceUsage, err := GetMachineResourceUsage(ctx, userClient, machine, caBundle)
 	if err != nil {
 		return fmt.Errorf("error getting machine resource request: %w", err)
 	}
@@ -53,29 +53,29 @@ func ValidateQuota(ctx context.Context, log *zap.SugaredLogger, seedClient, user
 
 	// add requested resources to current usage and compare
 	combinedUsage := NewResourceDetails(currentUsage.cpu, currentUsage.mem, currentUsage.storage)
-	combinedUsage.Cpu().Add(*quotaReq.Cpu())
-	combinedUsage.Memory().Add(*quotaReq.Memory())
-	combinedUsage.Storage().Add(*quotaReq.Storage())
+	combinedUsage.Cpu().Add(*machineResourceUsage.Cpu())
+	combinedUsage.Memory().Add(*machineResourceUsage.Memory())
+	combinedUsage.Storage().Add(*machineResourceUsage.Storage())
 
 	if quota.Cpu().Cmp(*combinedUsage.Cpu()) < 0 {
 		log.Debugw("requested CPU would exceed current quota", "request",
-			quotaReq.Cpu(), "quota", quota.Cpu(), "used", currentUsage.Cpu())
+			machineResourceUsage.Cpu(), "quota", quota.Cpu(), "used", currentUsage.Cpu())
 		return fmt.Errorf("requested CPU %q would exceed current quota (quota/used %q/%q)",
-			quotaReq.Cpu(), quota.Cpu(), currentUsage.Cpu())
+			machineResourceUsage.Cpu(), quota.Cpu(), currentUsage.Cpu())
 	}
 
 	if quota.Memory().Cmp(*combinedUsage.Memory()) < 0 {
 		log.Debugw("requested Memory would exceed current quota", "request",
-			quotaReq.Memory(), "quota", quota.Memory(), "used", currentUsage.Memory())
+			machineResourceUsage.Memory(), "quota", quota.Memory(), "used", currentUsage.Memory())
 		return fmt.Errorf("requested Memory %q would exceed current quota (quota/used %q/%q)",
-			quotaReq.Memory(), quota.Memory(), currentUsage.Memory())
+			machineResourceUsage.Memory(), quota.Memory(), currentUsage.Memory())
 	}
 
 	if quota.Storage().Cmp(*combinedUsage.Storage()) < 0 {
 		log.Debugw("requested disk size would exceed current quota", "request",
-			quotaReq.Storage(), "quota", quota.Storage(), "used", currentUsage.Storage())
+			machineResourceUsage.Storage(), "quota", quota.Storage(), "used", currentUsage.Storage())
 		return fmt.Errorf("requested disk size %q would exceed current quota (quota/used %q/%q)",
-			quotaReq.Storage(), quota.Storage(), currentUsage.Storage())
+			machineResourceUsage.Storage(), quota.Storage(), currentUsage.Storage())
 	}
 
 	return nil


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Adds a resource usage controller which calculates the clusters resource usage by listing through all Machines on the user cluster and adding them all up.

This is an EE feature

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9116 

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
EE Clusters will now have resource usage inf in their `status`
```
