### PR TITLE
Fix azure e2e size test

### DIFF
--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -1832,11 +1832,11 @@ func (r *TestClient) ListAzureSizes(credential, location string) (models.AzureSi
 		Credential: &credential,
 		Location:   &location,
 	}
-	SetupRetryParams(r.test, params, Backoff{
+	SetupRetryParamsWithTimeout(r.test, params, Backoff{
 		Duration: 1 * time.Second,
 		Steps:    4,
 		Factor:   1.5,
-	})
+	}, 30*time.Second)
 
 	sizesResponse, err := r.client.Azure.ListAzureSizes(params, r.bearerToken)
 	if err != nil {

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -1832,11 +1832,11 @@ func (r *TestClient) ListAzureSizes(credential, location string) (models.AzureSi
 		Credential: &credential,
 		Location:   &location,
 	}
-	SetupRetryParamsWithTimeout(r.test, params, Backoff{
+	SetupRetryParams(r.test, params, Backoff{
 		Duration: 1 * time.Second,
 		Steps:    4,
 		Factor:   1.5,
-	}, 30*time.Second)
+	})
 
 	sizesResponse, err := r.client.Azure.ListAzureSizes(params, r.bearerToken)
 	if err != nil {

--- a/pkg/test/e2e/utils/http.go
+++ b/pkg/test/e2e/utils/http.go
@@ -32,7 +32,7 @@ import (
 type Backoff wait.Backoff
 
 const (
-	apiRequestTimeout = 10 * time.Second
+	apiRequestTimeout = 30 * time.Second
 )
 
 type requestParameterHolder interface {
@@ -53,14 +53,6 @@ func SetupParams(t *testing.T, p requestParameterHolder, interval time.Duration,
 func SetupRetryParams(t *testing.T, p requestParameterHolder, backoff Backoff, ignoredStatusCodes ...int) {
 	p.SetHTTPClient(&http.Client{
 		Transport: NewRoundTripperWithRetries(t, apiRequestTimeout, backoff, ignoredStatusCodes...),
-	})
-}
-
-// SetupRetryParamsWithTimeout configure retries for HTTP calls based on backoff
-// parameters. Allows for setting the request timeout.
-func SetupRetryParamsWithTimeout(t *testing.T, p requestParameterHolder, backoff Backoff, timeout time.Duration, ignoredStatusCodes ...int) {
-	p.SetHTTPClient(&http.Client{
-		Transport: NewRoundTripperWithRetries(t, timeout, backoff, ignoredStatusCodes...),
 	})
 }
 

--- a/pkg/test/e2e/utils/http.go
+++ b/pkg/test/e2e/utils/http.go
@@ -32,6 +32,7 @@ import (
 type Backoff wait.Backoff
 
 const (
+	// Request timeout is set to 30s(was 10s) to avoid flakes because the requests for Azure sizes sometimes takes a long time.
 	apiRequestTimeout = 30 * time.Second
 )
 

--- a/pkg/test/e2e/utils/http.go
+++ b/pkg/test/e2e/utils/http.go
@@ -56,6 +56,14 @@ func SetupRetryParams(t *testing.T, p requestParameterHolder, backoff Backoff, i
 	})
 }
 
+// SetupRetryParamsWithTimeout configure retries for HTTP calls based on backoff
+// parameters. Allows for setting the request timeout.
+func SetupRetryParamsWithTimeout(t *testing.T, p requestParameterHolder, backoff Backoff, timeout time.Duration, ignoredStatusCodes ...int) {
+	p.SetHTTPClient(&http.Client{
+		Transport: NewRoundTripperWithRetries(t, timeout, backoff, ignoredStatusCodes...),
+	})
+}
+
 func NewRoundTripperWithRetries(t *testing.T, requestTimeout time.Duration, backoff Backoff, ignoredStatusCodes ...int) http.RoundTripper {
 	return &retryRoundTripper{
 		Backoff:            backoff,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Tries to fix the azure e2e test:
TestAzureSizesWithCredentials
which got really flaky recently. It seems that the problem is that getting the Azure sizes sometimes lasts longer then 10s which is the default timeout. 


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
