### PR TITLE
Automatically create Kubermatic namespace on seed clusters

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -126,12 +126,6 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
-	if seed.Spec.ExposeStrategy != "" {
-		if !kubermaticv1.AllExposeStrategies.Has(seed.Spec.ExposeStrategy) {
-			return fmt.Errorf("failed to validate seed: invalid expose strategy %q, must be one of %v", seed.Spec.ExposeStrategy, kubermaticv1.AllExposeStrategies)
-		}
-	}
-
 	seedCreators := []reconciling.NamedSeedCreatorGetter{
 		seedCreator(seed),
 	}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -126,6 +126,14 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
+	nsCreators := []reconciling.NamedNamespaceCreatorGetter{
+		namespaceCreator(seed.Namespace),
+	}
+
+	if err := reconciling.ReconcileNamespaces(ctx, nsCreators, "", client); err != nil {
+		return fmt.Errorf("failed to reconcile namespace: %w", err)
+	}
+
 	seedCreators := []reconciling.NamedSeedCreatorGetter{
 		seedCreator(seed),
 	}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
@@ -154,29 +154,6 @@ func TestReconcilingSeed(t *testing.T) {
 			},
 		},
 		{
-			name:       "invalid expose strategy",
-			shouldFail: true,
-			seed: &kubermaticv1.Seed{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-seed",
-					Namespace: "kubermatic",
-				},
-				Spec: kubermaticv1.SeedSpec{
-					Country:        "Germany",
-					ExposeStrategy: kubermaticv1.ExposeStrategy("wtf"),
-				},
-			},
-			config: &kubermaticv1.KubermaticConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kubermatic",
-					Namespace: "kubermatic",
-				},
-			},
-			existingSeeds: existingSeeds,
-			// actual check is done in the reconciler, nothing to validate here
-			validate: nil,
-		},
-		{
 			name: "sync config into seed",
 			seed: &kubermaticv1.Seed{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -19,7 +19,17 @@ package seedsync
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
+
+func namespaceCreator(namespace string) reconciling.NamedNamespaceCreatorGetter {
+	return func() (string, reconciling.NamespaceCreator) {
+		return namespace, func(n *corev1.Namespace) (*corev1.Namespace, error) {
+			return n, nil
+		}
+	}
+}
 
 func seedCreator(seed *kubermaticv1.Seed) reconciling.NamedSeedCreatorGetter {
 	return func() (string, reconciling.SeedCreator) {

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -83,20 +83,6 @@ const (
 	SkipReconcilingAnnotation = "kubermatic.k8c.io/skip-reconciling"
 )
 
-func NamespaceCreator(cfg *kubermaticv1.KubermaticConfiguration) reconciling.NamedNamespaceCreatorGetter {
-	return func() (string, reconciling.NamespaceCreator) {
-		return cfg.Namespace, func(n *corev1.Namespace) (*corev1.Namespace, error) {
-			if n.Labels == nil {
-				n.Labels = map[string]string{}
-			}
-
-			n.Labels[NameLabel] = cfg.Namespace
-
-			return n, nil
-		}
-	}
-}
-
 func DockercfgSecretCreator(cfg *kubermaticv1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
 	return func() (string, reconciling.SecretCreator) {
 		return DockercfgSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -103,10 +103,6 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		return fmt.Errorf("failed to apply defaults: %w", err)
 	}
 
-	if err := r.reconcileNamespaces(ctx, defaulted, logger); err != nil {
-		return err
-	}
-
 	if err := r.reconcileServiceAccounts(ctx, defaulted, logger); err != nil {
 		return err
 	}
@@ -198,20 +194,6 @@ func (r *Reconciler) cleanupDeletedConfiguration(ctx context.Context, config *ku
 	}
 
 	return kubernetes.TryRemoveFinalizer(ctx, r, config, common.CleanupFinalizer)
-}
-
-func (r *Reconciler) reconcileNamespaces(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
-	logger.Debug("Reconciling Namespaces")
-
-	creators := []reconciling.NamedNamespaceCreatorGetter{
-		common.NamespaceCreator(config),
-	}
-
-	if err := reconciling.ReconcileNamespaces(ctx, creators, "", r.Client); err != nil {
-		return fmt.Errorf("failed to reconcile Namespaces: %w", err)
-	}
-
-	return nil
 }
 
 func (r *Reconciler) reconcileConfigMaps(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, logger *zap.SugaredLogger) error {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -306,10 +306,6 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *kubermaticv1.K
 		return err
 	}
 
-	if err := r.reconcileNamespaces(ctx, cfg, seed, client, log); err != nil {
-		return err
-	}
-
 	if err := r.reconcileServiceAccounts(ctx, cfg, seed, client, log); err != nil {
 		return err
 	}
@@ -388,20 +384,6 @@ func (r *Reconciler) reconcileCRDs(ctx context.Context, cfg *kubermaticv1.Kuberm
 
 	if err := reconciling.ReconcileCustomResourceDefinitions(ctx, creators, "", client); err != nil {
 		return fmt.Errorf("failed to reconcile CRDs: %w", err)
-	}
-
-	return nil
-}
-
-func (r *Reconciler) reconcileNamespaces(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
-	log.Debug("reconciling Namespaces")
-
-	creators := []reconciling.NamedNamespaceCreatorGetter{
-		common.NamespaceCreator(cfg),
-	}
-
-	if err := reconciling.ReconcileNamespaces(ctx, creators, "", client); err != nil {
-		return fmt.Errorf("failed to reconcile Namespaces: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -72,7 +72,7 @@ type Reconciler struct {
 // for the given namespace. Will return an error if any API operation
 // failed, otherwise will return an empty dummy Result struct.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request.NamespacedName)
+	log := r.log.With("seed", request.Name)
 
 	err := r.reconcile(ctx, log, request.Name)
 	if err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Up until now, we have always insisted that admins create the `kubermatic` namespace on seed clusters manually. All controllers in KKP would refuse to reconcile if that namespace doesn't exist yet.

Now with the improved CRD handling for seeds, we want to automate their setup even more and so we have decided to drop this requirement (which was, IIRC, only meant as a stop if someone accidentally adds a cluster that should not be a seed) and create the namespace if we need to.

This PR implements this change. The setup flow for new seeds is a bit complex, but on purpose:

* The _Operator_ is always responsible for setting up KKP components (like controller-managers, secrets etc.). But it must be possible to run KKP without the operator being present (i.e. scaling it to 0 replicas should have no effect if an admin doesn't want to change anything in KKP).
* Synchronizing Seed resources into their seed clusters is something that always needs to happen, so my idea to merge the seed-sync controller into the operator died, as the operator is "optional".

So when you add a new Seed,

* the seed-sync controller will create the namespace on the seed,
* the seed-sync controller will copy the Seed resources into the seed cluster
* at this point the operator can find it there and begin to reconcile the seed-ctrl-mgr, webhooks etc.

And since the operator cannot do anything on the seed before the seed-sync controller has done its job, there is no point in having namespace-reconciling-code in the operator. This PR therefore removes the effectively dead code.

**Does this PR introduce a user-facing change?**:
```release-note
KKP now creates the `kubermatic` namespace on seed clusters automatically, so admins need to do one less step when setting up new seed clusters.
```
