### PR TITLE
update oauth2-proxy to v7.3.0

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: v9.9.9-dev
-appVersion: v7.2.1
+appVersion: v7.3.0
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.2.1
+    tag: v7.3.0
     pullPolicy: IfNotPresent
 
   # secret which holds the CA certificates that should be used when connecting to the provider


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.3.0 mentions

> This release includes fixes for a number of CVEs, we recomend to upgrade as soon as possible.

**Does this PR introduce a user-facing change?**:
```release-note
Update oauth2-proxy (IAP) to v7.3.0
```
