### PR TITLE
update promtail to 2.5.0

### DIFF
--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: promtail
 version: v9.9.9-dev
-appVersion: v2.4.2
+appVersion: v2.5.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:
   - kubermatic
@@ -31,5 +31,5 @@ maintainers:
     email: support@kubermatic.com
 dependencies:
   - name: promtail
-    version: "3.11.0"
+    version: "5.1.0"
     repository: "https://grafana.github.io/helm-charts"

--- a/charts/logging/promtail/test/default.yaml.out
+++ b/charts/logging/promtail/test/default.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: promtail/charts/promtail/templates/secret.yaml
@@ -19,10 +19,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 stringData:
   promtail.yaml: |
@@ -30,22 +30,15 @@ stringData:
       log_level: info
       http_listen_port: 3101
     
-    client:
-      url: http://loki:3100/loki/api/v1/push
-      # Maximum wait period before sending batch
-      batchwait: 1s
-      # Maximum batch size to accrue before sending, unit is byte
-      batchsize: 102400
-      # Maximum time to wait for server to respond to a request
-      timeout: 10s
-      backoff_config:
-        # Initial backoff time between retries
-        min_period: 100ms
-        # Maximum backoff time between retries
-        max_period: 5s
-        # Maximum number of retries when sending batches, 0 means infinite retries
-        max_retries: 20
-      
+    clients:
+      - backoff_config:
+          max_period: 5s
+          max_retries: 20
+          min_period: 100ms
+        batchsize: 102400
+        batchwait: 1s
+        external_labels: {}
+        timeout: 10s
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -321,10 +314,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: promtail
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -346,10 +339,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: promtail
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -367,10 +360,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -385,7 +378,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 8214fb5e32addb8342b5928a6b8e443237de2116beb204e198193647f9e8ef9c
+        checksum/config: ec7136d83086e81ed551df43ffb81f8a308bd3d4e463995c53daaf2013d59485
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:
@@ -405,7 +398,7 @@ spec:
         runAsUser: 0
       containers:
         - name: promtail
-          image: "docker.io/grafana/promtail:2.4.2"
+          image: "docker.io/grafana/promtail:2.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: promtail/charts/promtail/templates/secret.yaml
@@ -19,10 +19,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 stringData:
   promtail.yaml: |
@@ -30,22 +30,15 @@ stringData:
       log_level: info
       http_listen_port: 3101
     
-    client:
-      url: http://loki:3100/loki/api/v1/push
-      # Maximum wait period before sending batch
-      batchwait: 1s
-      # Maximum batch size to accrue before sending, unit is byte
-      batchsize: 102400
-      # Maximum time to wait for server to respond to a request
-      timeout: 10s
-      backoff_config:
-        # Initial backoff time between retries
-        min_period: 100ms
-        # Maximum backoff time between retries
-        max_period: 5s
-        # Maximum number of retries when sending batches, 0 means infinite retries
-        max_retries: 20
-      
+    clients:
+      - backoff_config:
+          max_period: 5s
+          max_retries: 20
+          min_period: 100ms
+        batchsize: 102400
+        batchwait: 1s
+        external_labels: {}
+        timeout: 10s
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -321,10 +314,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: promtail
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -346,10 +339,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: promtail
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -367,10 +360,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -385,7 +378,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 8214fb5e32addb8342b5928a6b8e443237de2116beb204e198193647f9e8ef9c
+        checksum/config: ec7136d83086e81ed551df43ffb81f8a308bd3d4e463995c53daaf2013d59485
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:
@@ -405,7 +398,7 @@ spec:
         runAsUser: 0
       containers:
         - name: promtail
-          image: "docker.io/grafana/promtail:2.4.2"
+          image: "docker.io/grafana/promtail:2.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: promtail/charts/promtail/templates/secret.yaml
@@ -19,10 +19,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 stringData:
   promtail.yaml: |
@@ -30,22 +30,15 @@ stringData:
       log_level: info
       http_listen_port: 3101
     
-    client:
-      url: http://loki:3100/loki/api/v1/push
-      # Maximum wait period before sending batch
-      batchwait: 1s
-      # Maximum batch size to accrue before sending, unit is byte
-      batchsize: 102400
-      # Maximum time to wait for server to respond to a request
-      timeout: 10s
-      backoff_config:
-        # Initial backoff time between retries
-        min_period: 100ms
-        # Maximum backoff time between retries
-        max_period: 5s
-        # Maximum number of retries when sending batches, 0 means infinite retries
-        max_retries: 20
-      
+    clients:
+      - backoff_config:
+          max_period: 5s
+          max_retries: 20
+          min_period: 100ms
+        batchsize: 102400
+        batchwait: 1s
+        external_labels: {}
+        timeout: 10s
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -321,10 +314,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: promtail
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -346,10 +339,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: promtail
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -367,10 +360,10 @@ metadata:
   name: promtail
   namespace: default
   labels:
-    helm.sh/chart: promtail-3.11.0
+    helm.sh/chart: promtail-5.1.0
     app.kubernetes.io/name: promtail
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -385,7 +378,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 8214fb5e32addb8342b5928a6b8e443237de2116beb204e198193647f9e8ef9c
+        checksum/config: ec7136d83086e81ed551df43ffb81f8a308bd3d4e463995c53daaf2013d59485
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:
@@ -405,7 +398,7 @@ spec:
         runAsUser: 0
       containers:
         - name: promtail
-          image: "docker.io/grafana/promtail:2.4.2"
+          image: "docker.io/grafana/promtail:2.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -55,25 +55,25 @@ promtail:
 
   config:
     lokiAddress: http://loki:3100/loki/api/v1/push
-    client:
-      # Maximum wait period before sending batch
-      batchwait: 1s
-      # Maximum batch size to accrue before sending, unit is byte
-      batchsize: 102400
+    clients:
+      - # Maximum wait period before sending batch
+        batchwait: 1s
+        # Maximum batch size to accrue before sending, unit is byte
+        batchsize: 102400
 
-      # Maximum time to wait for server to respond to a request
-      timeout: 10s
+        # Maximum time to wait for server to respond to a request
+        timeout: 10s
 
-      backoff_config:
-        # Initial backoff time between retries
-        min_period: 100ms
-        # Maximum backoff time between retries
-        max_period: 5s
-        # Maximum number of retries when sending batches, 0 means infinite retries
-        max_retries: 20
+        backoff_config:
+          # Initial backoff time between retries
+          min_period: 100ms
+          # Maximum backoff time between retries
+          max_period: 5s
+          # Maximum number of retries when sending batches, 0 means infinite retries
+          max_retries: 20
 
-      # The labels to add to any time series or alerts when communicating with loki
-      external_labels: {}
+        # The labels to add to any time series or alerts when communicating with loki
+        external_labels: {}
 
     serverPort: 3101
     positions:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
After #9648 broke our promtail chart and #9693 brought it back to life, this PR now properly updates the chart after upstream has fixed its issues.

Note that a single "client" configuration has been deprecated in promtail since forever (https://github.com/grafana/loki/pull/536), so this PR now moves to the new "clients" configuration, as does the upstream chart. This is a breaking change.

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Update Promtail to v2.5.0; the `config.client` configuration has been replaced by `config.clients` instead. If you overwrote the Promtail client (=Loki), please adjust your `values.yaml` accordingly.
```
