### PR TITLE
update Dex to 2.32.0

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: oauth
 version: v9.9.9-dev
-appVersion: v2.31.1
+appVersion: v2.32.0
 description: Dex
 keywords:
   - kubermatic

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -15,7 +15,7 @@
 dex:
   image:
     repository: "ghcr.io/dexidp/dex"
-    tag: "v2.31.1"
+    tag: "v2.32.0"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
https://github.com/dexidp/dex/releases/tag/v2.32.0 does not mention any breaking changes.

**Does this PR introduce a user-facing change?**:
```release-note
Update Dex to 2.32.0
```
