### PR TITLE
update blackbox-exporter to 0.21

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: blackbox-exporter
 version: v9.9.9-dev
-appVersion: v0.20.0
+appVersion: v0.21.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:
   - kubermatic

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -15,7 +15,7 @@
 blackboxExporter:
   image:
     repository: quay.io/prometheus/blackbox-exporter
-    tag: v0.20.0
+    tag: v0.21.0
     pullPolicy: IfNotPresent
 
   containers:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
What it says on the tin. This is built using Go 1.18, so

* [TLS 1.0 and 1.1 disabled by default client-side](https://go.dev/doc/go1.18#tls10).
* [Certificates signed with the SHA-1 hash function are rejected](https://go.dev/doc/go1.18#sha1).

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Update blackbox-exporter to 0.21.0; this disables support for TLS 1.0/1.1 by default and rejects certificates signed with SHA-1. Please refer to the [documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config) for more information.
```
