### PR TITLE
update karma to v0.103, improve default configuration

### DIFF
--- a/charts/monitoring/karma/Chart.yaml
+++ b/charts/monitoring/karma/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: karma
 version: v9.9.9-dev
-appVersion: v0.89
+appVersion: v0.103
 description: Dashboard for Prometheus Alertmanager
 keywords:
   - kubermatic

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -39,10 +39,10 @@ karma:
     # in-cluster access to Prometheus.
     # See https://github.com/prymitive/karma/blob/main/docs/CONFIGURATION.md#alert-history
     # for more information
-    # history:
-    #   rewrite:
-    #     - source: 'https://(.+).example.com'
-    #       uri: 'http://$1.monitoring.svc.cluster.local'
+    history:
+      rewrite:
+        - source: 'http://(.+)-[0-9]+:9090'
+          uri: 'http://$1.monitoring.svc.cluster.local:9090'
 
     alertmanager:
       interval: 60s
@@ -51,7 +51,7 @@ karma:
   images:
     karma:
       repository: docker.io/lmierzwa/karma
-      tag: v0.89
+      tag: v0.103
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This updates Karma and makes sure the default configuration is more usable for KKP admins.

**Does this PR introduce a user-facing change?**:
```release-note
update karma to v0.103
```
