### PR TITLE
Fix IPAM/dual-stack with Azure external CCM

### DIFF
--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -164,12 +164,11 @@ func getAzureVersion(version semver.Semver) (string, error) {
 }
 
 func getAzureFlags(data *resources.TemplateData) []string {
-	clusterCIDR := data.Cluster().Spec.ClusterNetwork.Pods.GetIPv4CIDR()
 	flags := []string{
-		// "false" for Azure CNI and "true" for other network plugins
-		"--allocate-node-cidrs=true",
-		// "false" for Azure CNI and "true" for other network plugins
-		"--configure-cloud-routes=true",
+		// "false" as we use IPAM in kube-controller-manager
+		"--allocate-node-cidrs=false",
+		// "false" as we use VXLAN overlay for pod network for all clusters ATM
+		"--configure-cloud-routes=false",
 		"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 		"--v=4",
 		"--cloud-config=/etc/kubernetes/cloud/config",
@@ -178,7 +177,6 @@ func getAzureFlags(data *resources.TemplateData) []string {
 		"--route-reconciliation-period=10s",
 		"--port=10267",
 		"--controllers=*,-cloud-node",
-		fmt.Sprintf("--cluster-cidr=%s", clusterCIDR),
 	}
 	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] {
 		flags = append(flags, "--cluster-name", data.Cluster().Name)

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=true","--configure-cloud-routes=true","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=false","--configure-cloud-routes=false","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node"]}'
         command:
         - /http-prober-bin/http-prober
         image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.18

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=true","--configure-cloud-routes=true","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=false","--configure-cloud-routes=false","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node"]}'
         command:
         - /http-prober-bin/http-prober
         image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.1.14

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=true","--configure-cloud-routes=true","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=false","--configure-cloud-routes=false","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node"]}'
         command:
         - /http-prober-bin/http-prober
         image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.23.11

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=true","--configure-cloud-routes=true","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"cloud-controller-manager","args":["--allocate-node-cidrs=false","--configure-cloud-routes=false","--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--v=4","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=azure","--leader-elect=true","--route-reconciliation-period=10s","--port=10267","--controllers=*,-cloud-node"]}'
         command:
         - /http-prober-bin/http-prober
         image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.24.0


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
In https://github.com/kubermatic/kubermatic/pull/9963, Azure external CCM support has been added. This is a follow-up PR to fix some networking aspects:

 - Since IPAM in Azure CCM [is not recommended for the production](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/site/content/en/topics/ipam.md), and we would not need its Azure-specific benefits ATM anyway, we should rather keep using the IPAM in kube-controller-manager (which also takes proper care of dual-stack IPAM).
 - NOTE: If we wanted wanted to use IPAM in Azure CCM in the future, we should disable it in kube-controller-manager (`--allocate-node-cidrs=false`), otherwise both are enabled and competing.
 - We don't need CCM to configure cloud routes for pod CIDRs, as ATM we use VXLAN overlay for pod network in all KKP-managed user clusters. That may change in the future if we do some cloud-provider-specific networking optimisations, but it would require some more changes.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
