### PR TITLE
try more than 2 commits when finding a gocache

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -94,7 +94,7 @@ presubmits:
               cpu: 3.5
             limits:
               memory: 4Gi
-  
+
   - name: pre-kubermatic-ccm-migration-azure-e2e
     run_if_changed: "(addons/azure-cloud-node-manager/|pkg/provider/cloud/azure/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/)"
     decorate: true
@@ -111,7 +111,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-6
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           env:
             - name: KUBERMATIC_EDITION
               value: ee


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Going back 2 commits was already pretty clever, but in cases where Prow does a batch merge, this might simply not be enough. And if we go back 2 commits, there is no reason not to go back even more. Even a cache that is 10 commits old would be helpful (I guess).

So this PR turns the if-if struct into a loop that tries 5 times to find a gocache. And it also fixes an oversight where the Azure CCM tests where still on Go 1.18.2, so they could never find a cache.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
