### PR TITLE
Make expose-strategy e2e tests headless

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -278,6 +278,9 @@ presubmits:
         - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
           securityContext:
             privileged: true
           resources:

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -75,10 +75,6 @@ make -C cmd/kubeletdnat-controller docker \
   GOOS="${GOOS}" \
   DOCKER_REPO="${DOCKER_REPO}" \
   TAG="${TAG}"
-make -C cmd/user-ssh-keys-agent docker \
-  GOOS="${GOOS}" \
-  DOCKER_REPO="${DOCKER_REPO}" \
-  TAG="${TAG}"
 make -C addons docker \
   DOCKER_REPO="${DOCKER_REPO}" \
   TAG="${TAG}"
@@ -95,7 +91,6 @@ time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "${KIN
 time kind load docker-image "${DOCKER_REPO}/addons:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/kubeletdnat-controller:${TAG}" --name "${KIND_CLUSTER_NAME}"
-time kind load docker-image "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" --name "${KIND_CLUSTER_NAME}"
 
 # This is just used as a const
 # NB: The CE requires Seeds to be named this way

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -199,7 +199,8 @@ retry 5 patch_kubermatic_domain
 echodate "Kubermatic ingress domain patched."
 
 echodate "Running tests..."
-go test --tags="$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy -v \
+go test -tags "$KUBERMATIC_EDITION,e2e" -v ./pkg/test/e2e/expose-strategy \
+  -ginkgo.v \
   -kubeconfig "$HOME/.kube/config" \
   -kubernetes-version "$USER_CLUSTER_KUBERNETES_VERSION" \
   -datacenter byo-kubernetes \

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -23,11 +23,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-function generate_secret {
-  cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
-  echo ''
-}
-
 # We replace the domain with a dns name relying on nip.io poining to the
 # nodeport-proxy service. This makes the testing of expose strategies relying
 # on nodeport-proxy very easy from within the kind cluster.
@@ -92,23 +87,19 @@ rm _build/kubermatic-installer
 make _build/kubermatic-installer
 
 # setup Kind cluster
-time retry 5 kind create cluster --name="${KIND_CLUSTER_NAME}"
+time kind create cluster --name="${KIND_CLUSTER_NAME}"
 kind export kubeconfig --name=${KIND_CLUSTER_NAME}
 
 # load nodeport-proxy image
-time retry 5 kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "${KIND_CLUSTER_NAME}"
-time retry 5 kind load docker-image "${DOCKER_REPO}/addons:${TAG}" --name "${KIND_CLUSTER_NAME}"
-time retry 5 kind load docker-image "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${TAG}" --name "${KIND_CLUSTER_NAME}"
-time retry 5 kind load docker-image "${DOCKER_REPO}/kubeletdnat-controller:${TAG}" --name "${KIND_CLUSTER_NAME}"
-time retry 5 kind load docker-image "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/addons:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/kubeletdnat-controller:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/user-ssh-keys-agent:${TAG}" --name "${KIND_CLUSTER_NAME}"
 
 # This is just used as a const
 # NB: The CE requires Seeds to be named this way
 export SEED_NAME=kubermatic
-
-# Tell the conformance tester what dummy account we configure for the e2e tests.
-export KUBERMATIC_OIDC_LOGIN="roxy@kubermatic.com"
-export KUBERMATIC_OIDC_PASSWORD="password"
 
 # Build binaries and load the Docker images into the kind cluster
 echodate "Building binaries for ${TAG}"
@@ -131,27 +122,13 @@ spec:
   ingress:
     domain: 127.0.0.1.nip.io
     disable: true
-  userCluster:
-    apiserverReplicas: 1
-  api:
-    replicas: 0
-    debugLog: true
   featureGates:
     TunnelingExposeStrategy: true
-  ui:
-    replicas: 0
-  # Dex integration
-  auth:
-    #tokenIssuer: "http://dex.oauth:5556/dex"
-    #issuerRedirectURL: "http://localhost:8000"
-    tokenIssuer: "https://127.0.0.1.nip.io/dex"
-    serviceAccountKey: "$(generate_secret)"
+    HeadlessInstallation: true
 EOF
 
 HELM_VALUES_FILE="${TMPDIR}/values.yaml"
 cat << EOF > ${HELM_VALUES_FILE}
-dex:
-  replicas: 0
 kubermaticOperator:
   image:
     repository: "quay.io/kubermatic/kubermatic${REPOSUFFIX}"
@@ -170,7 +147,7 @@ set_crds_version_annotation
   --helm-values "${HELM_VALUES_FILE}"
 
 # TODO: The installer should wait for everything to finish reconciling.
-#echodate "Waiting for Kubermatic Operator to deploy Master components..."
+echodate "Waiting for Kubermatic Operator to deploy Master components..."
 # sleep a bit to prevent us from checking the Deployments too early, before
 # the operator had time to reconcile
 sleep 5
@@ -203,7 +180,6 @@ spec:
   location: Hamburg
   kubeconfig:
     name: "${SEED_NAME}-kubeconfig"
-    namespace: kubermatic
     fieldPath: kubeconfig
   datacenters:
     byo-kubernetes:

--- a/pkg/test/e2e/expose-strategy/cluster.go
+++ b/pkg/test/e2e/expose-strategy/cluster.go
@@ -147,6 +147,8 @@ func (c *ClusterJig) CleanUp(ctx context.Context) error {
 }
 
 func (c *ClusterJig) waitForClusterControlPlaneReady(cl *kubermaticv1.Cluster) error {
+	c.Log.Debugw("Waiting for control plane to be ready...", "timeout", clusterReadinessTimeout)
+
 	return wait.PollImmediate(clusterReadinessCheckPeriod, clusterReadinessTimeout, func() (bool, error) {
 		if err := c.Client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: c.Name, Namespace: cl.Namespace}, cl); err != nil {
 			return false, err


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR makes use of the `HeadlessInstallation` feature gate for this e2e test. Since the user-ssh-key-agent is already disabled in the ClusterSpec, we don't need to build it. And I switched from CE to EE in the hopes that the gocache will then actually be used (it is :-) )

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
