### PR TITLE
Define ClusterRole for Kubermatic API

### DIFF
--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -134,6 +134,7 @@ func main() {
 	// We use the manager only to get a lister-backed ctrlruntimeclient.Client. We can not use it for most
 	// other actions, because it doesn't support impersonation (and can't be changed to do that as that would mean it has to replicate the apiservers RBAC for the lister)
 	mgr, err := manager.New(masterCfg, manager.Options{
+		Namespace: options.namespace,
 		BaseContext: func() context.Context {
 			return ctx
 		},

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -235,6 +235,7 @@ func (r *Reconciler) reconcileServiceAccounts(ctx context.Context, config *kuber
 
 	creators := []reconciling.NamedServiceAccountCreatorGetter{
 		kubermatic.ServiceAccountCreator(config),
+		kubermatic.APIServiceAccountCreator(),
 		common.WebhookServiceAccountCreator(config),
 	}
 
@@ -250,6 +251,7 @@ func (r *Reconciler) reconcileRoles(ctx context.Context, config *kubermaticv1.Ku
 
 	creators := []reconciling.NamedRoleCreatorGetter{
 		common.WebhookRoleCreator(config),
+		kubermatic.APIRoleCreator(),
 	}
 
 	if err := reconciling.ReconcileRoles(ctx, creators, config.Namespace, r.Client); err != nil {
@@ -264,6 +266,7 @@ func (r *Reconciler) reconcileRoleBindings(ctx context.Context, config *kubermat
 
 	creators := []reconciling.NamedRoleBindingCreatorGetter{
 		common.WebhookRoleBindingCreator(config),
+		kubermatic.APIRoleBindingCreator(),
 	}
 
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, config.Namespace, r.Client); err != nil {

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -277,6 +277,7 @@ func (r *Reconciler) reconcileClusterRoles(ctx context.Context, config *kubermat
 	logger.Debug("Reconciling ClusterRoles")
 
 	creators := []reconciling.NamedClusterRoleCreatorGetter{
+		kubermatic.APIClusterRoleCreator(config),
 		common.WebhookClusterRoleCreator(config),
 	}
 
@@ -292,6 +293,7 @@ func (r *Reconciler) reconcileClusterRoleBindings(ctx context.Context, config *k
 
 	creators := []reconciling.NamedClusterRoleBindingCreatorGetter{
 		kubermatic.ClusterRoleBindingCreator(config),
+		kubermatic.APIClusterRoleBindingCreator(config),
 		common.WebhookClusterRoleBindingCreator(config),
 	}
 

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -36,6 +37,56 @@ import (
 func apiPodLabels() map[string]string {
 	return map[string]string{
 		common.NameLabel: APIDeploymentName,
+	}
+}
+
+func APIClusterRoleName(cfg *kubermaticv1.KubermaticConfiguration) string {
+	return fmt.Sprintf("%s:%s-api", cfg.Namespace, cfg.Name)
+}
+
+func APIClusterRoleCreator(cfg *kubermaticv1.KubermaticConfiguration) reconciling.NamedClusterRoleCreatorGetter {
+	name := APIClusterRoleName(cfg)
+
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return name, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			}
+
+			return cr, nil
+		}
+	}
+}
+
+func APIClusterRoleBindingName(cfg *kubermaticv1.KubermaticConfiguration) string {
+	return fmt.Sprintf("%s:%s-api", cfg.Namespace, cfg.Name)
+}
+
+func APIClusterRoleBindingCreator(cfg *kubermaticv1.KubermaticConfiguration) reconciling.NamedClusterRoleBindingCreatorGetter {
+	name := APIClusterRoleBindingName(cfg)
+
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return name, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			}
+
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      apiServiceAccountName,
+					Namespace: cfg.Namespace,
+				},
+			}
+
+			return crb, nil
+		}
 	}
 }
 
@@ -69,7 +120,7 @@ func APIDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, workerName 
 				"fluentbit.io/parser":  "json_iso",
 			}
 
-			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+			d.Spec.Template.Spec.ServiceAccountName = apiServiceAccountName
 
 			volumes := []corev1.Volume{
 				{

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	serviceAccountName    = "kubermatic-master"
+	apiServiceAccountName = "kubermatic-api"
 	uiConfigConfigMapName = "ui-config"
 	ingressName           = "kubermatic"
 	APIDeploymentName     = "kubermatic-api"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In #10087 I tried to give the KKP operator fewer permissions than cluster-admin, but since other KKP components are still using cluster-admin and the operator has to grant these permissions to them, it itself also needed to be cluster-admin. So for now I gave up on #10087.

Instead, this PR introduces dedicated permissions for the KKP API (because I thought this component will be relatively easy). As it turns out, the API uses impersonation for really 99% of all things, so the ClusterRole is kinda small and still allows the API to "escape" its own role and assume some other. All the e2e tests pass and there are no additional errors being logged, so I think this should be good to go.

Future PRs will add RBAC for the master/seed ctrl managers as well.

**Special notes for your reviewer**:
In the `main.go`, we restrict the manager to the current namespace, because otherwise controller-runtime would watch all resources cluster-wide (i.e. the permission to get/list/watch secrets would need to be given cluster-wide).

**Does this PR introduce a user-facing change?**:
```release-note
The KKP API does not use `cluster-admin` permissions anymore.
```
