### PR TITLE
fix panic in installer

### DIFF
--- a/pkg/install/util/crd.go
+++ b/pkg/install/util/crd.go
@@ -48,6 +48,9 @@ func DeployCRDs(ctx context.Context, kubeClient ctrlruntimeclient.Client, log lo
 			// can react to the changed CRDs (the seed-operator will do the same when
 			// updating CRDs on seed clusters)
 			annotations := crd.GetAnnotations()
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
 			annotations[resources.VersionLabel] = versions.KubermaticCommit
 			crd.SetAnnotations(annotations)
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This prevents the installer from panicing when installing the OSM CRDs, which do not come with annotations already.

```
panic: assignment to entry in nil map

goroutine 1 [running]:
k8c.io/kubermatic/v2/pkg/install/util.DeployCRDs({0x1b4d170, 0xc00012a000}, {0x1b51b40, 0xc0006e92c0}, {0x1b55930, 0xc00047c690}, {0xc000612720?, 0x520580?}, 0xc00080d2c8)
        k8c.io/kubermatic/v2/pkg/install/util/crd.go:51 +0x34b
k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master.(*MasterStack).InstallKubermaticCRDs(0xc00047c540, {0x1b4d170, 0xc00012a000}, {_, _}, {_, _}, {{0x1b508d8, 0xc000689180}, 0xc00000e6d8, ...})
        k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master/stack.go:280 +0x17b
k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master.(*MasterStack).deployKubermaticOperator(0x1b4d170?, {0x1b4d170, 0xc00012a000}, _, {_, _}, {_, _}, {{0x1b508d8, 0xc000689180}, ...})
        k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master/stack.go:243 +0x24f
k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master.(*MasterStack).Deploy(0x8?, {0x1b4d170, 0xc00012a000}, {{0x1b508d8, 0xc000689180}, 0xc00000e6d8, {0x1b51b40, 0xc0006e92c0}, {0x7ffe8246605f, 0xc}, ...})
        k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master/stack.go:101 +0x3c5
main.DeployFunc.func1(0xc00076fc68?, {0xc0003546c0, 0x0, 0xc00076fc68?})
        k8c.io/kubermatic/v2/cmd/kubermatic-installer/cmd_deploy.go:304 +0x128d
main.handleErrors.func1(0xc0000eac80?, {0xc0003546c0?, 0x6?, 0x6?})
        k8c.io/kubermatic/v2/cmd/kubermatic-installer/shared.go:39 +0x30
github.com/spf13/cobra.(*Command).execute(0xc0000eac80, {0xc000354660, 0x6, 0x6})
        github.com/spf13/cobra@v1.4.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000ea780)
        github.com/spf13/cobra@v1.4.0/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.4.0/command.go:902
main.main()
        k8c.io/kubermatic/v2/cmd/kubermatic-installer/main.go:87 +0x32f
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
