### PR TITLE
Fix KubeVirt e2e tests Image Http Server

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -35,12 +35,12 @@ import (
 )
 
 const (
-	kubevirtRegistryAddr  = "http://10.244.1.19"
-	kubevirtCPUs          = "2"
-	kubevirtMemory        = "4Gi"
-	kubevirtDiskSize      = "25Gi"
-	kubevirtDiskClassName = "longhorn"
-	kubevirtDatacenter    = "kubevirt-europe-west3-c"
+	kubevirtImageHttpServerSvc = "http://image-repo.kube-system.svc.cluster.local/images"
+	kubevirtCPUs               = "2"
+	kubevirtMemory             = "4Gi"
+	kubevirtDiskSize           = "25Gi"
+	kubevirtDiskClassName      = "longhorn"
+	kubevirtDatacenter         = "kubevirt-europe-west3-c"
 )
 
 // GetKubevirtScenarios Returns a matrix of (version x operating system).
@@ -173,9 +173,9 @@ func (s *kubevirtScenario) getOSImage() (string, error) {
 
 	switch {
 	case os == providerconfig.OperatingSystemUbuntu:
-		return kubevirtRegistryAddr + "/ubuntu.img", nil
+		return kubevirtImageHttpServerSvc + "/ubuntu.img", nil
 	case os == providerconfig.OperatingSystemCentOS:
-		return kubevirtRegistryAddr + "/centos.img", nil
+		return kubevirtImageHttpServerSvc + "/centos.img", nil
 	default:
 		return "", fmt.Errorf("unsupported OS %q selected", os)
 	}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What does this PR do / Why do we need it**:
- Created a service for os images instead of Pod Ip (subject to changes)
- OS images are now in /usr/share/nginx/html/images (mounted from a PVC), so not lost when the pod is restarted.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
