### PR TITLE
use the new web-terminal Docker image

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -18,18 +18,14 @@ LABEL maintainer="support@kubermatic.com"
 ENV KUBECTL_VERSION=v1.22.9 \
     HELM_VERSION=v3.9.0
 
-
 RUN apk add --no-cache -U \
     bash \
     ca-certificates \
     curl \
     git \
-    ipvsadm \
     jq \
     make \
     openssh-client \
-    rsync \
-    socat \
     unzip \
     tar
 

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.1.0
+VERSION=0.2.0
 SUFFIX=""
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}${SUFFIX}" .

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-web-terminal.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/kubernetes/kubeconfig/kubeconfig
         - name: PS1
           value: '\$ '
-        image: quay.io/kubermatic/util:2.1.0
+        image: quay.io/kubermatic/web-terminal:0.2.0
         name: web-terminal
         resources:
           limits:

--- a/pkg/resources/web-terminal/deployment.go
+++ b/pkg/resources/web-terminal/deployment.go
@@ -88,7 +88,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/util:2.1.0",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/web-terminal:0.2.0",
 					Command: []string{"/bin/bash", "-c", "--"},
 					Args:    []string{"while true; do sleep 30; done;"},
 					Env: []corev1.EnvVar{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This makes sure that we actually use the new image for our web terminal. It also removes some tools which I find questionable, like socat or rsync, for a simple web terminal.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
