### PR TITLE
log cluster ID instead of human readable name

### DIFF
--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -320,21 +320,22 @@ func (r *reconciler) syncAllClustersNS(
 	actionFunc func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint, namespace string) error,
 ) error {
 	for _, userCluster := range clusterList {
-		clusterName := userCluster.Spec.HumanReadableName
+		clusterName := userCluster.Name
+		clusterLog := log.With("cluster", clusterName)
 
 		// cluster Validation
 		if userCluster.Spec.Pause {
-			log.Debugw("Cluster paused, skipping", "cluster", clusterName)
+			clusterLog.Debugw("Cluster paused, skipping")
 			continue
 		}
 
 		if userCluster.Status.NamespaceName == "" {
-			log.Debugw("Cluster has no namespace name yet, skipping", "cluster", clusterName)
+			clusterLog.Debugw("Cluster has no namespace name yet, skipping")
 			continue
 		}
 
 		if !userCluster.DeletionTimestamp.IsZero() {
-			log.Debugw("Cluster deletion in progress, skipping", "cluster", clusterName)
+			clusterLog.Debugw("Cluster deletion in progress, skipping")
 			continue
 		}
 
@@ -343,9 +344,9 @@ func (r *reconciler) syncAllClustersNS(
 				return fmt.Errorf("failed syncing constraint for cluster %s namespace: %w", clusterName, err)
 			}
 
-			log.Debugw("Reconciled constraint with cluster", "cluster", clusterName)
+			clusterLog.Debugw("Reconciled constraint with cluster")
 		} else {
-			log.Debugw("Cluster does not integrate with OPA, skipping", "cluster", clusterName)
+			clusterLog.Debugw("Cluster does not integrate with OPA, skipping")
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
All controllers in KKP log the cluster ID (name). This one controller used the human readable name for no good reason, so let's change it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
