### PR TITLE
Add a flag -o/--output to kubermatic-installer to allow json output

### DIFF
--- a/cmd/kubermatic-installer/main.go
+++ b/cmd/kubermatic-installer/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -30,6 +31,7 @@ import (
 
 type Options struct {
 	Verbose         bool
+	LogFormat       log.LogrusFormat
 	ChartsDirectory string
 }
 
@@ -63,6 +65,13 @@ func main() {
 			if options.Verbose {
 				logger.SetLevel(logrus.DebugLevel)
 			}
+
+			switch options.LogFormat {
+			case log.LogrusFormatJSON:
+				logger.SetFormatter(&logrus.JSONFormatter{})
+			case "", log.LogrusFormatConsole:
+				logger.SetFormatter(&logrus.TextFormatter{})
+			}
 		},
 	}
 
@@ -80,6 +89,7 @@ func main() {
 	})
 
 	rootCmd.PersistentFlags().BoolVarP(&options.Verbose, "verbose", "v", options.Verbose, "enable more verbose output")
+	rootCmd.PersistentFlags().VarP(&options.LogFormat, "output", "o", fmt.Sprintf("write logs in a specific output format. supported formats: %s", log.AvailableLogrusFormats.String()))
 	rootCmd.PersistentFlags().StringVar(&options.ChartsDirectory, "charts-directory", "", "filesystem path to the Kubermatic Helm charts (defaults to charts/)")
 
 	addCommands(rootCmd, logger, versions)

--- a/pkg/log/logrus.go
+++ b/pkg/log/logrus.go
@@ -18,6 +18,8 @@ package log
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -68,4 +70,59 @@ func Prefix(e *logrus.Entry, prefix string) *logrus.Entry {
 	ctx := context.WithValue(parentCtx, prefixKey, prefix)
 
 	return e.WithContext(ctx)
+}
+
+type LogrusFormat string
+
+// Type implements the pflag.Value interfaces.
+func (f *LogrusFormat) Type() string {
+	return "string"
+}
+
+// String implements the cli.Value and flag.Value interfaces.
+func (f *LogrusFormat) String() string {
+	return string(*f)
+}
+
+// Set implements the cli.Value and flag.Value interfaces.
+func (f *LogrusFormat) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "json":
+		*f = LogrusFormatJSON
+		return nil
+	case "console":
+		*f = LogrusFormatConsole
+		return nil
+	default:
+		return fmt.Errorf("invalid format '%s'", s)
+	}
+}
+
+type LogrusFormats []LogrusFormat
+
+const (
+	LogrusFormatJSON    LogrusFormat = "json"
+	LogrusFormatConsole LogrusFormat = "console"
+)
+
+var (
+	AvailableLogrusFormats = LogrusFormats{LogrusFormatJSON, LogrusFormatConsole}
+)
+
+func (f LogrusFormats) String() string {
+	const separator = ", "
+	var s string
+	for _, format := range f {
+		s = s + separator + string(format)
+	}
+	return strings.TrimPrefix(s, separator)
+}
+
+func (f LogrusFormats) Contains(s LogrusFormat) bool {
+	for _, format := range f {
+		if s == format {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/log/logrus.go
+++ b/pkg/log/logrus.go
@@ -117,12 +117,3 @@ func (f LogrusFormats) String() string {
 	}
 	return strings.TrimPrefix(s, separator)
 }
-
-func (f LogrusFormats) Contains(s LogrusFormat) bool {
-	for _, format := range f {
-		if s == format {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Not sure if we want to merge this, but I thought it would be neat to have the option for json log formatting in `kubermatic-installer`. The default of course stays with the nice formatter that logrus uses for human readability (filled under "console" in this new flag), but an `--output` (or shorthand `-o`) flag will allow to get json output if that is wanted (I can see this being useful with the upcoming `mirror-images` subcommand, for example).

This is what it would look like, as an example for an early failure on deploying:

```sh
$ ./_build/kubermatic-installer deploy
INFO[0000] 🚀 Initializing installer…                     edition="Enterprise Edition" version=2a9ece9131272f12e01b6331769fdd301239230d
ERRO[0000] ❌ Operation failed: no kubeconfig (--kubeconfig or $KUBECONFIG) given.

$  ./_build/kubermatic-installer deploy -o json
{"edition":1,"level":"info","msg":"🚀 Initializing installer…","time":"2022-06-21T17:00:30+02:00","version":"2a9ece9131272f12e01b6331769fdd301239230d"}
{"level":"error","msg":"❌ Operation failed: no kubeconfig (--kubeconfig or $KUBECONFIG) given.","time":"2022-06-21T17:00:30+02:00"}
```

WDYT?

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`kubermatic-installer` output can be formatted as json via a new `--output` flag
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>