### PR TITLE
fix ResourceQuota namespace not being properly set in reconcile

### DIFF
--- a/pkg/ee/resource-quota/resource-quota-syncer/syncer.go
+++ b/pkg/ee/resource-quota/resource-quota-syncer/syncer.go
@@ -55,7 +55,6 @@ const (
 type reconciler struct {
 	log          *zap.SugaredLogger
 	masterClient ctrlruntimeclient.Client
-	namespace    string
 	seedClients  map[string]ctrlruntimeclient.Client
 	recorder     record.EventRecorder
 }
@@ -96,7 +95,6 @@ func resourceQuotaCreatorGetter(rq *kubermaticv1.ResourceQuota) reconciling.Name
 	return func() (string, reconciling.KubermaticV1ResourceQuotaCreator) {
 		return rq.Name, func(c *kubermaticv1.ResourceQuota) (*kubermaticv1.ResourceQuota, error) {
 			c.Name = rq.Name
-			c.Namespace = kubermaticresources.KubermaticNamespace
 			c.Spec = rq.Spec
 			c.Status.GlobalUsage = rq.Status.GlobalUsage
 			return c, nil
@@ -155,7 +153,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	return r.syncAllSeeds(log, resourceQuota, func(seedClient ctrlruntimeclient.Client, resourceQuota *kubermaticv1.ResourceQuota) error {
-		return reconciling.ReconcileKubermaticV1ResourceQuotas(ctx, resourceQuotaCreatorGetters, r.namespace, seedClient)
+		return reconciling.ReconcileKubermaticV1ResourceQuotas(ctx, resourceQuotaCreatorGetters, kubermaticresources.KubermaticNamespace, seedClient)
 	})
 }
 

--- a/pkg/ee/resource-quota/resource-quota-syncer/syncer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-syncer/syncer_test.go
@@ -34,6 +34,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -102,7 +103,7 @@ func TestReconcile(t *testing.T) {
 				seedClients:  map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
 			}
 
-			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName, Namespace: kubermaticresources.KubermaticNamespace}}
 			if _, err := r.Reconcile(ctx, request); err != nil {
 				t.Fatalf("reconciling failed: %v", err)
 			}
@@ -150,6 +151,7 @@ func genResourceQuota(name string, deleted bool) *kubermaticv1.ResourceQuota {
 
 	rq := &kubermaticv1.ResourceQuota{}
 	rq.Name = name
+	rq.Namespace = kubermaticresources.KubermaticNamespace
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{
 			Name: "project1",


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fixes issue where synced ResourceQuota didnt have the namespace properly set.


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
