### PR TITLE
Improve etcd backup filenames

### DIFF
--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -422,7 +422,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		backupConfig.Status.CurrentBackups = []kubermaticv1.BackupStatus{{}}
 		backupToSchedule = &backupConfig.Status.CurrentBackups[0]
 		backupToSchedule.ScheduledTime = metav1.NewTime(r.clock.Now())
-		backupToSchedule.BackupName = backupConfig.Name
+		backupToSchedule.BackupName = fmt.Sprintf("%s.db", backupConfig.Name)
 		requeueAfter = 0
 	} else {
 		// compute the pending (i.e. latest past) and the next (i.e. earliest future) backup time,
@@ -455,7 +455,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		backupConfig.Status.CurrentBackups = append(backupConfig.Status.CurrentBackups, kubermaticv1.BackupStatus{})
 		backupToSchedule = &backupConfig.Status.CurrentBackups[len(backupConfig.Status.CurrentBackups)-1]
 		backupToSchedule.ScheduledTime = metav1.NewTime(pendingBackupTime)
-		backupToSchedule.BackupName = fmt.Sprintf("%s-%s", backupConfig.Name, backupToSchedule.ScheduledTime.UTC().Format("2006-01-02t15-04-05"))
+		backupToSchedule.BackupName = fmt.Sprintf("%s-%s.db", backupConfig.Name, backupToSchedule.ScheduledTime.UTC().Format("2006-01-02t15-04-05"))
 		requeueAfter = nextBackupTime.Sub(now)
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -260,7 +260,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(10, 0).UTC()),
-					BackupName:    "testbackup",
+					BackupName:    "testbackup.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -277,7 +277,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(100, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-40",
+					BackupName:    "testbackup-1970-01-01t00-01-40.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -285,7 +285,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(100, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-40",
+					BackupName:    "testbackup-1970-01-01t00-01-40.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -327,7 +327,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -335,7 +335,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -353,7 +353,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -361,13 +361,13 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(1200, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-20-00",
+					BackupName:    "testbackup-1970-01-01t00-20-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -386,7 +386,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(3600*24*15, 0).UTC()),
-					BackupName:    "testbackup-1970-01-16t00-00-00",
+					BackupName:    "testbackup-1970-01-16t00-00-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -405,7 +405,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(10, 0).UTC()),
-					BackupName:    "long-backup-config-name-abcdefghijk",
+					BackupName:    "long-backup-config-name-abcdefghijk.db",
 					JobName:       "testcluster-backup-long-backup-config-name-abcdefghijk-creaxxxx",
 					DeleteJobName: "testcluster-backup-long-backup-config-name-abcdefghijk-delexxxx",
 				},
@@ -485,13 +485,13 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-bbbb",
 					DeleteJobName: "testcluster-backup-testbackup-delete-bbbb",
 				},
@@ -500,14 +500,14 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-bbbb",
 					DeleteJobName: "testcluster-backup-testbackup-delete-bbbb",
 				},
@@ -523,21 +523,21 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(70, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-10",
+					BackupName:    "testbackup-1970-01-01t00-01-10.db",
 					JobName:       "testcluster-backup-testbackup-create-bbbb",
 					DeleteJobName: "testcluster-backup-testbackup-delete-bbbb",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -551,7 +551,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -560,7 +560,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(70, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-10",
+					BackupName:         "testbackup-1970-01-01t00-01-10.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(80, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -569,7 +569,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -588,7 +588,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
@@ -600,7 +600,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
@@ -691,7 +691,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -700,7 +700,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -709,7 +709,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-03-00",
+					BackupName:    "testbackup-1970-01-01t00-03-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -718,7 +718,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -728,7 +728,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -737,7 +737,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-03-00",
+					BackupName:    "testbackup-1970-01-01t00-03-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -754,7 +754,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -766,7 +766,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -787,7 +787,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -797,7 +797,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -806,7 +806,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -818,7 +818,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -828,7 +828,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -838,7 +838,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -858,7 +858,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -874,7 +874,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				// unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -895,7 +895,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				return kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-testbackup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(90+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -907,7 +907,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				result := kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-testbackup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(90+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1004,7 +1004,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// 3 backups with deletions marked as running, a 4th backup is only scheduled
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1014,7 +1014,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1024,7 +1024,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1034,7 +1034,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -1051,7 +1051,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// result: 1st backup's deletion marked as completed, 2nd one's restarted, 3rd and 4th unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1063,7 +1063,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1074,7 +1074,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1084,7 +1084,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -1098,7 +1098,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// 2 backups with deletions marked as running
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1108,7 +1108,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1128,7 +1128,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// result: both backups' deletions marked as completed, and we reconcile after the retention period
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1140,7 +1140,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1159,7 +1159,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 			existingBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				return kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(150+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1177,7 +1177,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 			expectedBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				result := kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(150+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1267,7 +1267,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// 2 backups with backup jobs marked as completed
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1276,7 +1276,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1288,7 +1288,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// (just so we can test them with the same current time)
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(80, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1300,7 +1300,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-dddd",
 					BackupFinishedTime: metav1.NewTime(time.Unix(140, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1328,7 +1328,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1337,7 +1337,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1346,7 +1346,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-dddd",
 					BackupFinishedTime: metav1.NewTime(time.Unix(140, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1372,7 +1372,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// 2 backups with backup jobs marked as failed
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1381,7 +1381,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1401,7 +1401,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// backups unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1410,7 +1410,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1431,7 +1431,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// one backup with deletion marked as completed, one with deletion marked as running, a 3rd backup is only scheduled
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1443,7 +1443,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1453,7 +1453,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -1470,7 +1470,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// result: 1st backup's job and status entry are deleted, other two unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1480,7 +1480,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},

--- a/pkg/storeuploader/storeuploader.go
+++ b/pkg/storeuploader/storeuploader.go
@@ -93,14 +93,14 @@ func (u *StoreUploader) Store(ctx context.Context, file, bucket, prefix string, 
 			return err
 		}
 		if !exists {
-			logger.Infow("Creating bucket")
+			logger.Info("Creating bucket")
 			if err := u.client.MakeBucket(ctx, bucket, minio.MakeBucketOptions{}); err != nil {
 				return err
 			}
 		}
 	}
 
-	objectName := fmt.Sprintf("%s-%s-%s-%s", prefix, prefixSeparator, time.Now().Format("2006-01-02T15:04:05"), path.Base(file))
+	objectName := fmt.Sprintf("%s-%s-%s-%s", prefix, prefixSeparator, time.Now().Format("2006-01-02T150405"), path.Base(file))
 	logger.Infow("Uploading file", "src", file, "dst", objectName)
 
 	_, err := u.client.FPutObject(ctx, bucket, objectName, file, minio.PutObjectOptions{})


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Not all S3 backends can handle files with colons (:) in them, apparently. Also it's hard to use the files because no file extension is present and you're not even sure if it's a tar.gz of the etcd or not.

This PR addresses both points. Existing backups should be untouched, but new ones should be more compatible.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #7337

**Does this PR introduce a user-facing change?**:
```release-note
etcd backup files are named differently (`foo-YYYY-MM-DDThh:mm:ss` to `foo-YYYY-MM-DDThhmmss.db`) to improve compatibility with different storage solutions
```
