### PR TITLE
mark Packet as a reconciling cloud provider

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	packetInstanceType = "c3.small.x86"
+	packetInstanceType = "m3.small.x86"
 )
 
 // GetPacketScenarios returns a matrix of (version x operating system).

--- a/pkg/provider/cloud/packet/provider.go
+++ b/pkg/provider/cloud/packet/provider.go
@@ -71,10 +71,9 @@ func (p *packet) InitializeCloudProvider(ctx context.Context, cluster *kubermati
 	return cluster, nil
 }
 
-// TODO: Hey, you! Yes, you! Why don't you implement reconciling for Packet? Would be really cool :)
-// func (p *packet) ReconcileCluster(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-// 	return cluster, nil
-// }
+func (p *packet) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
+	return p.InitializeCloudProvider(ctx, cluster, update)
+}
 
 // CleanUpCloudProvider.
 func (p *packet) CleanUpCloudProvider(_ context.Context, cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
As we do not manage any non-machine resources in Packet, implementing the reconciling was trivial.

Fixes #8146

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
