### PR TITLE
Reduce triggers for CCM migration prow jobs

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   - name: pre-kubermatic-ccm-migration-openstack-e2e
-    run_if_changed: "(pkg/|.prow/)"
+    run_if_changed: "(pkg/provider/cloud/openstack/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/|.prow/ccm-migrations.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -56,6 +56,7 @@ presubmits:
 
   - name: pre-kubermatic-ccm-migration-vsphere-e2e
     run_if_changed: "(pkg/|.prow/)"
+    run_if_changed: "(pkg/provider/cloud/vsphere/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/|.prow/ccm-migrations.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -96,7 +97,7 @@ presubmits:
               memory: 4Gi
 
   - name: pre-kubermatic-ccm-migration-azure-e2e
-    run_if_changed: "(addons/azure-cloud-node-manager/|pkg/provider/cloud/azure/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/)"
+    run_if_changed: "(addons/azure-cloud-node-manager/|pkg/provider/cloud/azure/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/|.prow/ccm-migrations.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We're running CCM migrations for OpenStack and vSphere on every single code change. That seems a little excessive, plus it triggers docker pull limits on vSphere quite fast.

This PR sets up some `run_if` rules that match what I did for the Azure CCM migration before.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
