### PR TITLE
Resource quota calculation controllers

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -74,6 +74,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	applicationSecretSynchronizerFactor := applicationSecretSynchronizerFactoryCreator(ctrlCtx)
 	presetSynchronizerFactory := presetSynchronizerFactoryCreator(ctrlCtx)
 	resourceQuotaSynchronizerFactory := resourceQuotaSynchronizerFactoryCreator(ctrlCtx)
+	resourceQuotaControllerFactory := resourceQuotaControllerFactoryCreator(ctrlCtx)
 
 	if err := seedcontrollerlifecycle.Add(ctrlCtx.ctx,
 		ctrlCtx.log,
@@ -93,6 +94,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 		applicationSecretSynchronizerFactor,
 		presetSynchronizerFactory,
 		resourceQuotaSynchronizerFactory,
+		resourceQuotaControllerFactory,
 	); err != nil {
 		//TODO: Find a better name
 		return fmt.Errorf("failed to create seedcontrollerlifecycle: %w", err)

--- a/cmd/master-controller-manager/wrappers_ce.go
+++ b/cmd/master-controller-manager/wrappers_ce.go
@@ -51,3 +51,9 @@ func resourceQuotaSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcon
 		return "", nil
 	}
 }
+
+func resourceQuotaControllerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+	return func(_ context.Context, _ manager.Manager, _ map[string]manager.Manager) (string, error) {
+		return "", nil
+	}
+}

--- a/cmd/master-controller-manager/wrappers_ee.go
+++ b/cmd/master-controller-manager/wrappers_ee.go
@@ -26,6 +26,7 @@ import (
 	seedcontrollerlifecycle "k8c.io/kubermatic/v2/pkg/controller/shared/seed-controller-lifecycle"
 	allowedregistrycontroller "k8c.io/kubermatic/v2/pkg/ee/allowed-registry-controller"
 	eemasterctrlmgr "k8c.io/kubermatic/v2/pkg/ee/cmd/master-controller-manager"
+	resourcequotamastercontroller "k8c.io/kubermatic/v2/pkg/ee/resource-quota/master-controller"
 	resourcequotasyncer "k8c.io/kubermatic/v2/pkg/ee/resource-quota/resource-quota-syncer"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
@@ -59,6 +60,17 @@ func resourceQuotaSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcon
 			masterMgr,
 			seedManagerMap,
 			ctrlCtx.log,
+		)
+	}
+}
+
+func resourceQuotaControllerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+	return func(ctx context.Context, masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+		return resourcequotamastercontroller.ControllerName, resourcequotamastercontroller.Add(
+			masterMgr,
+			seedManagerMap,
+			ctrlCtx.log,
+			ctrlCtx.workerCount,
 		)
 	}
 }

--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -85,6 +85,11 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 			return fmt.Errorf("failed to create %q controller: %w", name, err)
 		}
 	}
+
+	// init CE/EE-only controllers
+	if err := setupControllers(ctrlCtx); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/seed-controller-manager/wrappers_ce.go
+++ b/cmd/seed-controller-manager/wrappers_ce.go
@@ -34,3 +34,8 @@ func addFlags(fs *flag.FlagSet) {
 func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Reader, options controllerRunOptions) (provider.SeedGetter, error) {
 	return provider.SeedGetterFactory(ctx, client, options.seedName, options.namespace)
 }
+
+func setupControllers(_ *controllerContext) error {
+	// NOP, no CE-only controllers exist
+	return nil
+}

--- a/cmd/seed-controller-manager/wrappers_ee.go
+++ b/cmd/seed-controller-manager/wrappers_ee.go
@@ -21,8 +21,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	eeseedctrlmgr "k8c.io/kubermatic/v2/pkg/ee/cmd/seed-controller-manager"
+	resourcequotaseedcontroller "k8c.io/kubermatic/v2/pkg/ee/resource-quota/seed-controller"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,4 +36,12 @@ func addFlags(fs *flag.FlagSet) {
 
 func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Reader, options controllerRunOptions) (provider.SeedGetter, error) {
 	return eeseedctrlmgr.SeedGetterFactory(ctx, client, options.seedName, options.namespace)
+}
+
+func setupControllers(ctrlCtx *controllerContext) error {
+	if err := resourcequotaseedcontroller.Add(ctrlCtx.mgr, ctrlCtx.log, ctrlCtx.runOptions.workerName, ctrlCtx.runOptions.workerCount); err != nil {
+		return fmt.Errorf("failed to create resource quota controller: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -126,7 +126,7 @@ func (r *reconciler) reconcile(ctx context.Context, resourceQuota *kubermaticv1.
 		err := seedClient.Get(ctx, types.NamespacedName{Namespace: resourceQuota.Namespace, Name: resourceQuota.Name},
 			seedResourceQuota)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			return fmt.Errorf("error getting seed %q resource quota: %w", seed, err)

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -79,10 +79,10 @@ func Add(mgr manager.Manager,
 
 		resourceQuotaSource := &source.Kind{Type: &kubermaticv1.ResourceQuota{}}
 		if err := resourceQuotaSource.InjectCache(mgr.GetCache()); err != nil {
-			return fmt.Errorf("failed to inject cache into resourceQuotaSource for seed %s: %w", seedName, err)
+			return fmt.Errorf("failed to inject cache into resourceQuotaSource for seed %q: %w", seedName, err)
 		}
 		if err := c.Watch(resourceQuotaSource, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(resources.KubermaticNamespace)); err != nil {
-			return fmt.Errorf("failed to establish watch for clusters in seed %s: %w", seedName, err)
+			return fmt.Errorf("failed to establish watch for resource quotas in seed %q: %w", seedName, err)
 		}
 	}
 
@@ -100,7 +100,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get resourceQuota %s: %w", resourceQuota.Name, err)
+		return reconcile.Result{}, fmt.Errorf("failed to get resource quota %q: %w", resourceQuota.Name, err)
 	}
 
 	err := r.reconcile(ctx, resourceQuota, log)

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -1,0 +1,169 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package mastercontroller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const ControllerName = "kkp-master-resource-quota-controller"
+
+type reconciler struct {
+	masterClient ctrlruntimeclient.Client
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	seedClients  map[string]ctrlruntimeclient.Client
+}
+
+func Add(ctx context.Context,
+	mgr manager.Manager,
+	seedManagers map[string]manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+) error {
+	reconciler := &reconciler{
+		log:          log.Named(ControllerName),
+		recorder:     mgr.GetEventRecorderFor(ControllerName),
+		masterClient: mgr.GetClient(),
+		seedClients:  map[string]ctrlruntimeclient.Client{},
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	for seedName, seedManager := range seedManagers {
+		reconciler.seedClients[seedName] = seedManager.GetClient()
+
+		resourceQuotaSource := &source.Kind{Type: &kubermaticv1.ResourceQuota{}}
+		if err := resourceQuotaSource.InjectCache(mgr.GetCache()); err != nil {
+			return fmt.Errorf("failed to inject cache into resourceQuotaSource for seed %s: %w", seedName, err)
+		}
+		if err := c.Watch(resourceQuotaSource, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(resources.KubermaticNamespace)); err != nil {
+			return fmt.Errorf("failed to establish watch for clusters in seed %s: %w", seedName, err)
+		}
+	}
+
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.ResourceQuota{}}, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(resources.KubermaticNamespace)); err != nil {
+		return fmt.Errorf("failed to create watch for resource quota: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile calculates the resource usage for a resource quota and sets the local usage.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+	log.Debug("Reconciling")
+
+	resourceQuota := &kubermaticv1.ResourceQuota{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get resourceQuota %s: %w", resourceQuota.Name, err)
+	}
+
+	err := r.reconcile(ctx, resourceQuota, log)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Eventf(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, resourceQuota *kubermaticv1.ResourceQuota, log *zap.SugaredLogger) error {
+	// skip reconcile if resourceQuota is in delete state
+	if !resourceQuota.DeletionTimestamp.IsZero() {
+		log.Debug("resource quota is in deletion, skipping")
+		return nil
+	}
+
+	// for all related resource quotas on seeds, calculate global usage
+	globalUsage := kubermaticv1.NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
+	for seed, seedClient := range r.seedClients {
+		seedResourceQuota := &kubermaticv1.ResourceQuota{}
+		err := seedClient.Get(ctx, types.NamespacedName{Namespace: resourceQuota.Namespace, Name: resourceQuota.Name},
+			seedResourceQuota)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("error getting seed %q resource quota: %w", seed, err)
+		}
+		globalUsage.CPU.Add(*seedResourceQuota.Status.LocalUsage.CPU)
+		globalUsage.Memory.Add(*seedResourceQuota.Status.LocalUsage.Memory)
+		globalUsage.Storage.Add(*seedResourceQuota.Status.LocalUsage.Storage)
+	}
+
+	if err := r.ensureGlobalUsage(ctx, log, resourceQuota, globalUsage); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *reconciler) ensureGlobalUsage(ctx context.Context, log *zap.SugaredLogger, resourceQuota *kubermaticv1.ResourceQuota,
+	globalUsage *kubermaticv1.ResourceDetails) error {
+	if reflect.DeepEqual(*globalUsage, resourceQuota.Status.LocalUsage) {
+		log.Debugw("global usage is for resource quota is the same, not updating",
+			"cpu", globalUsage.CPU.String(),
+			"memory", globalUsage.Memory.String(),
+			"storage", globalUsage.Storage.String())
+		return nil
+	}
+	log.Debugw("global usage for resource quota needs update",
+		"cpu", globalUsage.CPU.String(),
+		"memory", globalUsage.Memory.String(),
+		"storage", globalUsage.Storage.String())
+
+	oldResourceQuota := resourceQuota.DeepCopy()
+
+	resourceQuota.Status.GlobalUsage = *globalUsage
+	if err := r.masterClient.Patch(ctx, resourceQuota, ctrlruntimeclient.MergeFrom(oldResourceQuota)); err != nil {
+		return fmt.Errorf("failed to patch resource quota %q: %w", resourceQuota.Name, err)
+	}
+
+	return nil
+}

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -57,8 +57,7 @@ type reconciler struct {
 	seedClients  map[string]ctrlruntimeclient.Client
 }
 
-func Add(ctx context.Context,
-	mgr manager.Manager,
+func Add(mgr manager.Manager,
 	seedManagers map[string]manager.Manager,
 	log *zap.SugaredLogger,
 	numWorkers int,

--- a/pkg/ee/resource-quota/master-controller/doc.go
+++ b/pkg/ee/resource-quota/master-controller/doc.go
@@ -1,0 +1,27 @@
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+/*
+Package mastercontroller is responsible for ensuring the calculation of the global resource usage for the resource quotas by listing
+all related resource quotas on seed clusters and adding up their resource usage.
+*/
+package mastercontroller

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -53,7 +53,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var ControllerName = "resource-quota-seed-controller"
+var ControllerName = "kkp-resource-quota-seed-controller"
 
 type reconciler struct {
 	log                     *zap.SugaredLogger
@@ -111,7 +111,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get resourceQuota %s: %w", resourceQuota.Name, ctrlruntimeclient.IgnoreNotFound(err))
+		return reconcile.Result{}, fmt.Errorf("failed to get resourceQuota %s: %w", resourceQuota.Name, err)
 	}
 
 	err := r.reconcile(ctx, resourceQuota, log)
@@ -218,7 +218,6 @@ func enqueueResourceQuota(client ctrlruntimeclient.Client, log *zap.SugaredLogge
 		}
 		subjectNameReq, err := labels.NewRequirement(kubermaticv1.ResourceQuotaSubjectNameLabelKey, selection.Equals, []string{projectId})
 		if err != nil {
-			log.Error(err)
 			utilruntime.HandleError(fmt.Errorf("error creating subject name req: %w", err))
 		}
 
@@ -227,7 +226,6 @@ func enqueueResourceQuota(client ctrlruntimeclient.Client, log *zap.SugaredLogge
 		if err := client.List(context.Background(), resourceQuotaList,
 			&ctrlruntimeclient.ListOptions{Namespace: kubermaticresources.KubermaticNamespace,
 				LabelSelector: labels.NewSelector().Add(*subjectNameReq)}); err != nil {
-			log.Error(err)
 			utilruntime.HandleError(fmt.Errorf("failed to list resourceQuotas: %w", err))
 		}
 

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -1,0 +1,243 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package seedcontroller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	recorder                record.EventRecorder
+	seedClient              ctrlruntimeclient.Client
+}
+
+func withClusterEventFilter() predicate.Predicate {
+	return predicate.Funcs{
+		// when cluster is created, no point to calculate yet as the machines are not created
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, ok := e.ObjectOld.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			newCluster, ok := e.ObjectNew.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			return !reflect.DeepEqual(oldCluster.Status.ResourceUsage, newCluster.Status.ResourceUsage)
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+var ControllerName = "resource-quota-seed-controller"
+
+func Add(ctx context.Context,
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	numWorkers int,
+) error {
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		seedClient:              mgr.GetClient(),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Cluster{}},
+		enqueueResourceQuota(reconciler.seedClient, reconciler.log),
+		workerlabel.Predicates(workerName),
+		withClusterEventFilter(),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for clusters: %w", err)
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.ResourceQuota{}},
+		&handler.EnqueueRequestForObject{},
+		kubermaticpred.ByNamespace(kubermaticresources.KubermaticNamespace),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for seed resource quotas: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile calculates the resource usage for a resource quota and sets the local usage.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+	log.Debug("Reconciling")
+
+	resourceQuota := &kubermaticv1.ResourceQuota{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get resourceQuota %s: %w", resourceQuota.Name, ctrlruntimeclient.IgnoreNotFound(err))
+	}
+
+	err := r.reconcile(ctx, resourceQuota, log)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Eventf(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, resourceQuota *kubermaticv1.ResourceQuota, log *zap.SugaredLogger) error {
+	// skip reconcile if resourceQuota is in delete state
+	if !resourceQuota.DeletionTimestamp.IsZero() {
+		log.Debug("resource quota is in deletion, skipping")
+		return nil
+	}
+
+	projectIdReq, err := labels.NewRequirement(kubermaticv1.ProjectIDLabelKey, selection.Equals, []string{resourceQuota.Spec.Subject.Name})
+	if err != nil {
+		return fmt.Errorf("error creating project id req: %w", err)
+	}
+
+	clusterList := &kubermaticv1.ClusterList{}
+	if err := r.seedClient.List(ctx, clusterList,
+		&ctrlruntimeclient.ListOptions{LabelSelector: r.workerNameLabelSelector.Add(*projectIdReq)}); err != nil {
+		return fmt.Errorf("failed listing clusters: %w", err)
+	}
+
+	localUsage := kubermaticv1.NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
+	for _, cluster := range clusterList.Items {
+		if cluster.Status.ResourceUsage != nil {
+			localUsage.CPU.Add(*cluster.Status.ResourceUsage.CPU)
+			localUsage.Memory.Add(*cluster.Status.ResourceUsage.Memory)
+			localUsage.Storage.Add(*cluster.Status.ResourceUsage.Storage)
+		}
+	}
+
+	if err = r.ensureLocalUsage(ctx, log, resourceQuota, localUsage); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *reconciler) ensureLocalUsage(ctx context.Context, log *zap.SugaredLogger, resourceQuota *kubermaticv1.ResourceQuota,
+	localUsage *kubermaticv1.ResourceDetails) error {
+	if reflect.DeepEqual(localUsage, resourceQuota.Status.LocalUsage) {
+		log.Debugw("local usage is for resource quota is the same, not updating",
+			"cpu", localUsage.CPU.String(),
+			"memory", localUsage.Memory.String(),
+			"storage", localUsage.Storage.String())
+		return nil
+	}
+	log.Debugw("local usage for resource quota needs update",
+		"cpu", localUsage.CPU.String(),
+		"memory", localUsage.Memory.String(),
+		"storage", localUsage.Storage.String())
+
+	oldResourceQuota := resourceQuota.DeepCopy()
+
+	resourceQuota.Status.LocalUsage = *localUsage
+	if err := r.seedClient.Patch(ctx, resourceQuota, ctrlruntimeclient.MergeFrom(oldResourceQuota)); err != nil {
+		return fmt.Errorf("failed to patch resource quota %q: %w", resourceQuota.Name, err)
+	}
+
+	return nil
+}
+
+func enqueueResourceQuota(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		clusterLabels := a.GetLabels()
+		projectId, ok := clusterLabels[kubermaticv1.ProjectIDLabelKey]
+		if !ok {
+			log.Debugw("cluster does not have `project-id` label, skipping", "cluster", a.GetName())
+		}
+		subjectNameReq, err := labels.NewRequirement(kubermaticv1.ResourceQuotaSubjectNameLabelKey, selection.Equals, []string{projectId})
+		if err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("error creating subject name req: %w", err))
+		}
+
+		resourceQuotaList := &kubermaticv1.ResourceQuotaList{}
+
+		if err := client.List(context.Background(), resourceQuotaList,
+			&ctrlruntimeclient.ListOptions{Namespace: kubermaticresources.KubermaticNamespace,
+				LabelSelector: labels.NewSelector().Add(*subjectNameReq)}); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list resourceQuotas: %w", err))
+		}
+
+		for _, rq := range resourceQuotaList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      rq.Name,
+				Namespace: rq.Namespace,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -111,7 +111,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get resourceQuota %s: %w", resourceQuota.Name, err)
+		return reconcile.Result{}, fmt.Errorf("failed to get resource quota %q: %w", resourceQuota.Name, err)
 	}
 
 	err := r.reconcile(ctx, resourceQuota, log)

--- a/pkg/ee/resource-quota/seed-controller/controller_test.go
+++ b/pkg/ee/resource-quota/seed-controller/controller_test.go
@@ -104,7 +104,6 @@ func TestReconcile(t *testing.T) {
 			if !reflect.DeepEqual(rq.Status.LocalUsage, tc.expectedUsage) {
 				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(rq.Status.LocalUsage, tc.expectedUsage))
 			}
-
 		})
 	}
 }

--- a/pkg/ee/resource-quota/seed-controller/controller_test.go
+++ b/pkg/ee/resource-quota/seed-controller/controller_test.go
@@ -1,0 +1,146 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package seedcontroller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const rqName = "resourceQuota"
+const projectId = "project1"
+
+func TestReconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = kubermaticv1.AddToScheme(scheme)
+
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	testCases := []struct {
+		name          string
+		requestName   string
+		resourceQuota *kubermaticv1.ResourceQuota
+		seedClient    ctrlruntimeclient.Client
+		expectedUsage kubermaticv1.ResourceDetails
+	}{
+		{
+			name:          "scenario 1: calculate rq local usage",
+			requestName:   rqName,
+			resourceQuota: genResourceQuota(rqName),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(genResourceQuota(rqName),
+					genCluster("c1", projectId, "2", "5G", "10G"),
+					genCluster("c2", projectId, "5", "2G", "8G"),
+					genCluster("notSameProjectCluster", "impostor", "3", "3G", "3G")).
+				Build(),
+			expectedUsage: *genResourceDetails("7", "7G", "18G"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &reconciler{
+				log:                     kubermaticlog.Logger,
+				recorder:                &record.FakeRecorder{},
+				workerNameLabelSelector: workerSelector,
+				seedClient:              tc.seedClient,
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName, Namespace: kubermaticresources.KubermaticNamespace}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			rq := &kubermaticv1.ResourceQuota{}
+			err := tc.seedClient.Get(ctx, request.NamespacedName, rq)
+
+			if err != nil {
+				t.Fatalf("failed to get resource quota: %v", err)
+			}
+
+			if !reflect.DeepEqual(rq.Status.LocalUsage, tc.expectedUsage) {
+				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(rq.Status.LocalUsage, tc.expectedUsage))
+			}
+
+		})
+	}
+}
+
+func genResourceQuota(name string) *kubermaticv1.ResourceQuota {
+	cpu := resource.MustParse("5")
+	mem := resource.MustParse("5G")
+	storage := resource.MustParse("10G")
+
+	rq := &kubermaticv1.ResourceQuota{}
+	rq.Name = name
+	rq.Namespace = kubermaticresources.KubermaticNamespace
+	rq.Spec = kubermaticv1.ResourceQuotaSpec{
+		Subject: kubermaticv1.Subject{
+			Name: "project1",
+			Kind: "project",
+		},
+		Quota: kubermaticv1.ResourceDetails{
+			CPU:     &cpu,
+			Memory:  &mem,
+			Storage: &storage,
+		},
+	}
+
+	return rq
+}
+
+func genResourceDetails(cpu, mem, storage string) *kubermaticv1.ResourceDetails {
+	return kubermaticv1.NewResourceDetails(resource.MustParse(cpu), resource.MustParse(mem), resource.MustParse(storage))
+}
+
+func genCluster(name, projectId, cpu, mem, storage string) *kubermaticv1.Cluster {
+	cluster := &kubermaticv1.Cluster{}
+	cluster.Name = name
+	cluster.Labels = map[string]string{kubermaticv1.ProjectIDLabelKey: projectId}
+	cluster.Status.ResourceUsage = genResourceDetails(cpu, mem, storage)
+
+	return cluster
+}

--- a/pkg/ee/resource-quota/seed-controller/doc.go
+++ b/pkg/ee/resource-quota/seed-controller/doc.go
@@ -1,0 +1,27 @@
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+/*
+Package seedcontroller is responsible for ensuring the calculation of the local resource usage for the resource quotas by listing
+all clusters of the resource quota project and adding up their resource usage.
+*/
+package seedcontroller


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds 2 resource quota controllers:
- seed level controller which calculates the local usage by adding up the cluster usage for clusters that belong to the resource quota subject
- master level controller which calculates the global usage by adding up the resource quota local usage across the seeds

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10125 


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added controllers for calculating resource quota global and local seed usage.
```
