### PR TITLE
Use sync-forever mode in Konnectivity agent to support apiserver scaling

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -83,7 +83,7 @@ func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrit
 					Args: []string{
 						"--logtostderr=true",
 						"-v=3",
-						"sync-forever=true",
+						"--sync-forever=true",
 						"--ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 						fmt.Sprintf("--proxy-server-host=%s", kServerHost),
 						fmt.Sprintf("--proxy-server-port=%d", kServerPort),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -83,6 +83,7 @@ func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrit
 					Args: []string{
 						"--logtostderr=true",
 						"-v=3",
+						"sync-forever=true",
 						"--ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 						fmt.Sprintf("--proxy-server-host=%s", kServerHost),
 						fmt.Sprintf("--proxy-server-port=%d", kServerPort),


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
Uses [sync-forever mode](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/285) in Konnectivity agent to support apiserver scaling.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #8701 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
