### PR TITLE
add requeue delays to dependant mla controllers

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -131,7 +131,7 @@ func (r *datasourceGrafanaReconciler) Reconcile(ctx context.Context, request rec
 		r.versions,
 		kubermaticv1.ClusterConditionMLAControllerReconcilingSuccess,
 		func() (*reconcile.Result, error) {
-			return r.datasourceGrafanaController.reconcile(ctx, cluster)
+			return r.datasourceGrafanaController.reconcile(ctx, cluster, log)
 		},
 	)
 	if err != nil {
@@ -171,7 +171,7 @@ func newDatasourceGrafanaController(
 	}
 }
 
-func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, log *zap.SugaredLogger) (*reconcile.Result, error) {
 	// disabled by default
 	if cluster.Spec.MLA == nil {
 		cluster.Spec.MLA = &kubermaticv1.MLASettings{}
@@ -208,7 +208,7 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		// This fails very often because of racing between the controllers - can't get a grafana organization from a project before it gets assigned
 		// Once the organization controller adds the annotation to the project, we will reconcile again, so we skip reconciliation in this case
 		// This works around potential resources abuse documented in https://github.com/kubermatic/kubermatic/issues/9970
-		r.log.Warnf("failed to get grafana org from a project, waiting until the next reconciliation: %w", err)
+		log.Warnf("failed to get grafana org from a project, waiting until the next reconciliation: %s", err)
 		return nil, nil
 	}
 	// set header from the very beginning so all other calls will be within this organization

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -236,7 +236,6 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 				},
 			},
 			hasFinalizer: true,
-			err:          false,
 		},
 		{
 			name:        "update org for project",

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
@@ -75,7 +75,7 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 		{
 			name:        "User not found",
 			requestName: "notfound",
-			err:         false,
+			err:         true,
 			objects: []ctrlruntimeclient.Object{
 				&kubermaticv1.UserProjectBinding{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller_test.go
@@ -75,7 +75,7 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 		{
 			name:        "User not found",
 			requestName: "notfound",
-			err:         true,
+			err:         false,
 			objects: []ctrlruntimeclient.Object{
 				&kubermaticv1.UserProjectBinding{
 					ObjectMeta: metav1.ObjectMeta{
@@ -94,6 +94,15 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 					},
 					Spec: kubermaticv1.ProjectSpec{
 						Name: "projectName",
+					},
+				},
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "update",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email:   "user2@email.com",
+						IsAdmin: true,
 					},
 				},
 			},
@@ -127,6 +136,72 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 					},
 					Spec: kubermaticv1.ProjectSpec{
 						Name: "projectName",
+					},
+				},
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "update",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email:   "user@email.com",
+						IsAdmin: true,
+					},
+				},
+			},
+			hasFinalizer: true,
+			requests: []request{
+				{
+					name:     "lookup user",
+					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name:     "get org by id",
+					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name:     "get org users",
+					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
+				},
+				{
+					name:     "add org user",
+					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
+				},
+			},
+		},
+		{
+			name:        "UserProjectBinding added - user does not exist",
+			requestName: "create",
+			objects: []ctrlruntimeclient.Object{
+				&kubermaticv1.UserProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "create",
+					},
+					Spec: kubermaticv1.UserProjectBindingSpec{
+						UserEmail: "user@email.com",
+						ProjectID: "projectID",
+						Group:     "owners-projectID",
+					},
+				},
+				&kubermaticv1.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "projectID",
+						Annotations: map[string]string{GrafanaOrgAnnotationKey: "1"},
+					},
+					Spec: kubermaticv1.ProjectSpec{
+						Name: "projectName",
+					},
+				},
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "update",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email:   "user2@email.com",
+						IsAdmin: true,
 					},
 				},
 			},
@@ -175,6 +250,15 @@ func TestOrgUserGrafanaReconcile(t *testing.T) {
 					},
 					Spec: kubermaticv1.ProjectSpec{
 						Name: "projectName",
+					},
+				},
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "update",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email:   "user@email.com",
+						IsAdmin: true,
 					},
 				},
 			},

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -215,8 +215,11 @@ func TestMLAIntegration(t *testing.T) {
 		t.Fatalf("waiting for grafana user: %v", err)
 	}
 	t.Log("user added to Grafana")
-	if user.IsGrafanaAdmin != true || user.OrgID != org.ID {
-		t.Fatalf("user[%v] expected to be Grafana Admin and has orgID=%d", user, org.ID)
+	if !utils.WaitFor(1*time.Second, timeout, func() bool {
+		user, _ = grafanaClient.LookupUser(ctx, "roxy-admin@kubermatic.com")
+		return (user.IsGrafanaAdmin == true) && (user.OrgID == org.ID)
+	}) {
+		t.Fatalf("user[%+v] expected to be Grafana Admin and have orgID=%d", user, org.ID)
 	}
 
 	orgUser, err := mla.GetGrafanaOrgUser(ctx, grafanaClient, org.ID, user.ID)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Some more controllers are actually dependent on the grafana organization controller and would keep triggering reconciliation as long as it hasn't finished. This PR introduces delays to those requests to lower the controller load.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
fixes #9970

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
