### PR TITLE
Update Kubermatic Community Slack links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please use the version selector at the top of the site to ensure you are using t
 
 ## Troubleshooting
 
-If you encounter issues [file an issue][1] or talk to us on the [#kubermatic channel][12] on the [Kubermatic Slack][15].
+If you encounter issues [file an issue][1] or talk to us on the [#kubermatic channel][12] on the [Kubermatic Community Slack][15] ([click here to join][16]).
 
 ## Contributing
 
@@ -140,8 +140,9 @@ See [the list of releases][3] to find out about feature changes.
 [3]: https://github.com/kubermatic/kubermatic/releases
 [4]: https://github.com/kubermatic/kubermatic/blob/master/CODE_OF_CONDUCT.md
 
-[12]: https://kubermatic.slack.com/messages/kubermatic
+[12]: https://kubermatic-community.slack.com/messages/kubermatic
 [13]: https://github.com/kubermatic/kubermatic/blob/master/Zenhub.md
-[15]: http://slack.kubermatic.io/
+[15]: http://kubermatic-community.slack.com
+[16]: https://join.slack.com/t/kubermatic-community/shared_invite/zt-vqjjqnza-dDw8BuUm3HvD4VGrVQ_ptw
 
 [21]: https://docs.kubermatic.com/kubermatic/


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The readme does not link to the Kubermatic Community Slack, but it probably should. The current links are not accessible. In addition, this PR adds the slack invite link from kubermatic.com to the readme to ease joining the community.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10168

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>