### PR TITLE
create cluster namespace first, then update ClusterStatus

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -32,7 +32,6 @@ import (
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -218,16 +217,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	log = log.With("cluster", cluster.Name)
 
-	// ensure new Cluster objects have basic status information set;
-	// this should be done regardless of ClusterAvailableForReconciling()
-	// and hence outside the ClusterReconcileWrapper
-	if err := r.reconcileClusterStatus(ctx, cluster); err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-
-		return reconcile.Result{}, err
-	}
-
 	// the update controller needs to determine the target version based on the spec
 	// before we can reconcile anything
 	if cluster.Status.Versions.ControlPlane == "" {
@@ -268,15 +257,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return *result, err
 }
 
-func (r *Reconciler) reconcileClusterStatus(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	return kubermaticv1helper.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
-		if c.Status.NamespaceName == "" {
-			c.Status.NamespaceName = kubernetesprovider.NamespaceName(cluster.Name)
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+	namespace, err := r.ensureNamespaceExists(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure cluster namespace: %w", err)
+	}
+
+	err = kubermaticv1helper.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
+		if c.Status.NamespaceName != namespace.Name {
+			c.Status.NamespaceName = namespace.Name
 		}
 	})
-}
+	if err != nil {
+		return nil, fmt.Errorf("failed to update cluster namespace status: %w", err)
+	}
 
-func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// synchronize cluster.status.health for Kubernetes clusters
 	if err := r.syncHealth(ctx, cluster); err != nil {
 		return nil, fmt.Errorf("failed to sync health: %w", err)
@@ -298,7 +293,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return &reconcile.Result{RequeueAfter: 10 * time.Second}, clusterdeletion.New(r.Client, userClusterClientGetter).CleanupCluster(ctx, log, cluster)
 	}
 
-	res, err := r.reconcileCluster(ctx, cluster)
+	res, err := r.reconcileCluster(ctx, cluster, namespace)
 	if err != nil {
 		updateErr := r.updateClusterError(ctx, cluster, kubermaticv1.ReconcileClusterError, err.Error())
 		if updateErr != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -24,6 +24,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -31,13 +32,7 @@ const (
 	reachableCheckPeriod = 5 * time.Second
 )
 
-func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
-	// Create the namespace
-	namespace, err := r.ensureNamespaceExists(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, namespace *corev1.Namespace) (*reconcile.Result, error) {
 	if !kuberneteshelper.HasFinalizer(cluster, apiv1.EtcdBackupConfigCleanupFinalizer) {
 		res, err := r.AddFinalizers(ctx, cluster, apiv1.EtcdBackupConfigCleanupFinalizer)
 		if err != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
@@ -51,6 +52,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -237,8 +239,13 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 
 // ensureNamespaceExists will create the cluster namespace.
 func (r *Reconciler) ensureNamespaceExists(ctx context.Context, cluster *kubermaticv1.Cluster) (*corev1.Namespace, error) {
+	namespace := cluster.Status.NamespaceName
+	if namespace == "" {
+		namespace = kubernetesprovider.NamespaceName(cluster.Name)
+	}
+
 	ns := &corev1.Namespace{}
-	err := r.Get(ctx, types.NamespacedName{Name: cluster.Status.NamespaceName}, ns)
+	err := r.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 	if err == nil {
 		return ns, nil // found it
 	}
@@ -248,12 +255,31 @@ func (r *Reconciler) ensureNamespaceExists(ctx context.Context, cluster *kuberma
 
 	ns = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cluster.Status.NamespaceName,
+			Name:            namespace,
 			OwnerReferences: []metav1.OwnerReference{r.getOwnerRefForCluster(cluster)},
 		},
 	}
-	if err := r.Create(ctx, ns); err != nil {
-		return nil, fmt.Errorf("failed to create Namespace %s: %w", cluster.Status.NamespaceName, err)
+	if err := r.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("failed to create Namespace %s: %w", namespace, err)
+	}
+
+	// before returning the namespace and putting its name into the cluster status,
+	// ensure that the namespace is in our cache, or else other controllers that
+	// want to reconcile might get confused
+	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		ns := &corev1.Namespace{}
+		err := r.Get(ctx, types.NamespacedName{Name: namespace}, ns)
+		if err == nil {
+			return true, nil
+		}
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for cluster namespace to appear in cache: %w", err)
 	}
 
 	// Creating() an object does not set the type meta, in fact it _resets_ it.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This prevents a race condition that can sometimes lead to controllers not being able to reconcile.

Previously, we first updated the ClusterStatus with the namespaceName and _then_ created the namespace. Between the actual creation and the namespace appearing in our caches, other controllers might already be triggered by the ClusterStatus change and begin their work. But they would then potentially fail.

This PR flips the order to first create the namespace, wait for it to exist in our cache and then update the ClusterStatus.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
