### PR TITLE
make project controller less noisy

### DIFF
--- a/pkg/controller/seed-controller-manager/project/controller.go
+++ b/pkg/controller/seed-controller-manager/project/controller.go
@@ -79,8 +79,8 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger, workerCount int) error {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {
-	log := r.log.With("request", req)
-	log.Info("Reconciling")
+	log := r.log.With("project", req.Name)
+	log.Debug("Reconciling")
 
 	project := &kubermaticv1.Project{}
 	if err := r.Get(ctx, req.NamespacedName, project); err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This reduces the log verbosity for the project controller, which is currently spamming the seed-ctrl-mgr logs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
