### PR TITLE
fix %w placeholder in log statement

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/grafana.go
+++ b/pkg/controller/seed-controller-manager/mla/grafana.go
@@ -128,8 +128,10 @@ func addDashboards(ctx context.Context, log *zap.SugaredLogger, grafanaClient *g
 			return fmt.Errorf("unable to unmarshal dashboard: %w", err)
 		}
 		if status, err := grafanaClient.SetDashboard(ctx, board, grafanasdk.SetDashboardParams{Overwrite: true}); err != nil {
-			log.Errorf("unable to set dashboard: %w (status: %s, message: %s)",
-				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+			log.Errorw("unable to set dashboard",
+				zap.Error(err),
+				"status", pointer.StringPtrDerefOr(status.Status, "no status"),
+				"message", pointer.StringPtrDerefOr(status.Message, "no message"))
 			return err
 		}
 	}
@@ -143,12 +145,14 @@ func deleteDashboards(ctx context.Context, log *zap.SugaredLogger, grafanaClient
 			return fmt.Errorf("unable to unmarshal dashboard: %w", err)
 		}
 		if board.UID == "" {
-			log.Debugf("dashboard %s doesn't have UID set, skipping", board.Title)
+			log.Debugw("dashboard doesn't have UID set, skipping", "title", board.Title)
 			continue
 		}
 		if status, err := grafanaClient.DeleteDashboardByUID(ctx, board.UID); err != nil {
-			log.Errorf("unable to delete dashboard: %w (status: %s, message: %s)",
-				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+			log.Errorw("unable to delete dashboard",
+				zap.Error(err),
+				"status", pointer.StringPtrDerefOr(status.Status, "no status"),
+				"message", pointer.StringPtrDerefOr(status.Message, "no message"))
 			return err
 		}
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This fixes log lines like

> {"level":"error","time":"2022-06-24T16:01:08.812Z","logger":"kubermatic_mla_controller","caller":"mla/grafana.go:131","msg":"unable to set dashboard: %!w(*url.Error=&{Post http://admin:***@grafana.mla.svc.cluster.local/api/dashboards/db 0xc00b90b860}) (status: no status, message: no message)","request":"mla/grafana-dashboards-kkp-kubernetes"}

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
