### PR TITLE
Introduce pkg/util/wait to provide better timeout feedback

### DIFF
--- a/cmd/conformance-tester/main.go
+++ b/cmd/conformance-tester/main.go
@@ -126,7 +126,7 @@ func main() {
 		log.Fatalw("Test failed", zap.Error(err))
 	}
 
-	log.Infof("Whole suite took %.2f seconds", time.Since(start).Seconds())
+	log.Infow("Test suite has completed successfully", "runtime", time.Since(start))
 }
 
 func setupKubeClients(ctx context.Context, opts *types.Options) error {

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -218,6 +218,8 @@ func (r *TestRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger
 	log = log.With("cluster", clusterName)
 
 	healthCheck := func() error {
+		log.Info("Waiting for cluster to be successfully reconciled...")
+
 		return wait.PollLog(log, 5*time.Second, 5*time.Minute, func() (transient error, terminal error) {
 			if err := r.opts.SeedClusterClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
 				return err, nil

--- a/cmd/conformance-tester/pkg/runner/waiters.go
+++ b/cmd/conformance-tester/pkg/runner/waiters.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,11 +28,12 @@ import (
 	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,19 +42,19 @@ func waitForControlPlane(ctx context.Context, log *zap.SugaredLogger, opts *ctyp
 	started := time.Now()
 	namespacedClusterName := types.NamespacedName{Name: clusterName}
 
-	err := wait.Poll(3*time.Second, opts.ControlPlaneReadyWaitTimeout, func() (done bool, err error) {
+	err := wait.Poll(3*time.Second, opts.ControlPlaneReadyWaitTimeout, func() (transient error, terminal error) {
 		newCluster := &kubermaticv1.Cluster{}
 
 		if err := opts.SeedClusterClient.Get(ctx, namespacedClusterName, newCluster); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, nil
+				return err, nil
 			}
 		}
 
 		// Check for this first, because otherwise we instantly return as the cluster-controller did not
 		// create any pods yet
 		if !newCluster.Status.ExtendedHealth.AllHealthy() {
-			return false, nil
+			return errors.New("cluster is not all healthy"), nil
 		}
 
 		controlPlanePods := &corev1.PodList{}
@@ -61,16 +63,21 @@ func waitForControlPlane(ctx context.Context, log *zap.SugaredLogger, opts *ctyp
 			controlPlanePods,
 			&ctrlruntimeclient.ListOptions{Namespace: newCluster.Status.NamespaceName},
 		); err != nil {
-			return false, fmt.Errorf("failed to list controlplane pods: %w", err)
+			return nil, fmt.Errorf("failed to list controlplane pods: %w", err)
 		}
 
+		unready := sets.NewString()
 		for _, pod := range controlPlanePods.Items {
 			if !util.PodIsReady(&pod) {
-				return false, nil
+				unready.Insert(pod.Name)
 			}
 		}
 
-		return true, nil
+		if unready.Len() == 0 {
+			return nil, nil
+		}
+
+		return fmt.Errorf("not all Pods are ready: %v", unready.List()), nil
 	})
 	// Timeout or other error
 	if err != nil {
@@ -104,26 +111,32 @@ func waitUntilAllPodsAreReady(ctx context.Context, log *zap.SugaredLogger, opts 
 	log.Info("Waiting for all pods to be ready...")
 	started := time.Now()
 
-	err := wait.Poll(opts.UserClusterPollInterval, timeout, func() (done bool, err error) {
+	err := wait.Poll(opts.UserClusterPollInterval, timeout, func() (transient error, terminal error) {
 		podList := &corev1.PodList{}
 		if err := userClusterClient.List(ctx, podList); err != nil {
-			log.Warnw("Failed to load pod list while waiting until all pods are running", zap.Error(err))
-			return false, nil
+			return fmt.Errorf("failed to list Pods in user cluster: %w", err), nil
 		}
 
+		unready := sets.NewString()
 		for _, pod := range podList.Items {
 			// Ignore pods failing kubelet admission (KKP #6185)
 			if !util.PodIsReady(&pod) && !podFailedKubeletAdmissionDueToNodeAffinityPredicate(&pod, log) {
-				return false, nil
+				unready.Insert(pod.Name)
 			}
 		}
-		return true, nil
+
+		if unready.Len() == 0 {
+			return nil, nil
+		}
+
+		return fmt.Errorf("not all Pods are ready: %v", unready.List()), nil
 	})
 	if err != nil {
 		return err
 	}
 
-	log.Debugf("All pods became ready after %.2f seconds", time.Since(started).Seconds())
+	log.Debugw("All pods became ready", "duration-in-seconds", time.Since(started).Seconds())
+
 	return nil
 }
 
@@ -133,25 +146,33 @@ func waitUntilAllPodsAreReady(ctx context.Context, log *zap.SugaredLogger, opts 
 func waitForMachinesToJoinCluster(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, timeout time.Duration) (time.Duration, error) {
 	startTime := time.Now()
 
-	err := wait.Poll(10*time.Second, timeout, func() (bool, error) {
+	err := wait.Poll(10*time.Second, timeout, func() (transient error, terminal error) {
 		machineList := &clusterv1alpha1.MachineList{}
 		if err := client.List(ctx, machineList); err != nil {
-			log.Warnw("Failed to list machines", zap.Error(err))
-			return false, nil
+			return fmt.Errorf("failed to list machines: %w", err), nil
 		}
 
+		missingMachines := sets.NewString()
 		for _, machine := range machineList.Items {
 			if machine.Status.NodeRef == nil || machine.Status.NodeRef.Name == "" {
-				log.Infow("Machine has no nodeRef yet", "machine", machine.Name)
-				return false, nil
+				missingMachines.Insert(machine.Name)
 			}
 		}
 
-		log.Infow("All machines got a Node", "duration-in-seconds", time.Since(startTime).Seconds())
-		return true, nil
+		if missingMachines.Len() == 0 {
+			return nil, nil
+		}
+
+		return fmt.Errorf("not all machines have joined: %v", missingMachines.List()), nil
 	})
 
-	return timeout - time.Since(startTime), err
+	elapsed := time.Since(startTime)
+
+	if err == nil {
+		log.Infow("All machines joined the cluster", "duration-in-seconds", elapsed.Seconds())
+	}
+
+	return timeout - elapsed, err
 }
 
 // WaitForNodesToBeReady waits for all nodes to be ready. It does so by checking the Nodes "Ready"
@@ -159,23 +180,31 @@ func waitForMachinesToJoinCluster(ctx context.Context, log *zap.SugaredLogger, c
 func waitForNodesToBeReady(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, timeout time.Duration) (time.Duration, error) {
 	startTime := time.Now()
 
-	err := wait.Poll(10*time.Second, timeout, func() (bool, error) {
+	err := wait.Poll(10*time.Second, timeout, func() (transient error, terminal error) {
 		nodeList := &corev1.NodeList{}
 		if err := client.List(ctx, nodeList); err != nil {
-			log.Warnw("Failed to list nodes", zap.Error(err))
-			return false, nil
+			return fmt.Errorf("failed to list nodes: %w", err), nil
 		}
 
+		unready := sets.NewString()
 		for _, node := range nodeList.Items {
 			if !util.NodeIsReady(node) {
-				log.Infow("Node is not ready", "node", node.Name)
-				return false, nil
+				unready.Insert(node.Name)
 			}
 		}
 
-		log.Infow("All nodes got ready", "duration-in-seconds", time.Since(startTime).Seconds())
-		return true, nil
+		if unready.Len() == 0 {
+			return nil, nil
+		}
+
+		return fmt.Errorf("not all nodes are ready: %v", unready.List()), nil
 	})
 
-	return timeout - time.Since(startTime), err
+	elapsed := time.Since(startTime)
+
+	if err == nil {
+		log.Infow("All nodes became ready", "duration-in-seconds", elapsed.Seconds())
+	}
+
+	return timeout - elapsed, err
 }

--- a/cmd/conformance-tester/pkg/runner/waiters.go
+++ b/cmd/conformance-tester/pkg/runner/waiters.go
@@ -43,7 +43,7 @@ func waitForControlPlane(ctx context.Context, log *zap.SugaredLogger, opts *ctyp
 
 	log.Infow("Waiting for control plane to become ready...", "timeout", opts.ControlPlaneReadyWaitTimeout)
 
-	err := wait.Poll(3*time.Second, opts.ControlPlaneReadyWaitTimeout, func() (transient error, terminal error) {
+	err := wait.PollLog(log, 5*time.Second, opts.ControlPlaneReadyWaitTimeout, func() (transient error, terminal error) {
 		newCluster := &kubermaticv1.Cluster{}
 
 		if err := opts.SeedClusterClient.Get(ctx, namespacedClusterName, newCluster); err != nil {
@@ -113,7 +113,7 @@ func waitUntilAllPodsAreReady(ctx context.Context, log *zap.SugaredLogger, opts 
 
 	log.Infow("Waiting for all Pods to be ready...", "timeout", timeout)
 
-	err := wait.Poll(opts.UserClusterPollInterval, timeout, func() (transient error, terminal error) {
+	err := wait.PollLog(log, opts.UserClusterPollInterval, timeout, func() (transient error, terminal error) {
 		podList := &corev1.PodList{}
 		if err := userClusterClient.List(ctx, podList); err != nil {
 			return fmt.Errorf("failed to list Pods in user cluster: %w", err), nil
@@ -150,7 +150,7 @@ func waitForMachinesToJoinCluster(ctx context.Context, log *zap.SugaredLogger, c
 
 	log.Infow("Waiting for machines to join cluster...", "timeout", timeout)
 
-	err := wait.Poll(10*time.Second, timeout, func() (transient error, terminal error) {
+	err := wait.PollLog(log, 10*time.Second, timeout, func() (transient error, terminal error) {
 		machineList := &clusterv1alpha1.MachineList{}
 		if err := client.List(ctx, machineList); err != nil {
 			return fmt.Errorf("failed to list machines: %w", err), nil
@@ -186,7 +186,7 @@ func waitForNodesToBeReady(ctx context.Context, log *zap.SugaredLogger, client c
 
 	log.Infow("Waiting for nodes to become ready...", "timeout", timeout)
 
-	err := wait.Poll(10*time.Second, timeout, func() (transient error, terminal error) {
+	err := wait.PollLog(log, 10*time.Second, timeout, func() (transient error, terminal error) {
 		nodeList := &corev1.NodeList{}
 		if err := client.List(ctx, nodeList); err != nil {
 			return fmt.Errorf("failed to list nodes: %w", err), nil

--- a/cmd/conformance-tester/pkg/tests/conformance.go
+++ b/cmd/conformance-tester/pkg/tests/conformance.go
@@ -30,13 +30,13 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/metrics"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/scenarios"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/cmd/conformance-tester/pkg/tests/conformance.go
+++ b/cmd/conformance-tester/pkg/tests/conformance.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/metrics"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/scenarios"
@@ -40,7 +41,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -313,15 +313,13 @@ func cleanupBeforeGinkgo(
 ) error {
 	log.Info("Removing non-default webhooks...")
 
-	if err := wait.PollImmediate(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (done bool, err error) {
+	if err := wait.PollImmediate(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
 		webhookList := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
 		if err := client.List(ctx, webhookList); err != nil {
-			log.Errorw("Failed to list webhooks", zap.Error(err))
-			return false, nil
+			return fmt.Errorf("failed to list webhooks: %w", err), nil
 		}
 
-		remaining := 0
-
+		remaining := sets.NewString()
 		for _, webhook := range webhookList.Items {
 			if webhooksToKeep.Has(webhook.Name) {
 				continue
@@ -337,10 +335,14 @@ func cleanupBeforeGinkgo(
 				}
 			}
 
-			remaining++
+			remaining.Insert(webhook.Name)
 		}
 
-		return remaining == 0, nil
+		if remaining.Len() == 0 {
+			return nil, nil
+		}
+
+		return fmt.Errorf("could not delete all webhooks: %v", remaining.List()), nil
 	}); err != nil {
 		return err
 	}

--- a/cmd/conformance-tester/pkg/tests/metrics.go
+++ b/cmd/conformance-tester/pkg/tests/metrics.go
@@ -158,7 +158,7 @@ func TestUserClusterPodAndNodeMetrics(ctx context.Context, log *zap.SugaredLogge
 		return fmt.Errorf("failed to create Pod: %w", err)
 	}
 
-	err := wait.Poll(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
+	err := wait.PollLog(log, opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
 		metricPod := &corev1.Pod{}
 		if err := userClusterClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, metricPod); err != nil {
 			return fmt.Errorf("failed to get test metric pod: %w", err), nil
@@ -175,7 +175,7 @@ func TestUserClusterPodAndNodeMetrics(ctx context.Context, log *zap.SugaredLogge
 	}
 
 	// check pod metrics
-	err = wait.Poll(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
+	err = wait.PollLog(log, opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
 		podMetrics := &v1beta1.PodMetrics{}
 		if err := userClusterClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, podMetrics); err != nil {
 			return fmt.Errorf("failed to get test metric pod metrics: %w", err), nil

--- a/cmd/conformance-tester/pkg/tests/metrics.go
+++ b/cmd/conformance-tester/pkg/tests/metrics.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -28,12 +29,12 @@ import (
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/semver"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -157,37 +158,36 @@ func TestUserClusterPodAndNodeMetrics(ctx context.Context, log *zap.SugaredLogge
 		return fmt.Errorf("failed to create Pod: %w", err)
 	}
 
-	err := wait.Poll(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (done bool, err error) {
+	err := wait.Poll(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
 		metricPod := &corev1.Pod{}
 		if err := userClusterClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, metricPod); err != nil {
-			log.Warnw("Failed to get test metric pod", zap.Error(err))
-			return false, nil
+			return fmt.Errorf("failed to get test metric pod: %w", err), nil
 		}
 
 		if !util.PodIsReady(metricPod) {
-			return false, nil
+			return errors.New("Pod is not ready"), nil
 		}
 
-		return true, nil
+		return nil, nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to check if test metrics pod is ready: %w", err)
 	}
 
 	// check pod metrics
-	err = wait.Poll(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (done bool, err error) {
+	err = wait.Poll(opts.UserClusterPollInterval, opts.CustomTestTimeout, func() (transient error, terminal error) {
 		podMetrics := &v1beta1.PodMetrics{}
 		if err := userClusterClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, podMetrics); err != nil {
-			log.Warnw("Failed to get test metric pod metrics", zap.Error(err))
-			return false, nil
+			return fmt.Errorf("failed to get test metric pod metrics: %w", err), nil
 		}
+
 		for _, cont := range podMetrics.Containers {
 			if cont.Usage.Memory().IsZero() {
-				log.Warnw("Metrics test pod memory usage is 0", zap.Error(err))
-				return false, nil
+				return errors.New("metrics test pod memory usage is 0"), nil
 			}
 		}
-		return true, nil
+
+		return nil, nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get metric test pod metrics: %w", err)

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type ConditionFunc func() (transient error, terminal error)
+type PollFunc func(interval, timeout time.Duration, condition k8swait.ConditionFunc) error
+
+func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
+	return enrich(k8swait.Poll, interval, timeout, condition)
+}
+
+func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
+	return enrich(k8swait.PollImmediate, interval, timeout, condition)
+}
+
+func enrich(upstream PollFunc, interval, timeout time.Duration, condition ConditionFunc) error {
+	var lastErr error
+
+	waitErr := upstream(interval, timeout, func() (done bool, err error) {
+		transient, terminal := condition()
+		if terminal != nil {
+			return false, terminal
+		}
+
+		lastErr = transient
+
+		return transient == nil, nil
+	})
+
+	if errors.Is(waitErr, k8swait.ErrWaitTimeout) && lastErr != nil {
+		waitErr = fmt.Errorf("%w; last error was: %v", waitErr, lastErr)
+	}
+
+	return waitErr
+}

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestPollSuccess(t *testing.T) {
+	executions := 0
+
+	err := Poll(1*time.Millisecond, 100*time.Millisecond, func() (error, error) {
+		executions++
+		return nil, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Poll should have returned nil, but returned %v", err)
+	}
+
+	if executions > 1 {
+		t.Fatalf("Poll should have only executed the condition once, but ran it %d times", executions)
+	}
+}
+
+func TestPollTimeout(t *testing.T) {
+	err := Poll(1*time.Millisecond, 10*time.Millisecond, func() (error, error) {
+		return errors.New("transient"), nil
+	})
+
+	if err == nil {
+		t.Fatal("Poll should have returned an error, but got nil")
+	}
+
+	if !errors.Is(err, k8swait.ErrWaitTimeout) {
+		t.Fatalf("err should be a wrapped ErrWaitTimeout, but is %+v", err)
+	}
+}
+
+func TestPollTerminalError(t *testing.T) {
+	executions := 0
+	terminal := errors.New("terminal")
+
+	err := Poll(1*time.Millisecond, 10*time.Millisecond, func() (error, error) {
+		executions++
+		return nil, terminal
+	})
+
+	if err == nil {
+		t.Fatal("Poll should have returned an error, but got nil")
+	}
+
+	// This specifically ensures that we get exactly the error that is returned
+	// by the condition, without any kind of wrapping.
+
+	//nolint:errorlint
+	if err != terminal {
+		t.Fatalf("err should has been the terminal error, but is %+v", err)
+	}
+}

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -18,6 +18,7 @@ package wait
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +53,10 @@ func TestPollTimeout(t *testing.T) {
 
 	if !errors.Is(err, k8swait.ErrWaitTimeout) {
 		t.Fatalf("err should be a wrapped ErrWaitTimeout, but is %+v", err)
+	}
+
+	if !strings.Contains(err.Error(), "transient") {
+		t.Fatalf("err should have returned the transient error message, but was: %v", err)
 	}
 }
 

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -37,7 +37,7 @@ func TestPollSuccess(t *testing.T) {
 		t.Fatalf("Poll should have returned nil, but returned %v", err)
 	}
 
-	if executions > 1 {
+	if executions != 1 {
 		t.Fatalf("Poll should have only executed the condition once, but ran it %d times", executions)
 	}
 }
@@ -71,6 +71,10 @@ func TestPollTerminalError(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("Poll should have returned an error, but got nil")
+	}
+
+	if executions != 1 {
+		t.Fatalf("Poll should have only executed the condition once, but ran it %d times", executions)
 	}
 
 	// This specifically ensures that we get exactly the error that is returned


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We use apimachinery's `wait` ("k8swait") in many places, but I often found it lacking.

Conditions have the signature of `func() (bool, error)`.

* If the error is not nil, the polling is stopped immediately and the err is returned.
* If the bool is true, the condition is met and `nil` is ultimately returned from polling.
* If the bool is false, the condition is tried again, possibly until a timeout happens. If a timeout happens, we only know _that_ a timeout happens, but not necessarily _why_.

We have a lot of polling conditions that consist of multiple criteria. If multiple code paths inside a condition `return false, nil`, we lose the disctinction, as from k8swait's perspective, it's just a plain timeout:

```go
err := wait.Poll("1s", "10s", func() (bool, error) {
   value, err := doStuff()
   if err != nil {
      return false, err
   }

   if value > 7 {
      return false, nil
   }

   computed := magic(value)
   if !computed.IsValid() {
      return false, nil
   }

   return true, nil
})
```

We can (and often did) resort to logging, but to me it was never clear on what log level to log:

```go
err := wait.Poll("1s", "10s", func() (bool, error) {
   value, err := doStuff()
   if err != nil {
      return false, err
   }

   if value > 7 {
      log.Debug("value is still larger than seven") // debug or info?
      return false, nil
   }

   computed := magic(value)
   if !computed.IsValid() {
      log.Debug("computed result is invalid") // debug or info?
      return false, nil
   }

   return true, nil
})
```

If you do it on INFO, it might be noisy and spammy. If you do it on DEBUG and a test fails, you will wonder "awww how do I now rerun these tests with debug logging enabled? What's the prow command for that?". Both options suck.

Another option is to write even more code and to split the 2 parts of the condition into 2 Poll calls:

```go
var value int

log.Info("Waiting for a valid number...")
err := wait.Poll("1s", "10s", func() (bool, err error) {
   value, err = doStuff()
   if err != nil {
      return false, err
   }

   return value <= 7, nil
})
if err != nil {
   log.Error("Failed to wait for valid number: %v", err)
}

log.Info("Waiting for magic...")
err := wait.Poll("1s", "10s", func() (bool, err error) {
   computed := magic(value)
   return computed.IsValid(), nil
})
if err != nil {
   log.Error("Failed to compute things: %v", err)
}
```

But now you need to manage multiple timeouts and if the value can change from the first Poll, you're s** out of luck.

I therefore propose a tiny extra package which wraps k8swait. The conditions that it uses follow `func() (transient error, terminal error)`. It works pretty much exactly like k8swait: In cases where you'd returned `false` with k8swait, you now return a transient error. If a timeout happens, the transient error is included in the final error, so you do not just get "timed out waiting for the condition", but "timed out waiting for the condition, because _transient error_":

```go
err := wait.Poll("1s", "10s", func() (error, error) {
   value, err := doStuff()
   if err != nil {
      return nil, err
   }

   if value > 7 {
      return errors.New("value is still larger than seven"), nil
   }

   computed := magic(value)
   if !computed.IsValid() {
      return errors.New("computed result is invalid") , nil
   }

   return nil, nil
})

fmt.Println(err) // => e.g. "timed out waiting for the condition: computed result is invalid"
```

The new package is not applicable everywhere, cause sometimes we know, from experience, that a progressing INFO/DEBUG logging during a condition is more convenient. By not logging in a condition, we lose a bit of "tracking" ability. So the new package is not a one-size-fits-all solution.

_However_ I extended the new wait package with `PollLog` and `PollImmediateLog`, which will log the current transient error on every iteration:

```go
// This PollLog statement...
err := wait.PollLog(log, "1s", "10s", func() (error, error) {
   conditions, err := getClusterConditions()
   if err != nil {
      return nil, err
   }

   if conditions.Valid() {
      return nil, nil
   }

   return fmt.Errorf("missing conditions: %v", conditions), nil
})

// would lead to

//{"level":"info","time":"2022-06-24T21:55:15Z","msg":"Waiting","status":"nmissing conditions: [a, b, c]"}
//{"level":"info","time":"2022-06-24T21:55:16Z","msg":"Waiting","status":"nmissing conditions: [a, b, c]"}
//{"level":"info","time":"2022-06-24T21:55:17Z","msg":"Waiting","status":"nmissing conditions: [a, c]"}
//{"level":"info","time":"2022-06-24T21:55:18Z","msg":"Waiting","status":"nmissing conditions: [c]"}
```

While this solves the "staring at the screen and not getting feedback is annoying"-problem. The only downside I can see from this is that we lose some of the structured logging benefits. Compare the log lines above to what you could do if you manually logged:

```go
err := wait.Poll("1s", "10s", func() (error, error) {
   conditions, err := getClusterConditions()
   if err != nil {
      return nil, err
   }

   if conditions.Valid() {
      return nil, nil
   }

   log.Info("Missing conditions", "conditions", conditions)

   return fmt.Errorf("missing conditions: %v", conditions), nil
})
```

But I would consider this a minor loss and if structured logging is really important, you can still do it manually and simply use Poll() instead of PollLog().

(During all the rewrites I noticed that Zap is perfectly capable to print nice looking time.Duration values, so there is no need to get the seconds and log `.Infow("...", "duration-in-seconds", elapsed.Seconds())`. So I changed a few places and made the logging a tiny bit more consistent.)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
