### PR TITLE
Update member information to poll for client URL in etcd-launcher

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -665,7 +665,15 @@ func (e *etcdCluster) removeDeadMembers(log *zap.SugaredLogger, unwantedMembers 
 		if member.Name == e.podName {
 			continue
 		}
+
 		if err = wait.Poll(1*time.Second, 15*time.Second, func() (bool, error) {
+			// attempt to update member in case a client URL has recently been added
+			if m, err := e.getMemberByName(member.Name, log); err != nil {
+				return false, err
+			} else if m != nil {
+				member = m
+			}
+
 			if len(member.ClientURLs) == 0 {
 				return false, nil
 			}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

A `wait` was wrapped around checking potential unwanted members in `etcd-launcher`, but within the wrapped function we were checking for the client URLs array length. That could never change though. This PR adds a small update to the `member` variable in case the member gets updated within the 15 seconds we're waiting for it to be considered unhealthy.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
