### PR TITLE
handle HTTP etcdbackup endpoints

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -191,8 +191,12 @@ spec:
       - /bin/sh
       - -c
       - |
-        s3cmd \
-          --ca-certs=/etc/ca-bundle/ca-bundle.pem \
+        SSL_FLAGS="--ca-certs=/etc/ca-bundle/ca-bundle.pem"
+        if [ "${INSECURE:-false}" == "true" ]; then
+          SSL_FLAGS="--no-ssl"
+        fi
+
+        s3cmd $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -768,8 +768,13 @@ command:
 - -c
 - |
   set -e
-  s3cmd \
-    --ca-certs=/etc/ca-bundle/ca-bundle.pem \
+
+  SSL_FLAGS="--ca-certs=/etc/ca-bundle/ca-bundle.pem"
+  if [ "${INSECURE:-false}" == "true" ]; then
+    SSL_FLAGS="--no-ssl"
+  fi
+
+  s3cmd $SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \
@@ -787,8 +792,12 @@ command:
 - /bin/sh
 - -c
 - |
-  s3cmd \
-    --ca-certs=/etc/ca-bundle/ca-bundle.pem \
+  SSL_FLAGS="--ca-certs=/etc/ca-bundle/ca-bundle.pem"
+  if [ "${INSECURE:-false}" == "true" ]; then
+    SSL_FLAGS="--no-ssl"
+  fi
+
+  s3cmd $SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -838,17 +838,17 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 	return nil, err
 }
 
-func isSecureURL(u string) bool {
+func isInsecureURL(u string) bool {
 	parsed, err := url.Parse(u)
 	if err != nil {
 		return false
 	}
 
-	// a hostname like "foo.com:9000" is parsed as {scheme: foo.com, host: ""},
-	// so we must make sure to not mis-interpret "https:9000" ({scheme: "https"}) as
-	// an HTTPS url
+	// a hostname like "foo.com:9000" is parsed as {scheme: "foo.com", host: ""},
+	// so we must make sure to not mis-interpret "http:9000" ({scheme: "http", host: ""}) as
+	// an HTTP url
 
-	return strings.ToLower(parsed.Scheme) == "https" && parsed.Host != ""
+	return strings.ToLower(parsed.Scheme) == "http" && parsed.Host != ""
 }
 
 func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus,
@@ -869,7 +869,7 @@ func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, clus
 		})
 
 		insecure := "false"
-		if !isSecureURL(destination.Endpoint) {
+		if isInsecureURL(destination.Endpoint) {
 			insecure = "true"
 		}
 
@@ -1033,7 +1033,7 @@ func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig
 		})
 
 		insecure := "false"
-		if !isSecureURL(destination.Endpoint) {
+		if isInsecureURL(destination.Endpoint) {
 			insecure = "true"
 		}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -19,6 +19,7 @@ package etcdbackup
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -94,6 +95,9 @@ const (
 	bucketNameEnvVarKey = "BUCKET_NAME"
 	// backupEndpointEnvVarKey defines the environment variable key for the backup endpoint.
 	backupEndpointEnvVarKey = "ENDPOINT"
+	// backupInsecureEnvVarKey defines the environment variable key for a boolean that tells whether the
+	// configured endpoint uses HTTPS ("false") or HTTP ("true").
+	backupInsecureEnvVarKey = "INSECURE"
 
 	// requeueAfter time after starting a job
 	// should be the time after which a started job will usually have completed.
@@ -834,6 +838,19 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 	return nil, err
 }
 
+func isSecureURL(u string) bool {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+
+	// a hostname like "foo.com:9000" is parsed as {scheme: foo.com, host: ""},
+	// so we must make sure to not mis-interpret "https:9000" ({scheme: "https"}) as
+	// an HTTPS url
+
+	return strings.ToLower(parsed.Scheme) == "https" && parsed.Host != ""
+}
+
 func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus,
 	destination *kubermaticv1.BackupDestination, storeContainer *corev1.Container) *batchv1.Job {
 	storeContainer = storeContainer.DeepCopy()
@@ -849,6 +866,16 @@ func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, clus
 		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
 			Name:  backupEndpointEnvVarKey,
 			Value: destination.Endpoint,
+		})
+
+		insecure := "false"
+		if !isSecureURL(destination.Endpoint) {
+			insecure = "true"
+		}
+
+		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
+			Name:  backupInsecureEnvVarKey,
+			Value: insecure,
 		})
 	}
 
@@ -1003,6 +1030,16 @@ func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig
 		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
 			Name:  backupEndpointEnvVarKey,
 			Value: destination.Endpoint,
+		})
+
+		insecure := "false"
+		if !isSecureURL(destination.Endpoint) {
+			insecure = "true"
+		}
+
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
+			Name:  backupInsecureEnvVarKey,
+			Value: insecure,
 		})
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -1718,3 +1718,27 @@ func containsEnvVar(envVars []corev1.EnvVar, envVar corev1.EnvVar) bool {
 	}
 	return false
 }
+
+func TestIsSecure(t *testing.T) {
+	testcases := []struct {
+		url    string
+		secure bool
+	}{
+		{url: "foo.com", secure: false},
+		{url: "foo.com:443", secure: false},
+		{url: "https", secure: false},
+		{url: "https:433", secure: false},
+		{url: "http://foo.com", secure: false},
+		{url: "https://foo.com", secure: true},
+		{url: "HtTpS://foo.com", secure: true},
+		{url: "HtTpS://foo.com:80", secure: true},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.url, func(t *testing.T) {
+			if isSecureURL(testcase.url) != testcase.secure {
+				t.Fatalf("Expected secure=%v, but got the opposite.", testcase.secure)
+			}
+		})
+	}
+}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -1719,25 +1719,26 @@ func containsEnvVar(envVars []corev1.EnvVar, envVar corev1.EnvVar) bool {
 	return false
 }
 
-func TestIsSecure(t *testing.T) {
+func TestIsInsecure(t *testing.T) {
 	testcases := []struct {
-		url    string
-		secure bool
+		url      string
+		insecure bool
 	}{
-		{url: "foo.com", secure: false},
-		{url: "foo.com:443", secure: false},
-		{url: "https", secure: false},
-		{url: "https:433", secure: false},
-		{url: "http://foo.com", secure: false},
-		{url: "https://foo.com", secure: true},
-		{url: "HtTpS://foo.com", secure: true},
-		{url: "HtTpS://foo.com:80", secure: true},
+		{url: "foo.com", insecure: false},
+		{url: "foo.com:443", insecure: false},
+		{url: "https", insecure: false},
+		{url: "https:433", insecure: false},
+		{url: "http://foo.com", insecure: true},
+		{url: "hTtP://foo.com", insecure: true},
+		{url: "https://foo.com", insecure: false},
+		{url: "HtTpS://foo.com", insecure: false},
+		{url: "HtTpS://foo.com:80", insecure: false},
 	}
 
 	for _, testcase := range testcases {
 		t.Run(testcase.url, func(t *testing.T) {
-			if isSecureURL(testcase.url) != testcase.secure {
-				t.Fatalf("Expected secure=%v, but got the opposite.", testcase.secure)
+			if isInsecureURL(testcase.url) != testcase.insecure {
+				t.Fatalf("Expected insecure=%v, but got the opposite.", testcase.insecure)
 			}
 		})
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
s3cmd assumes (rightfully so) HTTPS by default. But KKP allows to configure HTTP URLs for the etcd backup location, for example for an in-cluster Minio (like our default Helm chart). But HTTP URLs caused s3cmd to fail:

> ERROR: SSL certificate verification failure: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:727)

This PR adds some additional handling for HTTP URLs and configures s3cmd properly.

**Does this PR introduce a user-facing change?**:
```release-note
Fix handling insecure HTTP endpoints for etcd backups.
```
