### PR TITLE
consolidate the various ways we construct an S3 client

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -20,24 +20,22 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/util/s3"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1528,14 +1526,7 @@ func GetEtcdRestoreS3Client(ctx context.Context, restore *kubermaticv1.EtcdResto
 		return nil, "", errors.New("CA bundle does not contain any valid certificates")
 	}
 
-	s3Client, err := minio.New(endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
-		Secure: true,
-		Transport: &http.Transport{
-			TLSClientConfig:    &tls.Config{RootCAs: pool},
-			DisableCompression: true,
-		},
-	})
+	s3Client, err := s3.NewClient(endpoint, accessKeyID, secretAccessKey, pool)
 	if err != nil {
 		return nil, "", fmt.Errorf("error creating S3 client: %w", err)
 	}

--- a/pkg/storeuploader/storeuploader.go
+++ b/pkg/storeuploader/storeuploader.go
@@ -18,20 +18,19 @@ package storeuploader
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"io/fs"
-	"net/http"
 	"os"
 	"path"
 	"sort"
 	"time"
 
 	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/util/s3"
 )
 
 // prefix separator separates the prefix
@@ -49,20 +48,8 @@ type StoreUploader struct {
 }
 
 // New returns a new instance of the StoreUploader.
-func New(endpoint string, secure bool, accessKeyID, secretAccessKey string, logger *zap.SugaredLogger, rootCAs *x509.CertPool) (*StoreUploader, error) {
-	options := &minio.Options{
-		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
-		Secure: secure,
-	}
-
-	if rootCAs != nil {
-		options.Transport = &http.Transport{
-			TLSClientConfig:    &tls.Config{RootCAs: rootCAs},
-			DisableCompression: true,
-		}
-	}
-
-	client, err := minio.New(endpoint, options)
+func New(endpoint string, accessKeyID, secretAccessKey string, logger *zap.SugaredLogger, rootCAs *x509.CertPool) (*StoreUploader, error) {
+	client, err := s3.NewClient(endpoint, accessKeyID, secretAccessKey, rootCAs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/s3/client.go
+++ b/pkg/util/s3/client.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func NewClient(endpoint, accessKeyID, secretKey string, caBundle *x509.CertPool) (*minio.Client, error) {
+	secure := true
+
+	if strings.HasPrefix(endpoint, "https://") {
+		endpoint = strings.Replace(endpoint, "https://", "", 1)
+	} else if strings.HasPrefix(endpoint, "http://") {
+		endpoint = strings.Replace(endpoint, "http://", "", 1)
+		secure = false
+	}
+
+	options := &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKeyID, secretKey, ""),
+		Secure: secure,
+	}
+
+	if secure {
+		options.Transport = &http.Transport{
+			TLSClientConfig:    &tls.Config{RootCAs: caBundle},
+			DisableCompression: true,
+		}
+	}
+
+	return minio.New(endpoint, options)
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR introduces `pkg/util/s3` with a single function that takes care of building an S3 client both for HTTP and HTTPS endpoints. The remaining 4 or 5 spots in KKP were rewritten to use the new helper. There is only one place, the etcdrestore stuff, that now _learned_ how to deal with HTTP, all others were already capable of handling it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
