### PR TITLE
update Velero to 1.9.0

### DIFF
--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: velero
 version: v9.9.9-dev
-appVersion: v1.8.1
+appVersion: v1.9.0
 description: A Helm chart for Velero
 keywords:
   - kubermatic

--- a/charts/backup/velero/crd/backups.yaml
+++ b/charts/backup/velero/crd/backups.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -239,6 +239,40 @@ spec:
                         type: string
                       type: object
                   type: object
+                orLabelSelectors:
+                  description: OrLabelSelectors is list of metav1.LabelSelector to filter with when adding individual objects to the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in backup request, only one of them can be used.
+                  items:
+                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  nullable: true
+                  type: array
                 orderedResources:
                   additionalProperties:
                     type: string
@@ -269,6 +303,12 @@ spec:
                   format: date-time
                   nullable: true
                   type: string
+                csiVolumeSnapshotsAttempted:
+                  description: CSIVolumeSnapshotsAttempted is the total number of attempted CSI VolumeSnapshots for this backup.
+                  type: integer
+                csiVolumeSnapshotsCompleted:
+                  description: CSIVolumeSnapshotsCompleted is the total number of successfully completed CSI VolumeSnapshots for this backup.
+                  type: integer
                 errors:
                   description: Errors is a count of all error messages that were generated during execution of the backup.  The actual errors are in the backup's log file in object storage.
                   type: integer
@@ -276,6 +316,9 @@ spec:
                   description: Expiration is when this Backup is eligible for garbage-collection.
                   format: date-time
                   nullable: true
+                  type: string
+                failureReason:
+                  description: FailureReason is an error that caused the entire backup to fail.
                   type: string
                 formatVersion:
                   description: FormatVersion is the backup format version, including major, minor, and patch version.

--- a/charts/backup/velero/crd/backupstoragelocations.yaml
+++ b/charts/backup/velero/crd/backupstoragelocations.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -132,6 +132,9 @@ spec:
                   format: date-time
                   nullable: true
                   type: string
+                message:
+                  description: Message is a message about the backup storage location's status.
+                  type: string
                 phase:
                   description: Phase is the current state of the BackupStorageLocation.
                   enum:
@@ -142,5 +145,4 @@ spec:
           type: object
       served: true
       storage: true
-      subresources:
-        status: {}
+      subresources: {}

--- a/charts/backup/velero/crd/deletebackuprequests.yaml
+++ b/charts/backup/velero/crd/deletebackuprequests.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,7 +16,16 @@ spec:
     singular: deletebackuprequest
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - description: The name of the backup to be deleted
+          jsonPath: .spec.backupName
+          name: BackupName
+          type: string
+        - description: The status of the deletion request
+          jsonPath: .status.phase
+          name: Status
+          type: string
+      name: v1
       schema:
         openAPIV3Schema:
           description: DeleteBackupRequest is a request to delete one or more backups.
@@ -57,3 +66,4 @@ spec:
           type: object
       served: true
       storage: true
+      subresources: {}

--- a/charts/backup/velero/crd/downloadrequests.yaml
+++ b/charts/backup/velero/crd/downloadrequests.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -77,5 +77,3 @@ spec:
           type: object
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/charts/backup/velero/crd/podvolumebackups.yaml
+++ b/charts/backup/velero/crd/podvolumebackups.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,7 +16,39 @@ spec:
     singular: podvolumebackup
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - description: Pod Volume Backup status such as New/InProgress
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Time when this backup was started
+          jsonPath: .status.startTimestamp
+          name: Created
+          type: date
+        - description: Namespace of the pod containing the volume to be backed up
+          jsonPath: .spec.pod.namespace
+          name: Namespace
+          type: string
+        - description: Name of the pod containing the volume to be backed up
+          jsonPath: .spec.pod.name
+          name: Pod
+          type: string
+        - description: Name of the volume to be backed up
+          jsonPath: .spec.volume
+          name: Volume
+          type: string
+        - description: Restic repository identifier for this backup
+          jsonPath: .spec.repoIdentifier
+          name: Restic Repo
+          type: string
+        - description: Name of the Backup Storage Location where this backup should be stored
+          jsonPath: .spec.backupStorageLocation
+          name: Storage Location
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           properties:
@@ -124,3 +156,4 @@ spec:
           type: object
       served: true
       storage: true
+      subresources: {}

--- a/charts/backup/velero/crd/podvolumerestores.yaml
+++ b/charts/backup/velero/crd/podvolumerestores.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,7 +16,37 @@ spec:
     singular: podvolumerestore
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - description: Namespace of the pod containing the volume to be restored
+          jsonPath: .spec.pod.namespace
+          name: Namespace
+          type: string
+        - description: Name of the pod containing the volume to be restored
+          jsonPath: .spec.pod.name
+          name: Pod
+          type: string
+        - description: Name of the volume to be restored
+          jsonPath: .spec.volume
+          name: Volume
+          type: string
+        - description: Pod Volume Restore status such as New/InProgress
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Pod Volume Restore status such as New/InProgress
+          format: int64
+          jsonPath: .status.progress.totalBytes
+          name: TotalBytes
+          type: integer
+        - description: Pod Volume Restore status such as New/InProgress
+          format: int64
+          jsonPath: .status.progress.bytesDone
+          name: BytesDone
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           properties:
@@ -113,3 +143,4 @@ spec:
           type: object
       served: true
       storage: true
+      subresources: {}

--- a/charts/backup/velero/crd/resticrepositories.yaml
+++ b/charts/backup/velero/crd/resticrepositories.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,7 +16,11 @@ spec:
     singular: resticrepository
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           properties:
@@ -71,3 +75,4 @@ spec:
           type: object
       served: true
       storage: true
+      subresources: {}

--- a/charts/backup/velero/crd/restores.yaml
+++ b/charts/backup/velero/crd/restores.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -47,6 +47,10 @@ spec:
                     type: string
                   nullable: true
                   type: array
+                existingResourcePolicy:
+                  description: ExistingResourcePolicy specifies the restore behaviour for the kubernetes resource to be restored
+                  nullable: true
+                  type: string
                 hooks:
                   description: Hooks represent custom behaviors that should be executed during or post restore.
                   properties:
@@ -952,6 +956,40 @@ spec:
                     type: string
                   description: NamespaceMapping is a map of source namespace names to target namespace names to restore into. Any source namespaces not included in the map will be restored into namespaces of the same name.
                   type: object
+                orLabelSelectors:
+                  description: OrLabelSelectors is list of metav1.LabelSelector to filter with when restoring individual objects from the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in restore request, only one of them can be used
+                  items:
+                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  nullable: true
+                  type: array
                 preserveNodePorts:
                   description: PreserveNodePorts specifies whether to restore old nodePorts from backup.
                   nullable: true
@@ -960,6 +998,23 @@ spec:
                   description: RestorePVs specifies whether to restore all included PVs from snapshot (via the cloudprovider).
                   nullable: true
                   type: boolean
+                restoreStatus:
+                  description: RestoreStatus specifies which resources we should restore the status field. If nil, no objects are included. Optional.
+                  nullable: true
+                  properties:
+                    excludedResources:
+                      description: ExcludedResources specifies the resources to which will not restore the status.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                    includedResources:
+                      description: IncludedResources specifies the resources to which will restore the status. If empty, it applies to all resources.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                  type: object
                 scheduleName:
                   description: ScheduleName is the unique name of the Velero schedule to restore from. If specified, and BackupName is empty, Velero will restore from the most recent successful backup created from this schedule.
                   type: string

--- a/charts/backup/velero/crd/schedules.yaml
+++ b/charts/backup/velero/crd/schedules.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,7 +16,23 @@ spec:
     singular: schedule
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - description: Status of the schedule
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: A Cron expression defining when to run the Backup
+          jsonPath: .spec.schedule
+          name: Schedule
+          type: string
+        - description: The last time a Backup was run for this schedule
+          jsonPath: .status.lastBackup
+          name: LastBackup
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: Schedule is a Velero resource that represents a pre-scheduled or periodic Backup that should be run.
@@ -245,6 +261,40 @@ spec:
                             type: string
                           type: object
                       type: object
+                    orLabelSelectors:
+                      description: OrLabelSelectors is list of metav1.LabelSelector to filter with when adding individual objects to the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in backup request, only one of them can be used.
+                      items:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      nullable: true
+                      type: array
                     orderedResources:
                       additionalProperties:
                         type: string
@@ -299,3 +349,4 @@ spec:
           type: object
       served: true
       storage: true
+      subresources: {}

--- a/charts/backup/velero/crd/serverstatusrequests.yaml
+++ b/charts/backup/velero/crd/serverstatusrequests.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -70,5 +70,3 @@ spec:
           type: object
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/charts/backup/velero/crd/volumesnapshotlocations.yaml
+++ b/charts/backup/velero/crd/volumesnapshotlocations.yaml
@@ -1,4 +1,4 @@
-# This file has been generated with Velero v1.8.1. Do not edit.
+# This file has been generated with Velero v1.9.0. Do not edit.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -18,7 +18,7 @@ velero:
   # that also contains the restic binary
   image:
     repository: docker.io/velero/velero
-    tag: v1.8.1
+    tag: v1.9.0
     pullPolicy: IfNotPresent
 
   # CLI flags to pass to velero server; note that the two flags
@@ -30,21 +30,21 @@ velero:
   # At least one plugin provider image is required.
   initContainers:
   # - name: velero-plugin-for-aws
-  #   image: docker.io/velero/velero-plugin-for-aws:v1.4.1
+  #   image: docker.io/velero/velero-plugin-for-aws:v1.5.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
 
   # - name: velero-plugin-for-gcp
-  #   image: docker.io/velero/velero-plugin-for-gcp:v1.4.1
+  #   image: docker.io/velero/velero-plugin-for-gcp:v1.5.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
 
   # - name: velero-plugin-for-microsoft-azure
-  #   image: docker.io/velero/velero-plugin-for-microsoft-azure:v1.4.1
+  #   image: docker.io/velero/velero-plugin-for-microsoft-azure:v1.5.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -23,7 +23,7 @@ containerize ./hack/update-velero-crds.sh
 
 velero=velero
 if ! [ -x "$(command -v $velero)" ]; then
-  version=v1.8.1
+  version=v1.9.0
   url="https://github.com/vmware-tanzu/velero/releases/download/$version/velero-$version-linux-amd64.tar.gz"
   velero=/tmp/velero
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Thhe 1.9 migration notes (https://velero.io/docs/v1.9/upgrade-to-1.9/) do not mention anything special. We already took care of migrating to the new mechanism for the default backup storage location in a previous KKP release.

**Does this PR introduce a user-facing change?**:
```release-note
Update Velero to 1.9.0
```
