### PR TITLE
update Minio to RELEASE.2022-06-25T15-50-16Z

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: minio
 version: v9.9.9-dev
-appVersion: RELEASE.2022-02-16T00-35-27Z
+appVersion: RELEASE.2022-06-25T15-50-16Z
 description: minio
 keywords:
   - kubermatic

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2022-02-16T00-35-27Z'
+        image: 'docker.io/minio/minio:RELEASE.2022-06-25T15-50-16Z'
         args:
         - server
         - /storage

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2022-02-16T00-35-27Z'
+        image: 'docker.io/minio/minio:RELEASE.2022-06-25T15-50-16Z'
         args:
         - server
         - /storage

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -15,7 +15,7 @@
 minio:
   image:
     repository: docker.io/minio/minio
-    tag: RELEASE.2022-02-16T00-35-27Z
+    tag: RELEASE.2022-06-25T15-50-16Z
   storeSize: 100Gi
 
   # The is required to enable the BackupRestore controller so it can backup


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It's been nearly 6 months since the last Minio bump.

**Does this PR introduce a user-facing change?**:
```release-note
Update Minio to RELEASE.2022-06-25T15-50-16Z
```
