### PR TITLE
Bump vSphere CPI to 1.23.1 (for k8s 1.23.x) and 1.24.0 (for k8s 1.24.x)

### DIFF
--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -159,7 +159,7 @@ func getAzureVersion(version semver.Semver) (string, error) {
 	case v124:
 		fallthrough
 	default:
-		return "1.24.0", nil
+		return v1240, nil
 	}
 }
 

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -183,7 +183,7 @@ func getOSVersion(version semver.Semver) (string, error) {
 	case v124:
 		fallthrough
 	default:
-		return "1.24.0", nil
+		return v1240, nil
 	}
 }
 

--- a/pkg/resources/cloudcontroller/util.go
+++ b/pkg/resources/cloudcontroller/util.go
@@ -31,6 +31,8 @@ const (
 	v122 = "1.22"
 	v123 = "1.23"
 	v124 = "1.24"
+
+	v1240 = "1.24.0"
 )
 
 // ExternalCloudControllerFeatureSupported checks if the cloud provider supports

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -171,11 +171,11 @@ func getVsphereCPIVersion(version semver.Semver) string {
 	case v122:
 		return "1.22.6"
 	case v123:
-		fallthrough
+		return "1.23.1"
 	case v124:
 		fallthrough
 	//	By default return latest version
 	default:
-		return "1.23.0"
+		return "1.24.0"
 	}
 }

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -176,7 +176,6 @@ func getVsphereCPIVersion(version semver.Semver) string {
 		fallthrough
 	//	By default return latest version
 	default:
-		// nolint:goconst
-		return "1.24.0"
+		return v1240
 	}
 }

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -176,6 +176,7 @@ func getVsphereCPIVersion(version semver.Semver) string {
 		fallthrough
 	//	By default return latest version
 	default:
+		// nolint:goconst
 		return "1.24.0"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0
+        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.1
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0
+        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.24.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
There is a new release of vSphere CCM (also called CPI) available: https://github.com/kubernetes/cloud-provider-vsphere/releases/tag/v1.24.0

This PR adds it, plus bumps the 1.23.x series to the latest 1.23.1 release. The changelogs do not mention major changes apart from the Kubernetes 1.24 dependency bump for 1.24.0.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update vSphere CCM to 1.23.1 (for Kubernetes 1.23.x) and 1.24.0 (for Kubernetes 1.24.x)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>