### PR TITLE
Resource quota sync labels

### DIFF
--- a/cmd/master-controller-manager/wrappers_ee.go
+++ b/cmd/master-controller-manager/wrappers_ee.go
@@ -27,7 +27,7 @@ import (
 	allowedregistrycontroller "k8c.io/kubermatic/v2/pkg/ee/allowed-registry-controller"
 	eemasterctrlmgr "k8c.io/kubermatic/v2/pkg/ee/cmd/master-controller-manager"
 	resourcequotamastercontroller "k8c.io/kubermatic/v2/pkg/ee/resource-quota/master-controller"
-	resourcequotasyncer "k8c.io/kubermatic/v2/pkg/ee/resource-quota/resource-quota-syncer"
+	resourcequotasynchronizer "k8c.io/kubermatic/v2/pkg/ee/resource-quota/resource-quota-synchronizer"
 	"k8c.io/kubermatic/v2/pkg/provider"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,7 +56,7 @@ func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.C
 
 func resourceQuotaSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
 	return func(ctx context.Context, masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
-		return resourcequotasyncer.ControllerName, resourcequotasyncer.Add(
+		return resourcequotasynchronizer.ControllerName, resourcequotasynchronizer.Add(
 			masterMgr,
 			seedManagerMap,
 			ctrlCtx.log,

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
@@ -95,6 +95,7 @@ func resourceQuotaCreatorGetter(rq *kubermaticv1.ResourceQuota) reconciling.Name
 	return func() (string, reconciling.KubermaticV1ResourceQuotaCreator) {
 		return rq.Name, func(c *kubermaticv1.ResourceQuota) (*kubermaticv1.ResourceQuota, error) {
 			c.Name = rq.Name
+			c.Labels = rq.Labels
 			c.Spec = rq.Spec
 			c.Status.GlobalUsage = rq.Status.GlobalUsage
 			return c, nil

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
@@ -22,7 +22,7 @@
    END OF TERMS AND CONDITIONS
 */
 
-package resourcequotasyncer
+package resourcequotasynchronizer
 
 import (
 	"context"
@@ -49,7 +49,7 @@ import (
 
 const (
 	// This controller syncs the ResourceQuotas from the master cluster to the seed clusters.
-	ControllerName = "kkp-resource-quota-syncer"
+	ControllerName = "kkp-resource-quota-synchronizer"
 )
 
 type reconciler struct {

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -158,6 +158,7 @@ func genResourceQuota(name string, deleted bool) *kubermaticv1.ResourceQuota {
 	rq.Namespace = kubermaticresources.KubermaticNamespace
 	rq.Labels = map[string]string{
 		kubermaticv1.ResourceQuotaSubjectNameLabelKey: "project1",
+		kubermaticv1.ResourceQuotaSubjectKindLabelKey: "project",
 	}
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -140,6 +140,11 @@ func TestReconcile(t *testing.T) {
 			if reflect.DeepEqual(rq.Status.LocalUsage, tc.expectedRQ.Status.LocalUsage) {
 				t.Fatal("local usage should not be synced to seeds")
 			}
+
+			if !reflect.DeepEqual(rq.Labels, tc.expectedRQ.Labels) {
+				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(rq.Labels, tc.expectedRQ.Labels))
+			}
+
 		})
 	}
 }
@@ -152,6 +157,9 @@ func genResourceQuota(name string, deleted bool) *kubermaticv1.ResourceQuota {
 	rq := &kubermaticv1.ResourceQuota{}
 	rq.Name = name
 	rq.Namespace = kubermaticresources.KubermaticNamespace
+	rq.Labels = map[string]string{
+		kubermaticv1.ResourceQuotaSubjectNameLabelKey: "project1",
+	}
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{
 			Name: "project1",

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -22,7 +22,7 @@
    END OF TERMS AND CONDITIONS
 */
 
-package resourcequotasyncer
+package resourcequotasynchronizer
 
 import (
 	"context"

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -144,7 +144,6 @@ func TestReconcile(t *testing.T) {
 			if !reflect.DeepEqual(rq.Labels, tc.expectedRQ.Labels) {
 				t.Fatalf(" diff: %s", diff.ObjectGoPrintSideBySide(rq.Labels, tc.expectedRQ.Labels))
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Renames resource quota syncer to synchronizer to be aligned with the rest of the code
Syncs labels from master to seed resource quotas


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
