### PR TITLE
Use Go Generics for Reconciling

### DIFF
--- a/cmd/kubermatic-installer/cmd_convert_kubeconfig.go
+++ b/cmd/kubermatic-installer/cmd_convert_kubeconfig.go
@@ -242,16 +242,16 @@ func reconcileCluster(ctx context.Context, config *rest.Config, namespace string
 	client := mgr.GetClient()
 
 	log.Info("Reconciling ServiceAccount...")
-	if err := reconciling.ReconcileServiceAccounts(ctx, []reconciling.NamedServiceAccountCreatorGetter{
+	if err := reconciling.EnsureNamedObjects(ctx, client, namespace, []reconciling.NamedServiceAccountCreatorGetter{
 		serviceAccountCreatorGetter,
-	}, namespace, client); err != nil {
+	}); err != nil {
 		return "", fmt.Errorf("failed to create ServiceAccount: %w", err)
 	}
 
 	log.Info("Reconciling ClusterRoleBinding...")
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, []reconciling.NamedClusterRoleBindingCreatorGetter{
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", []reconciling.NamedClusterRoleBindingCreatorGetter{
 		clusterRoleCreatorGetterFactory(namespace),
-	}, "", client); err != nil {
+	}); err != nil {
 		return "", fmt.Errorf("failed to create ClusterRoleBinding: %w", err)
 	}
 

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -313,7 +313,7 @@ func main() {
 		creators := []reconciling.NamedCustomResourceDefinitionCreatorGetter{
 			machinecontrolerresources.MachineCRDCreator(),
 		}
-		if err := reconciling.ReconcileCustomResourceDefinitions(rootCtx, creators, "", mgr.GetClient()); err != nil {
+		if err := reconciling.EnsureNamedObjects(rootCtx, mgr.GetClient(), "", creators); err != nil {
 			// The mgr.Client is uninitianlized here and hence always returns a 404, regardless of the object existing or not
 			if !strings.Contains(err.Error(), `customresourcedefinitions.apiextensions.k8s.io "machines.cluster.k8s.io" already exists`) {
 				log.Fatalw("Failed to initially create the Machine CR", zap.Error(err))

--- a/docs/resource-handling.md
+++ b/docs/resource-handling.md
@@ -166,12 +166,8 @@ creators := []NamedSecretCreatorGetter{
 
 // controller-runtime controller:
 client := mgr.GetClient()
-informerFactory := mgr.GetCache()
-// cluster/monitoring controller
-client := cc.dynaimcClient
-informerFactory := cc.dynamicCache
 
-if err := ReconcileSecrets(creators, "some-namespace", client, informerFactory); err != nil {
+if err := reconciling.EnsureNamedObjects(ctx, client, "some-namespace", creators); err != nil {
 	return fmt.Errorf("failed to reconcile Secrets: %w", err)
 }
 ```

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -66,7 +66,7 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 		log.Infof("reconciling namespace '%s'", desiredNs.Name)
 
 		creators := []reconciling.NamedNamespaceCreatorGetter{
-			func() (name string, create reconciling.NamespaceCreator) {
+			func() (string, reconciling.NamespaceCreator) {
 				return desiredNs.Name, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
 					if desiredNs.Labels != nil {
 						if ns.Labels == nil {
@@ -90,7 +90,7 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 			},
 		}
 
-		if err := reconciling.ReconcileNamespaces(ctx, creators, "", userClient); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, userClient, "", creators); err != nil {
 			return fmt.Errorf("failed to reconcile namespace: %w", err)
 		}
 	}

--- a/pkg/clusterdeletion/volumes.go
+++ b/pkg/clusterdeletion/volumes.go
@@ -99,7 +99,7 @@ func (d *Deletion) disablePVCreation(ctx context.Context, userClusterClient ctrl
 	creatorGetters := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
 		creationPreventingWebhook("", []string{"persistentvolumes", "persistentvolumeclaims"}),
 	}
-	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creatorGetters, "", userClusterClient); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, userClusterClient, "", creatorGetters); err != nil {
 		return fmt.Errorf("failed to create ValidatingWebhookConfiguration to prevent creation of PVs/PVCs: %w", err)
 	}
 

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -115,7 +115,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, appDef *appskubermaticv1.ApplicationDefinition) error {
-		return reconciling.ReconcileAppsKubermaticV1ApplicationDefinitions(ctx, applicationDefCreatorGetters, "", seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, "", applicationDefCreatorGetters)
 	})
 	if err != nil {
 		r.recorder.Eventf(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -117,7 +117,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		secretCreator(seedsecret),
 	}
 	err = r.reconcileAllSeeds(ctx, log, seedsecret, func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
-		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, c)
+		return reconciling.EnsureNamedObjects(ctx, c, r.namespace, namedSecretCreatorGetter)
 	})
 	if err != nil {
 		r.recorder.Eventf(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -118,7 +118,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	err := r.syncAllSeeds(log, clusterTemplate, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
-		return reconciling.ReconcileKubermaticV1ClusterTemplates(ctx, clusterTemplateCreatorGetters, "", seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, "", clusterTemplateCreatorGetters)
 	})
 	if err != nil {
 		r.recorder.Eventf(clusterTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -147,7 +147,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	return r.syncAllSeeds(ctx, log, constraint, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint) error {
-		return reconciling.ReconcileKubermaticV1Constraints(ctx, constraintCreatorGetters, r.namespace, seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, r.namespace, constraintCreatorGetters)
 	})
 }
 

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -155,7 +155,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 	}
 
 	return r.syncAllSeeds(ctx, log, constraintTemplate, func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
-		return reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", seedClusterClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClusterClient, "", ctCreatorGetters)
 	})
 }
 

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -117,7 +117,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	err := r.syncAllSeeds(log, preset, func(seedClient ctrlruntimeclient.Client, preset *kubermaticv1.Preset) error {
-		return reconciling.ReconcileKubermaticV1Presets(ctx, presetCreatorGetters, "", seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, "", presetCreatorGetters)
 	})
 	if err != nil {
 		r.recorder.Eventf(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -121,7 +121,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	err := r.syncAllSeeds(log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
-		err := reconciling.ReconcileKubermaticV1Projects(ctx, projectCreatorGetters, "", seedClusterClient)
+		err := reconciling.EnsureNamedObjects(ctx, seedClusterClient, "", projectCreatorGetters)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile project: %w", err)
 		}

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -176,7 +176,7 @@ func (r *Reconciler) reconcileSeedServiceAccounts(ctx context.Context, seed *kub
 		seedServiceAccountCreator(seed),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, creators, seed.Namespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, seed.Namespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", seed.Namespace, err)
 	}
 
@@ -192,7 +192,7 @@ func (r *Reconciler) reconcileSeedRoles(ctx context.Context, seed *kubermaticv1.
 		seedMonitoringRoleCreator(seed),
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, creators, SeedMonitoringNamespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, SeedMonitoringNamespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", SeedMonitoringNamespace, err)
 	}
 
@@ -208,7 +208,7 @@ func (r *Reconciler) reconcileSeedRoleBindings(ctx context.Context, seed *kuberm
 		seedMonitoringRoleBindingCreator(seed),
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, creators, SeedMonitoringNamespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, SeedMonitoringNamespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in the namespace %s: %w", SeedMonitoringNamespace, err)
 	}
 
@@ -296,7 +296,7 @@ func (r *Reconciler) reconcileMasterSecrets(ctx context.Context, seed *kubermati
 		masterSecretCreator(seed, kubeconfig, credentials),
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, seed.Namespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, seed.Namespace, creators); err != nil {
 		return nil, fmt.Errorf("failed to reconcile Secrets in the namespace %s: %w", seed.Namespace, err)
 	}
 
@@ -323,7 +323,7 @@ func (r *Reconciler) reconcileMasterDeployments(ctx context.Context, seed *kuber
 		masterDeploymentCreator(seed, secret, registry.GetOverwriteFunc(config.Spec.UserCluster.OverwriteRegistry)),
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, creators, seed.Namespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, seed.Namespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %w", seed.Namespace, err)
 	}
 
@@ -335,7 +335,7 @@ func (r *Reconciler) reconcileMasterServices(ctx context.Context, seed *kubermat
 		masterServiceCreator(seed, secret),
 	}
 
-	if err := reconciling.ReconcileServices(ctx, creators, seed.Namespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, seed.Namespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile Services in the namespace %s: %w", seed.Namespace, err)
 	}
 
@@ -357,7 +357,7 @@ func (r *Reconciler) reconcileMasterGrafanaProvisioning(ctx context.Context, see
 		r.masterGrafanaConfigmapCreator(seeds),
 	}
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, MasterGrafanaNamespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, MasterGrafanaNamespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in the namespace %s: %w", MasterGrafanaNamespace, err)
 	}
 

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -130,7 +130,7 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		namespaceCreator(seed.Namespace),
 	}
 
-	if err := reconciling.ReconcileNamespaces(ctx, nsCreators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", nsCreators); err != nil {
 		return fmt.Errorf("failed to reconcile namespace: %w", err)
 	}
 
@@ -138,7 +138,7 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		seedCreator(seed),
 	}
 
-	if err := reconciling.ReconcileSeeds(ctx, seedCreators, seed.Namespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, seed.Namespace, seedCreators); err != nil {
 		return fmt.Errorf("failed to reconcile seed: %w", err)
 	}
 
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		configCreator(config),
 	}
 
-	if err := reconciling.ReconcileKubermaticConfigurations(ctx, configCreators, seed.Namespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, seed.Namespace, configCreators); err != nil {
 		return fmt.Errorf("failed to reconcile seed: %w", err)
 	}
 

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -123,7 +123,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	err := r.syncAllSeeds(log, userProjectBinding, func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error {
-		return reconciling.ReconcileKubermaticV1UserProjectBindings(ctx, userProjectBindingCreatorGetters, "", seedClusterClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClusterClient, "", userProjectBindingCreatorGetters)
 	})
 
 	if err != nil {

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -134,7 +134,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		userCreatorGetter(user),
 	}
 	err := r.syncAllSeeds(log, user, func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error {
-		err := reconciling.ReconcileKubermaticV1Users(ctx, userCreatorGetters, "", seedClusterClient)
+		err := reconciling.EnsureNamedObjects(ctx, seedClusterClient, "", userCreatorGetters)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile user: %w", err)
 		}

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -187,11 +187,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 	keys := buildUserSSHKeysForCluster(cluster.Name, userSSHKeys)
 
-	if err := reconciling.ReconcileSecrets(
+	if err := reconciling.EnsureNamedObjects(
 		ctx,
-		[]reconciling.NamedSecretCreatorGetter{updateUserSSHKeysSecrets(keys)},
-		cluster.Status.NamespaceName,
 		seedClient,
+		cluster.Status.NamespaceName,
+		[]reconciling.NamedSecretCreatorGetter{updateUserSSHKeysSecrets(keys)},
 	); err != nil {
 		return fmt.Errorf("failed to reconcile SSH key secret: %w", err)
 	}

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -204,7 +204,7 @@ func (r *Reconciler) reconcileConfigMaps(ctx context.Context, config *kubermatic
 		creators = append(creators, kubermatic.UIConfigConfigMapCreator(config))
 	}
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps: %w", err)
 	}
 
@@ -223,7 +223,7 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, config *kubermaticv1.
 		creators = append(creators, common.DockercfgSecretCreator(config))
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Secrets: %w", err)
 	}
 
@@ -239,7 +239,7 @@ func (r *Reconciler) reconcileServiceAccounts(ctx context.Context, config *kuber
 		common.WebhookServiceAccountCreator(config),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAccounts: %w", err)
 	}
 
@@ -254,7 +254,7 @@ func (r *Reconciler) reconcileRoles(ctx context.Context, config *kubermaticv1.Ku
 		kubermatic.APIRoleCreator(),
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, creators, config.Namespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile Roles: %w", err)
 	}
 
@@ -269,7 +269,7 @@ func (r *Reconciler) reconcileRoleBindings(ctx context.Context, config *kubermat
 		kubermatic.APIRoleBindingCreator(),
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, creators, config.Namespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings: %w", err)
 	}
 
@@ -284,7 +284,7 @@ func (r *Reconciler) reconcileClusterRoles(ctx context.Context, config *kubermat
 		common.WebhookClusterRoleCreator(config),
 	}
 
-	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoles: %w", err)
 	}
 
@@ -300,7 +300,7 @@ func (r *Reconciler) reconcileClusterRoleBindings(ctx context.Context, config *k
 		common.WebhookClusterRoleBindingCreator(config),
 	}
 
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBindings: %w", err)
 	}
 
@@ -332,7 +332,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, config *kubermati
 		modifiers = append(modifiers, reconciling.ImagePullSecretsWrapper(common.DockercfgSecretName))
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, creators, config.Namespace, r.Client, modifiers...); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments: %w", err)
 	}
 
@@ -353,7 +353,7 @@ func (r *Reconciler) reconcilePodDisruptionBudgets(ctx context.Context, config *
 		)
 	}
 
-	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %w", err)
 	}
 
@@ -374,7 +374,7 @@ func (r *Reconciler) reconcileServices(ctx context.Context, config *kubermaticv1
 		)
 	}
 
-	if err := reconciling.ReconcileServices(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Services: %w", err)
 	}
 
@@ -398,7 +398,7 @@ func (r *Reconciler) reconcileIngresses(ctx context.Context, config *kubermaticv
 		kubermatic.IngressCreator(config),
 	}
 
-	if err := reconciling.ReconcileIngresses(ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, config.Namespace, creators, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Ingresses: %w", err)
 	}
 
@@ -417,7 +417,7 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 		kubermatic.ResourceQuotaValidatingWebhookConfigurationCreator(ctx, config, r.Client),
 	}
 
-	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile Validating Webhooks: %w", err)
 	}
 
@@ -432,7 +432,7 @@ func (r *Reconciler) reconcileMutatingWebhooks(ctx context.Context, config *kube
 		kubermatic.ResourceQuotaMutatingWebhookConfigurationCreator(ctx, config, r.Client),
 	}
 
-	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r.Client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile Mutating Webhooks: %w", err)
 	}
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -268,7 +268,7 @@ func (r *Reconciler) cleanupDeletedSeed(ctx context.Context, cfg *kubermaticv1.K
 		modifiers = append(modifiers, reconciling.ImagePullSecretsWrapper(common.DockercfgSecretName))
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, creators, r.namespace, client, modifiers...); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, r.namespace, creators, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile webhook Deployment: %w", err)
 	}
 
@@ -382,7 +382,7 @@ func (r *Reconciler) reconcileCRDs(ctx context.Context, cfg *kubermaticv1.Kuberm
 		}
 	}
 
-	if err := reconciling.ReconcileCustomResourceDefinitions(ctx, creators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile CRDs: %w", err)
 	}
 
@@ -401,7 +401,7 @@ func (r *Reconciler) reconcileServiceAccounts(ctx context.Context, cfg *kubermat
 		creators = append(creators, nodeportproxy.ServiceAccountCreator(cfg))
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, creators, r.namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, r.namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Kubermatic ServiceAccounts: %w", err)
 	}
 
@@ -413,7 +413,7 @@ func (r *Reconciler) reconcileServiceAccounts(ctx context.Context, cfg *kubermat
 		}
 
 		// no ownership because these resources are most likely in a different namespace than Kubermatic
-		if err := reconciling.ReconcileServiceAccounts(ctx, creators, metav1.NamespaceSystem, client); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, metav1.NamespaceSystem, creators); err != nil {
 			return fmt.Errorf("failed to reconcile VPA ServiceAccounts: %w", err)
 		}
 	}
@@ -432,7 +432,7 @@ func (r *Reconciler) reconcileRoles(ctx context.Context, cfg *kubermaticv1.Kuber
 		creators = append(creators, nodeportproxy.RoleCreator())
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, creators, r.namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, r.namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Roles: %w", err)
 	}
 
@@ -450,7 +450,7 @@ func (r *Reconciler) reconcileRoleBindings(ctx context.Context, cfg *kubermaticv
 		creators = append(creators, nodeportproxy.RoleBindingCreator(cfg))
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, creators, r.namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, r.namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings: %w", err)
 	}
 
@@ -472,7 +472,7 @@ func (r *Reconciler) reconcileClusterRoles(ctx context.Context, cfg *kubermaticv
 		creators = append(creators, vpa.ClusterRoleCreators()...)
 	}
 
-	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoles: %w", err)
 	}
 
@@ -495,7 +495,7 @@ func (r *Reconciler) reconcileClusterRoleBindings(ctx context.Context, cfg *kube
 		creators = append(creators, vpa.ClusterRoleBindingCreators()...)
 	}
 
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", creators); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBindings: %w", err)
 	}
 
@@ -509,7 +509,7 @@ func (r *Reconciler) reconcileConfigMaps(ctx context.Context, cfg *kubermaticv1.
 		kubermaticseed.CABundleConfigMapCreator(caBundle),
 	}
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, cfg.Namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps: %w", err)
 	}
 
@@ -528,7 +528,7 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, cfg *kubermaticv1.Kub
 		creators = append(creators, common.DockercfgSecretCreator(cfg))
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, cfg.Namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Kubermatic Secrets: %w", err)
 	}
 
@@ -538,7 +538,7 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, cfg *kubermaticv1.Kub
 		}
 
 		// no ownership because these resources are most likely in a different namespace than Kubermatic
-		if err := reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, client); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, metav1.NamespaceSystem, creators); err != nil {
 			return fmt.Errorf("failed to reconcile VPA Secrets: %w", err)
 		}
 	}
@@ -578,7 +578,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, cfg *kubermaticv1
 		modifiers = append(modifiers, reconciling.ImagePullSecretsWrapper(common.DockercfgSecretName))
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, creators, r.namespace, client, modifiers...); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, r.namespace, creators, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile Kubermatic Deployments: %w", err)
 	}
 
@@ -590,7 +590,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, cfg *kubermaticv1
 		}
 
 		// no ownership because these resources are most likely in a different namespace than Kubermatic
-		if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, client, volumeLabelModifier); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, metav1.NamespaceSystem, creators, volumeLabelModifier); err != nil {
 			return fmt.Errorf("failed to reconcile VPA Deployments: %w", err)
 		}
 	}
@@ -609,7 +609,7 @@ func (r *Reconciler) reconcilePodDisruptionBudgets(ctx context.Context, cfg *kub
 		creators = append(creators, nodeportproxy.EnvoyPDBCreator())
 	}
 
-	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, cfg.Namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %w", err)
 	}
 
@@ -623,7 +623,7 @@ func (r *Reconciler) reconcileServices(ctx context.Context, cfg *kubermaticv1.Ku
 		common.WebhookServiceCreator(cfg, client),
 	}
 
-	if err := reconciling.ReconcileServices(ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, cfg.Namespace, creators, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Kubermatic Services: %w", err)
 	}
 
@@ -635,7 +635,7 @@ func (r *Reconciler) reconcileServices(ctx context.Context, cfg *kubermaticv1.Ku
 			nodeportproxy.ServiceCreator(seed),
 		}
 
-		if err := reconciling.ReconcileServices(ctx, creators, cfg.Namespace, client); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, cfg.Namespace, creators); err != nil {
 			return fmt.Errorf("failed to reconcile nodeport-proxy Services: %w", err)
 		}
 	}
@@ -646,7 +646,7 @@ func (r *Reconciler) reconcileServices(ctx context.Context, cfg *kubermaticv1.Ku
 		}
 
 		// no ownership because these resources are most likely in a different namespace than Kubermatic
-		if err := reconciling.ReconcileServices(ctx, creators, metav1.NamespaceSystem, client); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, metav1.NamespaceSystem, creators); err != nil {
 			return fmt.Errorf("failed to reconcile VPA Services: %w", err)
 		}
 	}
@@ -672,7 +672,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		)
 	}
 
-	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, validatingWebhookCreators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", validatingWebhookCreators); err != nil {
 		return fmt.Errorf("failed to reconcile validating Admission Webhooks: %w", err)
 	}
 
@@ -682,7 +682,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		kubermaticseed.MLAAdminSettingMutatingWebhookConfigurationCreator(ctx, cfg, client),
 	}
 
-	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, mutatingWebhookCreators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", mutatingWebhookCreators); err != nil {
 		return fmt.Errorf("failed to reconcile mutating Admission Webhooks: %w", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -288,7 +288,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 		return r.deleteCronJob(ctx, cluster)
 	}
 
-	return reconciling.ReconcileCronJobs(ctx, []reconciling.NamedCronJobCreatorGetter{r.cronjob(cluster, backupStoreContainer)}, metav1.NamespaceSystem, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r.Client, metav1.NamespaceSystem, []reconciling.NamedCronJobCreatorGetter{r.cronjob(cluster, backupStoreContainer)})
 }
 
 func getBackupStoreContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
@@ -368,7 +368,7 @@ func (r *Reconciler) ensureCronJobSecrets(ctx context.Context, cluster *kubermat
 		),
 	}
 
-	return reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r.Client, common.OwnershipModifierFactory(cluster, r.scheme))
+	return reconciling.EnsureNamedObjects(ctx, r.Client, metav1.NamespaceSystem, creators, common.OwnershipModifierFactory(cluster, r.scheme))
 }
 
 func (r *Reconciler) ensureCronJobConfigMaps(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -378,7 +378,7 @@ func (r *Reconciler) ensureCronJobConfigMaps(ctx context.Context, cluster *kuber
 		certificates.CABundleConfigMapCreator(name, r.caBundle),
 	}
 
-	return reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespaceSystem, r.Client, common.OwnershipModifierFactory(cluster, r.scheme))
+	return reconciling.EnsureNamedObjects(ctx, r.Client, metav1.NamespaceSystem, creators, common.OwnershipModifierFactory(cluster, r.scheme))
 }
 
 func (r *Reconciler) cleanupJob(cluster *kubermaticv1.Cluster, cleanupContainer *corev1.Container) *batchv1.Job {

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -209,13 +209,13 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	// creation, we must set some status fields and this requires us to wait for the Cluster object
 	// to appear in our caches.
 	name := types.NamespacedName{Name: newCluster.Name}
-	dummyCreator := func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+	dummyCreator := func(existing *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
 		return newCluster, nil
 	}
 
 	log.Infof("creating cluster %s", newCluster.Name)
 
-	if err := reconciling.EnsureNamedObject(ctx, name, dummyCreator, r.seedClient, &kubermaticv1.Cluster{}, false); err != nil {
+	if err := reconciling.EnsureNamedObject(ctx, r.seedClient, name, &kubermaticv1.Cluster{}, dummyCreator); err != nil {
 		return fmt.Errorf("failed to create cluster: %w", err)
 	}
 

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -272,7 +272,7 @@ func (r *reconciler) ensureConstraint(ctx context.Context, log *zap.SugaredLogge
 	}
 
 	if err := r.syncAllClustersNS(ctx, log, constraint, clusterList, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint, namespace string) error {
-		return reconciling.ReconcileKubermaticV1Constraints(ctx, constraintCreatorGetters, namespace, seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, namespace, constraintCreatorGetters)
 	}); err != nil {
 		return err
 	}

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -163,7 +163,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 	}
 
 	return r.syncAllClusters(ctx, log, constraintTemplate, func(userClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
-		return reconciling.ReconcileConstraintTemplates(ctx, ctCreatorGetters, "", userClusterClient)
+		return reconciling.EnsureNamedObjects(ctx, userClusterClient, "", ctCreatorGetters)
 	})
 }
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -1164,7 +1164,7 @@ func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cl
 		),
 	}
 
-	return reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r.Client, common.OwnershipModifierFactory(cluster, r.scheme))
+	return reconciling.EnsureNamedObjects(ctx, r.Client, metav1.NamespaceSystem, creators, common.OwnershipModifierFactory(cluster, r.scheme))
 }
 
 func caBundleConfigMapName(cluster *kubermaticv1.Cluster) string {
@@ -1178,7 +1178,7 @@ func (r *Reconciler) ensureConfigMaps(ctx context.Context, cluster *kubermaticv1
 		certificates.CABundleConfigMapCreator(name, r.caBundle),
 	}
 
-	return reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespaceSystem, r.Client, common.OwnershipModifierFactory(cluster, r.scheme))
+	return reconciling.EnsureNamedObjects(ctx, r.Client, metav1.NamespaceSystem, creators, common.OwnershipModifierFactory(cluster, r.scheme))
 }
 
 func parseCronSchedule(scheduleString string) (cron.Schedule, error) {

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -320,7 +320,7 @@ func (r *datasourceGrafanaController) ensureDeployments(ctx context.Context, c *
 	creators := []reconciling.NamedDeploymentCreatorGetter{
 		GatewayDeploymentCreator(data, settings),
 	}
-	if err := reconciling.ReconcileDeployments(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, c.Status.NamespaceName, creators); err != nil {
 		return err
 	}
 	return nil
@@ -330,7 +330,7 @@ func (r *datasourceGrafanaController) ensureConfigMaps(ctx context.Context, c *k
 	creators := []reconciling.NamedConfigMapCreatorGetter{
 		GatewayConfigMapCreator(c, r.mlaNamespace, settings),
 	}
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, c.Status.NamespaceName, creators); err != nil {
 		return fmt.Errorf("failed to ensure that the ConfigMap exists: %w", err)
 	}
 	return nil
@@ -341,7 +341,7 @@ func (r *datasourceGrafanaController) ensureSecrets(ctx context.Context, c *kube
 		GatewayCACreator(),
 		GatewayCertificateCreator(c, data.GetMLAGatewayCA),
 	}
-	if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, c.Status.NamespaceName, creators); err != nil {
 		return fmt.Errorf("failed to ensure that the Secrets exist: %w", err)
 	}
 	return nil
@@ -352,7 +352,7 @@ func (r *datasourceGrafanaController) ensureServices(ctx context.Context, c *kub
 		GatewayInternalServiceCreator(),
 		GatewayExternalServiceCreator(c),
 	}
-	return reconciling.ReconcileServices(ctx, creators, c.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, c.Status.NamespaceName, creators)
 }
 
 func (r *datasourceGrafanaController) CleanUp(ctx context.Context) error {

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -121,10 +121,10 @@ func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconci
 	}
 
 	if err := r.ruleGroupSyncController.syncClusterNS(ctx, log, ruleGroup, func(seedClient ctrlruntimeclient.Client, ruleGroup *kubermaticv1.RuleGroup, cluster *kubermaticv1.Cluster) error {
-		ruleGroupCreatorGetter := []reconciling.NamedKubermaticV1RuleGroupCreatorGetter{
+		ruleGroupCreatorGetters := []reconciling.NamedKubermaticV1RuleGroupCreatorGetter{
 			ruleGroupCreatorGetter(ruleGroup, cluster),
 		}
-		return reconciling.ReconcileKubermaticV1RuleGroups(ctx, ruleGroupCreatorGetter, cluster.Status.NamespaceName, seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, cluster.Status.NamespaceName, ruleGroupCreatorGetters)
 	}); err != nil {
 		r.recorder.Eventf(ruleGroup, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcle rulegroup %s: %w", ruleGroup.Name, err)

--- a/pkg/controller/seed-controller-manager/monitoring/resources.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources.go
@@ -72,7 +72,7 @@ func (r *Reconciler) ensureRoles(ctx context.Context, cluster *kubermaticv1.Clus
 		prometheus.RoleCreator(),
 	}
 
-	return reconciling.ReconcileRoles(ctx, getters, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, getters)
 }
 
 func (r *Reconciler) ensureRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -80,7 +80,7 @@ func (r *Reconciler) ensureRoleBindings(ctx context.Context, cluster *kubermatic
 		prometheus.RoleBindingCreator(cluster.Status.NamespaceName),
 	}
 
-	return reconciling.ReconcileRoleBindings(ctx, getters, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, getters)
 }
 
 // GetDeploymentCreators returns all DeploymentCreators that are currently in use.
@@ -95,7 +95,7 @@ func GetDeploymentCreators(data *resources.TemplateData) []reconciling.NamedDepl
 func (r *Reconciler) ensureDeployments(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetDeploymentCreators(data)
 
-	return reconciling.ReconcileDeployments(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, creators)
 }
 
 // GetSecretCreatorOperations returns all SecretCreators that are currently in use.
@@ -114,7 +114,7 @@ func GetSecretCreatorOperations(data *resources.TemplateData) []reconciling.Name
 func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	namedSecretCreatorGetters := GetSecretCreatorOperations(data)
 
-	if err := reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetters, cluster.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, namedSecretCreatorGetters); err != nil {
 		return fmt.Errorf("failed to ensure that the Secret exists: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func GetConfigMapCreators(data *resources.TemplateData) []reconciling.NamedConfi
 func (r *Reconciler) ensureConfigMaps(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetConfigMapCreators(data)
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, cluster.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, creators); err != nil {
 		return fmt.Errorf("failed to ensure that the ConfigMap exists: %w", err)
 	}
 
@@ -148,7 +148,7 @@ func GetStatefulSetCreators(data *resources.TemplateData) []reconciling.NamedSta
 func (r *Reconciler) ensureStatefulSets(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetStatefulSetCreators(data)
 
-	return reconciling.ReconcileStatefulSets(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, creators)
 }
 
 func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -169,7 +169,7 @@ func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, cluster *
 	if err != nil {
 		return fmt.Errorf("failed to create the functions to handle VPA resources: %w", err)
 	}
-	return reconciling.ReconcileVerticalPodAutoscalers(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, creators)
 }
 
 // GetServiceCreators returns all service creators that are currently in use.
@@ -182,7 +182,7 @@ func GetServiceCreators(data *resources.TemplateData) []reconciling.NamedService
 func (r *Reconciler) ensureServices(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetServiceCreators(data)
 
-	return reconciling.ReconcileServices(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, creators)
 }
 
 // GetServiceCreators returns all service creators that are currently in use.
@@ -195,5 +195,5 @@ func GetServiceAccountCreators() []reconciling.NamedServiceAccountCreatorGetter 
 func (r *Reconciler) ensureServiceAccounts(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetServiceAccountCreators()
 
-	return reconciling.ReconcileServiceAccounts(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.EnsureNamedObjects(ctx, r, cluster.Status.NamespaceName, creators)
 }

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -121,7 +121,7 @@ func (r *reconciler) createConstraint(ctx context.Context, constraint *kubermati
 		constraintCreatorGetter(constraint),
 	}
 
-	if err := reconciling.ReconcileUnstructureds(ctx, constraintCreatorGetters, "", r.userClient); err != nil {
+	if err := reconciling.EnsureNamedUnstructuredObjects(ctx, r.userClient, "", constraintCreatorGetters); err != nil {
 		return fmt.Errorf("failed to reconcile constraint: %w", err)
 	}
 	log.Debugw("constraint created")

--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -120,7 +120,7 @@ func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error
 		resources.OperatorServiceAccountCreator(),
 		resources.AgentServiceAccountCreator(),
 	}
-	if err := reconciling.ReconcileServiceAccounts(ctx, saCreators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, metav1.NamespaceSystem, saCreators); err != nil {
 		return fmt.Errorf("failed to reconcile the ServiceAccounts: %w", err)
 	}
 
@@ -128,7 +128,7 @@ func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error
 		resources.OperatorClusterRoleCreator(),
 		resources.AgentClusterRoleCreator(),
 	}
-	if err := reconciling.ReconcileClusterRoles(ctx, crCreators, metav1.NamespaceNone, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, metav1.NamespaceNone, crCreators); err != nil {
 		return fmt.Errorf("failed to reconcile the ClusterRoles: %w", err)
 	}
 
@@ -136,17 +136,17 @@ func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error
 		resources.OperatorClusterRoleBindingCreator(),
 		resources.AgentClusterRoleBindingCreator(),
 	}
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, crbCreators, metav1.NamespaceNone, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, metav1.NamespaceNone, crbCreators); err != nil {
 		return fmt.Errorf("failed to reconcile the ClusterRoleBindings: %w", err)
 	}
 
 	depCreators := getDeploymentCreators(r.overwriteRegistry, r.updateWindow)
-	if err := reconciling.ReconcileDeployments(ctx, depCreators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, metav1.NamespaceSystem, depCreators); err != nil {
 		return fmt.Errorf("failed to reconcile the Deployments: %w", err)
 	}
 
 	dsCreators := getDaemonSetCreators(r.overwriteRegistry)
-	if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, metav1.NamespaceSystem, dsCreators); err != nil {
 		return fmt.Errorf("failed to reconcile the DaemonSets: %w", err)
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/rbac/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/reconciler.go
@@ -82,7 +82,7 @@ func (r *reconciler) ensureRBACClusterRole(ctx context.Context, resourceName str
 		return fmt.Errorf("failed to init ClusterRole creator: %w", err)
 	}
 
-	if err := reconciling.ReconcileClusterRoles(ctx, []reconciling.NamedClusterRoleCreatorGetter{creator}, "", r); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, "", []reconciling.NamedClusterRoleCreatorGetter{creator}); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoles: %w", err)
 	}
 
@@ -95,7 +95,7 @@ func (r *reconciler) ensureRBACClusterRoleBinding(ctx context.Context, resourceN
 		return fmt.Errorf("failed to init ClusterRole creator: %w", err)
 	}
 
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, []reconciling.NamedClusterRoleBindingCreatorGetter{creator}, "", r); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, "", []reconciling.NamedClusterRoleBindingCreatorGetter{creator}); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBindings: %w", err)
 	}
 

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -108,7 +108,7 @@ func (r *Reconciler) reconcile(ctx context.Context, allowedRegistry *kubermaticv
 			allowedRegistryConstraintCreatorGetter(regSet),
 		}
 
-		err := reconciling.ReconcileKubermaticV1Constraints(ctx, constraintCreatorGetters, r.namespace, r.masterClient)
+		err := reconciling.EnsureNamedObjects(ctx, r.masterClient, r.namespace, constraintCreatorGetters)
 		if err != nil {
 			return fmt.Errorf("error ensuring AllowedRegistry Constraint Template: %w", err)
 		}
@@ -124,7 +124,7 @@ func (r *Reconciler) reconcile(ctx context.Context, allowedRegistry *kubermaticv
 	ctCreatorGetters := []reconciling.NamedKubermaticV1ConstraintTemplateCreatorGetter{
 		allowedRegistryCTCreatorGetter(),
 	}
-	err = reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", r.masterClient)
+	err = reconciling.EnsureNamedObjects(ctx, r.masterClient, "", ctCreatorGetters)
 	if err != nil {
 		return fmt.Errorf("error ensuring AllowedRegistry Constraint Template: %w", err)
 	}
@@ -134,7 +134,7 @@ func (r *Reconciler) reconcile(ctx context.Context, allowedRegistry *kubermaticv
 		allowedRegistryConstraintCreatorGetter(regSet),
 	}
 
-	err = reconciling.ReconcileKubermaticV1Constraints(ctx, constraintCreatorGetters, r.namespace, r.masterClient)
+	err = reconciling.EnsureNamedObjects(ctx, r.masterClient, r.namespace, constraintCreatorGetters)
 	if err != nil {
 		return fmt.Errorf("error ensuring AllowedRegistry Constraint Template: %w", err)
 	}

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
@@ -154,7 +154,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	return r.syncAllSeeds(log, resourceQuota, func(seedClient ctrlruntimeclient.Client, resourceQuota *kubermaticv1.ResourceQuota) error {
-		return reconciling.ReconcileKubermaticV1ResourceQuotas(ctx, resourceQuotaCreatorGetters, kubermaticresources.KubermaticNamespace, seedClient)
+		return reconciling.EnsureNamedObjects(ctx, seedClient, kubermaticresources.KubermaticNamespace, resourceQuotaCreatorGetters)
 	})
 }
 

--- a/pkg/handler/common/provider/kubevirt.go
+++ b/pkg/handler/common/provider/kubevirt.go
@@ -125,7 +125,7 @@ func KubeVirtVMIPresets(ctx context.Context, kubeconfig string, cluster *kuberma
 			presetCreators := []reconciling.NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter{
 				presetCreator(&vmiPreset),
 			}
-			if err := reconciling.ReconcileKubeVirtV1VirtualMachineInstancePresets(ctx, presetCreators, cluster.Status.NamespaceName, client); err != nil {
+			if err := reconciling.EnsureNamedObjects(ctx, client, cluster.Status.NamespaceName, presetCreators); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/provider/cloud/kubevirt/namespace.go
+++ b/pkg/provider/cloud/kubevirt/namespace.go
@@ -44,7 +44,7 @@ func reconcileNamespace(ctx context.Context, name string, cluster *kubermaticv1.
 		NamespaceCreator(name),
 	}
 
-	if err := reconciling.ReconcileNamespaces(ctx, creators, "", client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, "", creators); err != nil {
 		return cluster, fmt.Errorf("failed to reconcile Namespace: %w", err)
 	}
 

--- a/pkg/provider/cloud/kubevirt/preset.go
+++ b/pkg/provider/cloud/kubevirt/preset.go
@@ -52,7 +52,7 @@ func reconcilePresets(ctx context.Context, namespace string, client ctrlruntimec
 		presetCreators := []reconciling.NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter{
 			presetCreator(&preset),
 		}
-		if err := reconciling.ReconcileKubeVirtV1VirtualMachineInstancePresets(ctx, presetCreators, namespace, client); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, namespace, presetCreators); err != nil {
 			return err
 		}
 	}

--- a/pkg/provider/cloud/kubevirt/reconciler.go
+++ b/pkg/provider/cloud/kubevirt/reconciler.go
@@ -51,7 +51,7 @@ func (r *reconciler) ReconcileCSIServiceAccount(ctx context.Context) ([]byte, er
 	saCreators := []reconciling.NamedServiceAccountCreatorGetter{
 		csiServiceAccountCreator(csiResourceName),
 	}
-	if err := reconciling.ReconcileServiceAccounts(ctx, saCreators, csiServiceAccountNamespace, r.Client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, r, csiServiceAccountNamespace, saCreators); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provider/cloud/kubevirt/storage.go
+++ b/pkg/provider/cloud/kubevirt/storage.go
@@ -108,14 +108,14 @@ func reconcileCSIRoleRoleBinding(ctx context.Context, namespace string, client c
 	roleCreators := []reconciling.NamedRoleCreatorGetter{
 		csiRoleCreator(csiResourceName),
 	}
-	if err := reconciling.ReconcileRoles(ctx, roleCreators, namespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, namespace, roleCreators); err != nil {
 		return err
 	}
 
 	roleBindingCreators := []reconciling.NamedRoleBindingCreatorGetter{
 		csiRoleBindingCreator(csiResourceName, csiServiceAccountNamespace),
 	}
-	if err := reconciling.ReconcileRoleBindings(ctx, roleBindingCreators, namespace, client); err != nil {
+	if err := reconciling.EnsureNamedObjects(ctx, client, namespace, roleBindingCreators); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func reconcilePreAllocatedDataVolumes(ctx context.Context, cluster *kubermaticv1
 		dvCreator := []reconciling.NamedCDIv1beta1DataVolumeCreatorGetter{
 			dataVolumeCreator(dv),
 		}
-		if err := reconciling.ReconcileCDIv1beta1DataVolumes(ctx, dvCreator, cluster.Status.NamespaceName, client); err != nil {
+		if err := reconciling.EnsureNamedObjects(ctx, client, cluster.Status.NamespaceName, dvCreator); err != nil {
 			return fmt.Errorf("failed to reconcile Allocated DataVolume: %w", err)
 		}
 	}

--- a/pkg/resources/reconciling/wrapper.go
+++ b/pkg/resources/reconciling/wrapper.go
@@ -162,97 +162,69 @@ func DefaultPodSpec(oldPodSpec, newPodSpec corev1.PodSpec) (corev1.PodSpec, erro
 
 // DefaultDeployment defaults all Deployment attributes to the same values as they would get from the Kubernetes API.
 // In addition, the Deployment's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
-func DefaultDeployment(creator DeploymentCreator) DeploymentCreator {
-	return func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-		old := d.DeepCopy()
+func DefaultDeployment(oldObj, newObj *appsv1.Deployment) (ctrlruntimeclient.Object, error) {
+	var err error
 
-		d, err := creator(d)
-		if err != nil {
-			return nil, err
-		}
+	if newObj.Spec.Strategy.Type == "" {
+		newObj.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 
-		if d.Spec.Strategy.Type == "" {
-			d.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-
-			if d.Spec.Strategy.RollingUpdate == nil {
-				d.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 1,
-					},
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 0,
-					},
-				}
+		if newObj.Spec.Strategy.RollingUpdate == nil {
+			newObj.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
 			}
 		}
-
-		d.Spec.Template.Spec, err = DefaultPodSpec(old.Spec.Template.Spec, d.Spec.Template.Spec)
-		if err != nil {
-			return nil, err
-		}
-
-		return d, nil
 	}
+
+	newObj.Spec.Template.Spec, err = DefaultPodSpec(oldObj.Spec.Template.Spec, newObj.Spec.Template.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return newObj, nil
 }
 
 // DefaultStatefulSet defaults all StatefulSet attributes to the same values as they would get from the Kubernetes API.
 // In addition, the StatefulSet's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
-func DefaultStatefulSet(creator StatefulSetCreator) StatefulSetCreator {
-	return func(ss *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
-		old := ss.DeepCopy()
+func DefaultStatefulSet(oldObj, newObj *appsv1.StatefulSet) (ctrlruntimeclient.Object, error) {
+	var err error
 
-		ss, err := creator(ss)
-		if err != nil {
-			return nil, err
-		}
-
-		ss.Spec.Template.Spec, err = DefaultPodSpec(old.Spec.Template.Spec, ss.Spec.Template.Spec)
-		if err != nil {
-			return nil, err
-		}
-
-		return ss, nil
+	newObj.Spec.Template.Spec, err = DefaultPodSpec(oldObj.Spec.Template.Spec, newObj.Spec.Template.Spec)
+	if err != nil {
+		return nil, err
 	}
+
+	return newObj, nil
 }
 
 // DefaultDaemonSet defaults all DaemonSet attributes to the same values as they would get from the Kubernetes API.
 // In addition, the DaemonSet's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
-func DefaultDaemonSet(creator DaemonSetCreator) DaemonSetCreator {
-	return func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
-		old := ds.DeepCopy()
+func DefaultDaemonSet(oldObj, newObj *appsv1.DaemonSet) (ctrlruntimeclient.Object, error) {
+	var err error
 
-		ds, err := creator(ds)
-		if err != nil {
-			return nil, err
-		}
-
-		ds.Spec.Template.Spec, err = DefaultPodSpec(old.Spec.Template.Spec, ds.Spec.Template.Spec)
-		if err != nil {
-			return nil, err
-		}
-
-		return ds, nil
+	newObj.Spec.Template.Spec, err = DefaultPodSpec(oldObj.Spec.Template.Spec, newObj.Spec.Template.Spec)
+	if err != nil {
+		return nil, err
 	}
+
+	return newObj, nil
 }
 
 // DefaultCronJob defaults all CronJob attributes to the same values as they would get from the Kubernetes API.
 // In addition, the CronJob's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
-func DefaultCronJob(creator CronJobCreator) CronJobCreator {
-	return func(cj *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
-		old := cj.DeepCopy()
+func DefaultCronJob(oldObj, newObj *batchv1beta1.CronJob) (ctrlruntimeclient.Object, error) {
+	var err error
 
-		cj, err := creator(cj)
-		if err != nil {
-			return nil, err
-		}
-
-		cj.Spec.JobTemplate.Spec.Template.Spec, err = DefaultPodSpec(old.Spec.JobTemplate.Spec.Template.Spec, cj.Spec.JobTemplate.Spec.Template.Spec)
-		if err != nil {
-			return nil, err
-		}
-
-		return cj, nil
+	newObj.Spec.JobTemplate.Spec.Template.Spec, err = DefaultPodSpec(oldObj.Spec.JobTemplate.Spec.Template.Spec, newObj.Spec.JobTemplate.Spec.Template.Spec)
+	if err != nil {
+		return nil, err
 	}
+
+	return newObj, nil
 }

--- a/pkg/resources/reconciling/wrapper_test.go
+++ b/pkg/resources/reconciling/wrapper_test.go
@@ -503,7 +503,7 @@ func TestDefaultDeployment(t *testing.T) {
 	}
 
 	client := controllerruntimefake.NewClientBuilder().WithObjects(existingObject).Build()
-	if err := ReconcileDeployments(context.Background(), creators, testNamespace, client); err != nil {
+	if err := EnsureNamedObjects(context.Background(), client, testNamespace, creators); err != nil {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
@@ -576,7 +576,7 @@ func TestDefaultStatefulSet(t *testing.T) {
 	}
 
 	client := controllerruntimefake.NewClientBuilder().WithObjects(existingObject).Build()
-	if err := ReconcileStatefulSets(context.Background(), creators, testNamespace, client); err != nil {
+	if err := EnsureNamedObjects(context.Background(), client, testNamespace, creators); err != nil {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
@@ -649,7 +649,7 @@ func TestDefaultDaemonSet(t *testing.T) {
 	}
 
 	client := controllerruntimefake.NewClientBuilder().WithObjects(existingObject).Build()
-	if err := ReconcileDaemonSets(context.Background(), creators, testNamespace, client); err != nil {
+	if err := EnsureNamedObjects(context.Background(), client, testNamespace, creators); err != nil {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
@@ -730,7 +730,7 @@ func TestDefaultCronJob(t *testing.T) {
 	}
 
 	client := controllerruntimefake.NewClientBuilder().WithObjects(existingObject).Build()
-	if err := ReconcileCronJobs(context.Background(), creators, testNamespace, client); err != nil {
+	if err := EnsureNamedObjects(context.Background(), client, testNamespace, creators); err != nil {
 		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
 	}
 
@@ -842,16 +842,12 @@ func TestDeploymentStrategyDefaulting(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			creator := func(_ *appsv1.Deployment) (*appsv1.Deployment, error) {
-				return tc.in, nil
-			}
-			creator = DefaultDeployment(creator)
-			deployment, err := creator(&appsv1.Deployment{})
+			deployment, err := DefaultDeployment(&appsv1.Deployment{}, tc.in)
 			if err != nil {
 				t.Fatalf("error when calling creator: %v", err)
 			}
 
-			if err := tc.verify(deployment); err != nil {
+			if err := tc.verify(deployment.(*appsv1.Deployment)); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -2,12 +2,6 @@
 package reconciling
 
 import (
-	"context"
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	gatekeeperv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -27,1448 +21,235 @@ import (
 )
 
 // NamespaceCreator defines an interface to create/update Namespaces
-type NamespaceCreator = func(existing *corev1.Namespace) (*corev1.Namespace, error)
+type NamespaceCreator = GenericObjectCreator[*corev1.Namespace]
 
 // NamedNamespaceCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedNamespaceCreatorGetter = func() (name string, create NamespaceCreator)
-
-// NamespaceObjectWrapper adds a wrapper so the NamespaceCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func NamespaceObjectWrapper(create NamespaceCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*corev1.Namespace))
-		}
-		return create(&corev1.Namespace{})
-	}
-}
-
-// ReconcileNamespaces will create and update the Namespaces coming from the passed NamespaceCreator slice
-func ReconcileNamespaces(ctx context.Context, namedGetters []NamedNamespaceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := NamespaceObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Namespace{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Namespace %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedNamespaceCreatorGetter = GenericNamedObjectCreator[*corev1.Namespace]
 
 // ServiceCreator defines an interface to create/update Services
-type ServiceCreator = func(existing *corev1.Service) (*corev1.Service, error)
+type ServiceCreator = GenericObjectCreator[*corev1.Service]
 
 // NamedServiceCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedServiceCreatorGetter = func() (name string, create ServiceCreator)
-
-// ServiceObjectWrapper adds a wrapper so the ServiceCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ServiceObjectWrapper(create ServiceCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*corev1.Service))
-		}
-		return create(&corev1.Service{})
-	}
-}
-
-// ReconcileServices will create and update the Services coming from the passed ServiceCreator slice
-func ReconcileServices(ctx context.Context, namedGetters []NamedServiceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ServiceObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Service{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Service %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedServiceCreatorGetter = GenericNamedObjectCreator[*corev1.Service]
 
 // SecretCreator defines an interface to create/update Secrets
-type SecretCreator = func(existing *corev1.Secret) (*corev1.Secret, error)
+type SecretCreator = GenericObjectCreator[*corev1.Secret]
 
 // NamedSecretCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedSecretCreatorGetter = func() (name string, create SecretCreator)
-
-// SecretObjectWrapper adds a wrapper so the SecretCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func SecretObjectWrapper(create SecretCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*corev1.Secret))
-		}
-		return create(&corev1.Secret{})
-	}
-}
-
-// ReconcileSecrets will create and update the Secrets coming from the passed SecretCreator slice
-func ReconcileSecrets(ctx context.Context, namedGetters []NamedSecretCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := SecretObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Secret{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Secret %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedSecretCreatorGetter = GenericNamedObjectCreator[*corev1.Secret]
 
 // ConfigMapCreator defines an interface to create/update ConfigMaps
-type ConfigMapCreator = func(existing *corev1.ConfigMap) (*corev1.ConfigMap, error)
+type ConfigMapCreator = GenericObjectCreator[*corev1.ConfigMap]
 
 // NamedConfigMapCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedConfigMapCreatorGetter = func() (name string, create ConfigMapCreator)
-
-// ConfigMapObjectWrapper adds a wrapper so the ConfigMapCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ConfigMapObjectWrapper(create ConfigMapCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*corev1.ConfigMap))
-		}
-		return create(&corev1.ConfigMap{})
-	}
-}
-
-// ReconcileConfigMaps will create and update the ConfigMaps coming from the passed ConfigMapCreator slice
-func ReconcileConfigMaps(ctx context.Context, namedGetters []NamedConfigMapCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ConfigMapObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.ConfigMap{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ConfigMap %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedConfigMapCreatorGetter = GenericNamedObjectCreator[*corev1.ConfigMap]
 
 // ServiceAccountCreator defines an interface to create/update ServiceAccounts
-type ServiceAccountCreator = func(existing *corev1.ServiceAccount) (*corev1.ServiceAccount, error)
+type ServiceAccountCreator = GenericObjectCreator[*corev1.ServiceAccount]
 
 // NamedServiceAccountCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedServiceAccountCreatorGetter = func() (name string, create ServiceAccountCreator)
+type NamedServiceAccountCreatorGetter = GenericNamedObjectCreator[*corev1.ServiceAccount]
 
-// ServiceAccountObjectWrapper adds a wrapper so the ServiceAccountCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ServiceAccountObjectWrapper(create ServiceAccountCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*corev1.ServiceAccount))
-		}
-		return create(&corev1.ServiceAccount{})
-	}
-}
-
-// ReconcileServiceAccounts will create and update the ServiceAccounts coming from the passed ServiceAccountCreator slice
-func ReconcileServiceAccounts(ctx context.Context, namedGetters []NamedServiceAccountCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ServiceAccountObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.ServiceAccount{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ServiceAccount %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
-
-// EndpointsCreator defines an interface to create/update Endpointss
-type EndpointsCreator = func(existing *corev1.Endpoints) (*corev1.Endpoints, error)
+// EndpointsCreator defines an interface to create/update Endpoints
+type EndpointsCreator = GenericObjectCreator[*corev1.Endpoints]
 
 // NamedEndpointsCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedEndpointsCreatorGetter = func() (name string, create EndpointsCreator)
-
-// EndpointsObjectWrapper adds a wrapper so the EndpointsCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func EndpointsObjectWrapper(create EndpointsCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*corev1.Endpoints))
-		}
-		return create(&corev1.Endpoints{})
-	}
-}
-
-// ReconcileEndpoints will create and update the Endpoints coming from the passed EndpointsCreator slice
-func ReconcileEndpoints(ctx context.Context, namedGetters []NamedEndpointsCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := EndpointsObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Endpoints{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Endpoints %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedEndpointsCreatorGetter = GenericNamedObjectCreator[*corev1.Endpoints]
 
 // EndpointSliceCreator defines an interface to create/update EndpointSlices
-type EndpointSliceCreator = func(existing *discovery.EndpointSlice) (*discovery.EndpointSlice, error)
+type EndpointSliceCreator = GenericObjectCreator[*discovery.EndpointSlice]
 
 // NamedEndpointSliceCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedEndpointSliceCreatorGetter = func() (name string, create EndpointSliceCreator)
-
-// EndpointSliceObjectWrapper adds a wrapper so the EndpointSliceCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func EndpointSliceObjectWrapper(create EndpointSliceCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*discovery.EndpointSlice))
-		}
-		return create(&discovery.EndpointSlice{})
-	}
-}
-
-// ReconcileEndpointSlices will create and update the EndpointSlices coming from the passed EndpointSliceCreator slice
-func ReconcileEndpointSlices(ctx context.Context, namedGetters []NamedEndpointSliceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := EndpointSliceObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &discovery.EndpointSlice{}, false); err != nil {
-			return fmt.Errorf("failed to ensure EndpointSlice %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedEndpointSliceCreatorGetter = GenericNamedObjectCreator[*discovery.EndpointSlice]
 
 // StatefulSetCreator defines an interface to create/update StatefulSets
-type StatefulSetCreator = func(existing *appsv1.StatefulSet) (*appsv1.StatefulSet, error)
+type StatefulSetCreator = GenericObjectCreator[*appsv1.StatefulSet]
 
 // NamedStatefulSetCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedStatefulSetCreatorGetter = func() (name string, create StatefulSetCreator)
-
-// StatefulSetObjectWrapper adds a wrapper so the StatefulSetCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func StatefulSetObjectWrapper(create StatefulSetCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*appsv1.StatefulSet))
-		}
-		return create(&appsv1.StatefulSet{})
-	}
-}
-
-// ReconcileStatefulSets will create and update the StatefulSets coming from the passed StatefulSetCreator slice
-func ReconcileStatefulSets(ctx context.Context, namedGetters []NamedStatefulSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		create = DefaultStatefulSet(create)
-		createObject := StatefulSetObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.StatefulSet{}, false); err != nil {
-			return fmt.Errorf("failed to ensure StatefulSet %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedStatefulSetCreatorGetter = GenericNamedObjectCreator[*appsv1.StatefulSet]
 
 // DeploymentCreator defines an interface to create/update Deployments
-type DeploymentCreator = func(existing *appsv1.Deployment) (*appsv1.Deployment, error)
+type DeploymentCreator = GenericObjectCreator[*appsv1.Deployment]
 
 // NamedDeploymentCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedDeploymentCreatorGetter = func() (name string, create DeploymentCreator)
-
-// DeploymentObjectWrapper adds a wrapper so the DeploymentCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func DeploymentObjectWrapper(create DeploymentCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*appsv1.Deployment))
-		}
-		return create(&appsv1.Deployment{})
-	}
-}
-
-// ReconcileDeployments will create and update the Deployments coming from the passed DeploymentCreator slice
-func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		create = DefaultDeployment(create)
-		createObject := DeploymentObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.Deployment{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Deployment %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedDeploymentCreatorGetter = GenericNamedObjectCreator[*appsv1.Deployment]
 
 // DaemonSetCreator defines an interface to create/update DaemonSets
-type DaemonSetCreator = func(existing *appsv1.DaemonSet) (*appsv1.DaemonSet, error)
+type DaemonSetCreator = GenericObjectCreator[*appsv1.DaemonSet]
 
 // NamedDaemonSetCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedDaemonSetCreatorGetter = func() (name string, create DaemonSetCreator)
-
-// DaemonSetObjectWrapper adds a wrapper so the DaemonSetCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func DaemonSetObjectWrapper(create DaemonSetCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*appsv1.DaemonSet))
-		}
-		return create(&appsv1.DaemonSet{})
-	}
-}
-
-// ReconcileDaemonSets will create and update the DaemonSets coming from the passed DaemonSetCreator slice
-func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		create = DefaultDaemonSet(create)
-		createObject := DaemonSetObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.DaemonSet{}, false); err != nil {
-			return fmt.Errorf("failed to ensure DaemonSet %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedDaemonSetCreatorGetter = GenericNamedObjectCreator[*appsv1.DaemonSet]
 
 // PodDisruptionBudgetCreator defines an interface to create/update PodDisruptionBudgets
-type PodDisruptionBudgetCreator = func(existing *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, error)
+type PodDisruptionBudgetCreator = GenericObjectCreator[*policyv1.PodDisruptionBudget]
 
 // NamedPodDisruptionBudgetCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedPodDisruptionBudgetCreatorGetter = func() (name string, create PodDisruptionBudgetCreator)
-
-// PodDisruptionBudgetObjectWrapper adds a wrapper so the PodDisruptionBudgetCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func PodDisruptionBudgetObjectWrapper(create PodDisruptionBudgetCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*policyv1.PodDisruptionBudget))
-		}
-		return create(&policyv1.PodDisruptionBudget{})
-	}
-}
-
-// ReconcilePodDisruptionBudgets will create and update the PodDisruptionBudgets coming from the passed PodDisruptionBudgetCreator slice
-func ReconcilePodDisruptionBudgets(ctx context.Context, namedGetters []NamedPodDisruptionBudgetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := PodDisruptionBudgetObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &policyv1.PodDisruptionBudget{}, true); err != nil {
-			return fmt.Errorf("failed to ensure PodDisruptionBudget %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedPodDisruptionBudgetCreatorGetter = GenericNamedObjectCreator[*policyv1.PodDisruptionBudget]
 
 // VerticalPodAutoscalerCreator defines an interface to create/update VerticalPodAutoscalers
-type VerticalPodAutoscalerCreator = func(existing *autoscalingv1.VerticalPodAutoscaler) (*autoscalingv1.VerticalPodAutoscaler, error)
+type VerticalPodAutoscalerCreator = GenericObjectCreator[*autoscalingv1.VerticalPodAutoscaler]
 
 // NamedVerticalPodAutoscalerCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedVerticalPodAutoscalerCreatorGetter = func() (name string, create VerticalPodAutoscalerCreator)
-
-// VerticalPodAutoscalerObjectWrapper adds a wrapper so the VerticalPodAutoscalerCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func VerticalPodAutoscalerObjectWrapper(create VerticalPodAutoscalerCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*autoscalingv1.VerticalPodAutoscaler))
-		}
-		return create(&autoscalingv1.VerticalPodAutoscaler{})
-	}
-}
-
-// ReconcileVerticalPodAutoscalers will create and update the VerticalPodAutoscalers coming from the passed VerticalPodAutoscalerCreator slice
-func ReconcileVerticalPodAutoscalers(ctx context.Context, namedGetters []NamedVerticalPodAutoscalerCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := VerticalPodAutoscalerObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &autoscalingv1.VerticalPodAutoscaler{}, false); err != nil {
-			return fmt.Errorf("failed to ensure VerticalPodAutoscaler %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedVerticalPodAutoscalerCreatorGetter = GenericNamedObjectCreator[*autoscalingv1.VerticalPodAutoscaler]
 
 // ClusterRoleBindingCreator defines an interface to create/update ClusterRoleBindings
-type ClusterRoleBindingCreator = func(existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error)
+type ClusterRoleBindingCreator = GenericObjectCreator[*rbacv1.ClusterRoleBinding]
 
 // NamedClusterRoleBindingCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedClusterRoleBindingCreatorGetter = func() (name string, create ClusterRoleBindingCreator)
-
-// ClusterRoleBindingObjectWrapper adds a wrapper so the ClusterRoleBindingCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ClusterRoleBindingObjectWrapper(create ClusterRoleBindingCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*rbacv1.ClusterRoleBinding))
-		}
-		return create(&rbacv1.ClusterRoleBinding{})
-	}
-}
-
-// ReconcileClusterRoleBindings will create and update the ClusterRoleBindings coming from the passed ClusterRoleBindingCreator slice
-func ReconcileClusterRoleBindings(ctx context.Context, namedGetters []NamedClusterRoleBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ClusterRoleBindingObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.ClusterRoleBinding{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ClusterRoleBinding %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedClusterRoleBindingCreatorGetter = GenericNamedObjectCreator[*rbacv1.ClusterRoleBinding]
 
 // ClusterRoleCreator defines an interface to create/update ClusterRoles
-type ClusterRoleCreator = func(existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error)
+type ClusterRoleCreator = GenericObjectCreator[*rbacv1.ClusterRole]
 
 // NamedClusterRoleCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedClusterRoleCreatorGetter = func() (name string, create ClusterRoleCreator)
-
-// ClusterRoleObjectWrapper adds a wrapper so the ClusterRoleCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ClusterRoleObjectWrapper(create ClusterRoleCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*rbacv1.ClusterRole))
-		}
-		return create(&rbacv1.ClusterRole{})
-	}
-}
-
-// ReconcileClusterRoles will create and update the ClusterRoles coming from the passed ClusterRoleCreator slice
-func ReconcileClusterRoles(ctx context.Context, namedGetters []NamedClusterRoleCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ClusterRoleObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.ClusterRole{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ClusterRole %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedClusterRoleCreatorGetter = GenericNamedObjectCreator[*rbacv1.ClusterRole]
 
 // RoleCreator defines an interface to create/update Roles
-type RoleCreator = func(existing *rbacv1.Role) (*rbacv1.Role, error)
+type RoleCreator = GenericObjectCreator[*rbacv1.Role]
 
 // NamedRoleCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedRoleCreatorGetter = func() (name string, create RoleCreator)
-
-// RoleObjectWrapper adds a wrapper so the RoleCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func RoleObjectWrapper(create RoleCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*rbacv1.Role))
-		}
-		return create(&rbacv1.Role{})
-	}
-}
-
-// ReconcileRoles will create and update the Roles coming from the passed RoleCreator slice
-func ReconcileRoles(ctx context.Context, namedGetters []NamedRoleCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := RoleObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.Role{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Role %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedRoleCreatorGetter = GenericNamedObjectCreator[*rbacv1.Role]
 
 // RoleBindingCreator defines an interface to create/update RoleBindings
-type RoleBindingCreator = func(existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)
+type RoleBindingCreator = GenericObjectCreator[*rbacv1.RoleBinding]
 
 // NamedRoleBindingCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedRoleBindingCreatorGetter = func() (name string, create RoleBindingCreator)
-
-// RoleBindingObjectWrapper adds a wrapper so the RoleBindingCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func RoleBindingObjectWrapper(create RoleBindingCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*rbacv1.RoleBinding))
-		}
-		return create(&rbacv1.RoleBinding{})
-	}
-}
-
-// ReconcileRoleBindings will create and update the RoleBindings coming from the passed RoleBindingCreator slice
-func ReconcileRoleBindings(ctx context.Context, namedGetters []NamedRoleBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := RoleBindingObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.RoleBinding{}, false); err != nil {
-			return fmt.Errorf("failed to ensure RoleBinding %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedRoleBindingCreatorGetter = GenericNamedObjectCreator[*rbacv1.RoleBinding]
 
 // CustomResourceDefinitionCreator defines an interface to create/update CustomResourceDefinitions
-type CustomResourceDefinitionCreator = func(existing *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error)
+type CustomResourceDefinitionCreator = GenericObjectCreator[*apiextensionsv1.CustomResourceDefinition]
 
 // NamedCustomResourceDefinitionCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedCustomResourceDefinitionCreatorGetter = func() (name string, create CustomResourceDefinitionCreator)
-
-// CustomResourceDefinitionObjectWrapper adds a wrapper so the CustomResourceDefinitionCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func CustomResourceDefinitionObjectWrapper(create CustomResourceDefinitionCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*apiextensionsv1.CustomResourceDefinition))
-		}
-		return create(&apiextensionsv1.CustomResourceDefinition{})
-	}
-}
-
-// ReconcileCustomResourceDefinitions will create and update the CustomResourceDefinitions coming from the passed CustomResourceDefinitionCreator slice
-func ReconcileCustomResourceDefinitions(ctx context.Context, namedGetters []NamedCustomResourceDefinitionCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := CustomResourceDefinitionObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &apiextensionsv1.CustomResourceDefinition{}, false); err != nil {
-			return fmt.Errorf("failed to ensure CustomResourceDefinition %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedCustomResourceDefinitionCreatorGetter = GenericNamedObjectCreator[*apiextensionsv1.CustomResourceDefinition]
 
 // CronJobCreator defines an interface to create/update CronJobs
-type CronJobCreator = func(existing *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error)
+type CronJobCreator = GenericObjectCreator[*batchv1beta1.CronJob]
 
 // NamedCronJobCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedCronJobCreatorGetter = func() (name string, create CronJobCreator)
-
-// CronJobObjectWrapper adds a wrapper so the CronJobCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func CronJobObjectWrapper(create CronJobCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*batchv1beta1.CronJob))
-		}
-		return create(&batchv1beta1.CronJob{})
-	}
-}
-
-// ReconcileCronJobs will create and update the CronJobs coming from the passed CronJobCreator slice
-func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		create = DefaultCronJob(create)
-		createObject := CronJobObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &batchv1beta1.CronJob{}, false); err != nil {
-			return fmt.Errorf("failed to ensure CronJob %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedCronJobCreatorGetter = GenericNamedObjectCreator[*batchv1beta1.CronJob]
 
 // MutatingWebhookConfigurationCreator defines an interface to create/update MutatingWebhookConfigurations
-type MutatingWebhookConfigurationCreator = func(existing *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error)
+type MutatingWebhookConfigurationCreator = GenericObjectCreator[*admissionregistrationv1.MutatingWebhookConfiguration]
 
 // NamedMutatingWebhookConfigurationCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedMutatingWebhookConfigurationCreatorGetter = func() (name string, create MutatingWebhookConfigurationCreator)
-
-// MutatingWebhookConfigurationObjectWrapper adds a wrapper so the MutatingWebhookConfigurationCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func MutatingWebhookConfigurationObjectWrapper(create MutatingWebhookConfigurationCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*admissionregistrationv1.MutatingWebhookConfiguration))
-		}
-		return create(&admissionregistrationv1.MutatingWebhookConfiguration{})
-	}
-}
-
-// ReconcileMutatingWebhookConfigurations will create and update the MutatingWebhookConfigurations coming from the passed MutatingWebhookConfigurationCreator slice
-func ReconcileMutatingWebhookConfigurations(ctx context.Context, namedGetters []NamedMutatingWebhookConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := MutatingWebhookConfigurationObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, false); err != nil {
-			return fmt.Errorf("failed to ensure MutatingWebhookConfiguration %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedMutatingWebhookConfigurationCreatorGetter = GenericNamedObjectCreator[*admissionregistrationv1.MutatingWebhookConfiguration]
 
 // ValidatingWebhookConfigurationCreator defines an interface to create/update ValidatingWebhookConfigurations
-type ValidatingWebhookConfigurationCreator = func(existing *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error)
+type ValidatingWebhookConfigurationCreator = GenericObjectCreator[*admissionregistrationv1.ValidatingWebhookConfiguration]
 
 // NamedValidatingWebhookConfigurationCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedValidatingWebhookConfigurationCreatorGetter = func() (name string, create ValidatingWebhookConfigurationCreator)
-
-// ValidatingWebhookConfigurationObjectWrapper adds a wrapper so the ValidatingWebhookConfigurationCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ValidatingWebhookConfigurationObjectWrapper(create ValidatingWebhookConfigurationCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*admissionregistrationv1.ValidatingWebhookConfiguration))
-		}
-		return create(&admissionregistrationv1.ValidatingWebhookConfiguration{})
-	}
-}
-
-// ReconcileValidatingWebhookConfigurations will create and update the ValidatingWebhookConfigurations coming from the passed ValidatingWebhookConfigurationCreator slice
-func ReconcileValidatingWebhookConfigurations(ctx context.Context, namedGetters []NamedValidatingWebhookConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ValidatingWebhookConfigurationObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ValidatingWebhookConfiguration %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedValidatingWebhookConfigurationCreatorGetter = GenericNamedObjectCreator[*admissionregistrationv1.ValidatingWebhookConfiguration]
 
 // APIServiceCreator defines an interface to create/update APIServices
-type APIServiceCreator = func(existing *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error)
+type APIServiceCreator = GenericObjectCreator[*apiregistrationv1.APIService]
 
 // NamedAPIServiceCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedAPIServiceCreatorGetter = func() (name string, create APIServiceCreator)
+type NamedAPIServiceCreatorGetter = GenericNamedObjectCreator[*apiregistrationv1.APIService]
 
-// APIServiceObjectWrapper adds a wrapper so the APIServiceCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func APIServiceObjectWrapper(create APIServiceCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*apiregistrationv1.APIService))
-		}
-		return create(&apiregistrationv1.APIService{})
-	}
-}
-
-// ReconcileAPIServices will create and update the APIServices coming from the passed APIServiceCreator slice
-func ReconcileAPIServices(ctx context.Context, namedGetters []NamedAPIServiceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := APIServiceObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &apiregistrationv1.APIService{}, false); err != nil {
-			return fmt.Errorf("failed to ensure APIService %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
-
-// IngressCreator defines an interface to create/update Ingresss
-type IngressCreator = func(existing *networkingv1.Ingress) (*networkingv1.Ingress, error)
+// IngressCreator defines an interface to create/update Ingresses
+type IngressCreator = GenericObjectCreator[*networkingv1.Ingress]
 
 // NamedIngressCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedIngressCreatorGetter = func() (name string, create IngressCreator)
-
-// IngressObjectWrapper adds a wrapper so the IngressCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func IngressObjectWrapper(create IngressCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*networkingv1.Ingress))
-		}
-		return create(&networkingv1.Ingress{})
-	}
-}
-
-// ReconcileIngresses will create and update the Ingresses coming from the passed IngressCreator slice
-func ReconcileIngresses(ctx context.Context, namedGetters []NamedIngressCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := IngressObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &networkingv1.Ingress{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Ingress %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedIngressCreatorGetter = GenericNamedObjectCreator[*networkingv1.Ingress]
 
 // KubermaticConfigurationCreator defines an interface to create/update KubermaticConfigurations
-type KubermaticConfigurationCreator = func(existing *kubermaticv1.KubermaticConfiguration) (*kubermaticv1.KubermaticConfiguration, error)
+type KubermaticConfigurationCreator = GenericObjectCreator[*kubermaticv1.KubermaticConfiguration]
 
 // NamedKubermaticConfigurationCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticConfigurationCreatorGetter = func() (name string, create KubermaticConfigurationCreator)
-
-// KubermaticConfigurationObjectWrapper adds a wrapper so the KubermaticConfigurationCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticConfigurationObjectWrapper(create KubermaticConfigurationCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.KubermaticConfiguration))
-		}
-		return create(&kubermaticv1.KubermaticConfiguration{})
-	}
-}
-
-// ReconcileKubermaticConfigurations will create and update the KubermaticConfigurations coming from the passed KubermaticConfigurationCreator slice
-func ReconcileKubermaticConfigurations(ctx context.Context, namedGetters []NamedKubermaticConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticConfigurationObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.KubermaticConfiguration{}, false); err != nil {
-			return fmt.Errorf("failed to ensure KubermaticConfiguration %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticConfigurationCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.KubermaticConfiguration]
 
 // SeedCreator defines an interface to create/update Seeds
-type SeedCreator = func(existing *kubermaticv1.Seed) (*kubermaticv1.Seed, error)
+type SeedCreator = GenericObjectCreator[*kubermaticv1.Seed]
 
 // NamedSeedCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedSeedCreatorGetter = func() (name string, create SeedCreator)
-
-// SeedObjectWrapper adds a wrapper so the SeedCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func SeedObjectWrapper(create SeedCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.Seed))
-		}
-		return create(&kubermaticv1.Seed{})
-	}
-}
-
-// ReconcileSeeds will create and update the Seeds coming from the passed SeedCreator slice
-func ReconcileSeeds(ctx context.Context, namedGetters []NamedSeedCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := SeedObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.Seed{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Seed %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedSeedCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.Seed]
 
 // EtcdBackupConfigCreator defines an interface to create/update EtcdBackupConfigs
-type EtcdBackupConfigCreator = func(existing *kubermaticv1.EtcdBackupConfig) (*kubermaticv1.EtcdBackupConfig, error)
+type EtcdBackupConfigCreator = GenericObjectCreator[*kubermaticv1.EtcdBackupConfig]
 
 // NamedEtcdBackupConfigCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedEtcdBackupConfigCreatorGetter = func() (name string, create EtcdBackupConfigCreator)
-
-// EtcdBackupConfigObjectWrapper adds a wrapper so the EtcdBackupConfigCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func EtcdBackupConfigObjectWrapper(create EtcdBackupConfigCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.EtcdBackupConfig))
-		}
-		return create(&kubermaticv1.EtcdBackupConfig{})
-	}
-}
-
-// ReconcileEtcdBackupConfigs will create and update the EtcdBackupConfigs coming from the passed EtcdBackupConfigCreator slice
-func ReconcileEtcdBackupConfigs(ctx context.Context, namedGetters []NamedEtcdBackupConfigCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := EtcdBackupConfigObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.EtcdBackupConfig{}, false); err != nil {
-			return fmt.Errorf("failed to ensure EtcdBackupConfig %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedEtcdBackupConfigCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.EtcdBackupConfig]
 
 // ConstraintTemplateCreator defines an interface to create/update ConstraintTemplates
-type ConstraintTemplateCreator = func(existing *gatekeeperv1.ConstraintTemplate) (*gatekeeperv1.ConstraintTemplate, error)
+type ConstraintTemplateCreator = GenericObjectCreator[*gatekeeperv1.ConstraintTemplate]
 
 // NamedConstraintTemplateCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedConstraintTemplateCreatorGetter = func() (name string, create ConstraintTemplateCreator)
-
-// ConstraintTemplateObjectWrapper adds a wrapper so the ConstraintTemplateCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func ConstraintTemplateObjectWrapper(create ConstraintTemplateCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*gatekeeperv1.ConstraintTemplate))
-		}
-		return create(&gatekeeperv1.ConstraintTemplate{})
-	}
-}
-
-// ReconcileConstraintTemplates will create and update the ConstraintTemplates coming from the passed ConstraintTemplateCreator slice
-func ReconcileConstraintTemplates(ctx context.Context, namedGetters []NamedConstraintTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := ConstraintTemplateObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &gatekeeperv1.ConstraintTemplate{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ConstraintTemplate %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedConstraintTemplateCreatorGetter = GenericNamedObjectCreator[*gatekeeperv1.ConstraintTemplate]
 
 // KubermaticV1ConstraintTemplateCreator defines an interface to create/update ConstraintTemplates
-type KubermaticV1ConstraintTemplateCreator = func(existing *kubermaticv1.ConstraintTemplate) (*kubermaticv1.ConstraintTemplate, error)
+type KubermaticV1ConstraintTemplateCreator = GenericObjectCreator[*kubermaticv1.ConstraintTemplate]
 
 // NamedKubermaticV1ConstraintTemplateCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1ConstraintTemplateCreatorGetter = func() (name string, create KubermaticV1ConstraintTemplateCreator)
-
-// KubermaticV1ConstraintTemplateObjectWrapper adds a wrapper so the KubermaticV1ConstraintTemplateCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1ConstraintTemplateObjectWrapper(create KubermaticV1ConstraintTemplateCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.ConstraintTemplate))
-		}
-		return create(&kubermaticv1.ConstraintTemplate{})
-	}
-}
-
-// ReconcileKubermaticV1ConstraintTemplates will create and update the KubermaticV1ConstraintTemplates coming from the passed KubermaticV1ConstraintTemplateCreator slice
-func ReconcileKubermaticV1ConstraintTemplates(ctx context.Context, namedGetters []NamedKubermaticV1ConstraintTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1ConstraintTemplateObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.ConstraintTemplate{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ConstraintTemplate %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1ConstraintTemplateCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.ConstraintTemplate]
 
 // KubermaticV1ProjectCreator defines an interface to create/update Projects
-type KubermaticV1ProjectCreator = func(existing *kubermaticv1.Project) (*kubermaticv1.Project, error)
+type KubermaticV1ProjectCreator = GenericObjectCreator[*kubermaticv1.Project]
 
 // NamedKubermaticV1ProjectCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1ProjectCreatorGetter = func() (name string, create KubermaticV1ProjectCreator)
-
-// KubermaticV1ProjectObjectWrapper adds a wrapper so the KubermaticV1ProjectCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1ProjectObjectWrapper(create KubermaticV1ProjectCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.Project))
-		}
-		return create(&kubermaticv1.Project{})
-	}
-}
-
-// ReconcileKubermaticV1Projects will create and update the KubermaticV1Projects coming from the passed KubermaticV1ProjectCreator slice
-func ReconcileKubermaticV1Projects(ctx context.Context, namedGetters []NamedKubermaticV1ProjectCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1ProjectObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.Project{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Project %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1ProjectCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.Project]
 
 // KubermaticV1UserProjectBindingCreator defines an interface to create/update UserProjectBindings
-type KubermaticV1UserProjectBindingCreator = func(existing *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error)
+type KubermaticV1UserProjectBindingCreator = GenericObjectCreator[*kubermaticv1.UserProjectBinding]
 
 // NamedKubermaticV1UserProjectBindingCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1UserProjectBindingCreatorGetter = func() (name string, create KubermaticV1UserProjectBindingCreator)
-
-// KubermaticV1UserProjectBindingObjectWrapper adds a wrapper so the KubermaticV1UserProjectBindingCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1UserProjectBindingObjectWrapper(create KubermaticV1UserProjectBindingCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.UserProjectBinding))
-		}
-		return create(&kubermaticv1.UserProjectBinding{})
-	}
-}
-
-// ReconcileKubermaticV1UserProjectBindings will create and update the KubermaticV1UserProjectBindings coming from the passed KubermaticV1UserProjectBindingCreator slice
-func ReconcileKubermaticV1UserProjectBindings(ctx context.Context, namedGetters []NamedKubermaticV1UserProjectBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1UserProjectBindingObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.UserProjectBinding{}, false); err != nil {
-			return fmt.Errorf("failed to ensure UserProjectBinding %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1UserProjectBindingCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.UserProjectBinding]
 
 // KubermaticV1ConstraintCreator defines an interface to create/update Constraints
-type KubermaticV1ConstraintCreator = func(existing *kubermaticv1.Constraint) (*kubermaticv1.Constraint, error)
+type KubermaticV1ConstraintCreator = GenericObjectCreator[*kubermaticv1.Constraint]
 
 // NamedKubermaticV1ConstraintCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1ConstraintCreatorGetter = func() (name string, create KubermaticV1ConstraintCreator)
-
-// KubermaticV1ConstraintObjectWrapper adds a wrapper so the KubermaticV1ConstraintCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1ConstraintObjectWrapper(create KubermaticV1ConstraintCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.Constraint))
-		}
-		return create(&kubermaticv1.Constraint{})
-	}
-}
-
-// ReconcileKubermaticV1Constraints will create and update the KubermaticV1Constraints coming from the passed KubermaticV1ConstraintCreator slice
-func ReconcileKubermaticV1Constraints(ctx context.Context, namedGetters []NamedKubermaticV1ConstraintCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1ConstraintObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.Constraint{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Constraint %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1ConstraintCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.Constraint]
 
 // KubermaticV1UserCreator defines an interface to create/update Users
-type KubermaticV1UserCreator = func(existing *kubermaticv1.User) (*kubermaticv1.User, error)
+type KubermaticV1UserCreator = GenericObjectCreator[*kubermaticv1.User]
 
 // NamedKubermaticV1UserCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1UserCreatorGetter = func() (name string, create KubermaticV1UserCreator)
-
-// KubermaticV1UserObjectWrapper adds a wrapper so the KubermaticV1UserCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1UserObjectWrapper(create KubermaticV1UserCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.User))
-		}
-		return create(&kubermaticv1.User{})
-	}
-}
-
-// ReconcileKubermaticV1Users will create and update the KubermaticV1Users coming from the passed KubermaticV1UserCreator slice
-func ReconcileKubermaticV1Users(ctx context.Context, namedGetters []NamedKubermaticV1UserCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1UserObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.User{}, false); err != nil {
-			return fmt.Errorf("failed to ensure User %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1UserCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.User]
 
 // KubermaticV1ClusterTemplateCreator defines an interface to create/update ClusterTemplates
-type KubermaticV1ClusterTemplateCreator = func(existing *kubermaticv1.ClusterTemplate) (*kubermaticv1.ClusterTemplate, error)
+type KubermaticV1ClusterTemplateCreator = GenericObjectCreator[*kubermaticv1.ClusterTemplate]
 
 // NamedKubermaticV1ClusterTemplateCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1ClusterTemplateCreatorGetter = func() (name string, create KubermaticV1ClusterTemplateCreator)
+type NamedKubermaticV1ClusterTemplateCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.ClusterTemplate]
 
-// KubermaticV1ClusterTemplateObjectWrapper adds a wrapper so the KubermaticV1ClusterTemplateCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1ClusterTemplateObjectWrapper(create KubermaticV1ClusterTemplateCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.ClusterTemplate))
-		}
-		return create(&kubermaticv1.ClusterTemplate{})
-	}
-}
-
-// ReconcileKubermaticV1ClusterTemplates will create and update the KubermaticV1ClusterTemplates coming from the passed KubermaticV1ClusterTemplateCreator slice
-func ReconcileKubermaticV1ClusterTemplates(ctx context.Context, namedGetters []NamedKubermaticV1ClusterTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1ClusterTemplateObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.ClusterTemplate{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ClusterTemplate %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
-
-// NetworkPolicyCreator defines an interface to create/update NetworkPolicys
-type NetworkPolicyCreator = func(existing *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error)
+// NetworkPolicyCreator defines an interface to create/update NetworkPolicies
+type NetworkPolicyCreator = GenericObjectCreator[*networkingv1.NetworkPolicy]
 
 // NamedNetworkPolicyCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedNetworkPolicyCreatorGetter = func() (name string, create NetworkPolicyCreator)
-
-// NetworkPolicyObjectWrapper adds a wrapper so the NetworkPolicyCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func NetworkPolicyObjectWrapper(create NetworkPolicyCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*networkingv1.NetworkPolicy))
-		}
-		return create(&networkingv1.NetworkPolicy{})
-	}
-}
-
-// ReconcileNetworkPolicies will create and update the NetworkPolicies coming from the passed NetworkPolicyCreator slice
-func ReconcileNetworkPolicies(ctx context.Context, namedGetters []NamedNetworkPolicyCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := NetworkPolicyObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &networkingv1.NetworkPolicy{}, false); err != nil {
-			return fmt.Errorf("failed to ensure NetworkPolicy %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedNetworkPolicyCreatorGetter = GenericNamedObjectCreator[*networkingv1.NetworkPolicy]
 
 // KubermaticV1RuleGroupCreator defines an interface to create/update RuleGroups
-type KubermaticV1RuleGroupCreator = func(existing *kubermaticv1.RuleGroup) (*kubermaticv1.RuleGroup, error)
+type KubermaticV1RuleGroupCreator = GenericObjectCreator[*kubermaticv1.RuleGroup]
 
 // NamedKubermaticV1RuleGroupCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1RuleGroupCreatorGetter = func() (name string, create KubermaticV1RuleGroupCreator)
-
-// KubermaticV1RuleGroupObjectWrapper adds a wrapper so the KubermaticV1RuleGroupCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1RuleGroupObjectWrapper(create KubermaticV1RuleGroupCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.RuleGroup))
-		}
-		return create(&kubermaticv1.RuleGroup{})
-	}
-}
-
-// ReconcileKubermaticV1RuleGroups will create and update the KubermaticV1RuleGroups coming from the passed KubermaticV1RuleGroupCreator slice
-func ReconcileKubermaticV1RuleGroups(ctx context.Context, namedGetters []NamedKubermaticV1RuleGroupCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1RuleGroupObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.RuleGroup{}, false); err != nil {
-			return fmt.Errorf("failed to ensure RuleGroup %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1RuleGroupCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.RuleGroup]
 
 // AppsKubermaticV1ApplicationDefinitionCreator defines an interface to create/update ApplicationDefinitions
-type AppsKubermaticV1ApplicationDefinitionCreator = func(existing *appskubermaticv1.ApplicationDefinition) (*appskubermaticv1.ApplicationDefinition, error)
+type AppsKubermaticV1ApplicationDefinitionCreator = GenericObjectCreator[*appskubermaticv1.ApplicationDefinition]
 
 // NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter = func() (name string, create AppsKubermaticV1ApplicationDefinitionCreator)
-
-// AppsKubermaticV1ApplicationDefinitionObjectWrapper adds a wrapper so the AppsKubermaticV1ApplicationDefinitionCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func AppsKubermaticV1ApplicationDefinitionObjectWrapper(create AppsKubermaticV1ApplicationDefinitionCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*appskubermaticv1.ApplicationDefinition))
-		}
-		return create(&appskubermaticv1.ApplicationDefinition{})
-	}
-}
-
-// ReconcileAppsKubermaticV1ApplicationDefinitions will create and update the AppsKubermaticV1ApplicationDefinitions coming from the passed AppsKubermaticV1ApplicationDefinitionCreator slice
-func ReconcileAppsKubermaticV1ApplicationDefinitions(ctx context.Context, namedGetters []NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := AppsKubermaticV1ApplicationDefinitionObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appskubermaticv1.ApplicationDefinition{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ApplicationDefinition %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedAppsKubermaticV1ApplicationDefinitionCreatorGetter = GenericNamedObjectCreator[*appskubermaticv1.ApplicationDefinition]
 
 // KubeVirtV1VirtualMachineInstancePresetCreator defines an interface to create/update VirtualMachineInstancePresets
-type KubeVirtV1VirtualMachineInstancePresetCreator = func(existing *kubevirtv1.VirtualMachineInstancePreset) (*kubevirtv1.VirtualMachineInstancePreset, error)
+type KubeVirtV1VirtualMachineInstancePresetCreator = GenericObjectCreator[*kubevirtv1.VirtualMachineInstancePreset]
 
 // NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter = func() (name string, create KubeVirtV1VirtualMachineInstancePresetCreator)
-
-// KubeVirtV1VirtualMachineInstancePresetObjectWrapper adds a wrapper so the KubeVirtV1VirtualMachineInstancePresetCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubeVirtV1VirtualMachineInstancePresetObjectWrapper(create KubeVirtV1VirtualMachineInstancePresetCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubevirtv1.VirtualMachineInstancePreset))
-		}
-		return create(&kubevirtv1.VirtualMachineInstancePreset{})
-	}
-}
-
-// ReconcileKubeVirtV1VirtualMachineInstancePresets will create and update the KubeVirtV1VirtualMachineInstancePresets coming from the passed KubeVirtV1VirtualMachineInstancePresetCreator slice
-func ReconcileKubeVirtV1VirtualMachineInstancePresets(ctx context.Context, namedGetters []NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubeVirtV1VirtualMachineInstancePresetObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubevirtv1.VirtualMachineInstancePreset{}, false); err != nil {
-			return fmt.Errorf("failed to ensure VirtualMachineInstancePreset %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubeVirtV1VirtualMachineInstancePresetCreatorGetter = GenericNamedObjectCreator[*kubevirtv1.VirtualMachineInstancePreset]
 
 // KubermaticV1PresetCreator defines an interface to create/update Presets
-type KubermaticV1PresetCreator = func(existing *kubermaticv1.Preset) (*kubermaticv1.Preset, error)
+type KubermaticV1PresetCreator = GenericObjectCreator[*kubermaticv1.Preset]
 
 // NamedKubermaticV1PresetCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1PresetCreatorGetter = func() (name string, create KubermaticV1PresetCreator)
-
-// KubermaticV1PresetObjectWrapper adds a wrapper so the KubermaticV1PresetCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1PresetObjectWrapper(create KubermaticV1PresetCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.Preset))
-		}
-		return create(&kubermaticv1.Preset{})
-	}
-}
-
-// ReconcileKubermaticV1Presets will create and update the KubermaticV1Presets coming from the passed KubermaticV1PresetCreator slice
-func ReconcileKubermaticV1Presets(ctx context.Context, namedGetters []NamedKubermaticV1PresetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1PresetObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.Preset{}, false); err != nil {
-			return fmt.Errorf("failed to ensure Preset %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1PresetCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.Preset]
 
 // CDIv1beta1DataVolumeCreator defines an interface to create/update DataVolumes
-type CDIv1beta1DataVolumeCreator = func(existing *cdiv1beta1.DataVolume) (*cdiv1beta1.DataVolume, error)
+type CDIv1beta1DataVolumeCreator = GenericObjectCreator[*cdiv1beta1.DataVolume]
 
 // NamedCDIv1beta1DataVolumeCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedCDIv1beta1DataVolumeCreatorGetter = func() (name string, create CDIv1beta1DataVolumeCreator)
-
-// CDIv1beta1DataVolumeObjectWrapper adds a wrapper so the CDIv1beta1DataVolumeCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func CDIv1beta1DataVolumeObjectWrapper(create CDIv1beta1DataVolumeCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*cdiv1beta1.DataVolume))
-		}
-		return create(&cdiv1beta1.DataVolume{})
-	}
-}
-
-// ReconcileCDIv1beta1DataVolumes will create and update the CDIv1beta1DataVolumes coming from the passed CDIv1beta1DataVolumeCreator slice
-func ReconcileCDIv1beta1DataVolumes(ctx context.Context, namedGetters []NamedCDIv1beta1DataVolumeCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := CDIv1beta1DataVolumeObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &cdiv1beta1.DataVolume{}, false); err != nil {
-			return fmt.Errorf("failed to ensure DataVolume %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedCDIv1beta1DataVolumeCreatorGetter = GenericNamedObjectCreator[*cdiv1beta1.DataVolume]
 
 // KubermaticV1ResourceQuotaCreator defines an interface to create/update ResourceQuotas
-type KubermaticV1ResourceQuotaCreator = func(existing *kubermaticv1.ResourceQuota) (*kubermaticv1.ResourceQuota, error)
+type KubermaticV1ResourceQuotaCreator = GenericObjectCreator[*kubermaticv1.ResourceQuota]
 
 // NamedKubermaticV1ResourceQuotaCreatorGetter returns the name of the resource and the corresponding creator function
-type NamedKubermaticV1ResourceQuotaCreatorGetter = func() (name string, create KubermaticV1ResourceQuotaCreator)
-
-// KubermaticV1ResourceQuotaObjectWrapper adds a wrapper so the KubermaticV1ResourceQuotaCreator matches ObjectCreator.
-// This is needed as Go does not support function interface matching.
-func KubermaticV1ResourceQuotaObjectWrapper(create KubermaticV1ResourceQuotaCreator) ObjectCreator {
-	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
-		if existing != nil {
-			return create(existing.(*kubermaticv1.ResourceQuota))
-		}
-		return create(&kubermaticv1.ResourceQuota{})
-	}
-}
-
-// ReconcileKubermaticV1ResourceQuotas will create and update the KubermaticV1ResourceQuotas coming from the passed KubermaticV1ResourceQuotaCreator slice
-func ReconcileKubermaticV1ResourceQuotas(ctx context.Context, namedGetters []NamedKubermaticV1ResourceQuotaCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
-	for _, get := range namedGetters {
-		name, create := get()
-		createObject := KubermaticV1ResourceQuotaObjectWrapper(create)
-		createObject = createWithNamespace(createObject, namespace)
-		createObject = createWithName(createObject, name)
-
-		for _, objectModifier := range objectModifiers {
-			createObject = objectModifier(createObject)
-		}
-
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.ResourceQuota{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ResourceQuota %s/%s: %w", namespace, name, err)
-		}
-	}
-
-	return nil
-}
+type NamedKubermaticV1ResourceQuotaCreatorGetter = GenericNamedObjectCreator[*kubermaticv1.ResourceQuota]

--- a/pkg/test/e2e/nodeport-proxy/deployer.go
+++ b/pkg/test/e2e/nodeport-proxy/deployer.go
@@ -103,47 +103,47 @@ func (d *Deployer) SetUp(ctx context.Context) error {
 		return fmt.Errorf("failed to default seed: %w", err)
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, d.Namespace,
 		[]reconciling.NamedServiceAccountCreatorGetter{
 			nodeportproxy.ServiceAccountCreator(cfg),
-		}, d.Namespace, d.Client, recorderFunc); err != nil {
+		}, recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAcconts: %w", err)
 	}
-	if err := reconciling.ReconcileRoles(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, d.Namespace,
 		[]reconciling.NamedRoleCreatorGetter{
 			nodeportproxy.RoleCreator(),
-		}, d.Namespace, d.Client, recorderFunc); err != nil {
+		}, recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile Role: %w", err)
 	}
-	if err := reconciling.ReconcileRoleBindings(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, d.Namespace,
 		[]reconciling.NamedRoleBindingCreatorGetter{
 			nodeportproxy.RoleBindingCreator(cfg),
-		}, d.Namespace, d.Client, recorderFunc); err != nil {
+		}, recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBinding: %w", err)
 	}
-	if err := reconciling.ReconcileClusterRoles(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, "",
 		[]reconciling.NamedClusterRoleCreatorGetter{
 			nodeportproxy.ClusterRoleCreator(cfg),
-		}, "", d.Client, recorderFunc); err != nil {
+		}, recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRole: %w", err)
 	}
-	if err := reconciling.ReconcileClusterRoleBindings(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, "",
 		[]reconciling.NamedClusterRoleBindingCreatorGetter{
 			nodeportproxy.ClusterRoleBindingCreator(cfg),
-		}, "", d.Client, recorderFunc); err != nil {
+		}, recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBinding: %w", err)
 	}
-	if err := reconciling.ReconcileServices(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, d.Namespace,
 		[]reconciling.NamedServiceCreatorGetter{
 			nodeportproxy.ServiceCreator(seed)},
-		d.Namespace, d.Client, recorderFunc); err != nil {
+		recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile Services: %w", err)
 	}
-	if err := reconciling.ReconcileDeployments(ctx,
+	if err := reconciling.EnsureNamedObjects(ctx, d.Client, d.Namespace,
 		[]reconciling.NamedDeploymentCreatorGetter{
 			nodeportproxy.EnvoyDeploymentCreator(cfg, seed, false, d.Versions),
 			nodeportproxy.UpdaterDeploymentCreator(cfg, seed, d.Versions),
-		}, d.Namespace, d.Client, recorderFunc); err != nil {
+		}, recorderFunc); err != nil {
 		return fmt.Errorf("failed to reconcile Kubermatic Deployments: %w", err)
 	}
 


### PR DESCRIPTION
### What does this PR do

This PR is an experiment to see if and how Go Generics can improve our codebase. I chose the obvious target: our reconciling framework, the one piece in KKP where we rely heavily on code generation.

### Goals

* For a developer of a controller, the experience should stay the same. They should still simply call a function and be done, without too much type juggling.
* I want to get rid of the repeated (generated) code.

### The Results

... are mixed.

As it turns out, our reconciling is based around interfaces, generics and closures. Mixing and matching them is not easy and can lead to code that is quickly unreadable.

While this PR achieved the main goal of removing most of the generated code, there are still some leftovers. The `NamedXXXXXCreatorGetter` types are still auto-generated because it's much easier to write `[]reconciling.NamedConfigMapCreatorGetter` than `[]func(string, func (T) (T, error)) func (T) (T, error)`. So those generated types are really only for readability.

For the most part I was able to build the new reconciling based on generics. However the object modifiers (which should be called "object creator modifiers", as they do not modify an object but instead wrap around an ObjectCreator) I left as "interfaced", i.e. `func(ctrlruntime.Object) ctrlruntime.Object`. This is because they are meant to be generic (not _go generic_) and it just makes sense to use the interface that exists already. However this seemingly small piece of the puzzle makes things infinitely more complicated: All of the reconciling is generic, but the modifiers are interface-based. So now we need to convert between T and ctrlruntime.Object in a few places. You can see the type juggling in `makeGenericObjectCreator[T]` and `wrapGenericObjectModifier[T]`.

You might wonder "Why not simply make the modifiers generic?". Easy: If we made them generic (with Go generics), then whoever instantiates them needs to know the type of the object they are reconciling (so that they can do `modifier := reconciling.ObjectOwner[*corev1.ConfigMap]()`). This is trivial to know, but tedious to write. It also means that you cannot reuse a modifier for a different set of resources, so if your controller reconciles ConfigMaps, Secrets and Deployments, you need 3 distinct modifiers, one for each type. I found this to be too much hassle and rather opted to "fix it" in the reconciling framework (so the burden of dealing with all that nonsense is not put on the developer).

Similarily, unstructured objects were already special and continue to be special. We still need to inject the APIVersion/kind at some point and the super generic functions in the package simply do not allow for one special snowflake type. This means that for reconciling unstructured objects, one must use `EnsureNamedUnstructuredObjects`. Using the wrong function will lead to kube API errors and so it's very obvious that you've done something wrong (I thought about adding explicit panics and doing type checks, but doing type checks in a generic function feels just wrong.)

### Conclusion

To be honest, I am a bit underwhelmed. While I was able to save roughly 1k lines of code, the replacement code is super hard to read and even harder to understand. While developing I was blindly hacking on my keyboard until the red squiggly lines disappeared in my editor.

If we want to merge this and use it, cool. If not, also cool. Just because generics are new doesn't mean they are the right solution for us here.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
