### PR TITLE
Update kubevirt ccm config

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -472,6 +472,10 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 		creators = append(creators, resources.GetInternalKubeconfigCreator(
 			namespace, resources.CloudControllerManagerKubeconfigSecretName, resources.CloudControllerManagerCertUsername, nil, data, r.log,
 		))
+
+		if data.Cluster().Spec.Cloud.Kubevirt != nil {
+			creators = append(creators, cloudcontroller.GetKubeVirtInfraKubeConfigCreator(data))
+		}
 	}
 
 	if data.Cluster().Spec.Cloud.GCP != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -474,7 +474,7 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 		))
 
 		if data.Cluster().Spec.Cloud.Kubevirt != nil {
-			creators = append(creators, cloudcontroller.GetKubeVirtInfraKubeConfigCreator(data))
+			creators = append(creators, cloudconfig.KubeVirtInfraSecretCreator(data))
 		}
 	}
 

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -318,7 +318,7 @@ func CloudConfig(
 
 	case cloud.Kubevirt != nil:
 		cc := kubevirt.CloudConfig{
-			Kubeconfig: credentials.Kubevirt.KubeConfig,
+			Kubeconfig: "/etc/kubernetes/cloud/infra-kubeconfig",
 			Namespace:  cluster.Status.NamespaceName,
 		}
 		return cc.String()

--- a/pkg/resources/cloudconfig/secret.go
+++ b/pkg/resources/cloudconfig/secret.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudconfig
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func KubeVirtInfraSecretCreator(data *resources.TemplateData) reconciling.NamedSecretCreatorGetter {
+	return func() (name string, create reconciling.SecretCreator) {
+		return resources.KubeVirtInfraSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
+			if se.Data == nil {
+				se.Data = map[string][]byte{}
+			}
+			credentials, err := resources.GetCredentials(data)
+			if err != nil {
+				return nil, err
+			}
+			se.Data[resources.KubeVirtInfraSecretKey] = []byte(credentials.Kubevirt.KubeConfig)
+			return se, nil
+		}
+	}
+}

--- a/pkg/resources/cloudconfig/secret_test.go
+++ b/pkg/resources/cloudconfig/secret_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudconfig
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKubeVirtInfraSecretCreator(t *testing.T) {
+	testCases := []struct {
+		name               string
+		infraKubeconfig    string
+		expectedSecretData string
+		expectedError      error
+	}{
+		{name: "with kubeconfig", infraKubeconfig: "ZmFrZWt1YmVjb25maWcK", expectedSecretData: "ZmFrZWt1YmVjb25maWcK", expectedError: nil},
+		{name: "with empty kubeconfig", infraKubeconfig: "", expectedSecretData: "", expectedError: errors.New("configVar is nil")},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			fakeTemplateData := createFakeTemplateData(test.infraKubeconfig)
+			_, creator := KubeVirtInfraSecretCreator(fakeTemplateData)()
+			secret, err := creator(&corev1.Secret{})
+			assert.Equal(t, test.expectedError, err)
+			var actualSecretData string
+			if secret != nil {
+				actualSecretData = string(secret.Data[resources.KubeVirtInfraSecretKey])
+			}
+			assert.Equal(t, test.expectedSecretData, actualSecretData)
+		})
+	}
+}
+
+func createFakeTemplateData(kubeconfig string) *resources.TemplateData {
+	return resources.NewTemplateDataBuilder().WithCluster(&kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fake-Kubevirt-Cluster",
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: kubermaticv1.CloudSpec{Kubevirt: &kubermaticv1.KubevirtCloudSpec{
+				Kubeconfig:    kubeconfig,
+				CSIKubeconfig: kubeconfig,
+			}},
+		},
+	}).Build()
+}

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -32,10 +32,8 @@ import (
 )
 
 const (
-	KubeVirtCCMDeploymentName                       = "kubevirt-cloud-controller-manager"
-	KubeVirtCCMTag                                  = "v0.2.0"
-	CloudControllerManagerInfraKubeconfigSecretName = "cloud-controller-manager-infra-kubeconfig"
-	InfraKubeConfigSecretKey                        = "infra-kubeconfig"
+	KubeVirtCCMDeploymentName = "kubevirt-cloud-controller-manager"
+	KubeVirtCCMTag            = "v0.2.0"
 )
 
 var (
@@ -88,7 +86,7 @@ func kubevirtDeploymentCreator(data *resources.TemplateData) reconciling.NamedDe
 							Sources: []corev1.VolumeProjection{
 								{
 									Secret: &corev1.SecretProjection{
-										LocalObjectReference: corev1.LocalObjectReference{Name: CloudControllerManagerInfraKubeconfigSecretName},
+										LocalObjectReference: corev1.LocalObjectReference{Name: resources.KubeVirtInfraSecretName},
 									},
 								},
 								{
@@ -97,6 +95,7 @@ func kubevirtDeploymentCreator(data *resources.TemplateData) reconciling.NamedDe
 									},
 								},
 							},
+							DefaultMode: pointer.Int32(420),
 						},
 					},
 				},
@@ -148,20 +147,4 @@ func getKVFlags(data *resources.TemplateData) []string {
 		flags = append(flags, "--cluster-name", data.Cluster().Name)
 	}
 	return flags
-}
-
-func GetKubeVirtInfraKubeConfigCreator(data *resources.TemplateData) reconciling.NamedSecretCreatorGetter {
-	return func() (name string, create reconciling.SecretCreator) {
-		return CloudControllerManagerInfraKubeconfigSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
-			if se.Data == nil {
-				se.Data = map[string][]byte{}
-			}
-			credentials, err := resources.GetCredentials(data)
-			if err != nil {
-				return nil, err
-			}
-			se.Data[InfraKubeConfigSecretKey] = []byte(credentials.Kubevirt.KubeConfig)
-			return se, nil
-		}
-	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -469,6 +469,11 @@ const (
 
 	// EventRateLimitAdmisionPlugin defines the EventRateLimit admission plugin.
 	EventRateLimitAdmissionPlugin = "EventRateLimit"
+
+	// KubeVirtInfraSecretName is the name for the secret containing the kubeconfig of the kubevirt infra cluster.
+	KubeVirtInfraSecretName = "cloud-controller-manager-infra-kubeconfig"
+	// KubeVirtInfraSecretKey infra kubeconfig.
+	KubeVirtInfraSecretKey = "infra-kubeconfig"
 )
 
 const (


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR updates kubevirt CCM config to remove infra-kubeconfig from ConfigMap and mount it as Secert on kubevirt-cloud-controller-manager.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
