### PR TITLE
Use batch/v1 API instead of batch/v1beta1 for CronJobs

### DIFF
--- a/charts/telemetry/templates/cronjob.yaml
+++ b/charts/telemetry/templates/cronjob.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-job

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -127,8 +127,8 @@ func main() {
 			},
 			{
 				ResourceName:       "CronJob",
-				ImportAlias:        "batchv1beta1",
-				ResourceImportPath: "k8s.io/api/batch/v1beta1",
+				ImportAlias:        "batchv1",
+				ResourceImportPath: "k8s.io/api/batch/v1",
 				DefaultingFunc:     "DefaultCronJob",
 			},
 			{

--- a/pkg/controller/operator/seed/reconciler_ee_test.go
+++ b/pkg/controller/operator/seed/reconciler_ee_test.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/ee/metering"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -72,7 +72,7 @@ func TestMeteringReconciling(t *testing.T) {
 
 				seedClient := reconciler.seedClients[test.seedToReconcile]
 
-				cronJob := batchv1beta1.CronJob{}
+				cronJob := batchv1.CronJob{}
 				err := seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob)
 				if err != nil {
 					return fmt.Errorf("failed to find reporting cronjob: %w", err)
@@ -98,7 +98,7 @@ func TestMeteringReconciling(t *testing.T) {
 				seedClient := reconciler.seedClients[test.seedToReconcile]
 
 				// asserting that reporting cron job exists
-				cronJob := batchv1beta1.CronJob{}
+				cronJob := batchv1.CronJob{}
 				must(t, seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob))
 
 				seed := &kubermaticv1.Seed{}
@@ -144,7 +144,7 @@ func TestMeteringReconciling(t *testing.T) {
 				seedClient := reconciler.seedClients[test.seedToReconcile]
 
 				// asserting that reporting cron job exists
-				cronJob := batchv1beta1.CronJob{}
+				cronJob := batchv1.CronJob{}
 				must(t, seedClient.Get(ctx, types.NamespacedName{Namespace: "kubermatic", Name: "weekly-test"}, &cronJob))
 
 				// asserting that metering deployment exists

--- a/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/util/yaml"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -137,7 +137,7 @@ func TestEnsureBackupCronJob(t *testing.T) {
 		t.Fatalf("Error syncing cluster: %v", err)
 	}
 
-	cronJobs := &batchv1beta1.CronJobList{}
+	cronJobs := &batchv1.CronJobList{}
 	if err := reconciler.List(ctx, cronJobs); err != nil {
 		t.Fatalf("Error listing cronjobs: %v", err)
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -186,7 +186,7 @@ func Add(
 		&corev1.Namespace{},
 		&appsv1.StatefulSet{},
 		&appsv1.Deployment{},
-		&batchv1beta1.CronJob{},
+		&batchv1.CronJob{},
 		&policyv1.PodDisruptionBudget{},
 		&autoscalingv1.VerticalPodAutoscaler{},
 		&rbacv1.Role{},

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
@@ -40,7 +40,7 @@ import (
 // cronJobCreator returns the func to create/update the metering report cronjob.
 func cronJobCreator(seedName, reportName string, mrc *kubermaticv1.MeteringReportConfiguration, getRegistry registry.WithOverwriteFunc) reconciling.NamedCronJobCreatorGetter {
 	return func() (string, reconciling.CronJobCreator) {
-		return reportName, func(job *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
+		return reportName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			labels := job.GetLabels()
 			if labels == nil {
 				labels = make(map[string]string)

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -156,7 +156,7 @@ func cleanupOrphanedReportingCronJobs(ctx context.Context, client ctrlruntimecli
 		return err
 	}
 
-	existingReportingCronJobNamedMap := make(map[string]batchv1beta1.CronJob, len(existingReportingCronJobs.Items))
+	existingReportingCronJobNamedMap := make(map[string]batchv1.CronJob, len(existingReportingCronJobs.Items))
 	for _, existingCronJob := range existingReportingCronJobs.Items {
 		existingReportingCronJobNamedMap[existingCronJob.Name] = existingCronJob
 	}
@@ -194,7 +194,7 @@ func cleanupAllMeteringResources(ctx context.Context, client ctrlruntimeclient.C
 
 	for _, cronJob := range existingReportingCronJobs.Items {
 		key = types.NamespacedName{Namespace: cronJob.Namespace, Name: cronJob.Name}
-		if err := cleanupResource(ctx, client, key, &batchv1beta1.CronJob{}); err != nil {
+		if err := cleanupResource(ctx, client, key, &batchv1.CronJob{}); err != nil {
 			return fmt.Errorf("failed to cleanup metering CronJob: %w", err)
 		}
 	}
@@ -203,8 +203,8 @@ func cleanupAllMeteringResources(ctx context.Context, client ctrlruntimeclient.C
 }
 
 // fetchExistingReportingCronJobs returns a list of all existing reporting cronjobs.
-func fetchExistingReportingCronJobs(ctx context.Context, client ctrlruntimeclient.Client) (*batchv1beta1.CronJobList, error) {
-	existingReportingCronJobs := &batchv1beta1.CronJobList{}
+func fetchExistingReportingCronJobs(ctx context.Context, client ctrlruntimeclient.Client) (*batchv1.CronJobList, error) {
+	existingReportingCronJobs := &batchv1.CronJobList{}
 	listOpts := []ctrlruntimeclient.ListOption{
 		ctrlruntimeclient.InNamespace(resources.KubermaticNamespace),
 		ctrlruntimeclient.ListOption(ctrlruntimeclient.HasLabels{LabelKey}),

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -182,7 +182,7 @@ func getImagesFromCreators(log logrus.FieldLogger, templateData *resources.Templ
 
 	for _, createFunc := range cronjobCreators {
 		_, creator := createFunc()
-		cronJob, err := creator(&batchv1beta1.CronJob{})
+		cronJob, err := creator(&batchv1.CronJob{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resources/etcd/cronjob.go
+++ b/pkg/resources/etcd/cronjob.go
@@ -27,7 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,14 +41,14 @@ type cronJobCreatorData interface {
 // CronJobCreator returns the func to create/update the etcd defragger cronjob.
 func CronJobCreator(data cronJobCreatorData) reconciling.NamedCronJobCreatorGetter {
 	return func() (string, reconciling.CronJobCreator) {
-		return resources.EtcdDefragCronJobName, func(job *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
+		return resources.EtcdDefragCronJobName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			command, err := defraggerCommand(data)
 			if err != nil {
 				return nil, err
 			}
 
 			job.Name = resources.EtcdDefragCronJobName
-			job.Spec.ConcurrencyPolicy = batchv1beta1.ForbidConcurrent
+			job.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
 			var historyLimit int32
 			job.Spec.SuccessfulJobsHistoryLimit = &historyLimit
 			job.Spec.Schedule = "@every 3h"

--- a/pkg/resources/reconciling/wrapper.go
+++ b/pkg/resources/reconciling/wrapper.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -240,7 +240,7 @@ func DefaultDaemonSet(creator DaemonSetCreator) DaemonSetCreator {
 // DefaultCronJob defaults all CronJob attributes to the same values as they would get from the Kubernetes API.
 // In addition, the CronJob's PodSpec template gets defaulted with KKP-specific values (see DefaultPodSpec for details).
 func DefaultCronJob(creator CronJobCreator) CronJobCreator {
-	return func(cj *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
+	return func(cj *batchv1.CronJob) (*batchv1.CronJob, error) {
 		old := cj.DeepCopy()
 
 		cj, err := creator(cj)

--- a/pkg/resources/reconciling/wrapper_test.go
+++ b/pkg/resources/reconciling/wrapper_test.go
@@ -26,7 +26,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -677,19 +676,19 @@ func TestDefaultCronJob(t *testing.T) {
 
 	creators := []NamedCronJobCreatorGetter{
 		func() (string, CronJobCreator) {
-			return testResourceName, func(d *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
+			return testResourceName, func(d *batchv1.CronJob) (*batchv1.CronJob, error) {
 				return d, nil
 			}
 		},
 	}
 
-	existingObject := &batchv1beta1.CronJob{
+	existingObject := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testResourceName,
 			Namespace: testNamespace,
 		},
-		Spec: batchv1beta1.CronJobSpec{
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -703,10 +702,10 @@ func TestDefaultCronJob(t *testing.T) {
 		},
 	}
 
-	expectedObject := &batchv1beta1.CronJob{
+	expectedObject := &batchv1.CronJob{
 		ObjectMeta: existingObject.ObjectMeta,
-		Spec: batchv1beta1.CronJobSpec{
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -736,7 +735,7 @@ func TestDefaultCronJob(t *testing.T) {
 
 	key := ctrlruntimeclient.ObjectKeyFromObject(expectedObject)
 
-	actualCronJob := &batchv1beta1.CronJob{}
+	actualCronJob := &batchv1.CronJob{}
 	if err := client.Get(context.Background(), key, actualCronJob); err != nil {
 		t.Fatalf("Failed to get the CronJob from the client: %v", err)
 	}

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -13,7 +13,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -659,7 +659,7 @@ func ReconcileCustomResourceDefinitions(ctx context.Context, namedGetters []Name
 }
 
 // CronJobCreator defines an interface to create/update CronJobs
-type CronJobCreator = func(existing *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error)
+type CronJobCreator = func(existing *batchv1.CronJob) (*batchv1.CronJob, error)
 
 // NamedCronJobCreatorGetter returns the name of the resource and the corresponding creator function
 type NamedCronJobCreatorGetter = func() (name string, create CronJobCreator)
@@ -669,9 +669,9 @@ type NamedCronJobCreatorGetter = func() (name string, create CronJobCreator)
 func CronJobObjectWrapper(create CronJobCreator) ObjectCreator {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return create(existing.(*batchv1beta1.CronJob))
+			return create(existing.(*batchv1.CronJob))
 		}
-		return create(&batchv1beta1.CronJob{})
+		return create(&batchv1.CronJob{})
 	}
 }
 
@@ -688,7 +688,7 @@ func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGe
 			createObject = objectModifier(createObject)
 		}
 
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &batchv1beta1.CronJob{}, false); err != nil {
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &batchv1.CronJob{}, false); err != nil {
 			return fmt.Errorf("failed to ensure CronJob %s/%s: %w", namespace, name, err)
 		}
 	}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -47,7 +47,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -775,7 +775,7 @@ func TestLoadFiles(t *testing.T) {
 
 					for _, creatorGetter := range kubernetescontroller.GetCronJobCreators(data) {
 						_, create := creatorGetter()
-						res, err := create(&batchv1beta1.CronJob{})
+						res, err := create(&batchv1.CronJob{})
 						if err != nil {
 							t.Fatalf("failed to create CronJob: %v", err)
 						}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In the spirit of #10162, this replaces usage of the deprecated `batch/v1beta1` API with `batch/v1` for `CronJob` resources. CronJobs will not be served under `batch/v1beta1` in Kubernetes 1.25 and above (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125). No notable changes have been made to the API.

The `batch/v1` API is available since Kubernetes 1.21, which means all supported Kubernetes versions support it.

I've left one instance of `batchv1beta1` in the code, namely for extracting container images from resources. I'm not 100% sure we need it, but it seemed the safe thing to do. It might require removal when we upgrade client libraries to 1.25, but it does not affect the ability to install a master/seed on a Kubernetes 1.25 cluster, so we're good user-wise.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use batch/v1 API for CronJob resources 
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
