### PR TITLE
vcd: use lowercase for provider name

### DIFF
--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -37,7 +37,7 @@ presubmits:
             - name: VERSIONS_TO_TEST
               value: "v1.24.2"
             - name: PROVIDER
-              value: "vmware-cloud-director"
+              value: "vmwareclouddirector"
             - name: DISTRIBUTIONS
               value: ubuntu
             - name: SERVICE_ACCOUNT_KEY

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -19,7 +19,7 @@
 # - image source includes registry templating
 # - add a securityContext
 
-{{ if eq .Cluster.CloudProviderName "vmware-cloud-director" }}
+{{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 
 ---
 apiVersion: v1

--- a/addons/csi/vmware-cloud-director/csi-driver.yaml
+++ b/addons/csi/vmware-cloud-director/csi-driver.yaml
@@ -15,7 +15,7 @@
 # Sourced from:
 # - https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/1.2.0/manifests/csi-driver.yaml
 
-{{ if eq .Cluster.CloudProviderName "vmware-cloud-director" }}
+{{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 
 ---
 apiVersion: storage.k8s.io/v1

--- a/addons/csi/vmware-cloud-director/csi-node.yaml
+++ b/addons/csi/vmware-cloud-director/csi-node.yaml
@@ -19,7 +19,7 @@
 # - image source includes registry templating
 # - add a securityContext
 
-{{ if eq .Cluster.CloudProviderName "vmware-cloud-director" }}
+{{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 
 ---
 apiVersion: v1

--- a/addons/csi/vmware-cloud-director/vcloud-basic-auth.yaml
+++ b/addons/csi/vmware-cloud-director/vcloud-basic-auth.yaml
@@ -15,7 +15,7 @@
 # Sourced from:
 # - https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/1.2.0/manifests/vcloud-basic-auth.yaml
 
-{{ if eq .Cluster.CloudProviderName "vmware-cloud-director" }}
+{{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 
 apiVersion: v1
 kind: Secret

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -167,7 +167,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 {{ end }}
 
-{{ if eq .Cluster.CloudProviderName "vmware-cloud-director" }}
+{{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:

--- a/cmd/conformance-tester/pkg/scenarios/interface.go
+++ b/cmd/conformance-tester/pkg/scenarios/interface.go
@@ -98,7 +98,7 @@ func GetScenarios(opts *types.Options, log *zap.SugaredLogger) []Scenario {
 		log.Info("Adding Nutanix scenarios")
 		scenarios = append(scenarios, GetNutanixScenarios(opts.Versions)...)
 	}
-	if opts.Providers.Has("vmware-cloud-director") {
+	if opts.Providers.Has("vmwareclouddirector") {
 		log.Info("Adding VMware Cloud Director scenarios")
 		scenarios = append(scenarios, GetVMwareCloudDirectorScenarios(opts.Versions)...)
 	}

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -75,7 +75,7 @@ func (s *vmwareCloudDirectorScenario) APICluster(secrets types.Secrets) *apimode
 			Spec: &apimodels.ClusterSpec{
 				Cloud: &apimodels.CloudSpec{
 					DatacenterName: vmwareCloudDirectorDatacenter,
-					VmwareCloudDirector: &apimodels.VMwareCloudDirectorCloudSpec{
+					Vmwareclouddirector: &apimodels.VMwareCloudDirectorCloudSpec{
 						Username:     secrets.VMwareCloudDirector.Username,
 						Password:     secrets.VMwareCloudDirector.Password,
 						Organization: secrets.VMwareCloudDirector.Organization,
@@ -124,7 +124,7 @@ func (s *vmwareCloudDirectorScenario) NodeDeployments(_ context.Context, num int
 				Replicas: &replicas,
 				Template: &apimodels.NodeSpec{
 					Cloud: &apimodels.NodeCloudSpec{
-						VmwareCloudDirector: &apimodels.VMwareCloudDirectorNodeSpec{
+						Vmwareclouddirector: &apimodels.VMwareCloudDirectorNodeSpec{
 							Template:         fmt.Sprintf("machine-controller-%s", osName),
 							Catalog:          vmwareCloudDirectorCatalog,
 							CPUs:             vmwareCloudDirectorCPUs,

--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -90,7 +90,7 @@ type Options struct {
 }
 
 func NewDefaultOptions() *Options {
-	providers := sets.NewString("aws", "digitalocean", "openstack", "hetzner", "vsphere", "azure", "packet", "gcp", "nutanix", "vmware-cloud-director")
+	providers := sets.NewString("aws", "digitalocean", "openstack", "hetzner", "vsphere", "azure", "packet", "gcp", "nutanix", "vmwareclouddirector")
 
 	return &Options{
 		Client:                       "api",

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13583,13 +13583,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13601,6 +13594,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {
@@ -22369,7 +22369,7 @@
           "type": "string",
           "x-go-name": "ProviderName"
         },
-        "vmwareCloudDirector": {
+        "vmwareclouddirector": {
           "$ref": "#/definitions/VMwareCloudDirectorCloudSpec"
         },
         "vsphere": {
@@ -23452,7 +23452,7 @@
           "type": "string",
           "x-go-name": "Seed"
         },
-        "vmwareCloudDirector": {
+        "vmwareclouddirector": {
           "$ref": "#/definitions/DatacenterSpecVMwareCloudDirector"
         },
         "vsphere": {
@@ -27324,7 +27324,7 @@
         "packet": {
           "$ref": "#/definitions/PacketNodeSpec"
         },
-        "vmwareCloudDirector": {
+        "vmwareclouddirector": {
           "$ref": "#/definitions/VMwareCloudDirectorNodeSpec"
         },
         "vsphere": {
@@ -28986,7 +28986,7 @@
           },
           "x-go-name": "RequiredEmails"
         },
-        "vmwareCloudDirector": {
+        "vmwareclouddirector": {
           "$ref": "#/definitions/VMwareCloudDirector"
         },
         "vsphere": {
@@ -29201,7 +29201,7 @@
         "packet": {
           "$ref": "#/definitions/PublicPacketCloudSpec"
         },
-        "vmwareCloudDirector": {
+        "vmwareclouddirector": {
           "$ref": "#/definitions/PublicVMwareCloudDirectorCloudSpec"
         },
         "vsphere": {

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -200,7 +200,7 @@ spec:
         # domains, e.g. "example.com", one of which must match the email domain
         # exactly (i.e. "example.com" will not match "user@test.example.com").
         requiredEmails: []
-        vmwareCloudDirector:
+        vmwareclouddirector:
           # If set to true, disables the TLS certificate check against the endpoint.
           allowInsecure: false
           # The default catalog which contains the VM templates.

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -88,7 +88,7 @@ elif [[ $provider == "nutanix" ]]; then
     -nutanix-cluster-name=${NUTANIX_E2E_CLUSTER_NAME}
     -nutanix-project-name=${NUTANIX_E2E_PROJECT_NAME}
     -nutanix-subnet-name=${NUTANIX_E2E_SUBNET_NAME}"
-elif [[ $provider == "vmware-cloud-director" ]]; then
+elif [[ $provider == "vmwareclouddirector" ]]; then
   EXTRA_ARGS="-vmware-cloud-director-username=${VCD_USER}
     -vmware-cloud-director-password=${VCD_PASSWORD}
     -vmware-cloud-director-organization=${VCD_ORG}

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -77,7 +77,7 @@ spec:
       location: Hamburg
       country: DE
       spec:
-        vmwareCloudDirector:
+        vmwareclouddirector:
           url: "__VCD_URL__"
           allowInsecure: false
           catalog: "kubermatic"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -81,7 +81,7 @@ type DatacenterSpec struct {
 	Alibaba             *kubermaticv1.DatacenterSpecAlibaba             `json:"alibaba,omitempty"`
 	Anexia              *kubermaticv1.DatacenterSpecAnexia              `json:"anexia,omitempty"`
 	Nutanix             *kubermaticv1.DatacenterSpecNutanix             `json:"nutanix,omitempty"`
-	VMwareCloudDirector *kubermaticv1.DatacenterSpecVMwareCloudDirector `json:"vmwareCloudDirector,omitempty"`
+	VMwareCloudDirector *kubermaticv1.DatacenterSpecVMwareCloudDirector `json:"vmwareclouddirector,omitempty"`
 
 	//nolint:staticcheck
 	//lint:ignore SA5008 omitgenyaml is used by the example-yaml-generator
@@ -1042,7 +1042,7 @@ type PublicCloudSpec struct {
 	Alibaba             *PublicAlibabaCloudSpec             `json:"alibaba,omitempty"`
 	Anexia              *PublicAnexiaCloudSpec              `json:"anexia,omitempty"`
 	Nutanix             *PublicNutanixCloudSpec             `json:"nutanix,omitempty"`
-	VMwareCloudDirector *PublicVMwareCloudDirectorCloudSpec `json:"vmwareCloudDirector,omitempty"`
+	VMwareCloudDirector *PublicVMwareCloudDirectorCloudSpec `json:"vmwareclouddirector,omitempty"`
 }
 
 // PublicFakeCloudSpec is a public counterpart of apiv1.FakeCloudSpec.
@@ -1334,7 +1334,7 @@ type NodeCloudSpec struct {
 	Alibaba             *AlibabaNodeSpec             `json:"alibaba,omitempty"`
 	Anexia              *AnexiaNodeSpec              `json:"anexia,omitempty"`
 	Nutanix             *NutanixNodeSpec             `json:"nutanix,omitempty"`
-	VMwareCloudDirector *VMwareCloudDirectorNodeSpec `json:"vmwareCloudDirector,omitempty"`
+	VMwareCloudDirector *VMwareCloudDirectorNodeSpec `json:"vmwareclouddirector,omitempty"`
 }
 
 // UbuntuSpec ubuntu specific settings

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -916,7 +916,7 @@ type CloudSpec struct {
 	Alibaba             *AlibabaCloudSpec             `json:"alibaba,omitempty"`
 	Anexia              *AnexiaCloudSpec              `json:"anexia,omitempty"`
 	Nutanix             *NutanixCloudSpec             `json:"nutanix,omitempty"`
-	VMwareCloudDirector *VMwareCloudDirectorCloudSpec `json:"vmwareCloudDirector,omitempty"`
+	VMwareCloudDirector *VMwareCloudDirectorCloudSpec `json:"vmwareclouddirector,omitempty"`
 }
 
 // FakeCloudSpec specifies access data for a fake cloud.

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=digitalocean;hetzner;azure;vsphere;aws;openstack;packet;gcp;kubevirt;nutanix;alibaba;anexia;fake;vmware-cloud-director
+// +kubebuilder:validation:Enum=digitalocean;hetzner;azure;vsphere;aws;openstack;packet;gcp;kubevirt;nutanix;alibaba;anexia;fake;vmwareclouddirector
 
 type ProviderType string
 
@@ -51,7 +51,7 @@ const (
 	NutanixCloudProvider             ProviderType = "nutanix"
 	OpenstackCloudProvider           ProviderType = "openstack"
 	PacketCloudProvider              ProviderType = "packet"
-	VMwareCloudDirectorCloudProvider ProviderType = "vmware-cloud-director"
+	VMwareCloudDirectorCloudProvider ProviderType = "vmwareclouddirector"
 	VSphereCloudProvider             ProviderType = "vsphere"
 
 	DefaultSSHPort     = 22
@@ -379,7 +379,7 @@ type DatacenterSpec struct {
 	Packet              *DatacenterSpecPacket              `json:"packet,omitempty"`
 	Hetzner             *DatacenterSpecHetzner             `json:"hetzner,omitempty"`
 	VSphere             *DatacenterSpecVSphere             `json:"vsphere,omitempty"`
-	VMwareCloudDirector *DatacenterSpecVMwareCloudDirector `json:"vmwareCloudDirector,omitempty"`
+	VMwareCloudDirector *DatacenterSpecVMwareCloudDirector `json:"vmwareclouddirector,omitempty"`
 	GCP                 *DatacenterSpecGCP                 `json:"gcp,omitempty"`
 	Kubevirt            *DatacenterSpecKubevirt            `json:"kubevirt,omitempty"`
 	Alibaba             *DatacenterSpecAlibaba             `json:"alibaba,omitempty"`

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -59,7 +59,7 @@ type PresetSpec struct {
 	Alibaba             *Alibaba             `json:"alibaba,omitempty"`
 	Anexia              *Anexia              `json:"anexia,omitempty"`
 	Nutanix             *Nutanix             `json:"nutanix,omitempty"`
-	VMwareCloudDirector *VMwareCloudDirector `json:"vmwareCloudDirector,omitempty"`
+	VMwareCloudDirector *VMwareCloudDirector `json:"vmwareclouddirector,omitempty"`
 	GKE                 *GKE                 `json:"gke,omitempty"`
 	EKS                 *EKS                 `json:"eks,omitempty"`
 	AKS                 *AKS                 `json:"aks,omitempty"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1006,7 +1006,7 @@ spec:
                       for this cluster. This must match the given provider spec (e.g.
                       if the providerName is "aws", then the `aws` field must be set).
                     type: string
-                  vmwareCloudDirector:
+                  vmwareclouddirector:
                     description: VMwareCloudDirectorCloudSpec specifies access data
                       to VMware Cloud Director cloud.
                     properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -974,7 +974,7 @@ spec:
                       for this cluster. This must match the given provider spec (e.g.
                       if the providerName is "aws", then the `aws` field must be set).
                     type: string
-                  vmwareCloudDirector:
+                  vmwareclouddirector:
                     description: VMwareCloudDirectorCloudSpec specifies access data
                       to VMware Cloud Director cloud.
                     properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -584,7 +584,7 @@ spec:
                           - alibaba
                           - anexia
                           - fake
-                          - vmware-cloud-director
+                          - vmwareclouddirector
                           type: string
                         version:
                           description: Version is the Kubernetes version that must

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -350,7 +350,7 @@ spec:
                 items:
                   type: string
                 type: array
-              vmwareCloudDirector:
+              vmwareclouddirector:
                 properties:
                   datacenter:
                     type: string

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -447,7 +447,7 @@ spec:
                           items:
                             type: string
                           type: array
-                        vmwareCloudDirector:
+                        vmwareclouddirector:
                           properties:
                             allowInsecure:
                               description: If set to true, disables the TLS certificate

--- a/pkg/handler/v1/presets/credentials.go
+++ b/pkg/handler/v1/presets/credentials.go
@@ -45,7 +45,7 @@ var providerNames = []string{
 	"alibaba",
 	"anexia",
 	"nutanix",
-	"vmware-cloud-director",
+	"vmwareclouddirector",
 }
 
 // providerReq represents a request for provider name

--- a/pkg/handler/v1/presets/credentials_test.go
+++ b/pkg/handler/v1/presets/credentials_test.go
@@ -415,13 +415,13 @@ func TestCredentialEndpoint(t *testing.T) {
 		},
 		{
 			name:             "test no credentials for VMware Cloud Director",
-			provider:         "vmware-cloud-director",
+			provider:         "vmwareclouddirector",
 			httpStatus:       http.StatusOK,
 			expectedResponse: "{}",
 		},
 		{
 			name:     "test list of credential names for VMware Cloud Director",
-			provider: "vmware-cloud-director",
+			provider: "vmwareclouddirector",
 			credentials: []ctrlruntimeclient.Object{
 				&kubermaticv1.Preset{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/test/e2e/utils/apiclient/models/cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/cloud_spec.go
@@ -66,8 +66,8 @@ type CloudSpec struct {
 	// packet
 	Packet *PacketCloudSpec `json:"packet,omitempty"`
 
-	// vmware cloud director
-	VmwareCloudDirector *VMwareCloudDirectorCloudSpec `json:"vmwareCloudDirector,omitempty"`
+	// vmwareclouddirector
+	Vmwareclouddirector *VMwareCloudDirectorCloudSpec `json:"vmwareclouddirector,omitempty"`
 
 	// vsphere
 	Vsphere *VSphereCloudSpec `json:"vsphere,omitempty"`
@@ -125,7 +125,7 @@ func (m *CloudSpec) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateVmwareCloudDirector(formats); err != nil {
+	if err := m.validateVmwareclouddirector(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -367,17 +367,17 @@ func (m *CloudSpec) validatePacket(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *CloudSpec) validateVmwareCloudDirector(formats strfmt.Registry) error {
-	if swag.IsZero(m.VmwareCloudDirector) { // not required
+func (m *CloudSpec) validateVmwareclouddirector(formats strfmt.Registry) error {
+	if swag.IsZero(m.Vmwareclouddirector) { // not required
 		return nil
 	}
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.Validate(formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}
@@ -457,7 +457,7 @@ func (m *CloudSpec) ContextValidate(ctx context.Context, formats strfmt.Registry
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateVmwareCloudDirector(ctx, formats); err != nil {
+	if err := m.contextValidateVmwareclouddirector(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -663,14 +663,14 @@ func (m *CloudSpec) contextValidatePacket(ctx context.Context, formats strfmt.Re
 	return nil
 }
 
-func (m *CloudSpec) contextValidateVmwareCloudDirector(ctx context.Context, formats strfmt.Registry) error {
+func (m *CloudSpec) contextValidateVmwareclouddirector(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.ContextValidate(ctx, formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec.go
@@ -89,8 +89,8 @@ type DatacenterSpec struct {
 	// packet
 	Packet *DatacenterSpecPacket `json:"packet,omitempty"`
 
-	// vmware cloud director
-	VmwareCloudDirector *DatacenterSpecVMwareCloudDirector `json:"vmwareCloudDirector,omitempty"`
+	// vmwareclouddirector
+	Vmwareclouddirector *DatacenterSpecVMwareCloudDirector `json:"vmwareclouddirector,omitempty"`
 
 	// vsphere
 	Vsphere *DatacenterSpecVSphere `json:"vsphere,omitempty"`
@@ -152,7 +152,7 @@ func (m *DatacenterSpec) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateVmwareCloudDirector(formats); err != nil {
+	if err := m.validateVmwareclouddirector(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -413,17 +413,17 @@ func (m *DatacenterSpec) validatePacket(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *DatacenterSpec) validateVmwareCloudDirector(formats strfmt.Registry) error {
-	if swag.IsZero(m.VmwareCloudDirector) { // not required
+func (m *DatacenterSpec) validateVmwareclouddirector(formats strfmt.Registry) error {
+	if swag.IsZero(m.Vmwareclouddirector) { // not required
 		return nil
 	}
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.Validate(formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}
@@ -507,7 +507,7 @@ func (m *DatacenterSpec) ContextValidate(ctx context.Context, formats strfmt.Reg
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateVmwareCloudDirector(ctx, formats); err != nil {
+	if err := m.contextValidateVmwareclouddirector(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -729,14 +729,14 @@ func (m *DatacenterSpec) contextValidatePacket(ctx context.Context, formats strf
 	return nil
 }
 
-func (m *DatacenterSpec) contextValidateVmwareCloudDirector(ctx context.Context, formats strfmt.Registry) error {
+func (m *DatacenterSpec) contextValidateVmwareclouddirector(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.ContextValidate(ctx, formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}

--- a/pkg/test/e2e/utils/apiclient/models/node_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/node_cloud_spec.go
@@ -51,8 +51,8 @@ type NodeCloudSpec struct {
 	// packet
 	Packet *PacketNodeSpec `json:"packet,omitempty"`
 
-	// vmware cloud director
-	VmwareCloudDirector *VMwareCloudDirectorNodeSpec `json:"vmwareCloudDirector,omitempty"`
+	// vmwareclouddirector
+	Vmwareclouddirector *VMwareCloudDirectorNodeSpec `json:"vmwareclouddirector,omitempty"`
 
 	// vsphere
 	Vsphere *VSphereNodeSpec `json:"vsphere,omitempty"`
@@ -106,7 +106,7 @@ func (m *NodeCloudSpec) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateVmwareCloudDirector(formats); err != nil {
+	if err := m.validateVmwareclouddirector(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -329,17 +329,17 @@ func (m *NodeCloudSpec) validatePacket(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *NodeCloudSpec) validateVmwareCloudDirector(formats strfmt.Registry) error {
-	if swag.IsZero(m.VmwareCloudDirector) { // not required
+func (m *NodeCloudSpec) validateVmwareclouddirector(formats strfmt.Registry) error {
+	if swag.IsZero(m.Vmwareclouddirector) { // not required
 		return nil
 	}
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.Validate(formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}
@@ -415,7 +415,7 @@ func (m *NodeCloudSpec) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateVmwareCloudDirector(ctx, formats); err != nil {
+	if err := m.contextValidateVmwareclouddirector(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -605,14 +605,14 @@ func (m *NodeCloudSpec) contextValidatePacket(ctx context.Context, formats strfm
 	return nil
 }
 
-func (m *NodeCloudSpec) contextValidateVmwareCloudDirector(ctx context.Context, formats strfmt.Registry) error {
+func (m *NodeCloudSpec) contextValidateVmwareclouddirector(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.ContextValidate(ctx, formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}

--- a/pkg/test/e2e/utils/apiclient/models/preset_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/preset_spec.go
@@ -69,8 +69,8 @@ type PresetSpec struct {
 	// packet
 	Packet *Packet `json:"packet,omitempty"`
 
-	// vmware cloud director
-	VmwareCloudDirector *VMwareCloudDirector `json:"vmwareCloudDirector,omitempty"`
+	// vmwareclouddirector
+	Vmwareclouddirector *VMwareCloudDirector `json:"vmwareclouddirector,omitempty"`
 
 	// vsphere
 	Vsphere *VSphere `json:"vsphere,omitempty"`
@@ -140,7 +140,7 @@ func (m *PresetSpec) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateVmwareCloudDirector(formats); err != nil {
+	if err := m.validateVmwareclouddirector(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -439,17 +439,17 @@ func (m *PresetSpec) validatePacket(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *PresetSpec) validateVmwareCloudDirector(formats strfmt.Registry) error {
-	if swag.IsZero(m.VmwareCloudDirector) { // not required
+func (m *PresetSpec) validateVmwareclouddirector(formats strfmt.Registry) error {
+	if swag.IsZero(m.Vmwareclouddirector) { // not required
 		return nil
 	}
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.Validate(formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}
@@ -541,7 +541,7 @@ func (m *PresetSpec) ContextValidate(ctx context.Context, formats strfmt.Registr
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateVmwareCloudDirector(ctx, formats); err != nil {
+	if err := m.contextValidateVmwareclouddirector(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -795,14 +795,14 @@ func (m *PresetSpec) contextValidatePacket(ctx context.Context, formats strfmt.R
 	return nil
 }
 
-func (m *PresetSpec) contextValidateVmwareCloudDirector(ctx context.Context, formats strfmt.Registry) error {
+func (m *PresetSpec) contextValidateVmwareclouddirector(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.VmwareCloudDirector != nil {
-		if err := m.VmwareCloudDirector.ContextValidate(ctx, formats); err != nil {
+	if m.Vmwareclouddirector != nil {
+		if err := m.Vmwareclouddirector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("vmwareCloudDirector")
+				return ve.ValidateName("vmwareclouddirector")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("vmwareCloudDirector")
+				return ce.ValidateName("vmwareclouddirector")
 			}
 			return err
 		}

--- a/pkg/test/e2e/utils/apiclient/models/public_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/public_cloud_spec.go
@@ -60,8 +60,8 @@ type PublicCloudSpec struct {
 	// packet
 	Packet PublicPacketCloudSpec `json:"packet,omitempty"`
 
-	// vmware cloud director
-	VmwareCloudDirector PublicVMwareCloudDirectorCloudSpec `json:"vmwareCloudDirector,omitempty"`
+	// vmwareclouddirector
+	Vmwareclouddirector PublicVMwareCloudDirectorCloudSpec `json:"vmwareclouddirector,omitempty"`
 
 	// vsphere
 	Vsphere PublicVSphereCloudSpec `json:"vsphere,omitempty"`


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
In the initial implementation of VMware Cloud Director, the provider name in the preset, datacenter, cluster spec, etc. followed came case i.e. `vmwareCloudDirector`. This is the right approach but it leads to many issues when working with the front-end or API directly. 

Although I hate doing this but to simplify everything, I've just reworded it to `vmwareclouddirector` everywhere instead of having `vmwareCloudDirector` in Cluster Spec, `vmware-cloud-director` as provider name, etc. 

It also makes sense because we already do this for kubeadm provider https://github.com/kubermatic/kubermatic/blob/master/pkg/apis/kubermatic/v1/cluster.go#L907

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
