### PR TITLE
Fix project spam / Prevent reconciliation race condition

### DIFF
--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -122,7 +122,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedDef.UID == appDef.UID {
+		if seedDef.UID != "" && seedDef.UID == appDef.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -118,7 +118,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, appDef *appskubermaticv1.ApplicationDefinition) error {
 		seedDef := &appskubermaticv1.ApplicationDefinition{}
 		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(appDef), seedDef); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to fetch ClusterTemplate on seed cluster: %w", err)
+			return fmt.Errorf("failed to fetch ApplicationDefinition on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,6 +116,16 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, appDef *appskubermaticv1.ApplicationDefinition) error {
+		seedDef := &appskubermaticv1.ApplicationDefinition{}
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(appDef), seedDef); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch ClusterTemplate on seed cluster: %w", err)
+		}
+
+		// see project-synchronizer's syncAllSeeds comment
+		if seedDef.UID == appDef.UID {
+			return nil
+		}
+
 		return reconciling.ReconcileAppsKubermaticV1ApplicationDefinitions(ctx, applicationDefCreatorGetters, "", seedClient)
 	})
 	if err != nil {

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -119,7 +119,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	err = r.reconcileAllSeeds(ctx, log, seedsecret, func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
 		seedSecret := &corev1.Secret{}
 		if err := c.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seedsecret), seedSecret); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to fetch ClusterTemplate on seed cluster: %w", err)
+			return fmt.Errorf("failed to fetch Secret on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -117,6 +117,16 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		secretCreator(seedsecret),
 	}
 	err = r.reconcileAllSeeds(ctx, log, seedsecret, func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
+		seedSecret := &corev1.Secret{}
+		if err := c.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seedsecret), seedSecret); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch ClusterTemplate on seed cluster: %w", err)
+		}
+
+		// see project-synchronizer's syncAllSeeds comment
+		if seedSecret.UID != "" && seedSecret.UID == seedsecret.UID {
+			return nil
+		}
+
 		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, c)
 	})
 	if err != nil {

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -125,7 +125,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedTpl.UID == template.UID {
+		if seedTpl.UID != "" && seedTpl.UID == template.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,6 +119,16 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	err := r.syncAllSeeds(log, clusterTemplate, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
+		seedTpl := &kubermaticv1.ClusterTemplate{}
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(template), seedTpl); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch ClusterTemplate on seed cluster: %w", err)
+		}
+
+		// see project-synchronizer's syncAllSeeds comment
+		if seedTpl.UID == template.UID {
+			return nil
+		}
+
 		return reconciling.ReconcileKubermaticV1ClusterTemplates(ctx, clusterTemplateCreatorGetters, "", seedClient)
 	})
 	if err != nil {

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -154,7 +154,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedConst.UID == constraint.UID {
+		if seedConst.UID != "" && seedConst.UID == constraint.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -28,6 +28,7 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -147,6 +148,16 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	return r.syncAllSeeds(ctx, log, constraint, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint) error {
+		seedConst := &kubermaticv1.Constraint{}
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(constraint), seedConst); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch Constraint on seed cluster: %w", err)
+		}
+
+		// see project-synchronizer's syncAllSeeds comment
+		if seedConst.UID == constraint.UID {
+			return nil
+		}
+
 		return reconciling.ReconcileKubermaticV1Constraints(ctx, constraintCreatorGetters, r.namespace, seedClient)
 	})
 }

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -155,6 +155,16 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 	}
 
 	return r.syncAllSeeds(ctx, log, constraintTemplate, func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
+		seedCT := &kubermaticv1.ConstraintTemplate{}
+		if err := seedClusterClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(ct), seedCT); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch ConstraintTemplate on seed cluster: %w", err)
+		}
+
+		// see project-synchronizer's syncAllSeeds comment
+		if seedCT.UID == ct.UID {
+			return nil
+		}
+
 		return reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", seedClusterClient)
 	})
 }

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -161,7 +161,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedCT.UID == ct.UID {
+		if seedCT.UID != "" && seedCT.UID == ct.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -124,7 +124,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedPreset.UID == preset.UID {
+		if seedPreset.UID != "" && seedPreset.UID == preset.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,7 +97,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
 	preset := &kubermaticv1.Preset{}
-	if err := r.masterClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: request.Name}, preset); err != nil {
+	if err := r.masterClient.Get(ctx, request.NamespacedName, preset); err != nil {
 		return ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
@@ -117,6 +118,16 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	}
 
 	err := r.syncAllSeeds(log, preset, func(seedClient ctrlruntimeclient.Client, preset *kubermaticv1.Preset) error {
+		seedPreset := &kubermaticv1.Preset{}
+		if err := seedClient.Get(ctx, request.NamespacedName, seedPreset); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch preset on seed cluster: %w", err)
+		}
+
+		// see project-synchronizer's syncAllSeeds comment
+		if seedPreset.UID == preset.UID {
+			return nil
+		}
+
 		return reconciling.ReconcileKubermaticV1Presets(ctx, presetCreatorGetters, "", seedClient)
 	})
 	if err != nil {

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
@@ -120,12 +121,33 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	err := r.syncAllSeeds(log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
+		seedProject := &kubermaticv1.Project{}
+		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedProject); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to fetch project on seed cluster: %w", err)
+		}
+
+		// The informer can trigger a reconciliation before the cache backing the
+		// master client has been updated; this can make the reconciler read
+		// an old state and would replicate this old state onto seeds; if master
+		// and seed are the same cluster, this would effectively overwrite the
+		// change that just happened.
+		// To prevent this from occuring, we check the UID and refuse to update
+		// the project if the UID on the seed == UID on the master.
+		// Note that in this distinction cannot be made inside the creator function
+		// further down, as the reconciling framework reads the current state
+		// from cache and even if no changes were made (because of the UID match),
+		// it would still persist the new object and might overwrite the actual,
+		// new state.
+		if seedProject.UID == project.UID {
+			return nil
+		}
+
 		err := reconciling.ReconcileKubermaticV1Projects(ctx, projectCreatorGetters, "", seedClusterClient)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile project: %w", err)
 		}
 
-		seedProject := &kubermaticv1.Project{}
+		// fetch the updated project from the cache
 		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedProject); err != nil {
 			return fmt.Errorf("failed to fetch project on seed cluster: %w", err)
 		}

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -131,14 +131,14 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		// an old state and would replicate this old state onto seeds; if master
 		// and seed are the same cluster, this would effectively overwrite the
 		// change that just happened.
-		// To prevent this from occuring, we check the UID and refuse to update
+		// To prevent this from occurring, we check the UID and refuse to update
 		// the project if the UID on the seed == UID on the master.
 		// Note that in this distinction cannot be made inside the creator function
 		// further down, as the reconciling framework reads the current state
 		// from cache and even if no changes were made (because of the UID match),
 		// it would still persist the new object and might overwrite the actual,
 		// new state.
-		if seedProject.UID == project.UID {
+		if seedProject.UID != "" && seedProject.UID == project.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -45,11 +45,10 @@ const (
 )
 
 type reconciler struct {
-	log             *zap.SugaredLogger
-	recorder        record.EventRecorder
-	masterClient    ctrlruntimeclient.Client
-	masterAPIClient ctrlruntimeclient.Reader
-	seedClients     map[string]ctrlruntimeclient.Client
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	masterClient ctrlruntimeclient.Client
+	seedClients  map[string]ctrlruntimeclient.Client
 }
 
 func Add(
@@ -59,11 +58,10 @@ func Add(
 	numWorkers int,
 ) error {
 	r := &reconciler{
-		log:             log.Named(ControllerName),
-		recorder:        masterManager.GetEventRecorderFor(ControllerName),
-		masterClient:    masterManager.GetClient(),
-		masterAPIClient: masterManager.GetAPIReader(),
-		seedClients:     map[string]ctrlruntimeclient.Client{},
+		log:          log.Named(ControllerName),
+		recorder:     masterManager.GetEventRecorderFor(ControllerName),
+		masterClient: masterManager.GetClient(),
+		seedClients:  map[string]ctrlruntimeclient.Client{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -97,7 +95,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log := r.log.With("request", request)
 
 	project := &kubermaticv1.Project{}
-	if err := r.masterAPIClient.Get(ctx, request.NamespacedName, project); err != nil {
+	if err := r.masterClient.Get(ctx, request.NamespacedName, project); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -89,11 +89,10 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			r := &reconciler{
-				log:             kubermaticlog.Logger,
-				recorder:        &record.FakeRecorder{},
-				masterClient:    tc.masterClient,
-				masterAPIClient: tc.masterClient,
-				seedClients:     map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: tc.masterClient,
+				seedClients:  map[string]ctrlruntimeclient.Client{"test": tc.seedClient},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -140,7 +140,7 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 	}
 
 	// see project-synchronizer's syncAllSeeds comment
-	if seedInSeed.UID != seed.UID {
+	if seedInSeed.UID == "" || seedInSeed.UID != seed.UID {
 		seedCreators := []reconciling.NamedSeedCreatorGetter{
 			seedCreator(seed),
 		}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -134,12 +134,20 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		return fmt.Errorf("failed to reconcile namespace: %w", err)
 	}
 
-	seedCreators := []reconciling.NamedSeedCreatorGetter{
-		seedCreator(seed),
+	seedInSeed := &kubermaticv1.Seed{}
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seed), seedInSeed); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get seed: %w", err)
 	}
 
-	if err := reconciling.ReconcileSeeds(ctx, seedCreators, seed.Namespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile seed: %w", err)
+	// see project-synchronizer's syncAllSeeds comment
+	if seedInSeed.UID != seed.UID {
+		seedCreators := []reconciling.NamedSeedCreatorGetter{
+			seedCreator(seed),
+		}
+
+		if err := reconciling.ReconcileSeeds(ctx, seedCreators, seed.Namespace, client); err != nil {
+			return fmt.Errorf("failed to reconcile seed: %w", err)
+		}
 	}
 
 	configCreators := []reconciling.NamedKubermaticConfigurationCreatorGetter{
@@ -147,7 +155,7 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 	}
 
 	if err := reconciling.ReconcileKubermaticConfigurations(ctx, configCreators, seed.Namespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile seed: %w", err)
+		return fmt.Errorf("failed to reconcile Kubermatic configuration: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -130,7 +130,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedBinding.UID == userProjectBinding.UID {
+		if seedBinding.UID != "" && seedBinding.UID == userProjectBinding.UID {
 			return nil
 		}
 

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -142,7 +142,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedUser.UID == user.UID {
+		if seedUser.UID != "" && seedUser.UID == user.UID {
 			return nil
 		}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR started out as a follow-up to #8458: currently our master-ctrl-mgr is logging endless amounts of 

> I0704 11:00:40.462300       1 request.go:533] Waited for 992.304389ms due to client-side throttling, not priority and fairness, request: GET:[https://10.47.240.1:443/apis/kubermatic.k8c.io/v1/projects/f6ftmknwsj](https://10.47.240.1/apis/kubermatic.k8c.io/v1/projects/f6ftmknwsj)
> I0704 11:00:40.513170       1 request.go:533] Waited for 996.262182ms due to client-side throttling, not priority and fairness, request: GET:[https://10.47.240.1:443/apis/kubermatic.k8c.io/v1/projects/t6grwvrh7p](https://10.47.240.1/apis/kubermatic.k8c.io/v1/projects/t6grwvrh7p)
> I0704 11:00:40.562788       1 request.go:533] Waited for 995.034251ms due to client-side throttling, not priority and fairness, request: GET:[https://10.47.240.1:443/apis/kubermatic.k8c.io/v1/projects/cjf48fzv99](https://10.47.240.1/apis/kubermatic.k8c.io/v1/projects/cjf48fzv99)

The original fix for a flaky test made it so that we're using an APIReader instead of a cached client. I want to investigate whether we can solve this better.

---

So I learned that a controller that watches objects can be triggered about changes _before_ the cache has been updated. This is generally not a problem as we never really watch an Object X and then, during the reconciliation, _change_ Object X, too (except for the Status).

However we do have a bunch of controllers that replicate/mirror objects from the master cluster to all seeds. When those controllers accidentally read an older version of a resource and then attempt to copy that old version to a seed, everything is still fine. But when master and seed cluster are the same, then the controller will suddenly overwrite an object with itself, undoing the actual changes.

Using an API reader is a valid solution, but leads to the log spam above. This PR instead adds an UID check, which will make the controller never overwrite the object it was triggered by. This is also not perfect, but at least no more log spam?

I applied the same fix to all the controllers that replicate the same behaviour. In the future we might build a generic function, now that we have Go 1.18.

Fixes #10238

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
