### PR TITLE
Add pause field in kubeone cluster

### DIFF
--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -85,8 +85,16 @@ type ExternalClusterSpec struct {
 	// HumanReadableName is the cluster name provided by the user
 	HumanReadableName string `json:"humanReadableName"`
 
+	// KubeconfigReference is reference to cluster Kubeconfig
 	KubeconfigReference *providerconfig.GlobalSecretKeySelector `json:"kubeconfigReference,omitempty"`
-	CloudSpec           *ExternalClusterCloudSpec               `json:"cloudSpec,omitempty"`
+	// CloudSpec contains provider specific fields
+	CloudSpec *ExternalClusterCloudSpec `json:"cloudSpec,omitempty"`
+	// If this is set to true, the cluster will not be reconciled by KKP.
+	// This indicates that the user needs to do some action to resolve the pause.
+	Pause bool `json:"pause"`
+	// PauseReason is the reason why the cluster is not being managed. This field is for informational
+	// purpose only and can be set by a user or a controller to communicate the reason for pausing the cluster.
+	PauseReason string `json:"pauseReason,omitempty"`
 }
 
 // ExternalClusterCloudSpec mutually stores access data to a cloud provider.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -45,8 +45,7 @@ spec:
               kubernetes cluster.
             properties:
               cloudSpec:
-                description: ExternalClusterCloudSpec mutually stores access data
-                  to a cloud provider.
+                description: CloudSpec contains provider specific fields
                 properties:
                   aks:
                     properties:
@@ -359,8 +358,7 @@ spec:
                   user
                 type: string
               kubeconfigReference:
-                description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector
-                  because it is not cross namespace.
+                description: KubeconfigReference is reference to cluster Kubeconfig
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -397,8 +395,20 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              pause:
+                description: If this is set to true, the cluster will not be reconciled
+                  by KKP. This indicates that the user needs to do some action to
+                  resolve the pause.
+                type: boolean
+              pauseReason:
+                description: PauseReason is the reason why the cluster is not being
+                  managed. This field is for informational purpose only and can be
+                  set by a user or a controller to communicate the reason for pausing
+                  the cluster.
+                type: string
             required:
             - humanReadableName
+            - pause
             type: object
           status:
             description: ExternalClusterStatus denotes status information about an


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**: Add pause in kubeone cluster so that cluster will not be reconciled specially when there is a issue with the cluster and user is trying to fix it,

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
