### PR TITLE
Resource quota model unification

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -29478,11 +29478,11 @@
         "status": {
           "$ref": "#/definitions/ResourceQuotaStatus"
         },
-        "subject_kind": {
+        "subjectKind": {
           "type": "string",
           "x-go-name": "SubjectKind"
         },
-        "subject_name": {
+        "subjectName": {
           "type": "string",
           "x-go-name": "SubjectName"
         }

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -1410,8 +1410,8 @@ type OpenstackSubnetPool struct {
 // swagger:model ResourceQuota
 type ResourceQuota struct {
 	Name        string                           `json:"name"`
-	SubjectName string                           `json:"subject_name"`
-	SubjectKind string                           `json:"subject_kind"`
+	SubjectName string                           `json:"subjectName"`
+	SubjectKind string                           `json:"subjectKind"`
 	Quota       kubermaticv1.ResourceDetails     `json:"quota"`
 	Status      kubermaticv1.ResourceQuotaStatus `json:"status"`
 }

--- a/pkg/test/e2e/utils/apiclient/models/resource_quota.go
+++ b/pkg/test/e2e/utils/apiclient/models/resource_quota.go
@@ -22,10 +22,10 @@ type ResourceQuota struct {
 	Name string `json:"name,omitempty"`
 
 	// subject kind
-	SubjectKind string `json:"subject_kind,omitempty"`
+	SubjectKind string `json:"subjectKind,omitempty"`
 
 	// subject name
-	SubjectName string `json:"subject_name,omitempty"`
+	SubjectName string `json:"subjectName,omitempty"`
 
 	// quota
 	Quota *ResourceDetails `json:"quota,omitempty"`


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
In order to unify resource quota API model snake case has been replaced with camel case.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
