### PR TITLE
Extending rbac controller to support groupprojectbindings

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -514,53 +514,60 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 
 	// verbs for editors
 	//
-	// editors of a project
-	// special case - editors are not allowed to delete a project
-	if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.ProjectKindName {
-		return []string{"get", "update", "patch"}, nil
-	}
-	// special case - editors are not allowed to interact with members of a project (UserProjectBinding)
-	if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
-		return nil, nil
-	}
-	// special case - editors are not allowed to interact with service accounts (User)
-	if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.UserKindName {
-		return nil, nil
-	}
-
-	// editors of a named resource
 	if strings.HasPrefix(groupName, EditorGroupNamePrefix) {
+		// editors of a project
+		// special case - editors are not allowed to delete a project
+		if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.ProjectKindName {
+			return []string{"get", "update", "patch"}, nil
+		}
+
+		// special case - editors are not allowed to interact with members of a project (UserProjectBinding, GroupProjectBinding)
+		if resourceKind == kubermaticv1.UserProjectBindingKind || resourceKind == kubermaticv1.GroupProjectBindingKind {
+			return nil, nil
+		}
+
+		// special case - editors are not allowed to interact with service accounts (User)
+		if resourceKind == kubermaticv1.UserKindName {
+			return nil, nil
+		}
+
+		// editors of a named resource
 		return []string{"get", "update", "patch", "delete"}, nil
 	}
 
 	// verbs for viewers
 	//
-	// viewers of a named resource
-	// special case - viewers are not allowed to interact with members of a project (UserProjectBinding)
-	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
-		return nil, nil
-	}
-	// special case - viewers are not allowed to interact with service accounts (User)
-	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && resourceKind == kubermaticv1.UserKindName {
-		return nil, nil
-	}
 	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) {
+		// viewers of a named resource
+		// special case - viewers are not allowed to interact with members of a project (UserProjectBinding, GroupProjectBinding)
+		if resourceKind == kubermaticv1.UserProjectBindingKind || resourceKind == kubermaticv1.GroupProjectBindingKind {
+			return nil, nil
+		}
+
+		// special case - viewers are not allowed to interact with service accounts (User)
+		if resourceKind == kubermaticv1.UserKindName {
+			return nil, nil
+		}
+
 		return []string{"get"}, nil
 	}
 
 	// verbs for projectmanagers
 	//
-	// special case - projectmanagers are not allowed to interact with clusters
-	if strings.HasPrefix(groupName, ProjectManagerGroupNamePrefix) && resourceKind == kubermaticv1.ClusterKindName {
-		return nil, nil
-	}
-	if strings.HasPrefix(groupName, ProjectManagerGroupNamePrefix) && resourceKind == kubermaticv1.ExternalClusterKind {
-		return nil, nil
-	}
-	if strings.HasPrefix(groupName, ProjectManagerGroupNamePrefix) && resourceKind == kubermaticv1.ClusterTemplateInstanceKindName {
-		return nil, nil
-	}
 	if strings.HasPrefix(groupName, ProjectManagerGroupNamePrefix) {
+		// special cases - projectmanagers are not allowed to interact with clusters
+		if resourceKind == kubermaticv1.ClusterKindName {
+			return nil, nil
+		}
+
+		if resourceKind == kubermaticv1.ExternalClusterKind {
+			return nil, nil
+		}
+
+		if resourceKind == kubermaticv1.ClusterTemplateInstanceKindName {
+			return nil, nil
+		}
+
 		return []string{"get", "update", "patch", "delete"}, nil
 	}
 

--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -517,7 +517,7 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	if strings.HasPrefix(groupName, EditorGroupNamePrefix) {
 		// editors of a project
 		// special case - editors are not allowed to delete a project
-		if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.ProjectKindName {
+		if resourceKind == kubermaticv1.ProjectKindName {
 			return []string{"get", "update", "patch"}, nil
 		}
 

--- a/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
@@ -155,6 +155,15 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 				},
 			},
 		},
+
+		{
+			object: &kubermaticv1.GroupProjectBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticv1.GroupProjectBindingKind,
+				},
+			},
+		},
 	}
 
 	if err := newProjectRBACController(ctx, metrics, mgr, seedManagerMap, log, projectResources, workerPredicate); err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Those changes should allow impersonated client to access GroupProjectBinding resources. We need that in order to expose them though kubermatic-api.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10242 

**Special notes for your reviewer**:
I did small refactoring in the `generateVerbsForNamedResource` function. Let me know if we want to keep it or if it should get back to the original state.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
