### PR TITLE
get rid of the term 'customer'

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -2,7 +2,7 @@
 
 This directory contains all possible default addons.
 All addons will be build into a docker container which the kubermatic-addon-controller uses to install addons.
-The docker image should be freely accessible to let customers extend & modify this image for their own purpose.
+The docker image should be freely accessible to let admins extend & modify this image for their own purpose.
 
 ### Release / Development Cycle
 

--- a/cmd/kubermatic-webhook/options.go
+++ b/cmd/kubermatic-webhook/options.go
@@ -64,10 +64,10 @@ func initApplicationOptions() (appOptions, error) {
 
 	klog.InitFlags(nil)
 
-	flag.StringVar(&c.seedName, "seed-name", "", "The name of the seed this controller is running in. It will be used to build the absolute url for a customer cluster.")
+	flag.StringVar(&c.seedName, "seed-name", "", "The name of the seed this controller is running in. It will be used to build the absolute url for a user cluster.")
 	flag.Var(&c.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&c.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for Seed resources")
-	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all userclusters")
+	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all user clusters")
 	flag.StringVar(&configFile, "kubermatic-configuration-file", "", "(for development only) path to a KubermaticConfiguration YAML file")
 
 	c.webhook.AddFlags(flag.CommandLine)

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -113,7 +113,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.leaderElectionNamespace, "leader-election-namespace", "", "Leader election namespace. In-cluster discovery will be attempted in such case.")
 	flag.StringVar(&c.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the internal server is running on")
 	flag.StringVar(&c.externalURL, "external-url", "", "The external url for the apiserver host and the the dc.(Required)")
-	flag.StringVar(&c.seedName, "seed-name", "", "The name of the seed this controller is running in. It will be used to build the absolute url for a customer cluster.")
+	flag.StringVar(&c.seedName, "seed-name", "", "The name of the seed this controller is running in. It will be used to build the absolute url for a user cluster.")
 	flag.StringVar(&c.workerName, "worker-name", "", "The name of the worker that will only processes resources with label=worker-name.")
 	flag.IntVar(&c.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
 	flag.StringVar(&c.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")

--- a/docs/proposals/cloud-cost-exporter.md
+++ b/docs/proposals/cloud-cost-exporter.md
@@ -7,7 +7,7 @@
 ## Motivation and Background
 
 Billing in Cloud Environments is hard and sometimes almost obscure.
-We want to improve this situation for our customers.
+We want to improve this situation for KKP admins.
 For this reason, we want to create a Cloud Cost Exporter for Prometheus, which
 allows Prometheus to scrape the cost of the Kubermatic managed infrastructure.
 

--- a/docs/proposals/container-registry-credentials-per-usercluster.md
+++ b/docs/proposals/container-registry-credentials-per-usercluster.md
@@ -138,7 +138,7 @@ https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-accou
 
 ## Looking ahead
 
-To make this more accessible to customers we could build on top of this and extend the KKP dashboard
+To make this more accessible to KKP admins we could build on top of this and extend the KKP dashboard
 with an interface to manage this. Similar to the [SSH key feature][ssh key agent] container registry
 credentials could be managed from there.
 

--- a/docs/proposals/encryption-at-rest.md
+++ b/docs/proposals/encryption-at-rest.md
@@ -24,7 +24,7 @@ This proposal has the following goals. Also check [Motivation and Background](#m
 
 etcd is a distributed key-value store that is used by the Kubernetes API as data storage. By default, data in etcd is not encrypted at rest. KKP only encrypts etcd data in transit right now. Kubernetes provides the ability to configure a pluggable encryption mechanism that allows encrypting arbitrary resources (usually, `Secrets`) when stored in etcd. It supports a couple of "static" encryption schemes where a key is provided in the encryption configuration (secretbox, aesgcm, aescbc) and integration with an external KMS system via a plugin mechanism.
 
-Encrypting data in etcd for sensitive information like secret data is recommended by security benchmarks and best practices. It further improves the security of our etcd backup feature, as an attacker that gets hold of a backup archive cannot extract `Secrets` content from it. 
+Encrypting data in etcd for sensitive information like secret data is recommended by security benchmarks and best practices. It further improves the security of our etcd backup feature, as an attacker that gets hold of a backup archive cannot extract `Secrets` content from it.
 
 KKP users might want to encrypt their data at rest in user clusters to improve their security posture and/or fulfill regulatory requirements or prepare their environments for audits.
 
@@ -180,7 +180,7 @@ Even access to the encryption configuration `Secret` can be partially mitigated 
 
 Since Kubernetes does not offer another mechanism for data encryption at rest, alternatives are sparse. Considerations are mainly within the scope of "implementing the encryption configuration":
 
-* Developing a Hashicorp Vault KMS plugin: For customers that do not want to rely on cloud provider KMS services, Hashicorp Vault might be an interesting alternative to static key encryption. Since no KMS plugin exists, developing one is a consideration to keep in mind, depending on customer interest. For now, it seems out of scope. We should support cloud provider KMS plugins first.
+* Developing a Hashicorp Vault KMS plugin: For KKP admins that do not want to rely on cloud provider KMS services, Hashicorp Vault might be an interesting alternative to static key encryption. Since no KMS plugin exists, developing one is a consideration to keep in mind, depending on admin interest. For now, it seems out of scope. We should support cloud provider KMS plugins first.
 * Support encryption schemes `aesgcm` and `aescbc`:
   * `aesgcm`: Must be rotated every 200k writes, which might be hard to track. Since we do not plan to start with an automated key rotation scheme, this is discouraged by upstream.
   * `aescbc`: Considered weak as it's vulnerable to padding oracle attacks. Therefore not considered for inclusion.

--- a/docs/proposals/etcd-backup.md
+++ b/docs/proposals/etcd-backup.md
@@ -13,37 +13,37 @@ Recovery will be a documented, manual process. As we now use a StatefulSet with 
 
 The old way via the etcd operator had several downsides:
 
-*   etcd's were storing to `emtpyDir`
-*   multiple etcd's on the same host caused very high disk-io. Having one noisy etcd affects all others
-*   high frequency of restore operations when a host got replaced. Resulted in data loss
-*   direct code dependency to the etcd-operator crd
-*   etcd-operator had issues with recovering when encountering a concurrent write to the crd. Resulting in the etcd-operator ending to operate
+* etcd's were storing to `emtpyDir`
+* multiple etcd's on the same host caused very high disk-io. Having one noisy etcd affects all others
+* high frequency of restore operations when a host got replaced. Resulted in data loss
+* direct code dependency to the etcd-operator crd
+* etcd-operator had issues with recovering when encountering a concurrent write to the crd. Resulting in the etcd-operator ending to operate
 
 Since the move to the StatefulSet we already benefit from
 
-*   etcd's are more resilient thanks to PVC's
-*   noisy neighbors do not affect other's (PVC's + resource limits are now in place)
-*   Less external dependencies (no copied etcd crd anymore)
+* etcd's are more resilient thanks to PVC's
+* noisy neighbors do not affect other's (PVC's + resource limits are now in place)
+* Less external dependencies (no copied etcd crd anymore)
 
 ## Implementation
 
-**Basic**
+### Basic
 For each cluster a Kubernetes CronJob will be created.
 This Job will:
 - create a snapshot of the etcd cluster
 - Store snapshot to target (Default: S3)
 - Cleanup old snapshots (Default: keep last 20 revisions)
 
-**Creation of CronJob**
+### Creation of CronJob
 As this feature is not planned to be open sourced, we'll write a simple controller which will listen on Cluster resources and create/update CronJobs for backups.
 Each cluster will get a own CronJob.
 The controller will be running inside our controller-manager.
 The CronJob will be managed in a `reconciling` manner, meaning it should always be checked if it needs to be updated.
 
 The Job which should be executed needs to come from a template file.
-As we need to be able to let customers develop a own backup-solution.
+As we need to be able to let admins develop a own backup-solution.
 
-**Job**
+### Job
 The job should consist of 2 containers. Both share a emptyDir volume:
 - `init-container`
   - Creates the snapshot
@@ -53,16 +53,16 @@ The job should consist of 2 containers. Both share a emptyDir volume:
   - Stores snapshot to S3
   - Cleans up old snapshots (Defined by `revision`-flag)
 
-A customer should be able to replace the `store-container` with any custom container.
+An admin should be able to replace the `store-container` with any custom container.
 
-**Cleanup of backups after cluster deletion**
+### Cleanup of backups after cluster deletion
 The backup controller will register a finalizer on the cluster to be able to cleanup after a cluster has been deleted.
 When a cluster gets deleted a Job will be created from a admin defined template to delete the backups for the given cluster.
 
+### Store & Cleanup template
+Both, the store & cleanup container can be specified by the admin.
+To inject secrets into the containers the admin can use Environment variables:
 
-**Store & Cleanup template**
-Both, the store & cleanup container can be specified by the customer.
-To inject secrets into the containers the customer can use Environment variables:
 ```yaml
 command:
 - /bin/true

--- a/docs/proposals/integrate-upstream-machineset-and-machinedeployment-controllers.md
+++ b/docs/proposals/integrate-upstream-machineset-and-machinedeployment-controllers.md
@@ -5,7 +5,7 @@
 
 ## Motivation and Background
 
-In order to simplify management of nodes, we want to offer to our customers the possibility
+In order to simplify management of nodes, we want to offer to KKP admins the possibility
 of grouping identical machines into `machineSets` and manage configuration changes of `machineSets`
 via `machineDeployments`. This in turn means, that we need controllers for both `machineSets` and
 `machineDeployments`.

--- a/docs/proposals/kubelb.md
+++ b/docs/proposals/kubelb.md
@@ -6,7 +6,7 @@
 
 ## Goals
 
-KubeLB is a provider for multi cluster load balancing and service propagation. 
+KubeLB is a provider for multi cluster load balancing and service propagation.
 
 ## Non-Goals
 
@@ -19,9 +19,9 @@ KubeLB is a provider for multi cluster load balancing and service propagation.
 ## Motivation and Background
 
 Kubernetes does not offer an out of the box implementation of load balancers for clusters. The implementations of Network LB & Ingress LB that Kubernetes does ship with are all calls out to various IaaS platforms (GCP, AWS, Azure…). If you’re not running on a supported IaaS platform (GCP, AWS, Azure…), LoadBalancers & Ingress will not get provisioned.
-Solutions which are available e.g. MetalLB focus on a single cluster. KubeLB aims to provide load balancing for multiple clusters and takes the advantages of kubernetes itself. 
- 
-#### Possible features: 
+Solutions which are available e.g. MetalLB focus on a single cluster. KubeLB aims to provide load balancing for multiple clusters and takes the advantages of kubernetes itself.
+
+#### Possible features:
 
 * Implementation of service type LoadBalancer where it's not available
 
@@ -36,8 +36,8 @@ Solutions which are available e.g. MetalLB focus on a single cluster. KubeLB aim
 * Possible cost reduction as you can decide between KubeLB and IaaS LoadBalancer instances
 
 * Load balancing for internal networks
- 
-* In a multi cluster environment it can be useful to have a limited amount of entrypoints (Load balancer cluster) inside the network to do some security or monitoring. 
+
+* In a multi cluster environment it can be useful to have a limited amount of entrypoints (Load balancer cluster) inside the network to do some security or monitoring.
 
 * Make the actual Ingress Controller pluggable (easy implementation if e.g. someone wants to use nginx over envoy)
 
@@ -45,47 +45,47 @@ Solutions which are available e.g. MetalLB focus on a single cluster. KubeLB aim
 
 ## Implementation
 
-The overall implementation contains two different parts: 
+The overall implementation contains two different parts:
 
 **Agent**: Controller which is deployed in every user cluster. It watches for Services, Ingress resources and node changes. Updates or Creates a CRD inside the load balancing Cluster accordingly.
 
-**Manager**: Controller which is responsible for deploying and configuring the resources needed inside the load balancer cluster. Watcher for it's CRD which describes the load balancing endpoints and settings. 
+**Manager**: Controller which is responsible for deploying and configuring the resources needed inside the load balancer cluster. Watcher for it's CRD which describes the load balancing endpoints and settings.
 
 **Load balancer cluster requirements:**
 
 * Service type "LoadBalancer" implementation (This can be a cloud solution, or some single cluster implementations)
- 
+
 * Ingress controller installation
 
 #### Implementation L4
 
 **Agent**
 
-The agent watches for Services of type LoadBalancer/NodePort in the user cluster. In the user cluster itself for each service with type LoadBalancer a NodePort is allocated by default. 
-The agent creates a TCPLoadBalancer CRD inside the LB cluster. 
- 
-The agent watches for node changes like "remove", "add" and failures and will update all TCPLoadBalancer CRD accordingly. 
+The agent watches for Services of type LoadBalancer/NodePort in the user cluster. In the user cluster itself for each service with type LoadBalancer a NodePort is allocated by default.
+The agent creates a TCPLoadBalancer CRD inside the LB cluster.
+
+The agent watches for node changes like "remove", "add" and failures and will update all TCPLoadBalancer CRD accordingly.
 
 
 There are different scenarios where the agent takes action, dependent on the service type and LoadBalancer implementation:
 
-1. Type NodePort services: 
+1. Type NodePort services:
 
     Use this annotation to let the agent take action and create a LoadBalancer for this service.
 
     `kubernetes.io/service.class: kubelb`
- 
+
 2. For IaaS type load balancers:
 
     The controller will use the provisioned load balancers endpoint as its own endpoint.
     This also needs the Annotation described above to enable it.
-    
+
 3. For non implemented type load balancers
-    
+
     The controller will update the Status and IP of the Service in the user cluster, when the LB is provisioned or changed.
     The agent takes action by default and replaces the needs of a LoadBalancer implementation for each user cluster.
 
-**Manager** 
+**Manager**
 
 The Manager watches for the TCPLoadBalancer CRD and creates an Envoy deployment and Service of type LoadBalancer in the LB cluster. Envoy gets configured with the node endpoints of the user cluster.
 
@@ -94,7 +94,7 @@ This can be done in a preformat manner with envoy.
 
 **Notes**
 
-* It is possible to set `externalTrafficPolicy: Local` and reduce the amount of hops for the user cluster. However, it's not clear if its possible to preserve the client ip yet and its probably bound to Load Balancer used for the LB Cluster. 
+* It is possible to set `externalTrafficPolicy: Local` and reduce the amount of hops for the user cluster. However, it's not clear if its possible to preserve the client ip yet and its probably bound to Load Balancer used for the LB Cluster.
 
 * Kube-proxy is responsible for the behaviour of kubernetes services. Since we rely on these services inside the user cluster, it might be interesting to take some extra configuration.
 This is possible for kube-proxy which offers for example different proxy-modes (userspace, iptables or ipvs) which implement different load balancing mechanisms.
@@ -119,12 +119,12 @@ Out of the HTTPLoadBalancer CRD the manager creates an Ingress resource itself i
 
 **DNS and Domain**
 
-The LB cluster will have a domain assigned e.g. lb.example.com each cluster will have a dedicated subdomain CLUSTERNAME.lb.example.net. For an Ingress on the user cluster a subdomain will be created based on the pattern INGRESS.CLUSTERNAME.lb.example.net The user can reference this URL in his DNS as a CNAME for a customer URL e.g. example.com -> CNAME INGRESS.CLUSTERNAME.lb.example.net 
+The LB cluster will have a domain assigned e.g. lb.example.com each cluster will have a dedicated subdomain CLUSTERNAME.lb.example.net. For an Ingress on the user cluster a subdomain will be created based on the pattern INGRESS.CLUSTERNAME.lb.example.net The user can reference this URL in his DNS as a CNAME for a admin URL e.g. example.com -> CNAME INGRESS.CLUSTERNAME.lb.example.net
 
 **Notes**
 
 * It could make sense to use [Contour](https://projectcontour.io/) as an ingress controller since it aims for multi-team ingress delegation, which can be used for multiple clusters instead of teams.
-However, this requires some extra implementation steps because it makes use of its own CRD called HTTPProxy to provide the extra configuration possibilities. 
+However, this requires some extra implementation steps because it makes use of its own CRD called HTTPProxy to provide the extra configuration possibilities.
 
 <div style="text-align:center">
   <img src="images/kubelb-l7.png" width="100%" />
@@ -145,4 +145,4 @@ Single cluster implementation for service type "LoadBalancer"
 
 Cilium's [Maglev](https://cilium.io/blog/2020/11/10/cilium-19#maglev) implementation.
 
-Multi cluster networking by GKE with [Anthos](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-for-anthos) - Cloud only Solution 
+Multi cluster networking by GKE with [Anthos](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-for-anthos) - Cloud only Solution

--- a/docs/proposals/kubevirt-node-placement.md
+++ b/docs/proposals/kubevirt-node-placement.md
@@ -4,7 +4,7 @@
 
 **Status**: Draft proposal
 
-**Issues**: 
+**Issues**:
 
 * https://github.com/kubermatic/kubermatic/issues/8742
 
@@ -98,13 +98,13 @@ spec:
             storageClassName: local-path
             podAffinityPreset: ""                # Allowed values: "", "soft", "hard"
             podAntiAffinityPreset: "soft"        # Allowed values: "", "soft", "hard"
-            nodeAffinityPreset: 
+            nodeAffinityPreset:
                 type: "soft"                     # Allowed values: "", "soft", "hard"
                 key: "foo"
                 values:
                 - bar1
                 - bar2
-            nodeAntiAffinityPreset: 
+            nodeAntiAffinityPreset:
                 type: "soft"                     # Allowed values: "", "soft", "hard"
                 key: "foo"
                 values:
@@ -134,7 +134,7 @@ The added *providerSpec* part is:
 ```yaml
             podAffinityPreset: ""                # Allowed values: "", "soft", "hard"
             podAntiAffinityPreset: "soft"        # Allowed values: "", "soft", "hard"
-            nodeAffinityPreset: 
+            nodeAffinityPreset:
                 type: "soft"                     # Allowed values: "", "soft", "hard"
                 key: "foo"
                 values:
@@ -168,7 +168,7 @@ metadata:
   uid: 4034c48c-f61c-43bb-ab43-6c59e41d8605
 spec:
   dataVolumeTemplates:
-# ...  no change 
+# ...  no change
   template:
     metadata:
       creationTimestamp: null
@@ -176,9 +176,9 @@ spec:
         kubevirt.io/vm: prow-e2e-kubevirt-centos-1.22.5-7ljx725j-worker-q6h88-7d78kw5pl
     spec:
       affinity:
-          # Section podAntiAffinity present if: 
-          #         MD.providerSpec.value.cloudProviderSpec.podAntiAffinityPreset != "" 
-          podAntiAffinity: 
+          # Section podAntiAffinity present if:
+          #         MD.providerSpec.value.cloudProviderSpec.podAntiAffinityPreset != ""
+          podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:      # if podAntiAffinityPreset = "hard"
             # preferredDuringSchedulingIgnoredDuringExecution    # if podAntiAffinityPreset = "soft"
               - labelSelector:
@@ -191,8 +191,8 @@ spec:
                                                                 # already common to all machine from the same MD
                 topologyKey: topologyKey:kubernetes.io/hostname
             # Section podAffinity present if:
-            #        MD.providerSpec.value.cloudProviderSpec.podAffinityPreset != "" 
-            podAffinity: 
+            #        MD.providerSpec.value.cloudProviderSpec.podAffinityPreset != ""
+            podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:        # if podAffinityPreset = "hard"
               # preferredDuringSchedulingIgnoredDuringExecution      # if podAffinityPreset = "soft"
                 - labelSelector:
@@ -204,7 +204,7 @@ spec:
                   topologyKey: topologyKey:kubernetes.io/hostname
             # Section nodeAffinity present if:
             #         MD.providerSpec.value.cloudProviderSpec.nodeAffinityPreset.type != ""
-            nodeAffinity: 
+            nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:       # if nodeAffinityPreset.type = "hard"
               # preferredDuringSchedulingIgnoredDuringExecution     # if nodeAffinityPreset.type = "soft"
                 nodeSelectorTerms:
@@ -213,7 +213,7 @@ spec:
                     operator: In
                     values:
                     - bar1
-                    - bar2  
+                    - bar2
             #### same goes for nodeAntiAffinity
       dnsConfig:
         nameservers:
@@ -224,7 +224,7 @@ spec:
 ```
 
 
-In order to have a *podAffinity* and *podAntiAffinity*, we need a common label among the *Machine* as we reconcile and watch the *Machine*. 
+In order to have a *podAffinity* and *podAntiAffinity*, we need a common label among the *Machine* as we reconcile and watch the *Machine*.
 We already have a common label among the Machines from the same *MachineDeployment*, which is:
 ```yaml
 machine: md-<machine id>
@@ -234,7 +234,7 @@ We just need to add this label to the *VirtualMachineInstance*.
 
 ## Control of VM placement over infra cluster nodes
 
-**The customer is responsible of labelling the infra cluster nodes**
+**The admin is responsible of labelling the infra cluster nodes**
 
 Based on those existing infra cluster node labels, and with the facade defined in the MachineDeployment manifest and the VMi specification, we can have a quite flexible way of controlling the placement of the VMi on the infra cluster nodes.
 
@@ -250,7 +250,7 @@ This change requires an update of the dashboard to enter those values:
 
 ## Control of user cluster pod placement over infra cluster nodes
 
-Now, if the customer wants to control the placement of the user cluster workload over the infra cluster nodes, using affinity/antiaffinity, the user cluster nodes need to have the needed labels from the infra cluster replicated.
+Now, if the admin wants to control the placement of the user cluster workload over the infra cluster nodes, using affinity/antiaffinity, the user cluster nodes need to have the needed labels from the infra cluster replicated.
 
 **KubeVirt CCM is already replicating 2 topology labels from the infra cluster to the user cluster nodes:**
 - topology.kubernetes.io/region

--- a/docs/proposals/kubevirt-production-proposal.md
+++ b/docs/proposals/kubevirt-production-proposal.md
@@ -4,7 +4,7 @@
 
 **Status**: Draft proposal
 
-**Issues**: 
+**Issues**:
 
 * https://github.com/kubermatic/kubermatic/issues/7068
 * https://github.com/kubermatic/kubermatic/issues/6516
@@ -43,7 +43,7 @@ we should take to deliver production-ready KubeVirt, the document should evolve 
 The end user would like to have automatic deployment of KubeVirt addon with some additional components like Containerized Data Importer and Multus.
 Currently for KubeVirt we are not able to use the KKP addon mechanism because its purpose is not to install more complex projects (simple deployments).
 The scope of automation on our side is only limited to the k8s cluster (that means installing only k8s addons).
-It is expected that the configured k8s cluster is provided by the customer or KKP bare-metal cloud provider.
+It is expected that the configured k8s cluster is provided by the admin or KKP bare-metal cloud provider.
 
 ### Goals
 
@@ -95,7 +95,7 @@ or create your own custom template.
         * Improve selection, list all available and supported cloud images
     * Performance settings:
         * Allow to modify all crucial KubeVirt performance settings (only custom template)
-            * More about it in the Virtual Machine Flavors section 
+            * More about it in the Virtual Machine Flavors section
     * Resource settings:
         * Allow to change CPU (only custom template)
         * Allow to change memory (only custom template)
@@ -122,7 +122,7 @@ we have to fine-tune the implementation to add extra options that will cover the
 ### Overview
 
 We must provide generic templates for virtual machines that users can use.
-This is going to be useful for customers that don't have deep knowledge of virtualization,
+This is going to be useful for admins that don't have deep knowledge of virtualization,
 it should cover most of the use cases. For more advanced users we should allow the creation of custom VMs and
 support all features that KubeVirt provides regarding performance and scalability.
 
@@ -249,7 +249,7 @@ General overview of the standard network setting with a possibility to add custo
 
 ![Network isolation](images/kubevirt-network-isolation.png)
 
-VMs in the same cluster will be attached to the same VLANs and communication VM to VM (for the same KubeVirt cluster) 
+VMs in the same cluster will be attached to the same VLANs and communication VM to VM (for the same KubeVirt cluster)
 should go through the VLAN not over the pod network, pod network is only attached to expose the VM as a service.
 We should set appropriate pod network policies and routing tables on VMs to achieve the isolation goal.
 
@@ -264,7 +264,7 @@ The final goal is to deploy the CCM over Platform Extension, however, it is in t
 
 #### Underlying Cluster Exposure
 
-We can recommend and support metal-lb deployment in case a customer does not have a possibility (or does not want to) to use a self-provisioned edge.
+We can recommend and support metal-lb deployment in case an admin does not have a possibility (or does not want to) to use a self-provisioned edge.
 We have to set appropriate metal-lb setup that we would support based on benchmarking.
 
 #### Performance
@@ -287,16 +287,16 @@ as well we have to use libvirt to attach disks to nodes instead of using NFS dir
 ### Goals
 
 * Support for hot-pluggable disks to avoid attaching NFS storage directly to the VM.
-* Support for Data Volume registry 
+* Support for Data Volume registry
   * Host assisted data clone
   * Snapshot data clone (not every CSI driver and storage support this)
 * Provide optimal storage setup that work together with KubeVirt, it is about a document or support for storage solutions
-  we choose (customers often ask about that), like CEPH, Quobyte etc.
+  we choose (admins often ask about that), like CEPH, Quobyte etc.
 
 ### Non-Goals
 
 * Allow crossed namespace Data Volume registry
-* Support for live migration 
+* Support for live migration
     * In the future we want to support live migration
 
 ### Implementation

--- a/docs/proposals/machine-controller.md
+++ b/docs/proposals/machine-controller.md
@@ -30,7 +30,7 @@ Kubermatic-api:
 *   We create new v2 endpoints (backwards compatibility)
 *   Only one node per call (clear restful api)
 *   New API type for the node (abstracted version of the machine+node)
-*   The api creates machine resources in the customer cluster
+*   The api creates machine resources in the user cluster
 
 kubermatic-controller:
 *   The machine-controller gets deployed next to the existing node-controller (backwards compatibility)

--- a/docs/proposals/offline-mode.md
+++ b/docs/proposals/offline-mode.md
@@ -6,7 +6,7 @@
 
 ## Motivation and background
 
-In order to allow customers do use Kubermatic in an environment that has no access to the Internet we must
+In order to allow admins to use Kubermatic in an environment that has no access to the Internet we must
 find all places where Kubermatic downloads stuff from the Internet, add configuration options, test and document
 those.
 
@@ -25,7 +25,7 @@ Kubermatic:
 * Writing a script that downloads all required images, retags them and uploads them to a private registry
 * Add flag to the `cluster-controller` to set just the repository for all images
 * Provide an easy/convenient way to have an image pull secret available on all nodes
-* Allow dex to be configured to either use a customer-provided IDP or static user definitions
+* Allow dex to be configured to either use a admin-provided IDP or static user definitions
 * Write an e2e test for this:
     * Create a kubeadm seed + master cluster, during this phase Internet may be reachable
     * Execute the script that downloads and retags the images, during this phase Internet may be reachable

--- a/docs/proposals/openshift-ingress.md
+++ b/docs/proposals/openshift-ingress.md
@@ -27,7 +27,7 @@ The proposed implementation looks like this:
 
 * The human Kubermatic operator must provide a DNS domain per seed under which kubermatic will set up a wildcard domain per cluster
 * [External DNS](https://github.com/kubernetes-sigs/external-dns/) must be set up in the seed and configured
-	with the customers provider of choice
+	with the admin's provider of choice
 * Kubermatic runs a controller that manages a [`DNSEndpoint`](https://github.com/kubernetes-sigs/external-dns/blob/f763d2a4139746abd775c61642cb9e776b387ba6/docs/contributing/crd-source.md) custom resource and
     * Sets its `DNSName` to `*.<<clusterid>>.<<DNS_ZONE>>`
     * Synchronizes the `target` property of it with the ready nodes in the cluster

--- a/docs/proposals/user-cluster-mla.md
+++ b/docs/proposals/user-cluster-mla.md
@@ -234,7 +234,7 @@ within the organization. The regular users won’t be able to manage data source
 restricted to only see logs & matrics matching their organization. Also, Grafana can be configured with different
 permission levels (admin / editor / viewer) for different users according to their permission levels in the KKP project.
 
-For Managed Service Provider users (superusers), who should be able to access data of all Customer Clusters, a superuser
+For Managed Service Provider users (superusers), who should be able to access data of all User Clusters, a superuser
 Grafana organization will be created. The organization will have to be configured with multiple Loki and Cortex data
 sources off all User Clusters.
 

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -443,7 +443,7 @@ spec:
       # ScrapeAnnotationPrefix (if set) is used to make the in-cluster Prometheus scrape pods
       # inside the user clusters.
       scrapeAnnotationPrefix: monitoring.kubermatic.io
-    # NodePortRange is the port range for customer clusters - this must match the NodePort
+    # NodePortRange is the port range for user clusters - this must match the NodePort
     # range of the seed cluster.
     nodePortRange: 30000-32767
     # OperatingSystemManager configures the image repo and the tag version for osm deployment.

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -219,7 +219,7 @@ type KubermaticUserClusterConfiguration struct {
 	OverwriteRegistry string `json:"overwriteRegistry,omitempty"`
 	// Addons controls the optional additions installed into each user cluster.
 	Addons KubermaticAddonsConfiguration `json:"addons,omitempty"`
-	// NodePortRange is the port range for customer clusters - this must match the NodePort
+	// NodePortRange is the port range for user clusters - this must match the NodePort
 	// range of the seed cluster.
 	NodePortRange string `json:"nodePortRange,omitempty"`
 	// Monitoring can be used to fine-tune to in-cluster Prometheus.

--- a/pkg/controller/operator/seed/resources/nodeportproxy/service.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/service.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NB: Changing anything in this service can lead to new LoadBalancers being
-// created and IPs changing. This must not happen when customers upgrade Kubermatic,
+// created and IPs changing. This must not happen when admins upgrade Kubermatic,
 // as all existing kubeconfigs for user clusters would be broken.
 
 const (

--- a/pkg/controller/user-cluster-controller-manager/ipam/README.md
+++ b/pkg/controller/user-cluster-controller-manager/ipam/README.md
@@ -1,7 +1,8 @@
 # IP Address Management controller
 
 Responsibilities:
-* Used for customers that do not have DHCP available
+
+* Used for KKP setups that do not have DHCP available
 * Can only be used for vsphere, as all other platforms have DHCP
 * The IPAM controller gets configured with a set of subnets
 * For all machines with an `machine-controller.kubermatic.io/initializers` annotation that contains the value `ipam`, it will allocate an IP address

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -509,7 +509,7 @@ spec:
                         type: string
                     type: object
                   nodePortRange:
-                    description: NodePortRange is the port range for customer clusters
+                    description: NodePortRange is the port range for user clusters
                       - this must match the NodePort range of the seed cluster.
                     type: string
                   operatingSystemManager:

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -695,7 +695,7 @@ func GetMetricsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGet
 		availableResources[n.Name] = n.Status.Allocatable
 	}
 
-	dynamicClient, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+	dynamicClient, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -80,7 +80,7 @@ func GetAdminKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.Use
 	}
 
 	if adminUserInfo.IsAdmin {
-		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
+		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForUserCluster(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -93,9 +93,9 @@ func GetAdminKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.Use
 	}
 	if strings.HasPrefix(userInfo.Group, "viewers") {
 		filePrefix = "viewer"
-		adminClientCfg, err = clusterProvider.GetViewerKubeconfigForCustomerCluster(ctx, cluster)
+		adminClientCfg, err = clusterProvider.GetViewerKubeconfigForUserCluster(ctx, cluster)
 	} else {
-		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
+		adminClientCfg, err = clusterProvider.GetAdminKubeconfigForUserCluster(ctx, cluster)
 	}
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
@@ -133,7 +133,7 @@ func GetOidcKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.User
 	if err != nil {
 		return nil, err
 	}
-	adminClientCfg, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
+	adminClientCfg, err := clusterProvider.GetAdminKubeconfigForUserCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -207,7 +207,7 @@ func CreateOIDCKubeconfigEndpoint(ctx context.Context, projectProvider provider.
 			return nil, utilerrors.NewBadRequest("the token doesn't contain the mandatory \"email\" claim")
 		}
 
-		adminKubeConfig, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
+		adminKubeConfig, err := clusterProvider.GetAdminKubeconfigForUserCluster(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -331,7 +331,7 @@ func CreateOIDCKubeconfigSecretEndpoint(ctx context.Context, projectProvider pro
 			return nil, utilerrors.NewBadRequest("the token doesn't contain the mandatory \"email\" claim")
 		}
 
-		adminKubeConfig, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(ctx, cluster)
+		adminKubeConfig, err := clusterProvider.GetAdminKubeconfigForUserCluster(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -380,7 +380,7 @@ func CreateOIDCKubeconfigSecretEndpoint(ctx context.Context, projectProvider pro
 		rsp := createOIDCKubeconfigRsp{}
 		rsp.phase = kubeconfigGenerated
 		rsp.secureCookieMode = oidcCfg.CookieSecureMode
-		client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+		client, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -405,7 +405,7 @@ func ListMachineDeploymentMetrics(ctx context.Context, userInfoGetter provider.U
 		}
 	}
 
-	dynamicCLient, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+	dynamicCLient, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -559,7 +559,7 @@ func ListMachineDeploymentNodesEvents(ctx context.Context, userInfoGetter provid
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+	client, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -771,7 +771,7 @@ func apiNodeStatus(status apiv1.NodeStatus, inputNode *corev1.Node, hideInitialN
 }
 
 func getNodeList(ctx context.Context, cluster *kubermaticv1.Cluster, clusterProvider provider.ClusterProvider) (*corev1.NodeList, error) {
-	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+	client, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/common/role.go
+++ b/pkg/handler/common/role.go
@@ -46,7 +46,7 @@ func ListClusterRoleEndpoint(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+	client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -71,7 +71,7 @@ func ListClusterRoleNamesEndpoint(ctx context.Context, userInfoGetter provider.U
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+	client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -102,7 +102,7 @@ func ListRoleEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+	client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -127,7 +127,7 @@ func ListRoleNamesEndpoint(ctx context.Context, userInfoGetter provider.UserInfo
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+	client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -133,7 +133,7 @@ func UpgradeNodeDeploymentsEndpoint(ctx context.Context, userInfoGetter provider
 		return nil, utilerrors.NewBadRequest(err.Error())
 	}
 
-	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+	client, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -185,15 +185,15 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 
 		userEmailID := wsh.EncodeUserEmailtoID(authenticatedUser.Email)
 		podAndKubeconfigSecretName := userEmailID
-		k8sClient, err := clusterProvider.GetAdminK8sClientForCustomerCluster(ctx, cluster)
+		k8sClient, err := clusterProvider.GetAdminK8sClientForUserCluster(ctx, cluster)
 		if err != nil {
 			return
 		}
-		cfg, err := clusterProvider.GetAdminClientConfigForCustomerCluster(ctx, cluster)
+		cfg, err := clusterProvider.GetAdminClientConfigForUserCluster(ctx, cluster)
 		if err != nil {
 			return
 		}
-		client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+		client, err := clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 		if err != nil {
 			return
 		}

--- a/pkg/handler/v1/cluster/role.go
+++ b/pkg/handler/v1/cluster/role.go
@@ -56,7 +56,7 @@ func CreateClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -91,7 +91,7 @@ func CreateRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -269,7 +269,7 @@ func GetClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.End
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -296,7 +296,7 @@ func GetRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -324,7 +324,7 @@ func DeleteClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -356,7 +356,7 @@ func DeleteRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -468,7 +468,7 @@ func PatchRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -563,7 +563,7 @@ func PatchClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.E
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+		client, err := clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -303,12 +303,12 @@ func GetClusterClient(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, fmt.Errorf("failed to get user information: %w", err)
 	}
 	if adminUserInfo.IsAdmin {
-		return clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+		return clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user information: %w", err)
 	}
-	return clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
+	return clusterProvider.GetClientForUserCluster(ctx, userInfo, cluster)
 }

--- a/pkg/provider/kubernetes/cluster.go
+++ b/pkg/provider/kubernetes/cluster.go
@@ -325,8 +325,8 @@ func (p *ClusterProvider) Update(ctx context.Context, project *kubermaticv1.Proj
 	return newCluster, nil
 }
 
-// GetAdminKubeconfigForCustomerCluster returns the admin kubeconfig for the given cluster.
-func (p *ClusterProvider) GetAdminKubeconfigForCustomerCluster(ctx context.Context, c *kubermaticv1.Cluster) (*clientcmdapi.Config, error) {
+// GetAdminKubeconfigForUserCluster returns the admin kubeconfig for the given cluster.
+func (p *ClusterProvider) GetAdminKubeconfigForUserCluster(ctx context.Context, c *kubermaticv1.Cluster) (*clientcmdapi.Config, error) {
 	secret := &corev1.Secret{}
 	name := types.NamespacedName{
 		Namespace: c.Status.NamespaceName,
@@ -339,8 +339,8 @@ func (p *ClusterProvider) GetAdminKubeconfigForCustomerCluster(ctx context.Conte
 	return clientcmd.Load(secret.Data[resources.KubeconfigSecretKey])
 }
 
-// GetViewerKubeconfigForCustomerCluster returns the viewer kubeconfig for the given cluster.
-func (p *ClusterProvider) GetViewerKubeconfigForCustomerCluster(ctx context.Context, c *kubermaticv1.Cluster) (*clientcmdapi.Config, error) {
+// GetViewerKubeconfigForUserCluster returns the viewer kubeconfig for the given cluster.
+func (p *ClusterProvider) GetViewerKubeconfigForUserCluster(ctx context.Context, c *kubermaticv1.Cluster) (*clientcmdapi.Config, error) {
 	s := &corev1.Secret{}
 
 	if err := p.GetSeedClusterAdminRuntimeClient().Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.ViewerKubeconfigSecretName}, s); err != nil {
@@ -400,36 +400,36 @@ func (p *ClusterProvider) RevokeAdminKubeconfig(ctx context.Context, c *kubermat
 	return nil
 }
 
-// GetAdminClientForCustomerCluster returns a client to interact with all resources in the given cluster
+// GetAdminClientForUserCluster returns a client to interact with all resources in the given cluster
 //
 // Note that the client you will get has admin privileges.
-func (p *ClusterProvider) GetAdminClientForCustomerCluster(ctx context.Context, c *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error) {
+func (p *ClusterProvider) GetAdminClientForUserCluster(ctx context.Context, c *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error) {
 	return p.userClusterConnProvider.GetClient(ctx, c)
 }
 
-// GetAdminK8sClientForCustomerCluster returns a k8s go client to interact with all resources in the given cluster
+// GetAdminK8sClientForUserCluster returns a k8s go client to interact with all resources in the given cluster
 //
 // Note that the client you will get has admin privileges.
-func (p *ClusterProvider) GetAdminK8sClientForCustomerCluster(ctx context.Context, c *kubermaticv1.Cluster) (kubernetes.Interface, error) {
+func (p *ClusterProvider) GetAdminK8sClientForUserCluster(ctx context.Context, c *kubermaticv1.Cluster) (kubernetes.Interface, error) {
 	return p.userClusterConnProvider.GetK8sClient(ctx, c)
 }
 
-// GetAdminClientConfigForCustomerCluster returns a client config
+// GetAdminClientConfigForUserCluster returns a client config
 //
 // Note that the client you will get has admin privileges.
-func (p *ClusterProvider) GetAdminClientConfigForCustomerCluster(ctx context.Context, c *kubermaticv1.Cluster) (*restclient.Config, error) {
+func (p *ClusterProvider) GetAdminClientConfigForUserCluster(ctx context.Context, c *kubermaticv1.Cluster) (*restclient.Config, error) {
 	return p.userClusterConnProvider.GetClientConfig(ctx, c)
 }
 
-// GetClientForCustomerCluster returns a client to interact with all resources in the given cluster
+// GetClientForUserCluster returns a client to interact with all resources in the given cluster
 //
 // Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
 // This implies that you have to make sure the user has the appropriate permissions inside the user cluster.
-func (p *ClusterProvider) GetClientForCustomerCluster(ctx context.Context, userInfo *provider.UserInfo, c *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error) {
+func (p *ClusterProvider) GetClientForUserCluster(ctx context.Context, userInfo *provider.UserInfo, c *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error) {
 	return p.userClusterConnProvider.GetClient(ctx, c, p.withImpersonation(userInfo))
 }
 
-func (p *ClusterProvider) GetTokenForCustomerCluster(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (string, error) {
+func (p *ClusterProvider) GetTokenForUserCluster(ctx context.Context, userInfo *provider.UserInfo, cluster *kubermaticv1.Cluster) (string, error) {
 	parts := strings.Split(userInfo.Group, "-")
 	switch parts[0] {
 	case "editors":

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -183,11 +183,11 @@ type ClusterProvider interface {
 	// Delete deletes the given cluster
 	Delete(ctx context.Context, userInfo *UserInfo, cluster *kubermaticv1.Cluster) error
 
-	// GetAdminKubeconfigForCustomerCluster returns the admin kubeconfig for the given cluster
-	GetAdminKubeconfigForCustomerCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
+	// GetAdminKubeconfigForUserCluster returns the admin kubeconfig for the given cluster
+	GetAdminKubeconfigForUserCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
 
-	// GetViewerKubeconfigForCustomerCluster returns the viewer kubeconfig for the given cluster
-	GetViewerKubeconfigForCustomerCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
+	// GetViewerKubeconfigForUserCluster returns the viewer kubeconfig for the given cluster
+	GetViewerKubeconfigForUserCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
 
 	// RevokeViewerKubeconfig revokes viewer token and kubeconfig
 	RevokeViewerKubeconfig(ctx context.Context, c *kubermaticv1.Cluster) error
@@ -195,29 +195,29 @@ type ClusterProvider interface {
 	// RevokeAdminKubeconfig revokes the viewer token and kubeconfig
 	RevokeAdminKubeconfig(ctx context.Context, c *kubermaticv1.Cluster) error
 
-	// GetAdminClientForCustomerCluster returns a client to interact with all resources in the given cluster
+	// GetAdminClientForUserCluster returns a client to interact with all resources in the given cluster
 	//
 	// Note that the client you will get has admin privileges
-	GetAdminClientForCustomerCluster(context.Context, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+	GetAdminClientForUserCluster(context.Context, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
 
-	// GetAdminK8sClientForCustomerCluster returns a k8s go client to interact with all resources in the given cluster
+	// GetAdminK8sClientForUserCluster returns a k8s go client to interact with all resources in the given cluster
 	//
 	// Note that the client you will get has admin privileges
-	GetAdminK8sClientForCustomerCluster(context.Context, *kubermaticv1.Cluster) (kubernetes.Interface, error)
+	GetAdminK8sClientForUserCluster(context.Context, *kubermaticv1.Cluster) (kubernetes.Interface, error)
 
-	// GetAdminClientConfigForCustomerCluster returns a client config
+	// GetAdminClientConfigForUserCluster returns a client config
 	//
 	// Note that the client you will get has admin privileges.
-	GetAdminClientConfigForCustomerCluster(ctx context.Context, c *kubermaticv1.Cluster) (*restclient.Config, error)
+	GetAdminClientConfigForUserCluster(ctx context.Context, c *kubermaticv1.Cluster) (*restclient.Config, error)
 
-	// GetClientForCustomerCluster returns a client to interact with all resources in the given cluster
+	// GetClientForUserCluster returns a client to interact with all resources in the given cluster
 	//
 	// Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
-	GetClientForCustomerCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+	GetClientForUserCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
 
-	// GetTokenForCustomerCluster returns a token for the given cluster with permissions granted to group that
+	// GetTokenForUserCluster returns a token for the given cluster with permissions granted to group that
 	// user belongs to.
-	GetTokenForCustomerCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (string, error)
+	GetTokenForUserCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (string, error)
 
 	// IsCluster checks if cluster exist with the given name
 	IsCluster(ctx context.Context, clusterName string) bool

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -627,7 +627,7 @@ func createUserCluster(
 	log.Info("Retrieving cluster client...")
 	var clusterClient ctrlruntimeclient.Client
 	err = wait.Poll(1*time.Second, 30*time.Second, func() (transient error, terminal error) {
-		clusterClient, transient = clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
+		clusterClient, transient = clusterProvider.GetAdminClientForUserCluster(ctx, cluster)
 		return transient, nil
 	})
 	if err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Pretty much everywhere we use the term "usercluster" (or "user cluster"), but in a few places we also had the term "customer cluster". However, in _maaany_ places we used the term "customer" for "the person(s) who install/manage KKP". But a "customer cluster" is not managed by the customer, but _their_ customers (i.e., users). Confused yet?

This PR cleans up the naming.

* "KKP admins" are now what we call the people who setup/manage KKP itself (i.e. the master and seed clusters).
* "KKP users" are the people that login to KKP and manage userclusters.

Using the term "customer" has always irked me since we moved to open source. It feels gatekeeper-y to me, as in "we only care about people who pay us" and not in "we're an open source product". So getting rid of "customer", which is loaded and misleading, is important to me :-)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
