### PR TITLE
Fix nil pointer exception when cloud-init-settings secret annotations isn't initialised

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/secret.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/secret.go
@@ -35,7 +35,9 @@ func SecretCreator() reconciling.NamedSecretCreatorGetter {
 		return cloudInitGetterToken, func(sec *corev1.Secret) (*corev1.Secret, error) {
 			sec.Type = resources.ServiceAccountTokenType
 			sec.Namespace = resources.CloudInitSettingsNamespace
-			sec.Annotations[resources.ServiceAccountTokenAnnotation] = cloudInitGetterAnnotation
+			sec.Annotations = map[string]string{
+				resources.ServiceAccountTokenAnnotation: cloudInitGetterAnnotation,
+			}
 
 			return sec, nil
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Fix the initialization of the `cloud-init-getter-token` secret.
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
