### PR TITLE
[release/v2.20] remove telemetry uuid validation (#9930)

### DIFF
--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -215,13 +215,6 @@ func validateHelmValues(config *kubermaticv1.KubermaticConfiguration, helmValues
 		helmValues.Set(path, config.Spec.ImagePullSecret)
 	}
 
-	if !opt.DisableTelemetry {
-		path = yamled.Path{"telemetry", "uuid"}
-		if value, _ := helmValues.GetString(path); value == "" {
-			failures = append(failures, errors.New("Telemetry is enabled, but no UUID was configured; generate a UUID and set it as telemetry.uuid in your Helm values"))
-		}
-	}
-
 	defaultedConfig, err := defaults.DefaultConfiguration(config, zap.NewNop().Sugar())
 	if err != nil {
 		failures = append(failures, fmt.Errorf("failed to process KubermaticConfiguration: %w", err))


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Backport of #9930.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
