### PR TITLE
Upgrade Canal 3.22 to v3.22.3

### DIFF
--- a/addons/canal/canal_v3.22.yaml
+++ b/addons/canal/canal_v3.22.yaml
@@ -4148,7 +4148,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "docker.io" }}/calico/cni:v3.22.1'
+          image: '{{ Registry "docker.io" }}/calico/cni:v3.22.3'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4191,7 +4191,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "docker.io" }}/calico/node:v3.22.1'
+          image: '{{ Registry "docker.io" }}/calico/node:v3.22.3'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4432,7 +4432,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.22.1'
+          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.22.3'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
Upgrades Canal 3.22 to v3.22.3 to address several [issues](https://projectcalico.docs.tigera.io/archive/v3.22/release-notes/).

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade Canal 3.22 to v3.22.3
```
