### PR TITLE
fix panic in cluster validation

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -62,23 +62,23 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 
 	if spec.Version.Semver() == nil || spec.Version.String() == "" {
 		allErrs = append(allErrs, field.Required(parentFieldPath.Child("version"), "version is required but was not specified"))
-	}
+	} else {
+		var (
+			validVersions []string
+			versionValid  bool
+		)
 
-	var (
-		validVersions []string
-		versionValid  bool
-	)
-
-	for _, availableVersion := range versions {
-		validVersions = append(validVersions, availableVersion.Version.String())
-		if spec.Version.Semver().Equal(availableVersion.Version) {
-			versionValid = true
-			break
+		for _, availableVersion := range versions {
+			validVersions = append(validVersions, availableVersion.Version.String())
+			if spec.Version.Semver().Equal(availableVersion.Version) {
+				versionValid = true
+				break
+			}
 		}
-	}
 
-	if !versionValid {
-		allErrs = append(allErrs, field.NotSupported(parentFieldPath.Child("version"), spec.Version.String(), validVersions))
+		if !versionValid {
+			allErrs = append(allErrs, field.NotSupported(parentFieldPath.Child("version"), spec.Version.String(), validVersions))
+		}
 	}
 
 	if !kubermaticv1.AllExposeStrategies.Has(spec.ExposeStrategy) {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -21,7 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	semverlib "github.com/Masterminds/semver/v3"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/version"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
@@ -37,6 +41,32 @@ var (
 		},
 	}
 )
+
+func TestValidateClusterSpec(t *testing.T) {
+	tests := []struct {
+		name  string
+		spec  *kubermaticv1.ClusterSpec
+		valid bool
+	}{
+		{
+			name:  "empty spec should not cause a panic",
+			valid: false,
+			spec:  &kubermaticv1.ClusterSpec{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateClusterSpec(test.spec, dc, features.FeatureGate{}, []*version.Version{{
+				Version: semverlib.MustParse("1.2.3"),
+			}}, nil).ToAggregate()
+
+			if (err == nil) != test.valid {
+				t.Errorf("Extected err to be %v, got %v", test.valid, err)
+			}
+		})
+	}
+}
 
 func TestValidateCloudSpec(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
During my work on #10266 I accdentically stumbled upon a panic in our cluster validation: `spec.Version.Semver()` can return `nil` if the version is invalid or empty.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
