### PR TITLE
Adding webhook validation to avoid too big IPAM pools for range allocation type

### DIFF
--- a/pkg/webhook/ipampool/validation/validation.go
+++ b/pkg/webhook/ipampool/validation/validation.go
@@ -123,6 +123,11 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
 			if float64(numberOfPoolSubnetIPs) != numberOfPoolSubnetIPsFloat64 {
 				return errors.New("the pool is too big to be processed")
 			}
+
+			if bits-poolPrefix > 12 {
+				return errors.New("pool prefix is too low for range allocation type")
+			}
+
 			if dcConfig.AllocationRange > numberOfPoolSubnetIPs {
 				return errors.New("allocation range cannot be greater than the pool subnet possible number of IP addresses")
 			}

--- a/pkg/webhook/ipampool/validation/validation_test.go
+++ b/pkg/webhook/ipampool/validation/validation_test.go
@@ -156,6 +156,25 @@ func TestValidator(t *testing.T) {
 			expectedError: errors.New("the pool is too big to be processed"),
 		},
 		{
+			name: "pool too big for range allocation 2",
+			op:   admissionv1.Create,
+			ipamPool: &kubermaticv1.IPAMPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ipam-pool",
+				},
+				Spec: kubermaticv1.IPAMPoolSpec{
+					Datacenters: map[string]kubermaticv1.IPAMPoolDatacenterSettings{
+						"dc": {
+							Type:            "range",
+							PoolCIDR:        "192.168.0.1/19",
+							AllocationRange: 8,
+						},
+					},
+				},
+			},
+			expectedError: errors.New("pool prefix is too low for range allocation type"),
+		},
+		{
 			name: "allowed prefix creation",
 			op:   admissionv1.Create,
 			ipamPool: &kubermaticv1.IPAMPool{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds a validation to block too big pools when using the "range" type because of performance issues. If the user wants a huge pool, it should be using the "prefix" type.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
