### PR TITLE
Add project-id label to groupprojectbindings

### DIFF
--- a/pkg/ee/group-project-binding/controller/reconciler.go
+++ b/pkg/ee/group-project-binding/controller/reconciler.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if r.setOwnerRef {
-		// validate that GroupProjectBinding references an existing project and set an owner reference
+		// validate that GroupProjectBinding references an existing project and set an owner reference and project-id label
 
 		project := &kubermaticv1.Project{}
 		if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: binding.Spec.ProjectID}, project); err != nil {
@@ -85,6 +85,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 				Kind:       kubermaticv1.ProjectKindName,
 				Name:       project.Name,
 				UID:        project.UID,
+			})
+			kuberneteshelper.EnsureLabels(binding, map[string]string{
+				kubermaticv1.ProjectIDLabelKey: project.Name,
 			})
 		}); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to set project owner reference: %w", err)

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -383,3 +383,14 @@ func CheckContainerRuntime(ctx context.Context,
 	}
 	return "", fmt.Errorf("failed to fetch container runtime: no control plane nodes found with label %s", NodeControlPlaneLabel)
 }
+
+func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
+	labels := o.GetLabels()
+
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for key, value := range toEnsure {
+		labels[key] = value
+	}
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds project-id label to GroupProjectBindings so its easier to list them in various components and use cases

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
