### PR TITLE
Fix automatic Canal version upgrade for clusters with k8s 1.23+

### DIFF
--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -238,8 +238,8 @@ func (h *AdmissionHandler) mutateUpdate(oldCluster, newCluster *kubermaticv1.Clu
 				Version: "v3.22",
 			}
 			if cniVersion.Minor() < 21 {
-				// label the cluster with unsafe-cni-upgrade label to leave traces about the upgrade
-				// and pass the cluster validation
+				// if more than 1 minor version needs to be skipped, label the cluster with the unsafe-cni-upgrade label
+				// to leave traces about the upgrade and pass the cluster validation
 				if newCluster.Labels == nil {
 					newCluster.Labels = make(map[string]string)
 				}

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -32,6 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/test"
+	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -738,7 +739,7 @@ func TestHandle(t *testing.T) {
 							},
 							CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
 								Type:    kubermaticv1.CNIPluginTypeCanal,
-								Version: "v3.21",
+								Version: "v3.20",
 							},
 							Features: map[string]bool{
 								kubermaticv1.ApiserverNetworkPolicy:    true,
@@ -765,7 +766,7 @@ func TestHandle(t *testing.T) {
 							},
 							CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
 								Type:    kubermaticv1.CNIPluginTypeCanal,
-								Version: "v3.21",
+								Version: "v3.20",
 							},
 							Features: map[string]bool{
 								kubermaticv1.ApiserverNetworkPolicy:    true,
@@ -779,6 +780,7 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				defaultPatches,
 				jsonpatch.NewOperation("replace", "/spec/cniPlugin/version", "v3.22"),
+				jsonpatch.NewOperation("add", "/metadata/labels", map[string]interface{}{validation.UnsafeCNIUpgradeLabel: "true"}),
 			),
 		},
 		{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
As k8s 1.23+ requires the minimal Canal version v3.22, KKP does the automatic CNI upgrade with k8s control plane upgrade if it is necessary (user cluster running on an older Canal CNI version). This will not work properly if the Canal version is lower than v3.21, as more than one minor version would need be skipped. This PR allows it by adding the appropriate label on the cluster, which would also serve as a note to the user that unsafe CNI upgrade has been performed.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix automatic Canal version upgrade for clusters with k8s 1.23+
```
