### PR TITLE
fix OSM RBAC reconciling

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -377,9 +377,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 	}
 
 	if r.enableOperatingSystemManager {
-		creators = append(creators, operatingsystemmanager.KubeSystemRoleCreator(),
-			operatingsystemmanager.KubePublicRoleCreator(),
-			operatingsystemmanager.DefaultRoleCreator())
+		creators = append(creators, operatingsystemmanager.KubeSystemRoleCreator())
 	}
 
 	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
@@ -392,6 +390,10 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 		machinecontroller.KubePublicRoleCreator(),
 	}
 
+	if r.enableOperatingSystemManager {
+		creators = append(creators, operatingsystemmanager.KubePublicRoleCreator())
+	}
+
 	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespacePublic, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", metav1.NamespacePublic, err)
 	}
@@ -400,6 +402,10 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 	creators = []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.EndpointReaderRoleCreator(),
 		clusterautoscaler.DefaultRoleCreator(),
+	}
+
+	if r.enableOperatingSystemManager {
+		creators = append(creators, operatingsystemmanager.DefaultRoleCreator())
 	}
 
 	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceDefault, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/role.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/role.go
@@ -22,7 +22,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // KubeSystemRoleCreator returns the func to create/update the Role for the OSM
@@ -30,8 +29,6 @@ import (
 func KubeSystemRoleCreator() reconciling.NamedRoleCreatorGetter {
 	return func() (string, reconciling.RoleCreator) {
 		return resources.OperatingSystemManagerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Name = resources.OperatingSystemManagerRoleName
-			r.Namespace = metav1.NamespaceSystem
 			r.Labels = resources.BaseAppLabels(operatingsystemmanager.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
@@ -69,8 +66,6 @@ func KubeSystemRoleCreator() reconciling.NamedRoleCreatorGetter {
 func KubePublicRoleCreator() reconciling.NamedRoleCreatorGetter {
 	return func() (string, reconciling.RoleCreator) {
 		return resources.OperatingSystemManagerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Name = resources.OperatingSystemManagerRoleName
-			r.Namespace = metav1.NamespacePublic
 			r.Labels = resources.BaseAppLabels(operatingsystemmanager.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
@@ -93,8 +88,6 @@ func KubePublicRoleCreator() reconciling.NamedRoleCreatorGetter {
 func DefaultRoleCreator() reconciling.NamedRoleCreatorGetter {
 	return func() (string, reconciling.RoleCreator) {
 		return resources.OperatingSystemManagerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Name = resources.OperatingSystemManagerRoleName
-			r.Namespace = metav1.NamespaceDefault
 			r.Labels = resources.BaseAppLabels(operatingsystemmanager.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Creator functions cannot override the name or namespace of the resource that they are reconciling. In the old code, no matter how hard the creators tried to set a namespace, the ReconcileRoles() function would always override it. This made all 3 creator functions effectively reconcile the exact same Role, leading to a reconcile loop.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
