### PR TITLE
bump kubectl binaries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ ENV KUBERMATIC_CHARTS_DIRECTORY=/opt/charts/
 # To support a wider range of Kubernetes userclusters, we ship multiple
 # kubectl binaries and deduce which one to use based on the version skew
 # policy.
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.23.8/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.23
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.21
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.24.2/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.24
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.22.11/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.22
 
 RUN wget -O- https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz | tar xzOf - linux-amd64/helm > /usr/local/bin/helm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ADD https://storage.googleapis.com/kubernetes-release/release/v1.22.11/bin/linux
 
 RUN wget -O- https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz | tar xzOf - linux-amd64/helm > /usr/local/bin/helm
 
-# We need the ca-certs so they api doesn't crash because it can't verify the certificate of Dex
+# We need the ca-certs so the KKP API can verify the certificates of the OIDC server (usually Dex)
 RUN chmod +x /usr/local/bin/kubectl-* /usr/local/bin/helm && apk add ca-certificates
 
 # Do not needless copy all binaries into the image.

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -68,6 +68,31 @@ if [ -z "${SKIP_AWS_PROVIDER:-}" ]; then
   export AWS_TEST_ENDPOINT=http://localhost:4566
 fi
 
+# For the kubectl tests, we must build the final KKP docker image.
+if [ -z "${SKIP_KUBECTL_TESTS:-}" ]; then
+  echodate "Building dummy KKP image, set \$SKIP_KUBECTL_TESTS to skip..."
+
+  if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
+    start_docker_daemon_ci
+  fi
+
+  # we do not need actual KKP binaries in the image
+  touch \
+    _build/kubermatic-api \
+    _build/kubermatic-operator \
+    _build/kubermatic-installer \
+    _build/kubermatic-webhook \
+    _build/master-controller-manager \
+    _build/seed-controller-manager \
+    _build/user-cluster-controller-manager \
+    _build/user-cluster-webhook \
+
+  # the existence of this env var enables the integration tests
+  export KUBECTL_TEST_IMAGE=kkpkubectltest
+
+  docker build -t $KUBECTL_TEST_IMAGE .
+fi
+
 echodate "Running integration tests..."
 
 # Run integration tests and only integration tests by:

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -35,13 +35,13 @@ export CGO_ENABLED=1
 LOCALSTACK_TAG="${LOCALSTACK_TAG:-0.12.19}"
 LOCALSTACK_IMAGE="${LOCALSTACK_IMAGE:-localstack/localstack:$LOCALSTACK_TAG}"
 
+if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
+  start_docker_daemon_ci
+fi
+
 # For the AWS tests, we need a localstack container running.
 if [ -z "${SKIP_AWS_PROVIDER:-}" ]; then
   echodate "Setting up localstack container, set \$SKIP_AWS_PROVIDER to skip..."
-
-  if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
-    start_docker_daemon_ci
-  fi
 
   containerName=kkp-localstack
 
@@ -71,10 +71,6 @@ fi
 # For the kubectl tests, we must build the final KKP docker image.
 if [ -z "${SKIP_KUBECTL_TESTS:-}" ]; then
   echodate "Building dummy KKP image, set \$SKIP_KUBECTL_TESTS to skip..."
-
-  if [[ ! -z "${JOB_NAME:-}" ]] && [[ ! -z "${PROW_JOB_ID:-}" ]]; then
-    start_docker_daemon_ci
-  fi
 
   # we do not need actual KKP binaries in the image
   touch \

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -82,7 +82,7 @@ if [ -z "${SKIP_KUBECTL_TESTS:-}" ]; then
     _build/master-controller-manager \
     _build/seed-controller-manager \
     _build/user-cluster-controller-manager \
-    _build/user-cluster-webhook \
+    _build/user-cluster-webhook
 
   # the existence of this env var enables the integration tests
   export KUBECTL_TEST_IMAGE=kkpkubectltest

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -73,6 +73,7 @@ if [ -z "${SKIP_KUBECTL_TESTS:-}" ]; then
   echodate "Building dummy KKP image, set \$SKIP_KUBECTL_TESTS to skip..."
 
   # we do not need actual KKP binaries in the image
+  mkdir _build
   touch \
     _build/kubermatic-api \
     _build/kubermatic-operator \

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -75,5 +75,6 @@ echodate "Running integration tests..."
 # * Extracting the dirname as the `go test` command doesn't play well with individual files as args
 # * Prefixing them with `./` as that's needed by `go test` as well
 for file in $(grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ | xargs dirname | sort -u); do
+  echodate "Testing package ${file}..."
   go_test $(echo $file | sed 's/\//_/g') -tags "integration,${KUBERMATIC_EDITION:-ce}" -race ./${file} -v
 done

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	kubectl123 = "kubectl-1.23"
+	kubectl122 = "kubectl-1.22"
+	kubectl124 = "kubectl-1.24"
 )
 
 // BinaryForClusterVersion returns the full path to a kubectl binary
@@ -32,18 +33,20 @@ const (
 // returned if no suitable kubectl can be determined.
 // We take advantage of version skew policy for kubectl, v1.1.1 would
 // support v1.2.x and v1.0.x, to ship only mandatory variants for kubectl.
+// See https://kubernetes.io/releases/version-skew-policy/#kubectl for
+// more information.
 func BinaryForClusterVersion(version *semver.Semver) (string, error) {
 	var binary string
 
 	switch version.MajorMinor() {
 	case "1.21":
-		binary = "kubectl-1.21"
+		binary = kubectl122
 	case "1.22":
-		binary = kubectl123
+		binary = kubectl122
 	case "1.23":
-		binary = kubectl123
+		binary = kubectl124
 	case "1.24":
-		binary = kubectl123
+		binary = kubectl124
 	default:
 		return "", fmt.Errorf("unsupported Kubernetes version %v", version)
 	}

--- a/pkg/util/kubectl/kubectl_integration_test.go
+++ b/pkg/util/kubectl/kubectl_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
+	"k8c.io/kubermatic/v2/pkg/semver"
+)
+
+type kubectlVersionOutput struct {
+	Major      int    `json:"major"`
+	Minor      int    `json:"minor"`
+	GitVersion string `json:"gitVersion"`
+}
+
+func TestVersionSkewIsRespected(t *testing.T) {
+	for _, v := range defaults.DefaultKubernetesVersioning.Versions {
+		t.Run(v.String(), func(t *testing.T) {
+			if err := testVersionSkew(v); err != nil {
+				t.Errorf("Failed to get a kubectl version that's compatible to cluster version %q: %v", v, err)
+			}
+		})
+	}
+}
+
+func testVersionSkew(clusterVersison semver.Semver) error {
+	binary, err := BinaryForClusterVersion(&clusterVersison)
+	if err != nil {
+		return fmt.Errorf("no kubectl binary found: %w", err)
+	}
+
+	cmd := exec.Command(binary, "version", "--client", "--output", "json")
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to determine kubectl version: %w", err)
+	}
+
+	data := kubectlVersionOutput{}
+	if err := json.NewDecoder(&buf).Decode(&data); err != nil {
+		return fmt.Errorf("failed to decode kubectl output: %w", err)
+	}
+
+	kubectlVersion, err := semver.NewSemver(data.GitVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse %q as a semver: %w", data.GitVersion, err)
+	}
+
+	if err := VerifyVersionSkew(clusterVersison, *kubectlVersion); err != nil {
+		return fmt.Errorf("kubectl should have been compatible, but: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/util/kubectl/kubectl_integration_test.go
+++ b/pkg/util/kubectl/kubectl_integration_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 
 /*
-Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/kubectl/kubectl_integration_test.go
+++ b/pkg/util/kubectl/kubectl_integration_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 type kubectlVersionOutput struct {
-	Major      int    `json:"major"`
-	Minor      int    `json:"minor"`
-	GitVersion string `json:"gitVersion"`
+	ClientVersion struct {
+		GitVersion string `json:"gitVersion"`
+	} `json:"clientVersion"`
 }
 
 func TestVersionSkewIsRespected(t *testing.T) {
@@ -80,9 +80,9 @@ func testVersionSkew(clusterVersison semver.Semver, dockerImage string) error {
 		return fmt.Errorf("failed to decode kubectl output: %w", err)
 	}
 
-	kubectlVersion, err := semver.NewSemver(data.GitVersion)
+	kubectlVersion, err := semver.NewSemver(data.ClientVersion.GitVersion)
 	if err != nil {
-		return fmt.Errorf("failed to parse %q as a semver: %w", data.GitVersion, err)
+		return fmt.Errorf("failed to parse %q as a semver: %w", data.ClientVersion.GitVersion, err)
 	}
 
 	if err := VerifyVersionSkew(clusterVersison, *kubectlVersion); err != nil {

--- a/pkg/util/kubectl/kubectl_test.go
+++ b/pkg/util/kubectl/kubectl_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package kubectl
 
 import (
+	"fmt"
 	"testing"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
+	"k8c.io/kubermatic/v2/pkg/semver"
 )
 
 func TestKubectlForAllSupportedVersions(t *testing.T) {
@@ -28,5 +30,42 @@ func TestKubectlForAllSupportedVersions(t *testing.T) {
 		if err != nil {
 			t.Errorf("No kubectl binary found for cluster version %q: %v", v, err)
 		}
+	}
+}
+
+func TestVerifyVersionSkew(t *testing.T) {
+	testcases := []struct {
+		cluster string
+		kubectl string
+		valid   bool
+	}{
+		// different major versions are never compatible
+		{cluster: "1.5", kubectl: "2.5", valid: false},
+		{cluster: "2.5", kubectl: "1.5", valid: false},
+
+		// patch releases do not matter
+		{cluster: "1.5.100", kubectl: "1.5.999", valid: true},
+		{cluster: "1.5.999", kubectl: "1.5.100", valid: true},
+
+		// check actual skew policy
+		{cluster: "1.5", kubectl: "1.3", valid: false},
+		{cluster: "1.5", kubectl: "1.4", valid: true},
+		{cluster: "1.5", kubectl: "1.5", valid: true},
+		{cluster: "1.5", kubectl: "1.6", valid: true},
+		{cluster: "1.5", kubectl: "1.7", valid: false},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(fmt.Sprintf("%s vs. %s", testcase.cluster, testcase.kubectl), func(t *testing.T) {
+			err := VerifyVersionSkew(*semver.NewSemverOrDie(testcase.cluster), *semver.NewSemverOrDie(testcase.kubectl))
+
+			if testcase.valid && err != nil {
+				t.Fatalf("kubectl %s should have been compatible to cluster %s, but got error: %v", testcase.kubectl, testcase.cluster, err)
+			}
+
+			if !testcase.valid && err == nil {
+				t.Fatalf("kubectl %s should not have been compatible to cluster %s, but got no error", testcase.kubectl, testcase.cluster)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We stopped supporting k8s 1.21 (we still have code to reconcile it if an upgrade is delayed, but KKP 2.21 will not support creating new 1.21 clusters), so it's time to bump our kubectl binaries to be ready for k8s 1.25.

I also added some more tests to ensure that we do not only have a matching kubectl, but that this kubectl binary is also actually compatible to the cluster version. And to be super sure, I made it so that we test the actual Docker image we're publishing.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
