### PR TITLE
Resourcequotas to cluster scope

### DIFF
--- a/pkg/apis/kubermatic/v1/resource_quota.go
+++ b/pkg/apis/kubermatic/v1/resource_quota.go
@@ -31,6 +31,7 @@ const (
 	ProjectSubjectKind = "project"
 )
 
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -73,7 +73,7 @@ func WebhookClusterRoleCreator(cfg *kubermaticv1.KubermaticConfiguration) reconc
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"kubermatic.k8c.io"},
-					Resources: []string{"clustertemplates", "projects", "ipamallocations"},
+					Resources: []string{"clustertemplates", "projects", "ipamallocations", "resourcequotas"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			}
@@ -111,7 +111,7 @@ func WebhookRoleCreator(cfg *kubermaticv1.KubermaticConfiguration) reconciling.N
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"kubermatic.k8c.io"},
-					Resources: []string{"seeds", "kubermaticconfigurations", "resourcequotas"},
+					Resources: []string{"seeds", "kubermaticconfigurations"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/controller/operator/master/resources/kubermatic/webhooks.go
+++ b/pkg/controller/operator/master/resources/kubermatic/webhooks.go
@@ -204,7 +204,7 @@ func ResourceQuotaValidatingWebhookConfigurationCreator(ctx context.Context,
 			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
 			sideEffects := admissionregistrationv1.SideEffectClassNone
-			scope := admissionregistrationv1.NamespacedScope
+			scope := admissionregistrationv1.ClusterScope
 
 			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {
@@ -259,7 +259,7 @@ func ResourceQuotaMutatingWebhookConfigurationCreator(ctx context.Context, cfg *
 			failurePolicy := admissionregistrationv1.Fail
 			reinvocationPolicy := admissionregistrationv1.NeverReinvocationPolicy
 			sideEffects := admissionregistrationv1.SideEffectClassNone
-			scope := admissionregistrationv1.NamespacedScope
+			scope := admissionregistrationv1.ClusterScope
 
 			ca, err := common.WebhookCABundle(ctx, cfg, client)
 			if err != nil {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: ResourceQuotaList
     plural: resourcequotas
     singular: resourcequota
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp

--- a/pkg/ee/mutation/resourcequota/mutation_test.go
+++ b/pkg/ee/mutation/resourcequota/mutation_test.go
@@ -36,7 +36,6 @@ import (
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/webhook/resourcequota/mutation"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -303,9 +302,8 @@ func (r rawResourceQuotaGen) Do() []byte {
 			Kind:       "ResourceQuota",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.Name,
-			Namespace: resources.KubermaticNamespace,
-			Labels:    r.Labels,
+			Name:   r.Name,
+			Labels: r.Labels,
 		},
 		Spec: kubermaticv1.ResourceQuotaSpec{
 			Subject: kubermaticv1.Subject{

--- a/pkg/ee/resource-quota/handler_test.go
+++ b/pkg/ee/resource-quota/handler_test.go
@@ -36,7 +36,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,8 +47,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 	existingResourceQuotas := []ctrlruntimeclient.Object{
 		&kubermaticv1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("project-%s-1", projectName),
-				Namespace: resources.KubermaticNamespace,
+				Name: fmt.Sprintf("project-%s-1", projectName),
 				Labels: map[string]string{
 					kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
 					kubermaticv1.ResourceQuotaSubjectNameLabelKey: fmt.Sprintf("%s-1", projectName),
@@ -64,8 +62,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		&kubermaticv1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("project-%s-2", projectName),
-				Namespace: resources.KubermaticNamespace,
+				Name: fmt.Sprintf("project-%s-2", projectName),
 				Labels: map[string]string{
 					kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
 					kubermaticv1.ResourceQuotaSubjectNameLabelKey: fmt.Sprintf("%s-2", projectName),

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -33,8 +33,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
-	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -82,12 +80,12 @@ func Add(mgr manager.Manager,
 		if err := resourceQuotaSource.InjectCache(mgr.GetCache()); err != nil {
 			return fmt.Errorf("failed to inject cache into resourceQuotaSource for seed %q: %w", seedName, err)
 		}
-		if err := c.Watch(resourceQuotaSource, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(resources.KubermaticNamespace)); err != nil {
+		if err := c.Watch(resourceQuotaSource, &handler.EnqueueRequestForObject{}); err != nil {
 			return fmt.Errorf("failed to establish watch for resource quotas in seed %q: %w", seedName, err)
 		}
 	}
 
-	if err := c.Watch(&source.Kind{Type: &kubermaticv1.ResourceQuota{}}, &handler.EnqueueRequestForObject{}, predicate.ByNamespace(resources.KubermaticNamespace)); err != nil {
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.ResourceQuota{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("failed to create watch for resource quota: %w", err)
 	}
 

--- a/pkg/ee/resource-quota/master-controller/controller_test.go
+++ b/pkg/ee/resource-quota/master-controller/controller_test.go
@@ -31,7 +31,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
-	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -90,7 +89,7 @@ func TestReconcile(t *testing.T) {
 				seedClients:  tc.seedClients,
 			}
 
-			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName, Namespace: kubermaticresources.KubermaticNamespace}}
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
 			if _, err := r.Reconcile(ctx, request); err != nil {
 				t.Fatalf("reconciling failed: %v", err)
 			}
@@ -112,7 +111,6 @@ func TestReconcile(t *testing.T) {
 func genResourceQuota(name string, localUsage kubermaticv1.ResourceDetails) *kubermaticv1.ResourceQuota {
 	rq := &kubermaticv1.ResourceQuota{}
 	rq.Name = name
-	rq.Namespace = kubermaticresources.KubermaticNamespace
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{
 			Name: "project1",

--- a/pkg/ee/resource-quota/provider.go
+++ b/pkg/ee/resource-quota/provider.go
@@ -31,7 +31,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -57,8 +56,7 @@ func NewResourceQuotaProvider(createMasterImpersonatedClient kubernetes.Imperson
 func (p *ResourceQuotaProvider) GetUnsecured(ctx context.Context, name string) (*kubermaticv1.ResourceQuota, error) {
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := p.privilegedClient.Get(ctx, types.NamespacedName{
-		Name:      name,
-		Namespace: resources.KubermaticNamespace,
+		Name: name,
 	}, resourceQuota); err != nil {
 		return nil, err
 	}
@@ -82,8 +80,7 @@ func (p *ResourceQuotaProvider) Get(ctx context.Context, userInfo *provider.User
 	subject := kubermaticv1.Subject{Name: name, Kind: kind}
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := masterImpersonatedClient.Get(ctx, types.NamespacedName{
-		Name:      buildNameFromSubject(subject),
-		Namespace: resources.KubermaticNamespace,
+		Name: buildNameFromSubject(subject),
 	}, resourceQuota); err != nil {
 		return nil, err
 	}
@@ -92,7 +89,6 @@ func (p *ResourceQuotaProvider) Get(ctx context.Context, userInfo *provider.User
 
 func (p *ResourceQuotaProvider) ListUnsecured(ctx context.Context, labelSet map[string]string) (*kubermaticv1.ResourceQuotaList, error) {
 	listOpts := &ctrlruntimeclient.ListOptions{
-		Namespace:     resources.KubermaticNamespace,
 		LabelSelector: labels.SelectorFromSet(labelSet),
 	}
 	resourceQuotaList := &kubermaticv1.ResourceQuotaList{}
@@ -107,7 +103,6 @@ func (p *ResourceQuotaProvider) CreateUnsecured(ctx context.Context, subject kub
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
 			Labels:      map[string]string{},
-			Namespace:   resources.KubermaticNamespace,
 			Name:        buildNameFromSubject(subject),
 		},
 		Spec: kubermaticv1.ResourceQuotaSpec{

--- a/pkg/ee/resource-quota/provider_test.go
+++ b/pkg/ee/resource-quota/provider_test.go
@@ -33,7 +33,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	resourcequotas "k8c.io/kubermatic/v2/pkg/ee/resource-quota"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,8 +86,7 @@ func TestProviderGetResourceQuota(t *testing.T) {
 			existingObjects: []ctrlruntimeclient.Object{
 				&kubermaticv1.ResourceQuota{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("project-%s", projectName),
-						Namespace: resources.KubermaticNamespace,
+						Name: fmt.Sprintf("project-%s", projectName),
 					},
 					Spec: kubermaticv1.ResourceQuotaSpec{
 						Subject: kubermaticv1.Subject{
@@ -143,8 +141,7 @@ func TestProviderListResourceQuotas(t *testing.T) {
 	existingResourceQuotas := []ctrlruntimeclient.Object{
 		&kubermaticv1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("project-%s-1", projectName),
-				Namespace: resources.KubermaticNamespace,
+				Name: fmt.Sprintf("project-%s-1", projectName),
 				Labels: map[string]string{
 					kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
 					kubermaticv1.ResourceQuotaSubjectNameLabelKey: fmt.Sprintf("%s-1", projectName),
@@ -159,8 +156,7 @@ func TestProviderListResourceQuotas(t *testing.T) {
 		},
 		&kubermaticv1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("project-%s-2", projectName),
-				Namespace: resources.KubermaticNamespace,
+				Name: fmt.Sprintf("project-%s-2", projectName),
 				Labels: map[string]string{
 					kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
 					kubermaticv1.ResourceQuotaSubjectNameLabelKey: fmt.Sprintf("%s-2", projectName),

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
@@ -33,9 +33,7 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
-	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,8 +82,7 @@ func Add(masterMgr manager.Manager,
 	}
 
 	// Watch for changes to ResourceQuota
-	if err := c.Watch(&source.Kind{Type: &kubermaticv1.ResourceQuota{}}, &handler.EnqueueRequestForObject{},
-		predicate.ByNamespace(kubermaticresources.KubermaticNamespace)); err != nil {
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.ResourceQuota{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("failed to watch resource quotas: %w", err)
 	}
 
@@ -155,7 +152,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 	return r.syncAllSeeds(log, resourceQuota, func(seedClient ctrlruntimeclient.Client, rq *kubermaticv1.ResourceQuota) error {
 		// ensure resource quota
-		if err := reconciling.ReconcileKubermaticV1ResourceQuotas(ctx, resourceQuotaCreatorGetters, kubermaticresources.KubermaticNamespace, seedClient); err != nil {
+		if err := reconciling.ReconcileKubermaticV1ResourceQuotas(ctx, resourceQuotaCreatorGetters, "", seedClient); err != nil {
 			return err
 		}
 

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -33,7 +33,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
-	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -102,7 +101,7 @@ func TestReconcile(t *testing.T) {
 				seedClients:  map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
 			}
 
-			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName, Namespace: kubermaticresources.KubermaticNamespace}}
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
 			if _, err := r.Reconcile(ctx, request); err != nil {
 				t.Fatalf("reconciling failed: %v", err)
 			}
@@ -150,7 +149,6 @@ func genResourceQuota(name string, deleted bool) *kubermaticv1.ResourceQuota {
 
 	rq := &kubermaticv1.ResourceQuota{}
 	rq.Name = name
-	rq.Namespace = kubermaticresources.KubermaticNamespace
 	rq.Labels = map[string]string{
 		kubermaticv1.ResourceQuotaSubjectNameLabelKey: "project1",
 		kubermaticv1.ResourceQuotaSubjectKindLabelKey: "project",

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -33,8 +33,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
-	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
-	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
@@ -97,7 +95,6 @@ func Add(mgr manager.Manager,
 	if err := c.Watch(
 		&source.Kind{Type: &kubermaticv1.ResourceQuota{}},
 		&handler.EnqueueRequestForObject{},
-		kubermaticpred.ByNamespace(kubermaticresources.KubermaticNamespace),
 	); err != nil {
 		return fmt.Errorf("failed to create watch for seed resource quotas: %w", err)
 	}
@@ -227,8 +224,8 @@ func enqueueResourceQuota(client ctrlruntimeclient.Client, log *zap.SugaredLogge
 		resourceQuotaList := &kubermaticv1.ResourceQuotaList{}
 
 		if err := client.List(context.Background(), resourceQuotaList,
-			&ctrlruntimeclient.ListOptions{Namespace: kubermaticresources.KubermaticNamespace,
-				LabelSelector: labels.NewSelector().Add(*subjectNameReq)}); err != nil {
+			&ctrlruntimeclient.ListOptions{LabelSelector: labels.NewSelector().Add(*subjectNameReq)},
+		); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to list resourceQuotas: %w", err))
 		}
 

--- a/pkg/ee/resource-quota/seed-controller/controller_test.go
+++ b/pkg/ee/resource-quota/seed-controller/controller_test.go
@@ -30,7 +30,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
-	kubermaticresources "k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
@@ -88,7 +87,7 @@ func TestReconcile(t *testing.T) {
 				seedClient:              tc.seedClient,
 			}
 
-			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName, Namespace: kubermaticresources.KubermaticNamespace}}
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
 			if _, err := r.Reconcile(ctx, request); err != nil {
 				t.Fatalf("reconciling failed: %v", err)
 			}
@@ -110,7 +109,6 @@ func TestReconcile(t *testing.T) {
 func genResourceQuota(name string) *kubermaticv1.ResourceQuota {
 	rq := &kubermaticv1.ResourceQuota{}
 	rq.Name = name
-	rq.Namespace = kubermaticresources.KubermaticNamespace
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{
 			Name: "project1",

--- a/pkg/ee/validation/resourcequota/resourcequota.go
+++ b/pkg/ee/validation/resourcequota/resourcequota.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,9 +47,7 @@ func ValidateCreate(ctx context.Context,
 	}
 
 	currentQuotaList := &kubermaticv1.ResourceQuotaList{}
-	if err := client.List(ctx, currentQuotaList, &ctrlruntimeclient.ListOptions{
-		Namespace: resources.KubermaticNamespace,
-	}); err != nil {
+	if err := client.List(ctx, currentQuotaList, &ctrlruntimeclient.ListOptions{}); err != nil {
 		return fmt.Errorf("failed to list resource quotas: %w", err)
 	}
 

--- a/pkg/ee/validation/resourcequota/resourcequota_test.go
+++ b/pkg/ee/validation/resourcequota/resourcequota_test.go
@@ -30,7 +30,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/ee/validation/resourcequota"
-	"k8c.io/kubermatic/v2/pkg/resources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,8 +57,7 @@ func TestValidateCreate(t *testing.T) {
 			existingResourceQuota: []*kubermaticv1.ResourceQuota{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-quota",
-						Namespace: resources.KubermaticNamespace,
+						Name: "existing-quota",
 					},
 					Spec: kubermaticv1.ResourceQuotaSpec{
 						Subject: kubermaticv1.Subject{
@@ -71,8 +69,7 @@ func TestValidateCreate(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-quota1",
-						Namespace: resources.KubermaticNamespace,
+						Name: "existing-quota1",
 					},
 					Spec: kubermaticv1.ResourceQuotaSpec{
 						Subject: kubermaticv1.Subject{
@@ -85,8 +82,7 @@ func TestValidateCreate(t *testing.T) {
 			},
 			resourceQuotaToValidate: &kubermaticv1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-quota",
-					Namespace: resources.KubermaticNamespace,
+					Name: "new-quota",
 				},
 				Spec: kubermaticv1.ResourceQuotaSpec{
 					Subject: kubermaticv1.Subject{
@@ -102,8 +98,7 @@ func TestValidateCreate(t *testing.T) {
 			existingResourceQuota: []*kubermaticv1.ResourceQuota{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-quota",
-						Namespace: resources.KubermaticNamespace,
+						Name: "existing-quota",
 					},
 					Spec: kubermaticv1.ResourceQuotaSpec{
 						Subject: kubermaticv1.Subject{
@@ -116,8 +111,7 @@ func TestValidateCreate(t *testing.T) {
 			},
 			resourceQuotaToValidate: &kubermaticv1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-quota",
-					Namespace: resources.KubermaticNamespace,
+					Name: "new-quota",
 				},
 				Spec: kubermaticv1.ResourceQuotaSpec{
 					Subject: kubermaticv1.Subject{

--- a/pkg/resources/usercluster-webhook/rbac.go
+++ b/pkg/resources/usercluster-webhook/rbac.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -46,6 +47,15 @@ func ClusterRole() reconciling.NamedClusterRoleCreatorGetter {
 				{
 					APIGroups: []string{appskubermaticv1.GroupName},
 					Resources: []string{"applicationdefinitions", "applicationdefinitions/status"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{kubermaticv1.GroupName},
+					Resources: []string{"resourcequotas", "resourcequotas/status"},
 					Verbs: []string{
 						"get",
 						"list",

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -27,7 +27,6 @@ import (
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
-	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,7 +42,6 @@ func getResourceQuota(ctx context.Context, seedClient ctrlruntimeclient.Client, 
 	quotaList := &kubermaticv1.ResourceQuotaList{}
 	if err := seedClient.List(ctx, quotaList, &ctrlruntimeclient.ListOptions{
 		LabelSelector: subjectSelector,
-		Namespace:     resources.KubermaticNamespace,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to list resource quotas: %w", err)
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Initially ResourceQuotas were Namespace-scoped, and "forced" into the `kubermatic` namespace. As its related to the cluster scoped resources, like Project, it makes sense to have it cluster scoped as well.

Also it made rbacs difficult to manage properly as various components in different namespaces needed access to resource quotas.

As the ResourceQuotas were not released yet, better to do this now before the release.


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
