### PR TITLE
[release/v2.20] Use quay.io registry for Canal images, bump Canal v3.20 version to v3.20.5

### DIFF
--- a/addons/canal/canal_v3.20.yaml
+++ b/addons/canal/canal_v3.20.yaml
@@ -3791,7 +3791,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "docker.io" }}/calico/cni:v3.20.2'
+          image: '{{ Registry "quay.io" }}/calico/cni:v3.20.5'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3834,7 +3834,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "docker.io" }}/calico/node:v3.20.2'
+          image: '{{ Registry "quay.io" }}/calico/node:v3.20.5'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4065,7 +4065,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.20.2'
+          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.20.5'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/canal/canal_v3.21.yaml
+++ b/addons/canal/canal_v3.21.yaml
@@ -4136,7 +4136,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "docker.io" }}/calico/cni:v3.21.5'
+          image: '{{ Registry "quay.io" }}/calico/cni:v3.21.5'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4179,7 +4179,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "docker.io" }}/calico/node:v3.21.5'
+          image: '{{ Registry "quay.io" }}/calico/node:v3.21.5'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4410,7 +4410,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.21.5'
+          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.21.5'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/canal/canal_v3.22.yaml
+++ b/addons/canal/canal_v3.22.yaml
@@ -4136,7 +4136,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "docker.io" }}/calico/cni:v3.22.3'
+          image: '{{ Registry "quay.io" }}/calico/cni:v3.22.3'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4179,7 +4179,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "docker.io" }}/calico/node:v3.22.3'
+          image: '{{ Registry "quay.io" }}/calico/node:v3.22.3'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4410,7 +4410,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.22.3'
+          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.22.3'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/10305

assign /rastislavs

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use quay.io as the default registry for Canal CNI images, bump Canal v3.20 version to v3.20.5.
```
