### PR TITLE
update resourcequota rbacs after switch to cluster scope

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -505,6 +505,9 @@ func generateRBACRoleBindingForClusterNamespaceResourceAndServiceAccount(cluster
 // generateVerbsForNamedResource generates a set of verbs for a named resource
 // for example a "cluster" named "beefy-john".
 func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, error) {
+	if resourceKind == kubermaticv1.ResourceQuotaKindName {
+		return []string{"get"}, nil
+	}
 	// verbs for owners
 	//
 	// owners of a named resource
@@ -656,8 +659,6 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 			return []string{"get", "update", "delete"}, nil
 		case resourceKind == secretV1Kind:
 			return nil, nil
-		case resourceKind == kubermaticv1.ResourceQuotaKindName:
-			return []string{"get"}, nil
 		}
 	}
 

--- a/pkg/controller/master-controller-manager/rbac/mapper_test.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper_test.go
@@ -100,6 +100,12 @@ func TestGenerateVerbsForNamedResources(t *testing.T) {
 			expectedVerbs: []string{"get", "update", "patch", "delete"},
 			resourceKind:  "User",
 		},
+		{
+			name:          "scenario 12: the owners can get ResourceQuota resource",
+			groupName:     "owners-projectID",
+			expectedVerbs: []string{"get"},
+			resourceKind:  "ResourceQuota",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -1016,6 +1016,247 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:            "scenario 7: a proper set of RBAC ClusterRole/Binding is generated for a resource quota",
+			expectedActions: []string{"get"},
+
+			dependantToSync: &kubermaticv1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "project-thunderball",
+					UID:  types.UID("abcdID"),
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+							Kind:       kubermaticv1.ProjectKindName,
+							Name:       "thunderball",
+							UID:        "thunderballID",
+						},
+					},
+				},
+				Spec: kubermaticv1.ResourceQuotaSpec{
+					Subject: kubermaticv1.Subject{
+						Name: "thunderball",
+						Kind: "project",
+					},
+				},
+			},
+
+			expectedClusterRoles: []*rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:editors-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							kubermaticv1.AuthZRoleLabel: "editors-thunderball",
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"resourcequotas"},
+							ResourceNames: []string{"project-thunderball"},
+							Verbs:         []string{"get"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:owners-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							kubermaticv1.AuthZRoleLabel: "owners-thunderball",
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"resourcequotas"},
+							ResourceNames: []string{"project-thunderball"},
+							Verbs:         []string{"get"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:viewers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							kubermaticv1.AuthZRoleLabel: "viewers-thunderball",
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"resourcequotas"},
+							ResourceNames: []string{"project-thunderball"},
+							Verbs:         []string{"get"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							kubermaticv1.AuthZRoleLabel: "projectmanagers-thunderball",
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{"resourcequotas"},
+							ResourceNames: []string{"project-thunderball"},
+							Verbs:         []string{"get"},
+						},
+					},
+				},
+			},
+
+			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:owners-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "owners-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:resourcequota-project-thunderball:owners-thunderball",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:editors-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "editors-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:resourcequota-project-thunderball:editors-thunderball",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:viewers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "viewers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:resourcequota-project-thunderball:viewers-thunderball",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:resourcequota-project-thunderball:projectmanagers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ResourceQuotaKindName,
+								Name:       "project-thunderball",
+								UID:        "abcdID", // set manually
+							},
+						},
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "projectmanagers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:resourcequota-project-thunderball:projectmanagers-thunderball",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1252,256 +1493,7 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 		},
 
 		// scenario 2
-		{
-			name:            "scenario 2: a proper set of RBAC Role/Binding is generated for a resource quota",
-			expectedActions: []string{"get"},
 
-			dependantToSync: &kubermaticv1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "project-thunderball",
-					Namespace: "kubermatic",
-					UID:       types.UID("abcdID"),
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-							Kind:       kubermaticv1.ProjectKindName,
-							Name:       "thunderball",
-							UID:        "thunderballID",
-						},
-					},
-				},
-				Spec: kubermaticv1.ResourceQuotaSpec{
-					Subject: kubermaticv1.Subject{
-						Name: "thunderball",
-						Kind: "project",
-					},
-				},
-			},
-
-			expectedRoles: []*rbacv1.Role{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:editors-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-						Labels: map[string]string{
-							kubermaticv1.AuthZRoleLabel: "editors-thunderball",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
-							Resources:     []string{"resourcequotas"},
-							ResourceNames: []string{"project-thunderball"},
-							Verbs:         []string{"get"},
-						},
-					},
-				},
-
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:owners-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-						Labels: map[string]string{
-							kubermaticv1.AuthZRoleLabel: "owners-thunderball",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
-							Resources:     []string{"resourcequotas"},
-							ResourceNames: []string{"project-thunderball"},
-							Verbs:         []string{"get"},
-						},
-					},
-				},
-
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:viewers-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-						Labels: map[string]string{
-							kubermaticv1.AuthZRoleLabel: "viewers-thunderball",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
-							Resources:     []string{"resourcequotas"},
-							ResourceNames: []string{"project-thunderball"},
-							Verbs:         []string{"get"},
-						},
-					},
-				},
-
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:projectmanagers-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-						Labels: map[string]string{
-							kubermaticv1.AuthZRoleLabel: "projectmanagers-thunderball",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
-							Resources:     []string{"resourcequotas"},
-							ResourceNames: []string{"project-thunderball"},
-							Verbs:         []string{"get"},
-						},
-					},
-				},
-			},
-
-			expectedRoleBindings: []*rbacv1.RoleBinding{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:owners-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							APIGroup: rbacv1.GroupName,
-							Kind:     "Group",
-							Name:     "owners-thunderball",
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "Role",
-						Name:     "kubermatic:resourcequota-project-thunderball:owners-thunderball",
-					},
-				},
-
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:editors-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							APIGroup: rbacv1.GroupName,
-							Kind:     "Group",
-							Name:     "editors-thunderball",
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "Role",
-						Name:     "kubermatic:resourcequota-project-thunderball:editors-thunderball",
-					},
-				},
-
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:viewers-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							APIGroup: rbacv1.GroupName,
-							Kind:     "Group",
-							Name:     "viewers-thunderball",
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "Role",
-						Name:     "kubermatic:resourcequota-project-thunderball:viewers-thunderball",
-					},
-				},
-
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kubermatic:resourcequota-project-thunderball:projectmanagers-thunderball",
-						Namespace: "kubermatic",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ResourceQuotaKindName,
-								Name:       "project-thunderball",
-								UID:        "abcdID", // set manually
-							},
-						},
-						ResourceVersion: "1",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							APIGroup: rbacv1.GroupName,
-							Kind:     "Group",
-							Name:     "projectmanagers-thunderball",
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "Role",
-						Name:     "kubermatic:resourcequota-project-thunderball:projectmanagers-thunderball",
-					},
-				},
-			},
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Updates rbac-controller after changes to ResourceQuota scope

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
