### PR TITLE
improve naming of user printable columns

### DIFF
--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -37,7 +37,8 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.email",name="Email",type="string"
-// +kubebuilder:printcolumn:JSONPath=".spec.name",name="Name",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.name",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.admin",name="Admin",type="boolean"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 // User specifies a user.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -20,8 +20,11 @@ spec:
       name: Email
       type: string
     - jsonPath: .spec.name
-      name: Name
+      name: HumanReadableName
       type: string
+    - jsonPath: .spec.admin
+      name: Admin
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR improves the naming for the columns of User objects.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10253

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
