### PR TITLE
add providerName to externalclusters, add webhook to default it

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -36,6 +36,7 @@ import (
 	clustermutation "k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation"
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
 	clustertemplatevalidation "k8c.io/kubermatic/v2/pkg/webhook/clustertemplate/validation"
+	externalclustermutation "k8c.io/kubermatic/v2/pkg/webhook/externalcluster/mutation"
 	groupprojectbinding "k8c.io/kubermatic/v2/pkg/webhook/groupprojectbinding/validation"
 	ipampoolvalidation "k8c.io/kubermatic/v2/pkg/webhook/ipampool/validation"
 	kubermaticconfigurationvalidation "k8c.io/kubermatic/v2/pkg/webhook/kubermaticconfiguration/validation"
@@ -160,6 +161,11 @@ func main() {
 
 	// mutation cannot, because we require separate defaulting for CREATE and UPDATE operations
 	clustermutation.NewAdmissionHandler(mgr.GetClient(), configGetter, seedGetter, caPool).SetupWebhookWithManager(mgr)
+
+	// /////////////////////////////////////////
+	// setup ExternalCluster webhooks
+
+	externalclustermutation.NewAdmissionHandler().SetupWebhookWithManager(mgr)
 
 	// /////////////////////////////////////////
 	// setup ClusterTemplate webhooks

--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -32,10 +32,22 @@ const (
 	ExternalClusterKind = "ExternalCluster"
 )
 
+type ExternalClusterProvider string
+
+const (
+	ExternalClusterGKEProvider     ExternalClusterProvider = "gke"
+	ExternalClusterEKSProvider     ExternalClusterProvider = "eks"
+	ExternalClusterAKSProvider     ExternalClusterProvider = "aks"
+	ExternalClusterKubeOneProvider ExternalClusterProvider = "kubeone"
+)
+
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:JSONPath=".spec.humanReadableName",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.cloud.providerName",name="Provider",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.pause",name="Paused",type="boolean"
+// +kubebuilder:printcolumn:JSONPath=".status.condition.phase",name="Phase",type="string"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 // ExternalCluster is the object representing an external kubernetes cluster.
@@ -99,10 +111,11 @@ type ExternalClusterSpec struct {
 
 // ExternalClusterCloudSpec mutually stores access data to a cloud provider.
 type ExternalClusterCloudSpec struct {
-	GKE     *ExternalClusterGKECloudSpec     `json:"gke,omitempty"`
-	EKS     *ExternalClusterEKSCloudSpec     `json:"eks,omitempty"`
-	AKS     *ExternalClusterAKSCloudSpec     `json:"aks,omitempty"`
-	KubeOne *ExternalClusterKubeOneCloudSpec `json:"kubeone,omitempty"`
+	ProviderName ExternalClusterProvider          `json:"providerName"`
+	GKE          *ExternalClusterGKECloudSpec     `json:"gke,omitempty"`
+	EKS          *ExternalClusterEKSCloudSpec     `json:"eks,omitempty"`
+	AKS          *ExternalClusterAKSCloudSpec     `json:"aks,omitempty"`
+	KubeOne      *ExternalClusterKubeOneCloudSpec `json:"kubeone,omitempty"`
 }
 
 type ExternalClusterPhase string

--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -32,6 +32,8 @@ const (
 	ExternalClusterKind = "ExternalCluster"
 )
 
+// +kubebuilder:validation:Enum=gke;aks;eks;kubeone
+
 type ExternalClusterProvider string
 
 const (

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -63,6 +63,9 @@ const (
 	// ResourceQuotaAdmissionWebhookName is the name of the validating and mutating webhook for ResourceQuotas.
 	ResourceQuotaAdmissionWebhookName = "kubermatic-resourcequotas"
 
+	// ExternalClusterAdmissionWebhookName is the name of the mutating webhook for ExternalClusters.
+	ExternalClusterAdmissionWebhookName = "kubermatic-externalclusters"
+
 	// ApplicationDefinitionAdmissionWebhookName is the name of the validating webhook for ApplicationDefnition.
 	ApplicationDefinitionAdmissionWebhookName = "kubermatic-application-definitions"
 

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -173,28 +173,31 @@ func (r *Reconciler) cleanupDeletedConfiguration(ctx context.Context, config *ku
 		return fmt.Errorf("failed to clean up ClusterRoleBinding: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.UserAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
+	validating := []string{
+		common.UserAdmissionWebhookName,
+		common.UserSSHKeyAdmissionWebhookName,
+		common.SeedAdmissionWebhookName(config),
+		common.KubermaticConfigurationAdmissionWebhookName(config),
+		common.GroupProjectBindingAdmissionWebhookName,
+		common.ResourceQuotaAdmissionWebhookName,
 	}
 
-	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.UserSSHKeyAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
+	mutating := []string{
+		common.UserSSHKeyAdmissionWebhookName,
+		common.ExternalClusterAdmissionWebhookName,
+		common.ResourceQuotaAdmissionWebhookName,
 	}
 
-	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.SeedAdmissionWebhookName(config)); err != nil {
-		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
+	for _, webhook := range validating {
+		if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, webhook); err != nil {
+			return fmt.Errorf("failed to clean up validating webhook for %q: %w", webhook, err)
+		}
 	}
 
-	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.KubermaticConfigurationAdmissionWebhookName(config)); err != nil {
-		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
-	}
-
-	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.MutatingWebhookConfiguration{}, common.UserSSHKeyAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up MutatingWebhookConfiguration: %w", err)
-	}
-
-	if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.GroupProjectBindingAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %w", err)
+	for _, webhook := range mutating {
+		if err := common.CleanupClusterResource(ctx, r, &admissionregistrationv1.MutatingWebhookConfiguration{}, webhook); err != nil {
+			return fmt.Errorf("failed to clean up mutating webhook for %q: %w", webhook, err)
+		}
 	}
 
 	return kubernetes.TryRemoveFinalizer(ctx, r, config, common.CleanupFinalizer)
@@ -435,6 +438,7 @@ func (r *Reconciler) reconcileMutatingWebhooks(ctx context.Context, config *kube
 	creators := []reconciling.NamedMutatingWebhookConfigurationCreatorGetter{
 		kubermatic.UserSSHKeyMutatingWebhookConfigurationCreator(ctx, config, r.Client),
 		kubermatic.ResourceQuotaMutatingWebhookConfigurationCreator(ctx, config, r.Client),
+		kubermatic.ExternalClusterMutatingWebhookConfigurationCreator(ctx, config, r.Client),
 	}
 
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {

--- a/pkg/controller/operator/master/resources/kubermatic/webhooks.go
+++ b/pkg/controller/operator/master/resources/kubermatic/webhooks.go
@@ -308,6 +308,62 @@ func ResourceQuotaMutatingWebhookConfigurationCreator(ctx context.Context, cfg *
 	}
 }
 
+func ExternalClusterMutatingWebhookConfigurationCreator(ctx context.Context, cfg *kubermaticv1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
+		return common.ExternalClusterAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
+			matchPolicy := admissionregistrationv1.Exact
+			failurePolicy := admissionregistrationv1.Fail
+			reinvocationPolicy := admissionregistrationv1.NeverReinvocationPolicy
+			sideEffects := admissionregistrationv1.SideEffectClassNone
+			scope := admissionregistrationv1.ClusterScope
+
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
+			if err != nil {
+				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
+			}
+
+			hook.Webhooks = []admissionregistrationv1.MutatingWebhook{
+				{
+					Name:                    "externalclusters.kubermatic.k8c.io", // this should be a FQDN
+					AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
+					MatchPolicy:             &matchPolicy,
+					FailurePolicy:           &failurePolicy,
+					ReinvocationPolicy:      &reinvocationPolicy,
+					SideEffects:             &sideEffects,
+					TimeoutSeconds:          pointer.Int32Ptr(30),
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
+						CABundle: ca,
+						Service: &admissionregistrationv1.ServiceReference{
+							Name:      common.WebhookServiceName,
+							Namespace: cfg.Namespace,
+							Path:      pointer.StringPtr("/mutate-kubermatic-k8c-io-v1-externalcluster"),
+							Port:      pointer.Int32Ptr(443),
+						},
+					},
+					ObjectSelector:    &metav1.LabelSelector{},
+					NamespaceSelector: &metav1.LabelSelector{},
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{kubermaticv1.GroupName},
+								APIVersions: []string{"*"},
+								Resources:   []string{"externalclusters"},
+								Scope:       &scope,
+							},
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Update,
+							},
+						},
+					},
+				},
+			}
+
+			return hook, nil
+		}
+	}
+}
+
 func GroupProjectBindingValidatingWebhookConfigurationCreator(ctx context.Context,
 	cfg *kubermaticv1.KubermaticConfiguration,
 	client ctrlruntimeclient.Client,

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -368,6 +368,11 @@ spec:
                     - sshReference
                     type: object
                   providerName:
+                    enum:
+                    - gke
+                    - aks
+                    - eks
+                    - kubeone
                     type: string
                 required:
                 - providerName

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -19,6 +19,15 @@ spec:
     - jsonPath: .spec.humanReadableName
       name: HumanReadableName
       type: string
+    - jsonPath: .spec.cloud.providerName
+      name: Provider
+      type: string
+    - jsonPath: .spec.pause
+      name: Paused
+      type: boolean
+    - jsonPath: .status.condition.phase
+      name: Phase
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -358,6 +367,10 @@ spec:
                     - providerName
                     - sshReference
                     type: object
+                  providerName:
+                    type: string
+                required:
+                - providerName
                 type: object
               humanReadableName:
                 description: HumanReadableName is the cluster name provided by the

--- a/pkg/defaulting/externalcluster.go
+++ b/pkg/defaulting/externalcluster.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
+)
+
+// DefaultExternalClusterSpec defaults the cluster spec when creating a new external cluster.
+// This function assumes that the KubermaticConfiguration has already been defaulted
+// (as the KubermaticConfigurationGetter does that automatically).
+func DefaultExternalClusterSpec(ctx context.Context, spec *kubermaticv1.ExternalClusterSpec) error {
+	// Ensure provider name matches the given spec
+	providerName, err := provider.ExternalClusterCloudProviderName(spec.CloudSpec)
+	if err != nil {
+		return fmt.Errorf("failed to determine cloud provider: %w", err)
+	}
+
+	spec.CloudSpec.ProviderName = kubermaticv1.ExternalClusterProvider(providerName)
+
+	return nil
+}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -434,6 +434,34 @@ type ProjectMemberMapper interface {
 	MapUserToRoles(ctx context.Context, user *kubermaticv1.User, projectID string) (sets.String, error)
 }
 
+// ExternalClusterCloudProviderName returns the provider name for the given ExternalClusterCloudSpec.
+func ExternalClusterCloudProviderName(spec *kubermaticv1.ExternalClusterCloudSpec) (string, error) {
+	if spec == nil {
+		return "", errors.New("cloud spec is nil")
+	}
+
+	var clouds []kubermaticv1.ExternalClusterProvider
+	if spec.AKS != nil {
+		clouds = append(clouds, kubermaticv1.ExternalClusterAKSProvider)
+	}
+	if spec.EKS != nil {
+		clouds = append(clouds, kubermaticv1.ExternalClusterEKSProvider)
+	}
+	if spec.GKE != nil {
+		clouds = append(clouds, kubermaticv1.ExternalClusterGKEProvider)
+	}
+	if spec.KubeOne != nil {
+		clouds = append(clouds, kubermaticv1.ExternalClusterKubeOneProvider)
+	}
+	if len(clouds) == 0 {
+		return "", nil
+	}
+	if len(clouds) != 1 {
+		return "", fmt.Errorf("only one cloud provider can be set in ExternalClusterCloudSpec: %+v", spec)
+	}
+	return string(clouds[0]), nil
+}
+
 // ClusterCloudProviderName returns the provider name for the given CloudSpec.
 func ClusterCloudProviderName(spec kubermaticv1.CloudSpec) (string, error) {
 	var clouds []kubermaticv1.ProviderType

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -53,7 +53,7 @@ type AdmissionHandler struct {
 	caBundle     *x509.CertPool
 
 	// disableProviderMutation is only for unit tests, to ensure no
-	// provide would phone home to validate dummy test credentials
+	// provider would phone home to validate dummy test credentials
 	disableProviderMutation bool
 }
 

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -49,7 +49,7 @@ type validator struct {
 	caBundle     *x509.CertPool
 
 	// disableProviderValidation is only for unit tests, to ensure no
-	// provide would phone home to validate dummy test credentials
+	// provider would phone home to validate dummy test credentials
 	disableProviderValidation bool
 }
 

--- a/pkg/webhook/clustertemplate/validation/validation.go
+++ b/pkg/webhook/clustertemplate/validation/validation.go
@@ -46,7 +46,7 @@ type validator struct {
 	caBundle     *x509.CertPool
 
 	// disableProviderValidation is only for unit tests, to ensure no
-	// provide would phone home to validate dummy test credentials
+	// provider would phone home to validate dummy test credentials
 	disableProviderValidation bool
 }
 

--- a/pkg/webhook/externalcluster/mutation/mutation.go
+++ b/pkg/webhook/externalcluster/mutation/mutation.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating Kubermatic Cluster CRD.
+type AdmissionHandler struct {
+	log     logr.Logger
+	decoder *admission.Decoder
+}
+
+// NewAdmissionHandler returns a new cluster AdmissionHandler.
+func NewAdmissionHandler() *AdmissionHandler {
+	return &AdmissionHandler{}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-kubermatic-k8c-io-v1-externalcluster", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
+	h.log = l.WithName("externalcluster-mutation-handler")
+	return nil
+}
+
+func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	cluster := &kubermaticv1.ExternalCluster{}
+	oldCluster := &kubermaticv1.ExternalCluster{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		if err := h.decoder.Decode(req, cluster); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err := h.applyDefaults(ctx, cluster)
+		if err != nil {
+			h.log.Info("externalcluster mutation failed", "error", err)
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("externalcluster mutation request %s failed: %w", req.UID, err))
+		}
+
+		if err := h.mutateCreate(cluster); err != nil {
+			h.log.Info("externalcluster mutation failed", "error", err)
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("externalcluster mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Update:
+		if err := h.decoder.Decode(req, cluster); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := h.decoder.DecodeRaw(req.OldObject, oldCluster); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if cluster.DeletionTimestamp == nil {
+			// apply defaults to the existing clusters
+			err := h.applyDefaults(ctx, cluster)
+			if err != nil {
+				h.log.Info("externalcluster mutation failed", "error", err)
+				return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("externalcluster mutation request %s failed: %w", req.UID, err))
+			}
+
+			if err := h.mutateUpdate(oldCluster, cluster); err != nil {
+				h.log.Info("externalcluster mutation failed", "error", err)
+				return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("externalcluster mutation request %s failed: %w", req.UID, err))
+			}
+		}
+
+	case admissionv1.Delete:
+		return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on externalcluster resources", req.Operation))
+	}
+
+	mutatedCluster, err := json.Marshal(cluster)
+	if err != nil {
+		return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling externalcluster object failed: %w", err))
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedCluster)
+}
+
+func (h *AdmissionHandler) applyDefaults(ctx context.Context, c *kubermaticv1.ExternalCluster) error {
+	return defaulting.DefaultExternalClusterSpec(ctx, &c.Spec)
+}
+
+// mutateCreate is an addition to regular defaulting for new external clusters.
+func (h *AdmissionHandler) mutateCreate(newCluster *kubermaticv1.ExternalCluster) error {
+	return nil
+}
+
+// mutateCreate is an addition to regular defaulting for updated external clusters.
+func (h *AdmissionHandler) mutateUpdate(oldCluster, newCluster *kubermaticv1.ExternalCluster) error {
+	return nil
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Just like we do it for regular Cluster objects, this PR adds a `providerName` field to ExternalClusters, so we can pretty print the provider name in the output of `kubectl get externalclusters`.

This PR contains the necessary new webhook, configuration, defaulting etc.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
