### PR TITLE
Fix log levels

### DIFF
--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -129,8 +129,8 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return reconciling.ReconcileAppsKubermaticV1ApplicationDefinitions(ctx, applicationDefCreatorGetters, "", seedClient)
 	})
 	if err != nil {
-		r.recorder.Eventf(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		return fmt.Errorf("reconciled application definition: %s: %w", applicationDef.Name, err)
+		r.recorder.Event(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		return fmt.Errorf("reconciled application definition %s: %w", applicationDef.Name, err)
 	}
 
 	return nil

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -130,7 +130,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, c)
 	})
 	if err != nil {
-		r.recorder.Eventf(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciling secret %s failed: %w", seedsecret.Name, err)
 	}
 
@@ -150,7 +150,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		err := c.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &corev1.Secret{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Info("Secret already deleted")
+				log.Debug("Secret already deleted")
 				return nil
 			}
 			return err

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -132,7 +132,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return reconciling.ReconcileKubermaticV1ClusterTemplates(ctx, clusterTemplateCreatorGetters, "", seedClient)
 	})
 	if err != nil {
-		r.recorder.Eventf(clusterTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(clusterTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciled cluster template: %s: %w", clusterTemplate.Name, err)
 	}
 	return nil

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -114,7 +114,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, log, constraintTemplate)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Eventf(constraintTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(constraintTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -131,7 +131,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return reconciling.ReconcileKubermaticV1Presets(ctx, presetCreatorGetters, "", seedClient)
 	})
 	if err != nil {
-		r.recorder.Eventf(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciled preset: %s: %w", preset.Name, err)
 	}
 	return nil

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -164,7 +164,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 
 	if err != nil {
-		r.recorder.Eventf(project, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(project, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("reconciled project: %s: %w", project.Name, err)
 	}
 

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -88,11 +88,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if err := r.reconcile(ctx, config, seed, client, logger); err != nil {
-		r.recorder.Eventf(seed, corev1.EventTypeWarning, "ReconcilingFailed", "%v", err)
+		r.recorder.Event(seed, corev1.EventTypeWarning, "ReconcilingFailed", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile: %w", err)
 	}
 
-	logger.Info("Successfully reconciled")
+	logger.Debug("Successfully reconciled")
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
+++ b/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
@@ -128,7 +128,7 @@ func (r *reconcileServiceAccountProjectBinding) Reconcile(ctx context.Context, r
 
 	err := r.reconcile(ctx, log, sa)
 	if err != nil {
-		r.recorder.Eventf(sa, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(sa, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		log.Errorw("failed to reconcile", zap.Error(err))
 	}
 

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -138,7 +138,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 
 	if err != nil {
-		r.recorder.Eventf(userProjectBinding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(userProjectBinding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("reconciled userprojectbinding: %s: %w", userProjectBinding.Name, err)
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -166,7 +166,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return nil
 	})
 	if err != nil {
-		r.recorder.Eventf(user, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(user, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("reconciled user: %s: %w", user.Name, err)
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
@@ -119,7 +119,7 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 
 	err := r.reconcile(ctx, log, sshKey)
 	if err != nil {
-		r.recorder.Eventf(sshKey, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(sshKey, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		log.Errorw("Reconciling failed", zap.Error(err))
 	}
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -105,7 +105,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 	// to allow a step-by-step migration of seed clusters, it's possible to
 	// disable the operator's reconciling logic for seeds
 	if _, ok := seed.Annotations[common.SkipReconcilingAnnotation]; ok {
-		log.Info("seed is marked as paused, skipping reconciliation")
+		log.Debug("seed is marked as paused, skipping reconciliation")
 		return nil
 	}
 

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -214,7 +214,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -110,7 +110,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, instance, log)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
-		r.recorder.Eventf(instance, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(instance, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -178,7 +178,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, constraint, log)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
-		r.recorder.Eventf(constraint, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(constraint, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -127,7 +127,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, log, constraintTemplate)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Eventf(constraintTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(constraintTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -298,7 +298,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 }
 
 func (r *Reconciler) rebuildEtcdStatefulset(ctx context.Context, log *zap.SugaredLogger, restore *kubermaticv1.EtcdRestore, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
-	log.Infof("rebuildEtcdStatefulset")
+	log.Info("Rebuilding Statefulset...")
 
 	if cluster.Spec.Pause {
 		if err := kubermaticv1helper.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -139,7 +139,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 
 	// Ensure that cluster is in a state when creating ApplicationInstallation is permissible
 	if !cluster.Status.ExtendedHealth.ApplicationControllerHealthy() {
-		r.log.Info("Application controller not healthy")
+		r.log.Debug("Application controller not healthy")
 		return nil, nil
 	}
 

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
@@ -134,7 +134,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	// If cluster is not healthy yet there is nothing to do.
 	// If it gets healthy we'll get notified by the event. No need to requeue.
 	if !cluster.Status.ExtendedHealth.AllHealthy() {
-		r.log.Info("cluster not healthy")
+		r.log.Debug("cluster not healthy")
 		return nil, nil
 	}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -109,7 +109,7 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 
 	// check that all StatefulSets are created
 	if ok, err := r.statefulSetHealthCheck(ctx, cluster); !ok || err != nil {
-		r.log.Info("Skipping reconcile for StatefulSets, not healthy yet")
+		r.log.Debug("Skipping reconcile for StatefulSets, etcd is not healthy yet")
 	} else if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -126,7 +126,7 @@ func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconci
 		}
 		return reconciling.ReconcileKubermaticV1RuleGroups(ctx, ruleGroupCreatorGetter, cluster.Status.NamespaceName, seedClient)
 	}); err != nil {
-		r.recorder.Eventf(ruleGroup, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(ruleGroup, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcle rulegroup %s: %w", ruleGroup.Name, err)
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/seed-controller-manager/preset-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller.go
@@ -98,7 +98,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, preset, log)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
-		r.recorder.Eventf(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/ipam/ipam_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ipam/ipam_controller.go
@@ -91,7 +91,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, machine)
 	if err != nil {
-		r.recorder.Eventf(machine, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+		r.recorder.Event(machine, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -85,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, allowedRegistry)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Eventf(allowedRegistry, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(allowedRegistry, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/ee/group-project-binding/sync-controller/controller.go
+++ b/pkg/ee/group-project-binding/sync-controller/controller.go
@@ -127,7 +127,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 
 	if err != nil {
-		r.recorder.Eventf(groupProjectBinding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(groupProjectBinding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile groupprojectbinding '%s': %w", groupProjectBinding.Name, err)
 	}
 

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -105,7 +105,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, resourceQuota, log)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
-		r.recorder.Eventf(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -115,7 +115,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := r.reconcile(ctx, resourceQuota, log)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
-		r.recorder.Eventf(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Event(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -209,15 +209,15 @@ func IsDeploymentRolloutComplete(deployment *appsv1.Deployment, revision int64) 
 		)
 
 		if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-			logger.Info("deployment rollout did not complete: not all replicas have been updated")
+			logger.Debug("deployment rollout did not complete: not all replicas have been updated")
 			return false, nil
 		}
 		if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-			logger.Infow("deployment rollout did not complete: old replicas are pending termination", "pending", deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
+			logger.Debugw("deployment rollout did not complete: old replicas are pending termination", "pending", deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
 			return false, nil
 		}
 		if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-			logger.Info("deployment rollout did not complete: not enough updated replicas available")
+			logger.Debug("deployment rollout did not complete: not enough updated replicas available")
 			return false, nil
 		}
 

--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -78,7 +78,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 		// apply defaults to the existing addon
 		err := h.ensureClusterReference(ctx, addon)
 		if err != nil {
-			h.log.Info("addon mutation failed", "error", err)
+			h.log.Error(err, "addon mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("addon mutation request %s failed: %w", req.UID, err))
 		}
 
@@ -95,7 +95,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 
 		err := h.validateUpdate(ctx, oldAddon, addon)
 		if err != nil {
-			h.log.Info("addon mutation failed", "error", err)
+			h.log.Error(err, "addon mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("addon mutation request %s failed: %w", req.UID, err))
 		}
 

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -93,12 +93,12 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 
 		err := h.applyDefaults(ctx, cluster)
 		if err != nil {
-			h.log.Info("cluster mutation failed", "error", err)
+			h.log.Error(err, "cluster mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
 		}
 
 		if err := h.mutateCreate(cluster); err != nil {
-			h.log.Info("cluster mutation failed", "error", err)
+			h.log.Error(err, "cluster mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
 		}
 
@@ -114,12 +114,12 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 			// apply defaults to the existing clusters
 			err := h.applyDefaults(ctx, cluster)
 			if err != nil {
-				h.log.Info("cluster mutation failed", "error", err)
+				h.log.Error(err, "cluster mutation failed")
 				return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
 			}
 
 			if err := h.mutateUpdate(oldCluster, cluster); err != nil {
-				h.log.Info("cluster mutation failed", "error", err)
+				h.log.Error(err, "cluster mutation failed")
 				return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %w", req.UID, err))
 			}
 		}

--- a/pkg/webhook/mlaadminsetting/mutation/mutation.go
+++ b/pkg/webhook/mlaadminsetting/mutation/mutation.go
@@ -77,7 +77,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 		// apply defaults to the existing MLAAdminSetting
 		err := h.ensureClusterReference(ctx, adminSetting)
 		if err != nil {
-			h.log.Info("MLAAdminSetting mutation failed", "error", err)
+			h.log.Error(err, "MLAAdminSetting mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("MLAAdminSetting mutation request %s failed: %w", req.UID, err))
 		}
 
@@ -94,7 +94,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 
 		err := h.validateUpdate(ctx, oldSetting, adminSetting)
 		if err != nil {
-			h.log.Info("MLAAdminSetting mutation failed", "error", err)
+			h.log.Error(err, "MLAAdminSetting mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("MLAAdminSetting mutation request %s failed: %w", req.UID, err))
 		}
 

--- a/pkg/webhook/usersshkey/mutation/mutation.go
+++ b/pkg/webhook/usersshkey/mutation/mutation.go
@@ -73,7 +73,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 		}
 
 		if err := h.applyDefaults(ctx, sshKey, nil); err != nil {
-			h.log.Info("usersshkey mutation failed", "error", err)
+			h.log.Error(err, "usersshkey mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("usersshkey mutation request %s failed: %w", req.UID, err))
 		}
 
@@ -86,7 +86,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 		}
 
 		if err := h.applyDefaults(ctx, sshKey, oldKey); err != nil {
-			h.log.Info("usersshkey mutation failed", "error", err)
+			h.log.Error(err, "usersshkey mutation failed")
 			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("usersshkey mutation request %s failed: %w", req.UID, err))
 		}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We should use the INFO log level only for actionable messages, like when we actually created/deleted a resource. There is little use (IMHO) to log "Skipping reconcile for StatefulSets, is not healthy yet" over and over again. So this PR changes all log statements that used INFO to DEBUG if they only log non-essential progress information.

I also, randomly, replaced Eventf() with Event() where we don't actually do string formatting.

**Does this PR introduce a user-facing change?**:
```release-note
Improve log verbosity
```
