### PR TITLE
Dual-stack e2e: test host network IPs for Azure

### DIFF
--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -103,8 +103,8 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			},
 			cni:                 "cilium",
 			ipFamily:            util.DualStack,
-			skipNodes:           true,
-			skipHostNetworkPods: true,
+			skipNodes:           false,
+			skipHostNetworkPods: false,
 		},
 		{
 			cloudName: "azure",
@@ -114,8 +114,8 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			},
 			cni:                 "canal",
 			ipFamily:            util.DualStack,
-			skipNodes:           true,
-			skipHostNetworkPods: true,
+			skipNodes:           false,
+			skipHostNetworkPods: false,
 		},
 		{
 			cloudName: "aws",


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
Test host network IPs for Azure in dual-stack e2e tests, as the nodes have proper IPv6 addresses assigned, e.g.:
```
Addresses:
  Hostname:    jz5br84xhk-worker-k2zg69-568dd85b99-vcpfx
  InternalIP:  10.0.0.4
  InternalIP:  fd00::4
  ExternalIP:  20.101.69.4
```

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
