### PR TITLE
Support equinixmetal metros

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -24790,6 +24790,11 @@
             "type": "string"
           },
           "x-go-name": "Facilities"
+        },
+        "metro": {
+          "description": "Metros are facilities that are grouped together geographically and share capacity\nand networking features, see https://metal.equinix.com/developers/docs/locations/metros/",
+          "type": "string",
+          "x-go-name": "Metro"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -147,6 +147,7 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 						},
 						Packet: &kubermaticv1.DatacenterSpecPacket{
 							Facilities: []string{},
+							Metro:      "",
 						},
 						Hetzner: &kubermaticv1.DatacenterSpecHetzner{},
 						VSphere: &kubermaticv1.DatacenterSpecVSphere{

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -187,6 +187,9 @@ spec:
           # The list of enabled facilities, for example "ams1", for a full list of available
           # facilities see https://support.packet.com/kb/articles/data-centers
           facilities: []
+          # Metros are facilities that are grouped together geographically and share capacity
+          # and networking features, see https://metal.equinix.com/developers/docs/locations/metros/
+          metro: ""
         # ProviderReconciliationInterval is the time that must have passed since a
         # Cluster's status.lastProviderReconciliation to make the cliuster controller
         # perform an in-depth provider reconciliation, where for example missing security

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -549,7 +549,10 @@ type DatacenterSpecBringYourOwn struct {
 type DatacenterSpecPacket struct {
 	// The list of enabled facilities, for example "ams1", for a full list of available
 	// facilities see https://support.packet.com/kb/articles/data-centers
-	Facilities []string `json:"facilities"`
+	Facilities []string `json:"facilities,omitempty"`
+	// Metros are facilities that are grouped together geographically and share capacity
+	// and networking features, see https://metal.equinix.com/developers/docs/locations/metros/
+	Metro string `json:"metro,omitempty"`
 }
 
 // DatacenterSpecGCP describes a GCP datacenter.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -425,8 +425,11 @@ spec:
                               items:
                                 type: string
                               type: array
-                          required:
-                          - facilities
+                            metro:
+                              description: Metros are facilities that are grouped
+                                together geographically and share capacity and networking
+                                features, see https://metal.equinix.com/developers/docs/locations/metros/
+                              type: string
                           type: object
                         providerReconciliationInterval:
                           description: ProviderReconciliationInterval is the time

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -411,11 +411,20 @@ func getPacketProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc 
 		config.Tags[i].Value = tag
 	}
 
-	facilities := sets.NewString(dc.Spec.Packet.Facilities...)
-	config.Facilities = make([]providerconfig.ConfigVarString, len(facilities.List()))
-	for i, facility := range facilities.List() {
-		config.Facilities[i].Value = facility
+	var facilities = sets.String{}
+	if dc.Spec.Packet.Facilities != nil {
+		facilities = sets.NewString(dc.Spec.Packet.Facilities...)
+		config.Facilities = make([]providerconfig.ConfigVarString, len(facilities.List()))
+		for i, facility := range facilities.List() {
+			config.Facilities[i].Value = facility
+		}
 	}
+
+	if len(facilities) < 1 && dc.Spec.Packet.Metro == "" {
+		return nil, errors.New("equinixmetal metro or facilities must be specified")
+	}
+
+	config.Metro.Value = dc.Spec.Packet.Metro
 
 	ext := &runtime.RawExtension{}
 	b, err := json.Marshal(config)

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_packet.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_packet.go
@@ -20,6 +20,10 @@ type DatacenterSpecPacket struct {
 	// The list of enabled facilities, for example "ams1", for a full list of available
 	// facilities see https://support.packet.com/kb/articles/data-centers
 	Facilities []string `json:"facilities"`
+
+	// Metros are facilities that are grouped together geographically and share capacity
+	// and networking features, see https://metal.equinix.com/developers/docs/locations/metros/
+	Metro string `json:"metro,omitempty"`
 }
 
 // Validate validates this datacenter spec packet


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds support for Metros for equinixmetal cloud provider. Metros are facilities that are grouped together geographically and share capacity and networking features
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add metro support for equinixmetal 
```
