### PR TITLE
Allows user to delete External Cluster from the Cloud Provider

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -16816,6 +16816,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Action",
+            "description": "The action is used to check if to delete a externalcluster or a actual cluster",
+            "name": "action",
+            "in": "header"
           }
         ],
         "responses": {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -16820,7 +16820,7 @@
           {
             "type": "string",
             "x-go-name": "Action",
-            "description": "The action is used to check if to delete a externalcluster or a actual cluster",
+            "description": "The Action is used to check if to `Delete` the cluster:\nboth the actual cluter from the provider\nand the respective KKP cluster object\nBy default the cluster will `Disconnect` which means the KKP cluster object will be deleted,\ncluster still exists on the provider, but is no longer connected/imported in KKP",
             "name": "action",
             "in": "header"
           }

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -875,3 +875,20 @@ func getAKSClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 
 	return apiCluster, nil
 }
+
+func deleteAKSCluster(ctx context.Context, secretKeySelector provider.SecretKeySelectorValueFunc, cloud *kubermaticv1.ExternalClusterCloudSpec) error {
+	cred, err := aks.GetCredentialsForCluster(*cloud, secretKeySelector)
+	if err != nil {
+		return err
+	}
+	aksClient, err := aks.GetAKSClusterClient(cred)
+	if err != nil {
+		return err
+	}
+	err = aks.DeleteAKSCluster(ctx, aksClient, cloud)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -952,3 +952,22 @@ func EKSCapacityTypesEndpoint() endpoint.Endpoint {
 		return capacityTypes, nil
 	}
 }
+
+func deleteEKSCluster(ctx context.Context, secretKeySelector provider.SecretKeySelectorValueFunc, cloudSpec *kubermaticv1.ExternalClusterCloudSpec) error {
+	accessKeyID, secretAccessKey, err := eksprovider.GetCredentialsForCluster(*cloudSpec, secretKeySelector)
+	if err != nil {
+		return err
+	}
+
+	client, err := awsprovider.GetClientSet(accessKeyID, secretAccessKey, "", "", cloudSpec.EKS.Region)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.EKS.DeleteCluster(&eks.DeleteClusterInput{Name: &cloudSpec.EKS.Name})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -345,10 +345,14 @@ type deleteClusterReq struct {
 	// in: path
 	// required: true
 	ClusterID string `json:"cluster_id"`
-	// The action is used to check if to delete a externalcluster or a actual cluster
+	// The Action is used to check if to `Delete` the cluster:
+	// both the actual cluter from the provider
+	// and the respective KKP cluster object
+	// By default the cluster will `Disconnect` which means the KKP cluster object will be deleted,
+	// cluster still exists on the provider, but is no longer connected/imported in KKP
 	// in: header
 	// name: Action
-	// Possible values: DeleteExternalCluster, DeleteProviderCluster
+	// Possible values: Delete, Disconnect
 	Action string `json:"action"`
 }
 
@@ -384,9 +388,8 @@ func (req deleteClusterReq) Validate() error {
 			return nil
 		}
 		return fmt.Errorf("wrong action parameter, unsupported action: %s", req.Action)
-	} else {
-		return fmt.Errorf("the \"Action\" cannot be empty")
 	}
+	return nil
 }
 
 func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -49,8 +49,10 @@ import (
 )
 
 const (
-	warningType = "warning"
-	normalType  = "normal"
+	warningType      = "warning"
+	normalType       = "normal"
+	DeleteAction     = "delete"
+	DisconnectAction = "disconnect"
 )
 
 // createClusterReq defines HTTP request for createExternalCluster
@@ -271,7 +273,13 @@ func CreateEndpoint(
 	}
 }
 
-func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
+func DeleteEndpoint(userInfoGetter provider.UserInfoGetter,
+	projectProvider provider.ProjectProvider,
+	privilegedProjectProvider provider.PrivilegedProjectProvider,
+	clusterProvider provider.ExternalClusterProvider,
+	privilegedClusterProvider provider.PrivilegedExternalClusterProvider,
+	settingsProvider provider.SettingsProvider,
+) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if !AreExternalClustersEnabled(ctx, settingsProvider) {
 			return nil, utilerrors.New(http.StatusForbidden, "external cluster functionality is disabled")
@@ -292,8 +300,42 @@ func DeleteEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider prov
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return nil, deleteCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, project.Name, cluster)
+		if req.Action == DeleteAction {
+			err := deleteProviderCluster(ctx, cluster, privilegedClusterProvider)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return nil, deleteExternalCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, project.Name, cluster)
 	}
+}
+func deleteProviderCluster(ctx context.Context,
+	cluster *kubermaticv1.ExternalCluster,
+	privilegedClusterProvider provider.PrivilegedExternalClusterProvider,
+) error {
+	cloud := cluster.Spec.CloudSpec
+	if cloud != nil {
+		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, privilegedClusterProvider.GetMasterClient())
+		if cloud.AKS != nil {
+			err := deleteAKSCluster(ctx, secretKeySelector, cloud)
+			if err != nil {
+				return err
+			}
+		}
+		if cloud.EKS != nil {
+			err := deleteEKSCluster(ctx, secretKeySelector, cloud)
+			if err != nil {
+				return err
+			}
+		}
+		if cloud.GKE != nil {
+			err := deletGKECluster(ctx, secretKeySelector, cloud)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // deleteClusterReq defines HTTP request for deleteExternalCluster
@@ -303,6 +345,11 @@ type deleteClusterReq struct {
 	// in: path
 	// required: true
 	ClusterID string `json:"cluster_id"`
+	// The action is used to check if to delete a externalcluster or a actual cluster
+	// in: header
+	// name: Action
+	// Possible values: DeleteExternalCluster, DeleteProviderCluster
+	Action string `json:"action"`
 }
 
 func DecodeDeleteReq(c context.Context, r *http.Request) (interface{}, error) {
@@ -320,18 +367,26 @@ func DecodeDeleteReq(c context.Context, r *http.Request) (interface{}, error) {
 	}
 	req.ClusterID = clusterID
 
+	req.Action = r.Header.Get("Action")
 	return req, nil
 }
 
 // Validate validates DeleteEndpoint request.
 func (req deleteClusterReq) Validate() error {
 	if len(req.ProjectID) == 0 {
-		return fmt.Errorf("the project ID cannot be empty")
+		return fmt.Errorf("the \"ProjectID\" cannot be empty")
 	}
 	if len(req.ClusterID) == 0 {
-		return fmt.Errorf("the cluster ID cannot be empty")
+		return fmt.Errorf("the \"ClusterID\" cannot be empty")
 	}
-	return nil
+	if len(req.Action) > 0 {
+		if req.Action == DeleteAction || req.Action == DisconnectAction {
+			return nil
+		}
+		return fmt.Errorf("wrong action parameter, unsupported action: %s", req.Action)
+	} else {
+		return fmt.Errorf("the \"Action\" cannot be empty")
+	}
 }
 
 func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -475,7 +530,7 @@ func DecodeGetReq(c context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
-// Validate validates DeleteEndpoint request.
+// Validate validates GetEndpoint request.
 func (req GetClusterReq) Validate() error {
 	if len(req.ProjectID) == 0 {
 		return fmt.Errorf("the project ID cannot be empty")
@@ -1052,7 +1107,7 @@ func getCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, clu
 	return clusterProvider.Get(ctx, userInfo, clusterName)
 }
 
-func deleteCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, projectID string, cluster *kubermaticv1.ExternalCluster) error {
+func deleteExternalCluster(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider, projectID string, cluster *kubermaticv1.ExternalCluster) error {
 	adminUserInfo, err := userInfoGetter(ctx, "")
 	if err != nil {
 		return err

--- a/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -29,6 +29,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
+	externalcluster "k8c.io/kubermatic/v2/pkg/handler/v2/external_cluster"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -266,6 +267,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
 			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
+			req.Header.Set("Action", externalcluster.DisconnectAction)
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -766,3 +766,22 @@ func getGKEClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 
 	return apiCluster, nil
 }
+
+func deletGKECluster(ctx context.Context, secretKeySelector provider.SecretKeySelectorValueFunc, cloudSpec *kubermaticv1.ExternalClusterCloudSpec) error {
+	sa, err := secretKeySelector(cloudSpec.GKE.CredentialsReference, resources.GCPServiceAccount)
+	if err != nil {
+		return err
+	}
+	svc, project, err := gke.ConnectToContainerService(ctx, sa)
+	if err != nil {
+		return err
+	}
+
+	req := svc.Projects.Zones.Clusters.Delete(project, cloudSpec.GKE.Zone, cloudSpec.GKE.Name)
+	_, err = req.Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/provider/cloud/aks/provider.go
+++ b/pkg/provider/cloud/aks/provider.go
@@ -184,3 +184,14 @@ func convertAKSStatus(provisioningState string, powerState armcontainerservice.C
 		return apiv2.UNKNOWN
 	}
 }
+
+func DeleteAKSCluster(ctx context.Context, aksClient *armcontainerservice.ManagedClustersClient, cloud *kubermaticv1.ExternalClusterCloudSpec) error {
+	resourceGroup := cloud.AKS.ResourceGroup
+	clusterName := cloud.AKS.Name
+
+	_, err := aksClient.BeginDelete(ctx, resourceGroup, clusterName, &armcontainerservice.ManagedClustersClientBeginDeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/test/e2e/utils/apiclient/client/project/delete_external_cluster_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/project/delete_external_cluster_parameters.go
@@ -59,6 +59,12 @@ func NewDeleteExternalClusterParamsWithHTTPClient(client *http.Client) *DeleteEx
 */
 type DeleteExternalClusterParams struct {
 
+	/* Action.
+
+	   The action is used to check if to delete a externalcluster or a actual cluster
+	*/
+	Action *string
+
 	// ClusterID.
 	ClusterID string
 
@@ -118,6 +124,17 @@ func (o *DeleteExternalClusterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAction adds the action to the delete external cluster params
+func (o *DeleteExternalClusterParams) WithAction(action *string) *DeleteExternalClusterParams {
+	o.SetAction(action)
+	return o
+}
+
+// SetAction adds the action to the delete external cluster params
+func (o *DeleteExternalClusterParams) SetAction(action *string) {
+	o.Action = action
+}
+
 // WithClusterID adds the clusterID to the delete external cluster params
 func (o *DeleteExternalClusterParams) WithClusterID(clusterID string) *DeleteExternalClusterParams {
 	o.SetClusterID(clusterID)
@@ -147,6 +164,14 @@ func (o *DeleteExternalClusterParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
+
+	if o.Action != nil {
+
+		// header param action
+		if err := r.SetHeaderParam("action", *o.Action); err != nil {
+			return err
+		}
+	}
 
 	// path param cluster_id
 	if err := r.SetPathParam("cluster_id", o.ClusterID); err != nil {

--- a/pkg/test/e2e/utils/apiclient/client/project/delete_external_cluster_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/project/delete_external_cluster_parameters.go
@@ -61,7 +61,11 @@ type DeleteExternalClusterParams struct {
 
 	/* Action.
 
-	   The action is used to check if to delete a externalcluster or a actual cluster
+	     The Action is used to check if to `Delete` the cluster:
+	both the actual cluter from the provider
+	and the respective KKP cluster object
+	By default the cluster will `Disconnect` which means the KKP cluster object will be deleted,
+	cluster still exists on the provider, but is no longer connected/imported in KKP
 	*/
 	Action *string
 


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**:

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10299 

**Special notes for your reviewer**:
"Action" header in req is used to decide if user wants to disconnect the external cluster or to delete a cluster from cloud provider.

Please suggest other name if this seems ambigious

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allows user to delete External Cluster from the Cloud Provider
```
