### PR TITLE
Fix osm roles and rolebindings

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -463,9 +463,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 	}
 
 	if r.enableOperatingSystemManager {
-		creators = append(creators, operatingsystemmanager.KubeSystemRoleBindingCreator(),
-			operatingsystemmanager.KubePublicRoleBindingCreator(),
-			operatingsystemmanager.DefaultRoleBindingCreator())
+		creators = append(creators, operatingsystemmanager.KubeSystemRoleBindingCreator())
 	}
 
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
@@ -477,6 +475,10 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		machinecontroller.KubePublicRoleBindingCreator(),
 		machinecontroller.ClusterInfoAnonymousRoleBindingCreator(),
 	}
+	if r.enableOperatingSystemManager {
+		creators = append(creators, operatingsystemmanager.KubePublicRoleBindingCreator())
+	}
+
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespacePublic, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in kube-public Namespace: %w", err)
 	}
@@ -486,6 +488,10 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		machinecontroller.DefaultRoleBindingCreator(),
 		clusterautoscaler.DefaultRoleBindingCreator(),
 	}
+	if r.enableOperatingSystemManager {
+		creators = append(creators, operatingsystemmanager.DefaultRoleBindingCreator())
+	}
+
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceDefault, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in default Namespace: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/role.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/role.go
@@ -44,6 +44,16 @@ func KubeSystemRoleCreator() reconciling.NamedRoleCreatorGetter {
 				},
 				{
 					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+					Verbs: []string{
+						"create",
+						"update",
+						"get",
+						"list",
+					},
+				},
+				{
+					APIGroups: []string{""},
 					Resources: []string{"events"},
 					Verbs: []string{
 						"create",


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Based on the user reconciliations functions, resources that belong to the same namespace are grouped and reconciled together. In the previous implementation, this was not respected for OSM resources such as Roles and RoleBinding, which resulted to create those resources in the wrong namespaces. This PR fixed this issue by creating the needed permissions to the correct namespace. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
