### PR TITLE
Adding "ip version" information to OpenStack subnets listing endpoints

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -29659,6 +29659,12 @@
           "type": "string",
           "x-go-name": "ID"
         },
+        "ipVersion": {
+          "description": "IPversion is the IP protocol version (4 or 6)",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "IPVersion"
+        },
         "name": {
           "description": "Name is human-readable name for the subnet",
           "type": "string",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -714,6 +714,8 @@ type OpenstackSubnet struct {
 	ID string `json:"id"`
 	// Name is human-readable name for the subnet
 	Name string `json:"name"`
+	// IPversion is the IP protocol version (4 or 6)
+	IPVersion int `json:"ipVersion"`
 }
 
 // OpenstackTenant is the object representing a openstack tenant.

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -217,8 +217,9 @@ func GetOpenstackSubnets(ctx context.Context, userInfo *provider.UserInfo, seeds
 	apiSubnetIDs := []apiv1.OpenstackSubnet{}
 	for _, subnet := range subnets {
 		apiSubnetIDs = append(apiSubnetIDs, apiv1.OpenstackSubnet{
-			ID:   subnet.ID,
-			Name: subnet.Name,
+			ID:        subnet.ID,
+			Name:      subnet.Name,
+			IPVersion: subnet.IPVersion,
 		})
 	}
 

--- a/pkg/handler/v1/provider/openstack_test.go
+++ b/pkg/handler/v1/provider/openstack_test.go
@@ -218,8 +218,8 @@ func TestOpenstackEndpoints(t *testing.T) {
 			URL:         "/api/v1/providers/openstack/subnets",
 			QueryParams: map[string]string{"network_id": "foo"},
 			ExpectedResponse: `[
-				{"id": "08eae331-0402-425a-923c-34f7cfe39c1b", "name": "private-subnet"},
-				{"id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", "name": "my_subnet"}
+				{"id": "08eae331-0402-425a-923c-34f7cfe39c1b", "name": "private-subnet", "ipVersion": 4},
+				{"id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", "name": "my_subnet", "ipVersion": 4}
 			]`,
 		},
 		{
@@ -231,8 +231,8 @@ func TestOpenstackEndpoints(t *testing.T) {
 				test.GenDefaultPreset(),
 			},
 			ExpectedResponse: `[
-				{"id": "08eae331-0402-425a-923c-34f7cfe39c1b", "name": "private-subnet"},
-				{"id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", "name": "my_subnet"}
+				{"id": "08eae331-0402-425a-923c-34f7cfe39c1b", "name": "private-subnet", "ipVersion": 4},
+				{"id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", "name": "my_subnet", "ipVersion": 4}
 			]`,
 		},
 		{

--- a/pkg/test/e2e/utils/apiclient/models/openstack_subnet.go
+++ b/pkg/test/e2e/utils/apiclient/models/openstack_subnet.go
@@ -20,6 +20,9 @@ type OpenstackSubnet struct {
 	// Id uniquely identifies the subnet
 	ID string `json:"id,omitempty"`
 
+	// IPversion is the IP protocol version (4 or 6)
+	IPVersion int64 `json:"ipVersion,omitempty"`
+
 	// Name is human-readable name for the subnet
 	Name string `json:"name,omitempty"`
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds "ip version" information to OpenStack subnets listing endpoints.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10336

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
