### PR TITLE
Add `--skip-dependencies` flag to kubermatic-installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -57,10 +57,11 @@ type DeployOptions struct {
 	Kubeconfig  string
 	KubeContext string
 
-	HelmBinary  string
-	HelmValues  string
-	HelmTimeout time.Duration
-	Force       bool
+	HelmBinary       string
+	HelmValues       string
+	HelmTimeout      time.Duration
+	SkipDependencies bool
+	Force            bool
 
 	StorageClass     string
 	DisableTelemetry bool
@@ -112,6 +113,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *
 	cmd.PersistentFlags().StringVar(&opt.HelmValues, "helm-values", "", "full path to the Helm values.yaml used for customizing all charts")
 	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
 	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "full path to the Helm 3 binary to use")
+	cmd.PersistentFlags().BoolVar(&opt.SkipDependencies, "skip-dependencies", false, "skip pulling Helm chart dependencies (requires chart dependencies to be already downloaded)")
 	cmd.PersistentFlags().BoolVar(&opt.Force, "force", false, "perform Helm upgrades even when the release is up-to-date")
 
 	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", common.SupportedStorageClassProviders().List()))
@@ -202,6 +204,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 			EnableOpenstackCSIDriverMigration:  opt.MigrateOpenstackCSI,
 			EnableLogrotateMigration:           opt.MigrateLogrotate,
 			DisableTelemetry:                   opt.DisableTelemetry,
+			DisableDependencyUpdate:            opt.SkipDependencies,
 			Versions:                           versions,
 		}
 

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -124,7 +124,7 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 		return fmt.Errorf("failed to check to Helm release: %w", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, CertManagerNamespace, CertManagerReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, CertManagerNamespace, CertManagerReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -92,7 +92,7 @@ func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kub
 	// get an IP and this can require manual intervention based on the target environment
 	sublogger.Info("Deploying Helm chart…")
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, NginxIngressControllerNamespace, NginxIngressControllerReleaseName, opt.HelmValues, false, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, NginxIngressControllerNamespace, NginxIngressControllerReleaseName, opt.HelmValues, false, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		if isUpgrading {
 			return fmt.Errorf("failed to deploy Helm release: %w\n\nuse backup file to restore the deployment or re-try the installation after fixing any errors.", err)
 		}

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -138,7 +138,7 @@ func deployTelemetry(ctx context.Context, logger *logrus.Entry, kubeClient ctrlr
 		return fmt.Errorf("failed to check to Helm release: %w", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, TelemetryNamespace, TelemetryReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, TelemetryNamespace, TelemetryReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
@@ -221,7 +221,7 @@ func deployDex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntime
 		return fmt.Errorf("failed to check to Helm release: %w", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, DexNamespace, DexReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, DexNamespace, DexReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
@@ -264,7 +264,7 @@ func (s *MasterStack) deployKubermaticOperator(ctx context.Context, logger *logr
 		return fmt.Errorf("failed to check to Helm release: %w", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, KubermaticOperatorNamespace, KubermaticOperatorReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, KubermaticOperatorNamespace, KubermaticOperatorReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -179,7 +179,7 @@ func deployMinio(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunti
 		return fmt.Errorf("failed to check to Helm release: %w", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, MinioNamespace, MinioReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, MinioNamespace, MinioReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
@@ -206,7 +206,7 @@ func deployS3Exporter(ctx context.Context, logger *logrus.Entry, kubeClient ctrl
 		return fmt.Errorf("failed to check to Helm release: %w", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, S3ExporterNamespace, S3ExporterReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, S3ExporterNamespace, S3ExporterReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -53,6 +53,7 @@ type DeployOptions struct {
 	EnableOpenstackCSIDriverMigration  bool
 	EnableLogrotateMigration           bool
 	DisableTelemetry                   bool
+	DisableDependencyUpdate            bool
 }
 
 type Stack interface {

--- a/pkg/install/util/helm.go
+++ b/pkg/install/util/helm.go
@@ -70,7 +70,19 @@ func CheckHelmRelease(ctx context.Context, log logrus.FieldLogger, helmClient he
 	return release, nil
 }
 
-func DeployHelmChart(ctx context.Context, log logrus.FieldLogger, helmClient helm.Client, chart *helm.Chart, namespace string, releaseName string, values *yamled.Document, atomic bool, force bool, release *helm.Release) error {
+func DeployHelmChart(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	helmClient helm.Client,
+	chart *helm.Chart,
+	namespace string,
+	releaseName string,
+	values *yamled.Document,
+	atomic bool,
+	force bool,
+	skipDeps bool,
+	release *helm.Release,
+) error {
 	switch {
 	case release == nil:
 		log.Debug("Installing…")
@@ -113,8 +125,10 @@ func DeployHelmChart(ctx context.Context, log logrus.FieldLogger, helmClient hel
 		flags = append(flags, "--atomic")
 	}
 
-	if err := helmClient.BuildChartDependencies(chart.Directory, flags); err != nil {
-		return fmt.Errorf("failed to download dependencies: %w", err)
+	if !skipDeps {
+		if err := helmClient.BuildChartDependencies(chart.Directory, flags); err != nil {
+			return fmt.Errorf("failed to download dependencies: %w", err)
+		}
 	}
 
 	if err := helmClient.InstallChart(namespace, releaseName, chart.Directory, helmValues, nil, flags); err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

`kubermatic-installer` always tries to download Helm chart dependencies. Users in an offline scenario should be able to skip that step as they will not have access to upstream repositories.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10225

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--skip-dependencies` flag to kubermatic-installer that skips downloading Helm chart dependencies (requires chart dependencies to be downloaded already)
```


Signed-off-by: Marvin Beckers <marvin@kubermatic.com>