### PR TITLE
WIP - include resource usage in cluster output

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -97,7 +97,8 @@ var ProtectedClusterLabels = sets.NewString(WorkerNameLabelKey, ProjectIDLabelKe
 // +kubebuilder:printcolumn:JSONPath=".spec.humanReadableName",name="HumanReadableName",type="string"
 // +kubebuilder:printcolumn:JSONPath=".status.userEmail",name="Owner",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.version",name="Version",type="string"
-// +kubebuilder:printcolumn:JSONPath=".spec.cloud.providerName",name="Provider",type="string"
+// +kubebuilder:printcolumn:JSONPath=".spec.cloud.providerName",name="Provider",type="string",priority=2
+// +kubebuilder:printcolumn:JSONPath="{.status.resourceUsage.cpu} vCPU / {.status.resourceUsage.memory}",name="ResourceUsage",type="string",priority=1
 // +kubebuilder:printcolumn:JSONPath=".spec.cloud.dc",name="Datacenter",type="string"
 // +kubebuilder:printcolumn:JSONPath=".status.phase",name="Phase",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.pause",name="Paused",type="boolean"

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -27,6 +27,11 @@ spec:
       type: string
     - jsonPath: .spec.cloud.providerName
       name: Provider
+      priority: 2
+      type: string
+    - jsonPath: '{.status.resourceUsage.cpu} vCPU / {.status.resourceUsage.memory}'
+      name: ResourceUsage
+      priority: 1
       type: string
     - jsonPath: .spec.cloud.dc
       name: Datacenter


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include resource usage in `kubectl get clusters` output
```
