### PR TITLE
fix vmware cloud director storage calculation

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -699,7 +699,7 @@ func getVMwareCloudDirectorResourceRequirements(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse machine memory request to quantity, error: %w", err)
 	}
-	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", rawConfig.DiskSizeGB))
+	storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", *rawConfig.DiskSizeGB))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse machine storage request to quantity, error: %w", err)
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
fixes vmware cloud director storage calculation


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
