### PR TITLE
Modify project list endpoint to consult GroupProjectBindings

### DIFF
--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -861,6 +861,14 @@ func GenUser(id, name, email string) *kubermaticv1.User {
 	}
 }
 
+// GenUserWithGroups generates a User resource
+// note if the id is empty then it will be auto generated.
+func GenUserWithGroups(id, name, email string, groups []string) *kubermaticv1.User {
+	user := GenUser(id, name, email)
+	user.Spec.Groups = groups
+	return user
+}
+
 // GenInactiveProjectServiceAccount generates a Service Account resource.
 func GenInactiveProjectServiceAccount(id, name, group, projectName string) *kubermaticv1.User {
 	userName := kubermaticv1helper.EnsureProjectServiceAccountPrefix(id)

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -281,7 +281,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			groupProjectBindings, err := memberMapper.GroupMappingsFor(ctx, groupName)
 			if err != nil {
 				if isStatus(err, http.StatusNotFound) {
-					// We don't expect each group to have a corresponding GroupProjectMapping.
+					// We don't expect each group to have a corresponding GroupProjectBinding.
 					continue
 				}
 				return nil, common.KubernetesErrorToHTTPError(err)

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -293,6 +293,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			projectID := group.Spec.ProjectID
 
 			if projectIDSet.Has(projectID) {
+				// The project has been already added either from user or other group bindings.
 				continue
 			}
 

--- a/pkg/provider/kubernetes/member.go
+++ b/pkg/provider/kubernetes/member.go
@@ -203,6 +203,24 @@ func (p *ProjectMemberProvider) MappingsFor(ctx context.Context, userEmail strin
 	return memberMappings, nil
 }
 
+// GroupMappingsFor returns the list of projects (bindings) for the given group
+// This function is unsafe in a sense that it uses privileged account to list all members in the system.
+func (p *ProjectMemberProvider) GroupMappingsFor(ctx context.Context, groupName string) ([]*kubermaticv1.GroupProjectBinding, error) {
+	allBindings := &kubermaticv1.GroupProjectBindingList{}
+	if err := p.clientPrivileged.List(ctx, allBindings); err != nil {
+		return nil, err
+	}
+
+	var bindingsForGroup []*kubermaticv1.GroupProjectBinding
+	for _, binding := range allBindings.Items {
+		if binding.Spec.Group == groupName {
+			bindingsForGroup = append(bindingsForGroup, binding.DeepCopy())
+		}
+	}
+
+	return bindingsForGroup, nil
+}
+
 // MapUserToRoles returns the roles of the user in the project. It searches across the user project bindings and the group
 // project bindings for the user and returns the role set.
 // This function is unsafe in a sense that it uses privileged account to list all userProjectBindings and groupProjectBindings in the system.

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -428,6 +428,10 @@ type ProjectMemberMapper interface {
 	// This function is unsafe in a sense that it uses privileged account to list all members in the system
 	MappingsFor(ctx context.Context, userEmail string) ([]*kubermaticv1.UserProjectBinding, error)
 
+	// GroupMappingsFor returns the list of projects (bindings) for the given group
+	// This function is unsafe in a sense that it uses privileged account to list all members in the system.
+	GroupMappingsFor(ctx context.Context, groupName string) ([]*kubermaticv1.GroupProjectBinding, error)
+
 	// MapUserToRoles returns the roles of the user in the project. It searches across the user project bindings and the group
 	// project bindings for the user and returns the roles.
 	// This function is unsafe in a sense that it uses privileged account to list all userProjectBindings and groupProjectBindings in the system.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
As we added support for OIDC groups and introduced GroupProjectBindings resource, now we need to consult those changes in the endpoint for listing projects designated for user. Idea is to return all projects which have bindings to groups assigned to logged in user. 

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10351 

**Special notes for your reviewer**:
I'm aware that this may significantly slow down listing of projects in the Dashboard's overview. As an alternative we could consider listing all existing projects and then filtering it based on user and group bindings. I suggest trying solution from this PR and optimise it in case of a significant slowdown.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
