### PR TITLE
Make the KubeAwareEncoder less verbose

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -65,7 +65,8 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	)
 	projectLabelSynchronizerFactory := projectLabelSynchronizerFactoryCreator(ctrlCtx)
 	userSSHKeySynchronizerFactory := userSSHKeySynchronizerFactoryCreator(ctrlCtx)
-	masterconstraintSynchronizerFactory := masterconstraintSynchronizerFactoryCreator(ctrlCtx)
+	masterConstraintSynchronizerFactory := masterConstraintSynchronizerFactoryCreator(ctrlCtx)
+	masterConstraintTemplateSynchronizerFactory := masterConstraintTemplateSynchronizerFactoryCreator(ctrlCtx)
 	userSynchronizerFactory := userSynchronizerFactoryCreator(ctrlCtx)
 	clusterTemplateSynchronizerFactory := clusterTemplateSynchronizerFactoryCreator(ctrlCtx)
 	userProjectBindingSynchronizerFactory := userProjectBindingSynchronizerFactoryCreator(ctrlCtx)
@@ -85,7 +86,8 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 		rbacControllerFactory,
 		projectLabelSynchronizerFactory,
 		userSSHKeySynchronizerFactory,
-		masterconstraintSynchronizerFactory,
+		masterConstraintSynchronizerFactory,
+		masterConstraintTemplateSynchronizerFactory,
 		userSynchronizerFactory,
 		clusterTemplateSynchronizerFactory,
 		userProjectBindingSynchronizerFactory,
@@ -116,9 +118,6 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	}
 	if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter, ctrlCtx.configGetter); err != nil {
 		return fmt.Errorf("failed to create seedproxy controller: %w", err)
-	}
-	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
-		return fmt.Errorf("failed to create master constraint template controller: %w", err)
 	}
 	if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
 		return fmt.Errorf("failed to create external cluster controller: %w", err)
@@ -185,7 +184,7 @@ func userSSHKeySynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontro
 	}
 }
 
-func masterconstraintSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+func masterConstraintSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
 	return func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		return masterconstraintsynchronizer.ControllerName, masterconstraintsynchronizer.Add(
 			ctrlCtx.ctx,
@@ -193,6 +192,19 @@ func masterconstraintSynchronizerFactoryCreator(ctrlCtx *controllerContext) seed
 			ctrlCtx.namespace,
 			seedManagerMap,
 			ctrlCtx.log,
+		)
+	}
+}
+
+func masterConstraintTemplateSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+	return func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+		return masterconstrainttemplatecontroller.ControllerName, masterconstrainttemplatecontroller.Add(
+			ctrlCtx.ctx,
+			ctrlCtx.mgr,
+			ctrlCtx.log,
+			1,
+			ctrlCtx.namespace,
+			seedManagerMap,
 		)
 	}
 }

--- a/pkg/controller/kubeletdnat-controller/controller.go
+++ b/pkg/controller/kubeletdnat-controller/controller.go
@@ -164,7 +164,7 @@ func (r *Reconciler) syncDnatRules(ctx context.Context) error {
 
 	if !equality.Semantic.DeepEqual(actualRules, desiredRules) || !haveJump || !haveMasquerade {
 		// Need to update chain in kernel.
-		r.log.Debugw("Updating iptables chain in kernel", "rules-count", len(desiredRules))
+		r.log.Infow("Updating iptables chain in kernel", "rules-count", len(desiredRules))
 		if err := r.applyDNATRules(desiredRules, haveJump, haveMasquerade); err != nil {
 			return fmt.Errorf("failed to apply iptable rules: %w", err)
 		}

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -46,7 +46,7 @@ type reconciler struct {
 	log          *zap.SugaredLogger
 	recorder     record.EventRecorder
 	masterClient ctrlruntimeclient.Client
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -59,7 +59,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -81,24 +81,24 @@ func Add(
 
 // Reconcile reconciles ApplicationDefinition objects from master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("resource", request.Name)
+	log := r.log.With("appdefinition", request.Name)
 	log.Debug("Processing")
 
-	err := r.reconcile(ctx, log, request)
+	applicationDef := &appskubermaticv1.ApplicationDefinition{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, applicationDef); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	err := r.reconcile(ctx, log, applicationDef)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Event(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
-	applicationDef := &appskubermaticv1.ApplicationDefinition{}
-
-	if err := r.masterClient.Get(ctx, request.NamespacedName, applicationDef); err != nil {
-		return ctrlruntimeclient.IgnoreNotFound(err)
-	}
-
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition) error {
 	// handling deletion
 	if !applicationDef.DeletionTimestamp.IsZero() {
 		if err := r.handleDeletion(ctx, log, applicationDef); err != nil {
@@ -115,21 +115,22 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		applicationDefCreatorGetter(applicationDef),
 	}
 
-	err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, appDef *appskubermaticv1.ApplicationDefinition) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		log.Debug("Reconciling application definition with seed")
+
 		seedDef := &appskubermaticv1.ApplicationDefinition{}
-		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(appDef), seedDef); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(applicationDef), seedDef); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch ApplicationDefinition on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedDef.UID != "" && seedDef.UID == appDef.UID {
+		if seedDef.UID != "" && seedDef.UID == applicationDef.UID {
 			return nil
 		}
 
 		return reconciling.ReconcileAppsKubermaticV1ApplicationDefinitions(ctx, applicationDefCreatorGetters, "", seedClient)
 	})
 	if err != nil {
-		r.recorder.Event(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciled application definition %s: %w", applicationDef.Name, err)
 	}
 
@@ -138,7 +139,9 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition) error {
 	if kuberneteshelper.HasFinalizer(applicationDef, appskubermaticv1.ApplicationDefinitionSeedCleanupFinalizer) {
-		if err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, applicationDef *appskubermaticv1.ApplicationDefinition) error {
+		if err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+			log.Debug("Deleting application definition on seed")
+
 			err := seedClient.Delete(ctx, &appskubermaticv1.ApplicationDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: applicationDef.Name,
@@ -153,21 +156,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, applicationDef, appskubermaticv1.ApplicationDefinitionSeedCleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to remove application definition finalizer %s: %w", applicationDef.Name, err)
 		}
-	}
-	return nil
-}
-
-func (r *reconciler) syncAllSeeds(log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition, action func(seedClient ctrlruntimeclient.Client, applicationDef *appskubermaticv1.ApplicationDefinition) error) error {
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling application definition with seed")
-
-		err := action(seedClient, applicationDef)
-		if err != nil {
-			return fmt.Errorf("failed syncing application definition %s for seed %s: %w", applicationDef.Name, seedName, err)
-		}
-		log.Debug("Reconciled application definition with seed")
 	}
 	return nil
 }

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -23,12 +23,12 @@ import (
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -48,7 +48,7 @@ type reconciler struct {
 	recorder     record.EventRecorder
 	masterClient ctrlruntimeclient.Client
 	namespace    string
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -62,7 +62,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -82,43 +82,46 @@ func Add(
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("secret", request)
 	log.Debug("Processing")
 
-	err := r.reconcile(ctx, log, request)
+	secret := &corev1.Secret{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		// handling deletion
+		delSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: r.namespace}}
+		if err := r.handleDeletion(ctx, log, delSecret); err != nil {
+			err = fmt.Errorf("failed to delete secret: %w", err)
+
+			log.Errorw("ReconcilingError", zap.Error(err))
+			r.recorder.Event(delSecret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	err := r.reconcile(ctx, log, secret)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
-	secret := &corev1.Secret{}
-
-	var err error
-	if err = r.masterClient.Get(ctx, request.NamespacedName, secret); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		} else {
-			// handling deletion
-			delSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: r.namespace}}
-			if err := r.handleDeletion(ctx, log, delSecret); err != nil {
-				return fmt.Errorf("failed to delete secret: %w", err)
-			}
-			return nil
-		}
-	}
-
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
 	seedsecret := secret.DeepCopy()
 	seedsecret.SetResourceVersion("")
 
 	namedSecretCreatorGetter := []reconciling.NamedSecretCreatorGetter{
 		secretCreator(seedsecret),
 	}
-	err = r.reconcileAllSeeds(ctx, log, seedsecret, func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedSecret := &corev1.Secret{}
-		if err := c.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seedsecret), seedSecret); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seedsecret), seedSecret); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch Secret on seed cluster: %w", err)
 		}
 
@@ -127,10 +130,9 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 			return nil
 		}
 
-		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, c)
+		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, seedClient)
 	})
 	if err != nil {
-		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciling secret %s failed: %w", seedsecret.Name, err)
 	}
 
@@ -146,8 +148,9 @@ func secretCreator(s *corev1.Secret) reconciling.NamedSecretCreatorGetter {
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
-	delfunc := func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
-		err := c.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &corev1.Secret{})
+	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		seedSecret := &corev1.Secret{}
+		err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(secret), seedSecret)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Debug("Secret already deleted")
@@ -156,26 +159,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return err
 		}
 
-		return c.Delete(ctx, secret)
-	}
-
-	return r.reconcileAllSeeds(ctx, log, secret, delfunc)
-}
-
-func (r *reconciler) reconcileAllSeeds(ctx context.Context, log *zap.SugaredLogger, obj ctrlruntimeclient.Object, action func(context.Context, *zap.SugaredLogger, ctrlruntimeclient.Client, ctrlruntimeclient.Object) error) error {
-	kind := obj.GetObjectKind().GroupVersionKind().Kind
-	name := obj.GetName()
-
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling %s %s with seed", kind, name)
-
-		err := action(ctx, log, seedClient, obj)
-		if err != nil {
-			return fmt.Errorf("failed syncing %s %q for seed %q: %w", kind, name, seedName, err) // we need seedName here, as we don't have it wrapped via log.With
-		}
-		log.Debugf("Reconciled %s %s with seed", kind, name)
-	}
-	return nil
+		return seedClient.Delete(ctx, seedSecret)
+	})
 }

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -48,7 +48,7 @@ const (
 type reconciler struct {
 	log          *zap.SugaredLogger
 	masterClient ctrlruntimeclient.Client
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 	recorder     record.EventRecorder
 }
 
@@ -61,7 +61,7 @@ func Add(
 	r := &reconciler{
 		log:          log,
 		masterClient: masterMgr.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 		recorder:     masterMgr.GetEventRecorderFor(ControllerName),
 	}
 
@@ -85,23 +85,24 @@ func Add(
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("resource", request.Name)
+	log := r.log.With("template", request.Name)
 	log.Debug("Processing")
 
-	err := r.reconcile(ctx, log, request)
+	clusterTemplate := &kubermaticv1.ClusterTemplate{}
+	if err := r.masterClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: request.Name}, clusterTemplate); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	err := r.reconcile(ctx, log, clusterTemplate)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Event(clusterTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
-	clusterTemplate := &kubermaticv1.ClusterTemplate{}
-	if err := r.masterClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: request.Name}, clusterTemplate); err != nil {
-		return ctrlruntimeclient.IgnoreNotFound(err)
-	}
-
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clusterTemplate *kubermaticv1.ClusterTemplate) error {
 	// handling deletion
 	if !clusterTemplate.DeletionTimestamp.IsZero() {
 		if err := r.handleDeletion(ctx, log, clusterTemplate); err != nil {
@@ -118,21 +119,20 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		clusterTemplateCreatorGetter(clusterTemplate),
 	}
 
-	err := r.syncAllSeeds(log, clusterTemplate, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedTpl := &kubermaticv1.ClusterTemplate{}
-		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(template), seedTpl); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(clusterTemplate), seedTpl); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch ClusterTemplate on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedTpl.UID != "" && seedTpl.UID == template.UID {
+		if seedTpl.UID != "" && seedTpl.UID == clusterTemplate.UID {
 			return nil
 		}
 
 		return reconciling.ReconcileKubermaticV1ClusterTemplates(ctx, clusterTemplateCreatorGetters, "", seedClient)
 	})
 	if err != nil {
-		r.recorder.Event(clusterTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciled cluster template: %s: %w", clusterTemplate.Name, err)
 	}
 	return nil
@@ -140,7 +140,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, template *kubermaticv1.ClusterTemplate) error {
 	if kuberneteshelper.HasFinalizer(template, apiv1.ClusterTemplateSeedCleanupFinalizer) {
-		if err := r.syncAllSeeds(log, template, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
+		if err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, _ *zap.SugaredLogger) error {
 			err := seedClient.Delete(ctx, &kubermaticv1.ClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: template.Name,
@@ -158,7 +158,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 	}
 
 	if kuberneteshelper.HasFinalizer(template, apiv1.CredentialsSecretsCleanupFinalizer) {
-		if err := r.syncAllSeeds(log, template, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
+		if err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, _ *zap.SugaredLogger) error {
 			err := seedClient.Delete(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      template.Credential,
@@ -175,21 +175,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		}
 	}
 
-	return nil
-}
-
-func (r *reconciler) syncAllSeeds(log *zap.SugaredLogger, template *kubermaticv1.ClusterTemplate, action func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error) error {
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling cluster template with seed")
-
-		err := action(seedClient, template)
-		if err != nil {
-			return fmt.Errorf("failed syncing cluster template %s for seed %s: %w", template.Name, seedName, err)
-		}
-		log.Debug("Reconciled cluster template with seed")
-	}
 	return nil
 }
 

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -26,7 +26,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,12 +48,11 @@ const (
 )
 
 type reconciler struct {
-	log              *zap.SugaredLogger
-	recorder         record.EventRecorder
-	masterClient     ctrlruntimeclient.Client
-	namespace        string
-	seedsGetter      provider.SeedsGetter
-	seedClientGetter provider.SeedClientGetter
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	masterClient ctrlruntimeclient.Client
+	namespace    string
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(ctx context.Context,
@@ -62,21 +60,23 @@ func Add(ctx context.Context,
 	log *zap.SugaredLogger,
 	numWorkers int,
 	namespace string,
-	seedsGetter provider.SeedsGetter,
-	seedKubeconfigGetter provider.SeedKubeconfigGetter,
+	seedManagers map[string]manager.Manager,
 ) error {
 	reconciler := &reconciler{
-		log:              log.Named(ControllerName),
-		recorder:         mgr.GetEventRecorderFor(ControllerName),
-		masterClient:     mgr.GetClient(),
-		namespace:        namespace,
-		seedsGetter:      seedsGetter,
-		seedClientGetter: provider.SeedClientGetterFactory(seedKubeconfigGetter),
+		log:          log.Named(ControllerName),
+		recorder:     mgr.GetEventRecorderFor(ControllerName),
+		masterClient: mgr.GetClient(),
+		namespace:    namespace,
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
 	if err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	for seedName, seedManager := range seedManagers {
+		reconciler.seedClients[seedName] = seedManager.GetClient()
 	}
 
 	if err := c.Watch(
@@ -99,7 +99,7 @@ func Add(ctx context.Context,
 
 // Reconcile reconciles the kubermatic constraint template on the master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("template", request.Name)
 	log.Debug("Reconciling")
 
 	constraintTemplate := &kubermaticv1.ConstraintTemplate{}
@@ -125,19 +125,14 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 			return nil
 		}
 
-		err := r.syncAllSeeds(ctx, log, constraintTemplate, func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
-			err := seedClusterClient.Delete(ctx, &kubermaticv1.ConstraintTemplate{
+		err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+			err := seedClient.Delete(ctx, &kubermaticv1.ConstraintTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: constraintTemplate.Name,
 				},
 			})
 
-			if apierrors.IsNotFound(err) {
-				log.Debug("constraint template not found, returning")
-				return nil
-			}
-
-			return err
+			return ctrlruntimeclient.IgnoreNotFound(err)
 		})
 		if err != nil {
 			return err
@@ -154,46 +149,19 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 		constraintTemplateCreatorGetter(constraintTemplate),
 	}
 
-	return r.syncAllSeeds(ctx, log, constraintTemplate, func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
+	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedCT := &kubermaticv1.ConstraintTemplate{}
-		if err := seedClusterClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(ct), seedCT); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(constraintTemplate), seedCT); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch ConstraintTemplate on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedCT.UID != "" && seedCT.UID == ct.UID {
+		if seedCT.UID != "" && seedCT.UID == constraintTemplate.UID {
 			return nil
 		}
 
-		return reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", seedClusterClient)
+		return reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", seedClient)
 	})
-}
-
-func (r *reconciler) syncAllSeeds(
-	ctx context.Context,
-	log *zap.SugaredLogger,
-	constraintTemplate *kubermaticv1.ConstraintTemplate,
-	action func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error,
-) error {
-	seeds, err := r.seedsGetter()
-	if err != nil {
-		return fmt.Errorf("failed listing seeds: %w", err)
-	}
-
-	for _, seed := range seeds {
-		seedClient, err := r.seedClientGetter(seed)
-		if err != nil {
-			return fmt.Errorf("failed getting seed client for seed %s: %w", seed.Name, err)
-		}
-
-		err = action(seedClient, constraintTemplate)
-		if err != nil {
-			return fmt.Errorf("failed syncing constraint template for seed %s: %w", seed.Name, err)
-		}
-		log.Debugw("Reconciled constraint template with seed", "seed", seed.Name)
-	}
-
-	return nil
 }
 
 func constraintTemplateCreatorGetter(kubeCT *kubermaticv1.ConstraintTemplate) reconciling.NamedKubermaticV1ConstraintTemplateCreatorGetter {

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -89,10 +89,7 @@ func TestReconcile(t *testing.T) {
 				log:          kubermaticlog.Logger,
 				recorder:     &record.FakeRecorder{},
 				masterClient: tc.masterClient,
-				seedsGetter:  test.CreateTestSeedsGetter(ctx, tc.masterClient),
-				seedClientGetter: func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
-					return tc.seedClient, nil
-				},
+				seedClients:  map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -84,7 +84,7 @@ func Add(
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("resource", request.Name)
+	log := r.log.With("preset", request.Name)
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -24,6 +24,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +46,7 @@ const ControllerName = "kkp-project-label-synchronizer"
 type reconciler struct {
 	log                     *zap.SugaredLogger
 	masterClient            ctrlruntimeclient.Client
-	seedClients             map[string]ctrlruntimeclient.Client
+	seedClients             kuberneteshelper.SeedClientMap
 	workerNameLabelSelector labels.Selector
 }
 
@@ -89,7 +90,7 @@ func Add(
 	r := &reconciler{
 		log:                     log,
 		masterClient:            masterManager.GetClient(),
-		seedClients:             map[string]ctrlruntimeclient.Client{},
+		seedClients:             kuberneteshelper.SeedClientMap{},
 		workerNameLabelSelector: workerSelector,
 	}
 

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -123,7 +123,7 @@ func Add(
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With(kubermaticv1.ProjectIDLabelKey, request.Name)
+	log := r.log.With("project", request.Name)
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -49,7 +49,7 @@ type reconciler struct {
 	log          *zap.SugaredLogger
 	recorder     record.EventRecorder
 	masterClient ctrlruntimeclient.Client
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -62,7 +62,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -120,9 +120,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		projectCreatorGetter(project),
 	}
 
-	err := r.syncAllSeeds(log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedProject := &kubermaticv1.Project{}
-		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedProject); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, request.NamespacedName, seedProject); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch project on seed cluster: %w", err)
 		}
 
@@ -142,20 +142,20 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return nil
 		}
 
-		err := reconciling.ReconcileKubermaticV1Projects(ctx, projectCreatorGetters, "", seedClusterClient)
+		err := reconciling.ReconcileKubermaticV1Projects(ctx, projectCreatorGetters, "", seedClient)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile project: %w", err)
 		}
 
 		// fetch the updated project from the cache
-		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedProject); err != nil {
+		if err := seedClient.Get(ctx, request.NamespacedName, seedProject); err != nil {
 			return fmt.Errorf("failed to fetch project on seed cluster: %w", err)
 		}
 
 		if !equality.Semantic.DeepEqual(seedProject.Status, project.Status) {
 			oldProject := seedProject.DeepCopy()
 			seedProject.Status = project.Status
-			if err := seedClusterClient.Status().Patch(ctx, seedProject, ctrlruntimeclient.MergeFrom(oldProject)); err != nil {
+			if err := seedClient.Status().Patch(ctx, seedProject, ctrlruntimeclient.MergeFrom(oldProject)); err != nil {
 				return fmt.Errorf("failed to update project status on seed cluster: %w", err)
 			}
 		}
@@ -172,8 +172,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, project *kubermaticv1.Project) error {
-	err := r.syncAllSeeds(log, project, func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error {
-		return ctrlruntimeclient.IgnoreNotFound(seedClusterClient.Delete(ctx, project))
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		return ctrlruntimeclient.IgnoreNotFound(seedClient.Delete(ctx, project))
 	})
 	if err != nil {
 		return err

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -93,7 +93,7 @@ func Add(
 
 // Reconcile reconciles Kubermatic Project objects on the master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("project", request.Name)
 
 	project := &kubermaticv1.Project{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, project); err != nil {

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -61,7 +61,7 @@ type Reconciler struct {
 // an error if any API operation failed, otherwise will return an empty
 // dummy Result struct.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("seed", request.NamespacedName.String())
+	log := r.log.With("seed", request)
 	log.Debug("reconciling seed")
 
 	return reconcile.Result{}, r.reconcile(ctx, request.Name, log)

--- a/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
@@ -70,7 +70,7 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	logger := r.log.With("seed", request.Name)
+	logger := r.log.With("seed", request)
 	logger.Debug("Reconciling")
 
 	seed := &kubermaticv1.Seed{}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -47,7 +47,7 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	logger := r.log.With("seed", request.Name)
+	logger := r.log.With("seed", request)
 	logger.Debug("Reconciling")
 
 	seed := &kubermaticv1.Seed{}

--- a/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
+++ b/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
@@ -115,6 +115,9 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger) error {
 }
 
 func (r *reconcileServiceAccountProjectBinding) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("serviceaccount", request)
+	log.Debug("Reconciling")
+
 	sa := &kubermaticv1.User{}
 	if err := r.Get(ctx, request.NamespacedName, sa); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -122,9 +125,6 @@ func (r *reconcileServiceAccountProjectBinding) Reconcile(ctx context.Context, r
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to get user: %w", err)
 	}
-
-	log := r.log.With("serviceaccount", sa.Name)
-	log.Debug("Reconciling")
 
 	err := r.reconcile(ctx, log, sa)
 	if err != nil {

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -101,7 +101,8 @@ func Add(
 
 // Reconcile reconciles Kubermatic UserProjectBinding objects on the master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("userprojectbinding", request)
+	log.Debug("Reconciling")
 
 	userProjectBinding := &kubermaticv1.UserProjectBinding{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, userProjectBinding); err != nil {

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -50,7 +50,7 @@ type reconciler struct {
 	log          *zap.SugaredLogger
 	recorder     record.EventRecorder
 	masterClient ctrlruntimeclient.Client
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -63,7 +63,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -123,9 +123,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		userProjectBindingCreatorGetter(userProjectBinding),
 	}
 
-	err := r.syncAllSeeds(log, userProjectBinding, func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedBinding := &kubermaticv1.UserProjectBinding{}
-		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedBinding); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, request.NamespacedName, seedBinding); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch UserProjectBinding on seed cluster: %w", err)
 		}
 
@@ -134,7 +134,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return nil
 		}
 
-		return reconciling.ReconcileKubermaticV1UserProjectBindings(ctx, userProjectBindingCreatorGetters, "", seedClusterClient)
+		return reconciling.ReconcileKubermaticV1UserProjectBindings(ctx, userProjectBindingCreatorGetters, "", seedClient)
 	})
 
 	if err != nil {
@@ -145,30 +145,14 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, userProjectBinding *kubermaticv1.UserProjectBinding) error {
-	err := r.syncAllSeeds(log, userProjectBinding, func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error {
-		if err := seedClusterClient.Delete(ctx, userProjectBinding); err != nil {
-			return ctrlruntimeclient.IgnoreNotFound(err)
-		}
-		return nil
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		return ctrlruntimeclient.IgnoreNotFound(seedClient.Delete(ctx, userProjectBinding))
 	})
 	if err != nil {
 		return err
 	}
 
 	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, userProjectBinding, apiv1.SeedUserProjectBindingCleanupFinalizer)
-}
-
-func (r *reconciler) syncAllSeeds(
-	log *zap.SugaredLogger,
-	userProjectBinding *kubermaticv1.UserProjectBinding,
-	action func(seedClusterClient ctrlruntimeclient.Client, userProjectBinding *kubermaticv1.UserProjectBinding) error) error {
-	for seedName, seedClient := range r.seedClients {
-		if err := action(seedClient, userProjectBinding); err != nil {
-			return fmt.Errorf("failed syncing userprojectbinding for seed %s: %w", seedName, err)
-		}
-		log.Debugw("Reconciled userprojectbinding with seed", "seed", seedName)
-	}
-	return nil
 }
 
 func enqueueUserProjectBindingsForSeed(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {

--- a/pkg/controller/master-controller-manager/user-project-binding/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller.go
@@ -69,6 +69,9 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger) error {
 }
 
 func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("userprojectbinding", request)
+	log.Debug("Reconciling")
+
 	projectBinding := &kubermaticv1.UserProjectBinding{}
 	if err := r.Get(ctx, request.NamespacedName, projectBinding); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -76,9 +79,6 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 		}
 		return reconcile.Result{}, err
 	}
-
-	log := r.log.With("userprojectbinding", projectBinding.Name)
-	log.Debug("Reconciling")
 
 	err := r.reconcile(ctx, log, projectBinding)
 	if err != nil {

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -111,7 +111,8 @@ func withEventFilter() predicate.Predicate {
 
 // Reconcile reconciles Kubermatic User objects (excluding service account users) on the master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("user", request)
+	log.Debug("Reconciling")
 
 	user := &kubermaticv1.User{}
 	// using the reader here to bypass the cache. It is necessary because we update the same object we are watching

--- a/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
@@ -106,6 +106,9 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger) error {
 }
 
 func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("usersshkey", request)
+	log.Debug("Reconciling")
+
 	sshKey := &kubermaticv1.UserSSHKey{}
 	if err := r.Get(ctx, request.NamespacedName, sshKey); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -113,9 +116,6 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 		}
 		return reconcile.Result{}, err
 	}
-
-	log := r.log.With("usersshkey", sshKey.Name)
-	log.Debug("Reconciling")
 
 	err := r.reconcile(ctx, log, sshKey)
 	if err != nil {

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -127,7 +127,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("seed", request.Namespace, "cluster", request.Name)
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -26,6 +26,7 @@ import (
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
@@ -59,7 +60,7 @@ type Reconciler struct {
 	masterClient ctrlruntimeclient.Client
 	log          *zap.SugaredLogger
 	workerName   string
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -79,7 +80,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		workerName:   workerName,
 		masterClient: mgr.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
@@ -227,7 +228,7 @@ func buildUserSSHKeysForCluster(clusterName string, keys *kubermaticv1.UserSSHKe
 }
 
 // enqueueAllClusters enqueues all clusters.
-func enqueueAllClusters(ctx context.Context, clients map[string]ctrlruntimeclient.Client, workerSelector labels.Selector) handler.EventHandler {
+func enqueueAllClusters(ctx context.Context, clients kuberneteshelper.SeedClientMap, workerSelector labels.Selector) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
 		var requests []reconcile.Request
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -72,7 +72,8 @@ type Reconciler struct {
 // for the given namespace. Will return an error if any API operation
 // failed, otherwise will return an empty dummy Result struct.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("seed", request.Name)
+	log := r.log.With("seed", request)
+	log.Debug("reconciling")
 
 	err := r.reconcile(ctx, log, request.Name)
 	if err != nil {
@@ -83,8 +84,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seedName string) error {
-	log.Debug("reconciling")
-
 	// find requested seed
 	seeds, err := r.seedsGetter()
 	if err != nil {

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -204,7 +204,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	log = r.log.With("cluster", cluster.Name, "addon", addon.Name)
+	log = r.log.With("cluster", cluster, "addon", addon.Name)
 
 	// Add a wrapping here so we can emit an event on error
 	result, err := kubermaticv1helper.ClusterReconcileWrapper(

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -128,7 +128,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -179,6 +179,9 @@ func (w *runnableWrapper) Start(ctx context.Context) error {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request)
+	log.Debug("Processing")
+
 	config, err := r.configGetter(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -188,9 +191,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-
-	log := r.log.With("request", request)
-	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: request.Name}, cluster); err != nil {

--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -106,7 +106,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}
@@ -116,7 +116,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, err
 	}
-	log = log.With("cluster", cluster.Name)
 
 	// Add a wrapping here so we can emit an event on error
 	result, err := kubermaticv1helper.ClusterReconcileWrapper(

--- a/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
@@ -76,7 +76,7 @@ func Add(mgr manager.Manager, numWorkers int, log *zap.SugaredLogger, versions k
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("cluster", request.Name)
+	log := r.log.With("cluster", request)
 	log.Debug("Reconciling")
 
 	cluster := &kubermaticv1.Cluster{}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -95,7 +95,7 @@ func Add(
 
 // Reconcile reconciles the kubermatic cluster template instance in the seed cluster.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("template", request)
 	log.Debug("Reconciling")
 
 	instance := &kubermaticv1.ClusterTemplateInstance{}

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -167,7 +167,7 @@ func ByLabel(key string) predicate.Funcs {
 // Reconcile reconciles the kubermatic constraints in the seed cluster and syncs them to all user clusters namespace
 // which have opa integration enabled.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("constraint", request)
 	log.Debug("Reconciling")
 
 	constraint := &kubermaticv1.Constraint{}

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -111,7 +111,7 @@ func Add(ctx context.Context,
 // Reconcile reconciles the kubermatic constraint template on the seed cluster to all user clusters
 // which have opa integration enabled.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("template", request)
 	log.Debug("Reconciling")
 
 	constraintTemplate := &kubermaticv1.ConstraintTemplate{}

--- a/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
@@ -135,7 +135,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -183,6 +183,9 @@ func Add(
 
 // Reconcile handle etcd backups reconciliation.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("backupconfig", request)
+	log.Debug("Processing")
+
 	seed, err := r.seedGetter()
 	if err != nil {
 		return reconcile.Result{}, err
@@ -197,9 +200,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
 		return reconcile.Result{}, nil
 	}
-
-	log := r.log.With("request", request)
-	log.Debug("Processing")
 
 	backupConfig := &kubermaticv1.EtcdBackupConfig{}
 	if err := r.Get(ctx, request.NamespacedName, backupConfig); err != nil {

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -118,6 +118,9 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("restore", request)
+	log.Debug("Processing")
+
 	seed, err := r.seedGetter()
 	if err != nil {
 		return reconcile.Result{}, err
@@ -127,9 +130,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
 		return reconcile.Result{}, nil
 	}
-
-	log := r.log.With("request", request)
-	log.Debug("Processing")
 
 	restore := &kubermaticv1.EtcdRestore{}
 	if err := r.Get(ctx, request.NamespacedName, restore); err != nil {

--- a/pkg/controller/seed-controller-manager/ipam/controller.go
+++ b/pkg/controller/seed-controller-manager/ipam/controller.go
@@ -118,7 +118,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -204,7 +204,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}
@@ -215,7 +215,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, err
 	}
-	log = log.With("cluster", cluster.Name)
 
 	// the update controller needs to determine the target version based on the spec
 	// before we can reconcile anything

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -149,7 +149,7 @@ func newAlertmanagerReconciler(
 }
 
 func (r *alertmanagerReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}
@@ -175,7 +175,7 @@ func (r *alertmanagerReconciler) Reconcile(ctx context.Context, request reconcil
 		},
 	)
 	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
+		log.Errorw("Failed to reconcile cluster", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	if result == nil {

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
@@ -102,7 +102,7 @@ func newDashboardGrafanaReconciler(
 }
 
 func (r *dashboardGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("configmap", request)
 	log.Debug("Processing")
 
 	configMap := &corev1.ConfigMap{}

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -104,7 +104,7 @@ func newDatasourceGrafanaReconciler(
 }
 
 func (r *datasourceGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}
@@ -135,7 +135,7 @@ func (r *datasourceGrafanaReconciler) Reconcile(ctx context.Context, request rec
 		},
 	)
 	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
+		log.Errorw("Failed to reconcile", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	if result == nil {

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
@@ -94,7 +94,7 @@ func newOrgGrafanaReconciler(
 }
 
 func (r *orgGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("project", request)
 	log.Debug("Processing")
 
 	project := &kubermaticv1.Project{}

--- a/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_user_grafana_controller.go
@@ -104,7 +104,7 @@ func newOrgUserGrafanaReconciler(
 }
 
 func (r *orgUserGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("userprojectbinding", request)
 	log.Debug("Processing")
 
 	userProjectBinding := &kubermaticv1.UserProjectBinding{}

--- a/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go
@@ -110,7 +110,7 @@ func newRatelimitCortexReconciler(
 }
 
 func (r *ratelimitCortexReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("setting", request)
 	log.Debug("Processing")
 
 	mlaAdminSetting := &kubermaticv1.MLAAdminSetting{}

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -151,7 +151,7 @@ func newRuleGroupReconciler(
 }
 
 func (r *ruleGroupReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("rulegroup", request)
 	log.Debug("Processing")
 
 	ruleGroup := &kubermaticv1.RuleGroup{}
@@ -189,7 +189,7 @@ func (r *ruleGroupReconciler) Reconcile(ctx context.Context, request reconcile.R
 		},
 	)
 	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
+		log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	if result == nil {

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -101,7 +101,7 @@ func newRuleGroupSyncReconciler(
 }
 
 func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("rulegroup", request)
 	log.Debug("Processing")
 
 	ruleGroup := &kubermaticv1.RuleGroup{}

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -98,7 +98,7 @@ func newUserGrafanaReconciler(
 }
 
 func (r *userGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("user", request)
 	log.Debug("Processing")
 
 	user := &kubermaticv1.User{}

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -151,8 +151,8 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
-	log.Debug("Processing")
+	log := r.log.With("cluster", request)
+	log.Debug("Reconciling")
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
@@ -161,8 +161,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster: %w", err)
 	}
-
-	log = log.With("cluster", cluster.Name)
 
 	if cluster.DeletionTimestamp != nil {
 		// Cluster got deleted - all monitoring components will be automatically garbage collected (Due to the ownerRef)

--- a/pkg/controller/seed-controller-manager/preset-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller.go
@@ -83,7 +83,7 @@ func Add(
 
 // Reconcile reconciles the kubermatic cluster template instance in the seed cluster.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("preset", request)
 	log.Debug("Reconciling")
 
 	preset := &kubermaticv1.Preset{}

--- a/pkg/controller/seed-controller-manager/project/controller.go
+++ b/pkg/controller/seed-controller-manager/project/controller.go
@@ -79,7 +79,7 @@ func Add(mgr manager.Manager, log *zap.SugaredLogger, workerCount int) error {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {
-	log := r.log.With("project", req.Name)
+	log := r.log.With("project", req)
 	log.Debug("Reconciling")
 
 	project := &kubermaticv1.Project{}

--- a/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
+++ b/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
@@ -94,7 +94,7 @@ func Add(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("cluster", request)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}

--- a/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
+++ b/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
@@ -88,6 +88,9 @@ func Add(
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request)
+	log.Debug("Processing")
+
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.client.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -99,9 +102,10 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	err := r.reconcile(ctx, cluster)
 	if err != nil {
-		r.log.With("cluster", request.Name).Errorw("Failed to reconcile cluster", zap.Error(err))
+		log.Errorw("Failed to reconcile cluster", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -103,7 +103,7 @@ func Add(mgr manager.Manager, numWorkers int, workerName string, configGetter pr
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("cluster", request.Name)
+	log := r.log.With("cluster", request)
 	log.Debug("Reconciling")
 
 	cluster := &kubermaticv1.Cluster{}

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -24,8 +24,9 @@ import (
 	"strconv"
 	"strings"
 
-	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"go.uber.org/zap"
+
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"go.uber.org/zap"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -394,4 +395,19 @@ func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
 		labels[key] = value
 	}
 	o.SetLabels(labels)
+}
+
+type SeedClientMap map[string]ctrlruntimeclient.Client
+
+type SeedVisitorFunc func(seedName string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error
+
+func (m SeedClientMap) Each(ctx context.Context, log *zap.SugaredLogger, visitor SeedVisitorFunc) error {
+	for seedName, seedClient := range m {
+		err := visitor(seedName, seedClient, log.With("seed", seedName))
+		if err != nil {
+			return fmt.Errorf("failed processing Seed %s: %w", seedName, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -25,8 +25,6 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	ctrlruntimelzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func init() {
@@ -157,7 +155,7 @@ func New(debug bool, format Format) *zap.Logger {
 		zap.ErrorOutput(sink),
 	}
 
-	coreLog := zapcore.NewCore(&ctrlruntimelzap.KubeAwareEncoder{Encoder: enc}, sink, lvl)
+	coreLog := zapcore.NewCore(&KubeAwareEncoder{Encoder: enc}, sink, lvl)
 	return zap.New(coreLog, opts...)
 }
 

--- a/pkg/log/zap_kube_encoder.go
+++ b/pkg/log/zap_kube_encoder.go
@@ -21,6 +21,7 @@ import (
 
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/log/zap_kube_encoder.go
+++ b/pkg/log/zap_kube_encoder.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // KubeAwareEncoder is based on sigs.k8s.io/controller-runtime/pkg/log/zap.KubeAwareEncoder,
@@ -63,6 +64,13 @@ func (k *KubeAwareEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Fie
 					Type:   zapcore.StringType,
 					Key:    field.Key,
 					String: k.encodeNamespacedName(val),
+				}
+
+			case reconcile.Request:
+				fields[i] = zapcore.Field{
+					Type:   zapcore.StringType,
+					Key:    field.Key,
+					String: k.encodeNamespacedName(val.NamespacedName),
 				}
 			}
 		}

--- a/pkg/log/zap_kube_encoder.go
+++ b/pkg/log/zap_kube_encoder.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// KubeAwareEncoder is based on sigs.k8s.io/controller-runtime/pkg/log/zap.KubeAwareEncoder,
+// but uses the stringified format for object references as described in
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging#object-reference-format-in-logs
+type KubeAwareEncoder struct {
+	// Encoder is the zapcore.Encoder that this encoder delegates to
+	zapcore.Encoder
+}
+
+// Clone implements zapcore.Encoder.
+func (k *KubeAwareEncoder) Clone() zapcore.Encoder {
+	return &KubeAwareEncoder{
+		Encoder: k.Encoder.Clone(),
+	}
+}
+
+// EncodeEntry implements zapcore.Encoder.
+func (k *KubeAwareEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	for i, field := range fields {
+		if field.Type == zapcore.StringerType || field.Type == zapcore.ReflectType {
+			switch val := field.Interface.(type) {
+			case runtime.Object:
+				encoded, err := k.encodeObject(val)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encode %v: %w", field.Interface, err)
+				}
+
+				fields[i] = zapcore.Field{
+					Type:   zapcore.StringType,
+					Key:    field.Key,
+					String: encoded,
+				}
+
+			case types.NamespacedName:
+				fields[i] = zapcore.Field{
+					Type:   zapcore.StringType,
+					Key:    field.Key,
+					String: k.encodeNamespacedName(val),
+				}
+			}
+		}
+	}
+
+	return k.Encoder.EncodeEntry(entry, fields)
+}
+
+func (k *KubeAwareEncoder) encodeNamespacedName(name types.NamespacedName) string {
+	if name.Namespace == "" {
+		return name.Name
+	}
+
+	return fmt.Sprintf("%s/%s", name.Namespace, name.Name)
+}
+
+func (k *KubeAwareEncoder) encodeObject(obj runtime.Object) (string, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return "", fmt.Errorf("got runtime.Object without object metadata: %v", obj)
+	}
+
+	return k.encodeNamespacedName(types.NamespacedName{
+		Namespace: objMeta.GetNamespace(),
+		Name:      objMeta.GetName(),
+	}), nil
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR does two things (that's a great start, isn't it?):

* It adds a custom Zap encoder that uses `{"obj":"namespace/name"}` instead of `{"obj":{"namespace":"namespace","name":"name"}}`, just better readability. This goes a bit against controller-runtime, but follows Kubernetes upstream.
* While going through our controllers to harmonize the logging code a bit, thanks to the new encoder, I noticed that the `master-constraint-template-synchonizer` is not using the seed-lifecycle-controller (and thereby re-invents getting seed clients). I rewrote it to make it work like its little sister, the `master-constraint-synchronizer`.
* And since I saw a lot of syncAllSeeds() functions (nearly all controllers in the master-ctrl-mgr had such a function), I moved it to the Kubernetes helpers as `SeedClientMap.Each()`. This just gets rid of a lot of redundant code.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
