### PR TITLE
Add extra volumes and volume mounts to oauth chart

### DIFF
--- a/charts/oauth/templates/deployment.yaml
+++ b/charts/oauth/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
         - name: themes
           mountPath: /srv/dex/web/themes/light
           readOnly: true
+{{- if .Values.dex.extraVolumeMounts }}
+{{ toYaml .Values.dex.extraVolumeMounts | indent 8 }}
+{{- end -}}
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.certMount | trim | indent 8 }}
 {{- end }}
         resources:
@@ -67,6 +70,9 @@ spec:
       - name: themes
         secret:
           secretName: themes
+{{- if .Values.dex.extraVolumes }}
+{{ toYaml .Values.dex.extraVolumes | indent 6 }}
+{{- end -}}
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.certVolume | trim | indent 6 }}
 {{- end }}
       nodeSelector:

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -90,6 +90,11 @@ dex:
         weight: 10
   tolerations: []
 
+  # mount additional volumes into the dex Pod to provide data from outside the chart
+  # (for example a service account file for Google provider group support).
+  extraVolumes: []
+  extraVolumeMounts: []
+
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
   # If you want to deploy your own certificate without relying on cert-manager
   # uncomment the next line and remove subsequent certIssuer configuration.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Some dex connectors (for example, the `google` connector, see [this section](https://dexidp.io/docs/connectors/google/#fetching-groups-from-google)) support/require supplying files within dex. This adds the ability to mount external volume data into the dex Pod if desired.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Chart oauth supports mounting extra volumes into dex deployment to supply data from outside the chart
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
