### PR TITLE
refactor master-constraint-template-synchronizer to use seed-lifecycle-controller

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -65,7 +65,8 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	)
 	projectLabelSynchronizerFactory := projectLabelSynchronizerFactoryCreator(ctrlCtx)
 	userSSHKeySynchronizerFactory := userSSHKeySynchronizerFactoryCreator(ctrlCtx)
-	masterconstraintSynchronizerFactory := masterconstraintSynchronizerFactoryCreator(ctrlCtx)
+	masterConstraintSynchronizerFactory := masterConstraintSynchronizerFactoryCreator(ctrlCtx)
+	masterConstraintTemplateSynchronizerFactory := masterConstraintTemplateSynchronizerFactoryCreator(ctrlCtx)
 	userSynchronizerFactory := userSynchronizerFactoryCreator(ctrlCtx)
 	clusterTemplateSynchronizerFactory := clusterTemplateSynchronizerFactoryCreator(ctrlCtx)
 	userProjectBindingSynchronizerFactory := userProjectBindingSynchronizerFactoryCreator(ctrlCtx)
@@ -85,7 +86,8 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 		rbacControllerFactory,
 		projectLabelSynchronizerFactory,
 		userSSHKeySynchronizerFactory,
-		masterconstraintSynchronizerFactory,
+		masterConstraintSynchronizerFactory,
+		masterConstraintTemplateSynchronizerFactory,
 		userSynchronizerFactory,
 		clusterTemplateSynchronizerFactory,
 		userProjectBindingSynchronizerFactory,
@@ -116,9 +118,6 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	}
 	if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter, ctrlCtx.configGetter); err != nil {
 		return fmt.Errorf("failed to create seedproxy controller: %w", err)
-	}
-	if err := masterconstrainttemplatecontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, 1, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
-		return fmt.Errorf("failed to create master constraint template controller: %w", err)
 	}
 	if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
 		return fmt.Errorf("failed to create external cluster controller: %w", err)
@@ -185,7 +184,7 @@ func userSSHKeySynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontro
 	}
 }
 
-func masterconstraintSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+func masterConstraintSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
 	return func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		return masterconstraintsynchronizer.ControllerName, masterconstraintsynchronizer.Add(
 			ctrlCtx.ctx,
@@ -193,6 +192,19 @@ func masterconstraintSynchronizerFactoryCreator(ctrlCtx *controllerContext) seed
 			ctrlCtx.namespace,
 			seedManagerMap,
 			ctrlCtx.log,
+		)
+	}
+}
+
+func masterConstraintTemplateSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+	return func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+		return masterconstrainttemplatecontroller.ControllerName, masterconstrainttemplatecontroller.Add(
+			ctrlCtx.ctx,
+			ctrlCtx.mgr,
+			ctrlCtx.log,
+			1,
+			ctrlCtx.namespace,
+			seedManagerMap,
 		)
 	}
 }

--- a/pkg/controller/kubeletdnat-controller/controller.go
+++ b/pkg/controller/kubeletdnat-controller/controller.go
@@ -164,7 +164,7 @@ func (r *Reconciler) syncDnatRules(ctx context.Context) error {
 
 	if !equality.Semantic.DeepEqual(actualRules, desiredRules) || !haveJump || !haveMasquerade {
 		// Need to update chain in kernel.
-		r.log.Debugw("Updating iptables chain in kernel", "rules-count", len(desiredRules))
+		r.log.Infow("Updating iptables chain in kernel", "rules-count", len(desiredRules))
 		if err := r.applyDNATRules(desiredRules, haveJump, haveMasquerade); err != nil {
 			return fmt.Errorf("failed to apply iptable rules: %w", err)
 		}

--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -46,7 +46,7 @@ type reconciler struct {
 	log          *zap.SugaredLogger
 	recorder     record.EventRecorder
 	masterClient ctrlruntimeclient.Client
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -59,7 +59,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -81,24 +81,24 @@ func Add(
 
 // Reconcile reconciles ApplicationDefinition objects from master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("resource", request.Name)
+	log := r.log.With("appdefinition", request.Name)
 	log.Debug("Processing")
 
-	err := r.reconcile(ctx, log, request)
+	applicationDef := &appskubermaticv1.ApplicationDefinition{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, applicationDef); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	err := r.reconcile(ctx, log, applicationDef)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Event(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
-	applicationDef := &appskubermaticv1.ApplicationDefinition{}
-
-	if err := r.masterClient.Get(ctx, request.NamespacedName, applicationDef); err != nil {
-		return ctrlruntimeclient.IgnoreNotFound(err)
-	}
-
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition) error {
 	// handling deletion
 	if !applicationDef.DeletionTimestamp.IsZero() {
 		if err := r.handleDeletion(ctx, log, applicationDef); err != nil {
@@ -115,21 +115,22 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		applicationDefCreatorGetter(applicationDef),
 	}
 
-	err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, appDef *appskubermaticv1.ApplicationDefinition) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		log.Debug("Reconciling application definition with seed")
+
 		seedDef := &appskubermaticv1.ApplicationDefinition{}
-		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(appDef), seedDef); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(applicationDef), seedDef); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch ApplicationDefinition on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedDef.UID != "" && seedDef.UID == appDef.UID {
+		if seedDef.UID != "" && seedDef.UID == applicationDef.UID {
 			return nil
 		}
 
 		return reconciling.ReconcileAppsKubermaticV1ApplicationDefinitions(ctx, applicationDefCreatorGetters, "", seedClient)
 	})
 	if err != nil {
-		r.recorder.Event(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciled application definition %s: %w", applicationDef.Name, err)
 	}
 
@@ -138,7 +139,9 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition) error {
 	if kuberneteshelper.HasFinalizer(applicationDef, appskubermaticv1.ApplicationDefinitionSeedCleanupFinalizer) {
-		if err := r.syncAllSeeds(log, applicationDef, func(seedClient ctrlruntimeclient.Client, applicationDef *appskubermaticv1.ApplicationDefinition) error {
+		if err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+			log.Debug("Deleting application definition on seed")
+
 			err := seedClient.Delete(ctx, &appskubermaticv1.ApplicationDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: applicationDef.Name,
@@ -153,21 +156,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, applicationDef, appskubermaticv1.ApplicationDefinitionSeedCleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to remove application definition finalizer %s: %w", applicationDef.Name, err)
 		}
-	}
-	return nil
-}
-
-func (r *reconciler) syncAllSeeds(log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition, action func(seedClient ctrlruntimeclient.Client, applicationDef *appskubermaticv1.ApplicationDefinition) error) error {
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling application definition with seed")
-
-		err := action(seedClient, applicationDef)
-		if err != nil {
-			return fmt.Errorf("failed syncing application definition %s for seed %s: %w", applicationDef.Name, seedName, err)
-		}
-		log.Debug("Reconciled application definition with seed")
 	}
 	return nil
 }

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -101,6 +101,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 			return reconcile.Result{}, err
 		}
+
+		return reconcile.Result{}, nil
 	}
 
 	err := r.reconcile(ctx, log, secret)

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -23,12 +23,12 @@ import (
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -48,7 +48,7 @@ type reconciler struct {
 	recorder     record.EventRecorder
 	masterClient ctrlruntimeclient.Client
 	namespace    string
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -62,7 +62,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -82,43 +82,46 @@ func Add(
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("secret", request)
 	log.Debug("Processing")
 
-	err := r.reconcile(ctx, log, request)
+	secret := &corev1.Secret{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		// handling deletion
+		delSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: r.namespace}}
+		if err := r.handleDeletion(ctx, log, delSecret); err != nil {
+			err = fmt.Errorf("failed to delete secret: %w", err)
+
+			log.Errorw("ReconcilingError", zap.Error(err))
+			r.recorder.Event(delSecret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	err := r.reconcile(ctx, log, secret)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
-	secret := &corev1.Secret{}
-
-	var err error
-	if err = r.masterClient.Get(ctx, request.NamespacedName, secret); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		} else {
-			// handling deletion
-			delSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: r.namespace}}
-			if err := r.handleDeletion(ctx, log, delSecret); err != nil {
-				return fmt.Errorf("failed to delete secret: %w", err)
-			}
-			return nil
-		}
-	}
-
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
 	seedsecret := secret.DeepCopy()
 	seedsecret.SetResourceVersion("")
 
 	namedSecretCreatorGetter := []reconciling.NamedSecretCreatorGetter{
 		secretCreator(seedsecret),
 	}
-	err = r.reconcileAllSeeds(ctx, log, seedsecret, func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedSecret := &corev1.Secret{}
-		if err := c.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seedsecret), seedSecret); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seedsecret), seedSecret); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch Secret on seed cluster: %w", err)
 		}
 
@@ -127,10 +130,9 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 			return nil
 		}
 
-		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, c)
+		return reconciling.ReconcileSecrets(ctx, namedSecretCreatorGetter, r.namespace, seedClient)
 	})
 	if err != nil {
-		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return fmt.Errorf("reconciling secret %s failed: %w", seedsecret.Name, err)
 	}
 
@@ -146,8 +148,9 @@ func secretCreator(s *corev1.Secret) reconciling.NamedSecretCreatorGetter {
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
-	delfunc := func(ctx context.Context, log *zap.SugaredLogger, c ctrlruntimeclient.Client, o ctrlruntimeclient.Object) error {
-		err := c.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &corev1.Secret{})
+	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		seedSecret := &corev1.Secret{}
+		err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(secret), seedSecret)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Debug("Secret already deleted")
@@ -156,26 +159,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return err
 		}
 
-		return c.Delete(ctx, secret)
-	}
-
-	return r.reconcileAllSeeds(ctx, log, secret, delfunc)
-}
-
-func (r *reconciler) reconcileAllSeeds(ctx context.Context, log *zap.SugaredLogger, obj ctrlruntimeclient.Object, action func(context.Context, *zap.SugaredLogger, ctrlruntimeclient.Client, ctrlruntimeclient.Object) error) error {
-	kind := obj.GetObjectKind().GroupVersionKind().Kind
-	name := obj.GetName()
-
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling %s %s with seed", kind, name)
-
-		err := action(ctx, log, seedClient, obj)
-		if err != nil {
-			return fmt.Errorf("failed syncing %s %q for seed %q: %w", kind, name, seedName, err) // we need seedName here, as we don't have it wrapped via log.With
-		}
-		log.Debugf("Reconciled %s %s with seed", kind, name)
-	}
-	return nil
+		return seedClient.Delete(ctx, seedSecret)
+	})
 }

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -27,6 +27,7 @@ import (
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -50,7 +51,7 @@ type reconciler struct {
 	log          *zap.SugaredLogger
 	masterClient ctrlruntimeclient.Client
 	namespace    string
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 	recorder     record.EventRecorder
 }
 
@@ -65,7 +66,7 @@ func Add(ctx context.Context,
 		log:          log,
 		masterClient: masterMgr.GetClient(),
 		namespace:    namespace,
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 		recorder:     masterMgr.GetEventRecorderFor(ControllerName),
 	}
 
@@ -101,38 +102,24 @@ func constraintCreatorGetter(constraint *kubermaticv1.Constraint) reconciling.Na
 
 // Reconcile reconciles the kubermatic constraints in the master cluster and syncs them to all seeds.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("resource", request.Name)
+	log := r.log.With("constraint", request.Name)
 	log.Debug("Processing")
 
-	err := r.reconcile(ctx, log, request)
+	constraint := &kubermaticv1.Constraint{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, constraint); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	err := r.reconcile(ctx, log, constraint)
 	if err != nil {
 		log.Errorw("ReconcilingError", zap.Error(err))
+		r.recorder.Event(constraint, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return reconcile.Result{}, err
 }
 
-func (r *reconciler) syncAllSeeds(ctx context.Context, log *zap.SugaredLogger, constraint *kubermaticv1.Constraint, action func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint) error) error {
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling constraint with seed")
-
-		err := action(seedClient, constraint)
-		if err != nil {
-			return fmt.Errorf("failed syncing constraint %s for seed %s: %w", constraint.Name, seedName, err)
-		}
-		log.Debug("Reconciled constraint with seed")
-	}
-	return nil
-}
-
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
-	constraint := &kubermaticv1.Constraint{}
-	if err := r.masterClient.Get(ctx, request.NamespacedName, constraint); err != nil {
-		return ctrlruntimeclient.IgnoreNotFound(err)
-	}
-
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, constraint *kubermaticv1.Constraint) error {
 	// handling deletion
 	if !constraint.DeletionTimestamp.IsZero() {
 		if err := r.handleDeletion(ctx, log, constraint); err != nil {
@@ -149,7 +136,9 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		constraintCreatorGetter(constraint),
 	}
 
-	return r.syncAllSeeds(ctx, log, constraint, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint) error {
+	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		log.Debug("Reconciling constraint with seed")
+
 		seedConst := &kubermaticv1.Constraint{}
 		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(constraint), seedConst); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch Constraint on seed cluster: %w", err)
@@ -170,7 +159,9 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return nil
 	}
 
-	err := r.syncAllSeeds(ctx, log, constraint, func(seedClient ctrlruntimeclient.Client, constraint *kubermaticv1.Constraint) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		log.Debug("Deleting Constraint on Seed")
+
 		err := seedClient.Delete(ctx, &kubermaticv1.Constraint{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      constraint.Name,

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -25,7 +25,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -51,12 +50,11 @@ const (
 )
 
 type reconciler struct {
-	log              *zap.SugaredLogger
-	recorder         record.EventRecorder
-	masterClient     ctrlruntimeclient.Client
-	namespace        string
-	seedsGetter      provider.SeedsGetter
-	seedClientGetter provider.SeedClientGetter
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	masterClient ctrlruntimeclient.Client
+	namespace    string
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(ctx context.Context,
@@ -64,21 +62,23 @@ func Add(ctx context.Context,
 	log *zap.SugaredLogger,
 	numWorkers int,
 	namespace string,
-	seedsGetter provider.SeedsGetter,
-	seedKubeconfigGetter provider.SeedKubeconfigGetter,
+	seedManagers map[string]manager.Manager,
 ) error {
 	reconciler := &reconciler{
-		log:              log.Named(ControllerName),
-		recorder:         mgr.GetEventRecorderFor(ControllerName),
-		masterClient:     mgr.GetClient(),
-		namespace:        namespace,
-		seedsGetter:      seedsGetter,
-		seedClientGetter: provider.SeedClientGetterFactory(seedKubeconfigGetter),
+		log:          log.Named(ControllerName),
+		recorder:     mgr.GetEventRecorderFor(ControllerName),
+		masterClient: mgr.GetClient(),
+		namespace:    namespace,
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
 	if err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	for seedName, seedManager := range seedManagers {
+		reconciler.seedClients[seedName] = seedManager.GetClient()
 	}
 
 	if err := c.Watch(
@@ -101,7 +101,7 @@ func Add(ctx context.Context,
 
 // Reconcile reconciles the kubermatic constraint template on the master cluster to all seed clusters.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("request", request)
+	log := r.log.With("template", request.Name)
 	log.Debug("Reconciling")
 
 	constraintTemplate := &kubermaticv1.ConstraintTemplate{}
@@ -127,19 +127,14 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 			return nil
 		}
 
-		err := r.syncAllSeeds(ctx, log, constraintTemplate, func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
-			err := seedClusterClient.Delete(ctx, &kubermaticv1.ConstraintTemplate{
+		err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+			err := seedClient.Delete(ctx, &kubermaticv1.ConstraintTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: constraintTemplate.Name,
 				},
 			})
 
-			if apierrors.IsNotFound(err) {
-				log.Debug("constraint template not found, returning")
-				return nil
-			}
-
-			return err
+			return ctrlruntimeclient.IgnoreNotFound(err)
 		})
 		if err != nil {
 			return err
@@ -156,46 +151,19 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cons
 		constraintTemplateCreatorGetter(constraintTemplate),
 	}
 
-	return r.syncAllSeeds(ctx, log, constraintTemplate, func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error {
+	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedCT := &kubermaticv1.ConstraintTemplate{}
-		if err := seedClusterClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(ct), seedCT); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(constraintTemplate), seedCT); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch ConstraintTemplate on seed cluster: %w", err)
 		}
 
 		// see project-synchronizer's syncAllSeeds comment
-		if seedCT.UID != "" && seedCT.UID == ct.UID {
+		if seedCT.UID != "" && seedCT.UID == constraintTemplate.UID {
 			return nil
 		}
 
-		return reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", seedClusterClient)
+		return reconciling.ReconcileKubermaticV1ConstraintTemplates(ctx, ctCreatorGetters, "", seedClient)
 	})
-}
-
-func (r *reconciler) syncAllSeeds(
-	ctx context.Context,
-	log *zap.SugaredLogger,
-	constraintTemplate *kubermaticv1.ConstraintTemplate,
-	action func(seedClusterClient ctrlruntimeclient.Client, ct *kubermaticv1.ConstraintTemplate) error,
-) error {
-	seeds, err := r.seedsGetter()
-	if err != nil {
-		return fmt.Errorf("failed listing seeds: %w", err)
-	}
-
-	for _, seed := range seeds {
-		seedClient, err := r.seedClientGetter(seed)
-		if err != nil {
-			return fmt.Errorf("failed getting seed client for seed %s: %w", seed.Name, err)
-		}
-
-		err = action(seedClient, constraintTemplate)
-		if err != nil {
-			return fmt.Errorf("failed syncing constraint template for seed %s: %w", seed.Name, err)
-		}
-		log.Debugw("Reconciled constraint template with seed", "seed", seed.Name)
-	}
-
-	return nil
 }
 
 func constraintTemplateCreatorGetter(kubeCT *kubermaticv1.ConstraintTemplate) reconciling.NamedKubermaticV1ConstraintTemplateCreatorGetter {

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -88,10 +88,7 @@ func TestReconcile(t *testing.T) {
 				log:          kubermaticlog.Logger,
 				recorder:     &record.FakeRecorder{},
 				masterClient: tc.masterClient,
-				seedsGetter:  test.CreateTestSeedsGetter(ctx, tc.masterClient),
-				seedClientGetter: func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
-					return tc.seedClient, nil
-				},
+				seedClients:  map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -49,7 +49,7 @@ const (
 type reconciler struct {
 	log          *zap.SugaredLogger
 	masterClient ctrlruntimeclient.Client
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 	recorder     record.EventRecorder
 }
 
@@ -62,7 +62,7 @@ func Add(
 	r := &reconciler{
 		log:          log,
 		masterClient: masterMgr.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 		recorder:     masterMgr.GetEventRecorderFor(ControllerName),
 	}
 
@@ -119,7 +119,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		presetCreatorGetter(preset),
 	}
 
-	err := r.syncAllSeeds(log, preset, func(seedClient ctrlruntimeclient.Client, preset *kubermaticv1.Preset) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedPreset := &kubermaticv1.Preset{}
 		if err := seedClient.Get(ctx, request.NamespacedName, seedPreset); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch preset on seed cluster: %w", err)
@@ -141,7 +141,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, preset *kubermaticv1.Preset) error {
 	if kuberneteshelper.HasFinalizer(preset, cleanupFinalizer) {
-		if err := r.syncAllSeeds(log, preset, func(seedClient ctrlruntimeclient.Client, preset *kubermaticv1.Preset) error {
+		if err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 			err := seedClient.Delete(ctx, &kubermaticv1.Preset{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: preset.Name,
@@ -158,21 +158,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		}
 	}
 
-	return nil
-}
-
-func (r *reconciler) syncAllSeeds(log *zap.SugaredLogger, preset *kubermaticv1.Preset, action func(seedClient ctrlruntimeclient.Client, preset *kubermaticv1.Preset) error) error {
-	for seedName, seedClient := range r.seedClients {
-		log := log.With("seed", seedName)
-
-		log.Debug("Reconciling preset with seed")
-
-		err := action(seedClient, preset)
-		if err != nil {
-			return fmt.Errorf("failed syncing preset %s for seed %s: %w", preset.Name, seedName, err)
-		}
-		log.Debug("Reconciled preset with seed")
-	}
 	return nil
 }
 

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -24,6 +24,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +46,7 @@ const ControllerName = "kkp-project-label-synchronizer"
 type reconciler struct {
 	log                     *zap.SugaredLogger
 	masterClient            ctrlruntimeclient.Client
-	seedClients             map[string]ctrlruntimeclient.Client
+	seedClients             kuberneteshelper.SeedClientMap
 	workerNameLabelSelector labels.Selector
 }
 
@@ -89,7 +90,7 @@ func Add(
 	r := &reconciler{
 		log:                     log,
 		masterClient:            masterManager.GetClient(),
-		seedClients:             map[string]ctrlruntimeclient.Client{},
+		seedClients:             kuberneteshelper.SeedClientMap{},
 		workerNameLabelSelector: workerSelector,
 	}
 

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -184,20 +184,6 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, project, cleanupFinalizer)
 }
 
-func (r *reconciler) syncAllSeeds(
-	log *zap.SugaredLogger,
-	project *kubermaticv1.Project,
-	action func(seedClusterClient ctrlruntimeclient.Client, project *kubermaticv1.Project) error,
-) error {
-	for seedName, seedClient := range r.seedClients {
-		if err := action(seedClient, project); err != nil {
-			return fmt.Errorf("failed syncing project for seed %s: %w", seedName, err)
-		}
-		log.Debugw("Reconciled project with seed", "seed", seedName)
-	}
-	return nil
-}
-
 func enqueueAllProjects(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
 		var requests []reconcile.Request

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -53,7 +53,7 @@ type reconciler struct {
 	recorder        record.EventRecorder
 	masterClient    ctrlruntimeclient.Client
 	masterAPIReader ctrlruntimeclient.Reader
-	seedClients     map[string]ctrlruntimeclient.Client
+	seedClients     kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -67,7 +67,7 @@ func Add(
 		recorder:        masterManager.GetEventRecorderFor(ControllerName),
 		masterClient:    masterManager.GetClient(),
 		masterAPIReader: masterManager.GetAPIReader(),
-		seedClients:     map[string]ctrlruntimeclient.Client{},
+		seedClients:     kuberneteshelper.SeedClientMap{},
 	}
 
 	c, err := controller.New(ControllerName, masterManager, controller.Options{Reconciler: r, MaxConcurrentReconciles: numWorkers})
@@ -137,9 +137,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	userCreatorGetters := []reconciling.NamedKubermaticV1UserCreatorGetter{
 		userCreatorGetter(user),
 	}
-	err := r.syncAllSeeds(log, user, func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error {
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		seedUser := &kubermaticv1.User{}
-		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedUser); err != nil && !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, request.NamespacedName, seedUser); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to fetch user on seed cluster: %w", err)
 		}
 
@@ -148,19 +148,19 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return nil
 		}
 
-		err := reconciling.ReconcileKubermaticV1Users(ctx, userCreatorGetters, "", seedClusterClient)
+		err := reconciling.ReconcileKubermaticV1Users(ctx, userCreatorGetters, "", seedClient)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile user: %w", err)
 		}
 
-		if err := seedClusterClient.Get(ctx, request.NamespacedName, seedUser); err != nil {
+		if err := seedClient.Get(ctx, request.NamespacedName, seedUser); err != nil {
 			return fmt.Errorf("failed to fetch user on seed cluster: %w", err)
 		}
 
 		if !equality.Semantic.DeepEqual(user.Status, seedUser.Status) {
 			oldSeedUser := seedUser.DeepCopy()
 			seedUser.Status = *user.Status.DeepCopy()
-			if err := seedClusterClient.Status().Patch(ctx, seedUser, ctrlruntimeclient.MergeFrom(oldSeedUser)); err != nil {
+			if err := seedClient.Status().Patch(ctx, seedUser, ctrlruntimeclient.MergeFrom(oldSeedUser)); err != nil {
 				return fmt.Errorf("failed to update user status on seed cluster: %w", err)
 			}
 		}
@@ -175,29 +175,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, user *kubermaticv1.User) error {
-	err := r.syncAllSeeds(log, user, func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error {
-		if err := seedClusterClient.Delete(ctx, user); err != nil {
-			return ctrlruntimeclient.IgnoreNotFound(err)
-		}
-		return nil
+	err := r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		return ctrlruntimeclient.IgnoreNotFound(seedClient.Delete(ctx, user))
 	})
 	if err != nil {
 		return err
 	}
 
 	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, user, cleanupFinalizer)
-}
-
-func (r *reconciler) syncAllSeeds(
-	log *zap.SugaredLogger,
-	user *kubermaticv1.User,
-	action func(seedClusterClient ctrlruntimeclient.Client, user *kubermaticv1.User) error) error {
-	for seedName, seedClient := range r.seedClients {
-		err := action(seedClient, user)
-		if err != nil {
-			return fmt.Errorf("failed syncing user for seed %s: %w", seedName, err)
-		}
-		log.Debugw("Reconciled user with seed", "seed", seedName)
-	}
-	return nil
 }

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -26,6 +26,7 @@ import (
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
@@ -59,7 +60,7 @@ type Reconciler struct {
 	masterClient ctrlruntimeclient.Client
 	log          *zap.SugaredLogger
 	workerName   string
-	seedClients  map[string]ctrlruntimeclient.Client
+	seedClients  kuberneteshelper.SeedClientMap
 }
 
 func Add(
@@ -79,7 +80,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		workerName:   workerName,
 		masterClient: mgr.GetClient(),
-		seedClients:  map[string]ctrlruntimeclient.Client{},
+		seedClients:  kuberneteshelper.SeedClientMap{},
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
@@ -227,7 +228,7 @@ func buildUserSSHKeysForCluster(clusterName string, keys *kubermaticv1.UserSSHKe
 }
 
 // enqueueAllClusters enqueues all clusters.
-func enqueueAllClusters(ctx context.Context, clients map[string]ctrlruntimeclient.Client, workerSelector labels.Selector) handler.EventHandler {
+func enqueueAllClusters(ctx context.Context, clients kuberneteshelper.SeedClientMap, workerSelector labels.Selector) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
 		var requests []reconcile.Request
 

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -24,8 +24,9 @@ import (
 	"strconv"
 	"strings"
 
-	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"go.uber.org/zap"
+
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR refactors one of the last few controllers in the master-ctrl-mgr to use the seed-lifecycle.

I also added `kuberneteshelper.SeedClientMap` with an `Each` function in order to get rid of the maaaaany `syncAllSeeds()` functions throughout the controllers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
