### PR TITLE
Group support for external user

### DIFF
--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -255,7 +255,7 @@ func GetOwnersForProject(ctx context.Context, userInfo *provider.UserInfo, proje
 	if err != nil {
 		return nil, err
 	}
-	projectOwners := []apiv1.User{}
+	var projectOwners []apiv1.User
 	for _, projectMember := range allProjectMembers {
 		if rbac.ExtractGroupPrefix(projectMember.Spec.Group) == rbac.OwnerGroupNamePrefix {
 			user, err := userProvider.UserByEmail(ctx, projectMember.Spec.UserEmail)

--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -276,17 +276,9 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			projectIDSet.Insert(projectInternal.Name)
 		}
 
-		var groupMappings []*kubermaticv1.GroupProjectBinding
-		for _, groupName := range userInfo.Groups {
-			groupProjectBindings, err := memberMapper.GroupMappingsFor(ctx, groupName)
-			if err != nil {
-				if isStatus(err, http.StatusNotFound) {
-					// We don't expect each group to have a corresponding GroupProjectBinding.
-					continue
-				}
-				return nil, common.KubernetesErrorToHTTPError(err)
-			}
-			groupMappings = append(groupMappings, groupProjectBindings...)
+		groupMappings, err := memberMapper.GroupMappingsFor(ctx, userInfo.Groups)
+		if err != nil {
+			return nil, err
 		}
 
 		for _, group := range groupMappings {

--- a/pkg/handler/v2/user/user.go
+++ b/pkg/handler/v2/user/user.go
@@ -48,7 +48,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, userProvider provider.
 
 		result := make([]apiv1.User, 0)
 		for _, crdUser := range list {
-			apiUser := apiv1.ConvertInternalUserToExternal(&crdUser, false)
+			apiUser := apiv1.ConvertInternalUserToExternal(&crdUser, false, nil, nil)
 			result = append(result, *apiUser)
 		}
 

--- a/pkg/provider/kubernetes/member.go
+++ b/pkg/provider/kubernetes/member.go
@@ -205,20 +205,22 @@ func (p *ProjectMemberProvider) MappingsFor(ctx context.Context, userEmail strin
 
 // GroupMappingsFor returns the list of projects (bindings) for the given group
 // This function is unsafe in a sense that it uses privileged account to list all members in the system.
-func (p *ProjectMemberProvider) GroupMappingsFor(ctx context.Context, groupName string) ([]*kubermaticv1.GroupProjectBinding, error) {
+func (p *ProjectMemberProvider) GroupMappingsFor(ctx context.Context, groups []string) ([]*kubermaticv1.GroupProjectBinding, error) {
+	groupSet := sets.NewString(groups...)
+
 	allBindings := &kubermaticv1.GroupProjectBindingList{}
 	if err := p.clientPrivileged.List(ctx, allBindings); err != nil {
 		return nil, err
 	}
 
-	var bindingsForGroup []*kubermaticv1.GroupProjectBinding
+	var bindingsForGivenGroups []*kubermaticv1.GroupProjectBinding
 	for _, binding := range allBindings.Items {
-		if binding.Spec.Group == groupName {
-			bindingsForGroup = append(bindingsForGroup, binding.DeepCopy())
+		if groupSet.Has(binding.Spec.Group) {
+			bindingsForGivenGroups = append(bindingsForGivenGroups, binding.DeepCopy())
 		}
 	}
 
-	return bindingsForGroup, nil
+	return bindingsForGivenGroups, nil
 }
 
 // MapUserToRoles returns the roles of the user in the project. It searches across the user project bindings and the group

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -429,9 +429,9 @@ type ProjectMemberMapper interface {
 	// This function is unsafe in a sense that it uses privileged account to list all members in the system
 	MappingsFor(ctx context.Context, userEmail string) ([]*kubermaticv1.UserProjectBinding, error)
 
-	// GroupMappingsFor returns the list of projects (bindings) for the given group
+	// GroupMappingsFor returns the list of projects (bindings) for the given set of groups
 	// This function is unsafe in a sense that it uses privileged account to list all members in the system.
-	GroupMappingsFor(ctx context.Context, groupName string) ([]*kubermaticv1.GroupProjectBinding, error)
+	GroupMappingsFor(ctx context.Context, userGroups []string) ([]*kubermaticv1.GroupProjectBinding, error)
 
 	// MapUserToRoles returns the roles of the user in the project. It searches across the user project bindings and the group
 	// project bindings for the user and returns the roles.


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Dashboard uses `/me` websocket in order to gather information about current user. We forgot to modify this endpoint after introducing groups and this PR tries to address this issue.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
