### PR TITLE
Fix oauth charts templating when certVolume is set

### DIFF
--- a/charts/oauth/templates/deployment.yaml
+++ b/charts/oauth/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           readOnly: true
 {{- if .Values.dex.extraVolumeMounts }}
 {{ toYaml .Values.dex.extraVolumeMounts | indent 8 }}
-{{- end -}}
+{{- end }}
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.certMount | trim | indent 8 }}
 {{- end }}
         resources:
@@ -72,7 +72,7 @@ spec:
           secretName: themes
 {{- if .Values.dex.extraVolumes }}
 {{ toYaml .Values.dex.extraVolumes | indent 6 }}
-{{- end -}}
+{{- end }}
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.certVolume | trim | indent 6 }}
 {{- end }}
       nodeSelector:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

Whoopsie daisies. When `certVolume` is set, oauth templates break.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
