### PR TITLE
Set cluster-isolation network policy type explicitly

### DIFF
--- a/pkg/provider/cloud/kubevirt/networkpolicy.go
+++ b/pkg/provider/cloud/kubevirt/networkpolicy.go
@@ -42,6 +42,9 @@ func clusterIsolationNetworkPolicyCreator() reconciling.NamedNetworkPolicyCreato
 						},
 					},
 				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+				},
 			}
 			return np, nil
 		}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It fixes reonciliation of `cluster-isolation` network policy for KubeVirt cloud provider.
When the object is being created some mutation webhook of k8s sets the network policy type to the object.
If we don't set this explicitly the reconciliation for KubeVirt will fail on the https://github.com/kubermatic/kubermatic/blob/master/pkg/resources/reconciling/ensure.go#L120 while comparing objects.


**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
