### PR TITLE
Move finalizers out of API-only package

### DIFF
--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -36,7 +36,6 @@ import (
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/tests"
 	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -337,8 +336,8 @@ func (r *TestRunner) executeTests(
 				return err
 			}
 			cluster.Finalizers = append(cluster.Finalizers,
-				apiv1.InClusterPVCleanupFinalizer,
-				apiv1.InClusterLBCleanupFinalizer,
+				kubermaticv1.InClusterPVCleanupFinalizer,
+				kubermaticv1.InClusterLBCleanupFinalizer,
 			)
 			return r.opts.SeedClusterClient.Update(ctx, cluster)
 		})

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2699,32 +2699,3 @@ type MeteringReportConfiguration struct {
 // ReportURL represent an S3 pre signed URL to download a report
 // swagger:model MeteringReportURL
 type ReportURL string
-
-const (
-	// NodeDeletionFinalizer indicates that the nodes still need cleanup.
-	NodeDeletionFinalizer = "kubermatic.k8c.io/delete-nodes"
-	// InClusterPVCleanupFinalizer indicates that the PVs still need cleanup.
-	InClusterPVCleanupFinalizer = "kubermatic.k8c.io/cleanup-in-cluster-pv"
-	// InClusterLBCleanupFinalizer indicates that the LBs still need cleanup.
-	InClusterLBCleanupFinalizer = "kubermatic.k8c.io/cleanup-in-cluster-lb"
-	// NamespaceCleanupFinalizer indicates that the cluster namespace still exists and the owning Cluster object
-	// must not yet be deleted.
-	NamespaceCleanupFinalizer = "kubermatic.k8c.io/cleanup-namespace"
-	// CredentialsSecretsCleanupFinalizer indicates that secrets for credentials still need cleanup.
-	CredentialsSecretsCleanupFinalizer = "kubermatic.k8c.io/cleanup-credentials-secrets"
-	// ExternalClusterKubeOneNamespaceCleanupFinalizer indicates that kubeone cluster namespace still need cleanup.
-	ExternalClusterKubeOneNamespaceCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeone-namespace"
-	// ExternalClusterKubeconfigCleanupFinalizer indicates that secrets for kubeconfig still need cleanup.
-	ExternalClusterKubeconfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeconfig-secret"
-	// EtcdBackConfigCleanupFinalizer indicates that EtcdBackupConfigs for the cluster still need cleanup.
-	EtcdBackupConfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-etcdbackupconfigs"
-	// GatekeeperConstraintCleanupFinalizer indicates that gatkeeper constraints on the user cluster need cleanup.
-	GatekeeperConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-constraints"
-	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup.
-	KubermaticConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-constraints"
-)
-
-const (
-	InitialMachineDeploymentRequestAnnotation        = "kubermatic.io/initial-machinedeployment-request"
-	InitialApplicationInstallationsRequestAnnotation = "kubermatic.io/initial-application-installations-request"
-)

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2712,49 +2712,16 @@ const (
 	NamespaceCleanupFinalizer = "kubermatic.k8c.io/cleanup-namespace"
 	// CredentialsSecretsCleanupFinalizer indicates that secrets for credentials still need cleanup.
 	CredentialsSecretsCleanupFinalizer = "kubermatic.k8c.io/cleanup-credentials-secrets"
-	// ExternalClusterKubeOneManifestSecretCleanupFinalizer indicates that secrets for manifest secret still need cleanup.
-	ExternalClusterKubeOneManifestSecretCleanupFinalizer = "kubermatic.k8c.io/cleanup-manifest-secret"
-	// ExternalClusterKubeOneSSHSecretCleanupFinalizer indicates that secrets for ssh secret still need cleanup.
-	ExternalClusterKubeOneSSHSecretCleanupFinalizer = "kubermatic.k8c.io/cleanup-ssh-secret"
 	// ExternalClusterKubeOneNamespaceCleanupFinalizer indicates that kubeone cluster namespace still need cleanup.
 	ExternalClusterKubeOneNamespaceCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeone-namespace"
-	// UserClusterRoleCleanupFinalizer indicates that user cluster role still need cleanup.
-	UserClusterRoleCleanupFinalizer = "kubermatic.k8c.io/user-cluster-role"
 	// ExternalClusterKubeconfigCleanupFinalizer indicates that secrets for kubeconfig still need cleanup.
 	ExternalClusterKubeconfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeconfig-secret"
 	// EtcdBackConfigCleanupFinalizer indicates that EtcdBackupConfigs for the cluster still need cleanup.
 	EtcdBackupConfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-etcdbackupconfigs"
-	// GatekeeperConstraintTemplateCleanupFinalizer indicates that synced gatekeeper Constraint Templates on user cluster need cleanup.
-	GatekeeperConstraintTemplateCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-constraint-templates"
-	// GatekeeperSeedConstraintTemplateCleanupFinalizer indicates that synced gatekeeper Constraint Templates on seed clusters need cleanup.
-	GatekeeperSeedConstraintTemplateCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-master-constraint-templates"
-	// GatekeeperSeedConstraintCleanupFinalizer indicates that synced gatekeeper Constraint on seed clusters need cleanup.
-	GatekeeperSeedConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-seed-constraint"
 	// GatekeeperConstraintCleanupFinalizer indicates that gatkeeper constraints on the user cluster need cleanup.
 	GatekeeperConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-constraints"
-	// KubermaticUserClusterNsDefaultConstraintCleanupFinalizer indicates that kubermatic constraints on the user cluster namespace need cleanup.
-	KubermaticUserClusterNsDefaultConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-usercluster-ns-default-constraints"
 	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup.
 	KubermaticConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-constraints"
-	// SeedProjectCleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup.
-	SeedProjectCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-projects"
-	// SeedUserProjectBindingCleanupFinalizer indicates that Kubermatic UserProjectBindings on the seed clusters need cleanup.
-	SeedUserProjectBindingCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-user-project-bindings"
-	// SeedGroupProjectBindingCleanupFinalizer indicates that Kubermatic GroupProjectBindings on the seed clusters need cleanup.
-	SeedGroupProjectBindingCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-group-project-bindings"
-	// SeedUserCleanupFinalizer indicates that Kubermatic Users on the seed clusters need cleanup.
-	SeedUserCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-users"
-	// ClusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup.
-	// This finalizer is deprecated and should not be used anymore since we migrated to using owner references for cleanup.
-	ClusterRoleBindingsCleanupFinalizer = "kubermatic.k8c.io/cleanup-cluster-role-bindings"
-	// ClusterTemplateSeedCleanupFinalizer indicates that synced cluster template on seed clusters need cleanup.
-	ClusterTemplateSeedCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-cluster-template"
-	// AllowedRegistryCleanupFinalizer indicates that allowed registry Constraints need to be cleaned up.
-	AllowedRegistryCleanupFinalizer = "kubermatic.k8c.io/cleanup-allowed-registry"
-	// PresetSeedCleanupFinalizer indicates that synced preset on seed clusters need cleanup.
-	PresetSeedCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-preset"
-	// ResourceQuotaSeedCleanupFinalizer indicates that synced resource quota on seed clusters needs cleanup.
-	ResourceQuotaSeedCleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-resource-quota"
 )
 
 const (

--- a/pkg/apis/kubermatic/v1/common.go
+++ b/pkg/apis/kubermatic/v1/common.go
@@ -44,3 +44,35 @@ const (
 	// for each user cluster.
 	ExposeStrategyTunneling ExposeStrategy = "Tunneling"
 )
+
+// Finalizers should be kept to their controllers. Only if a finalizer is
+// used by multiple controllers should it be placed here.
+
+const (
+	// NodeDeletionFinalizer indicates that the nodes still need cleanup.
+	NodeDeletionFinalizer = "kubermatic.k8c.io/delete-nodes"
+	// NamespaceCleanupFinalizer indicates that the cluster namespace still exists and the owning Cluster object
+	// must not yet be deleted.
+	NamespaceCleanupFinalizer = "kubermatic.k8c.io/cleanup-namespace"
+	// InClusterPVCleanupFinalizer indicates that the PVs still need cleanup.
+	InClusterPVCleanupFinalizer = "kubermatic.k8c.io/cleanup-in-cluster-pv"
+	// InClusterLBCleanupFinalizer indicates that the LBs still need cleanup.
+	InClusterLBCleanupFinalizer = "kubermatic.k8c.io/cleanup-in-cluster-lb"
+	// CredentialsSecretsCleanupFinalizer indicates that secrets for credentials still need cleanup.
+	CredentialsSecretsCleanupFinalizer = "kubermatic.k8c.io/cleanup-credentials-secrets"
+	// ExternalClusterKubeOneNamespaceCleanupFinalizer indicates that kubeone cluster namespace still need cleanup.
+	ExternalClusterKubeOneNamespaceCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeone-namespace"
+	// ExternalClusterKubeconfigCleanupFinalizer indicates that secrets for kubeconfig still need cleanup.
+	ExternalClusterKubeconfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubeconfig-secret"
+	// EtcdBackConfigCleanupFinalizer indicates that EtcdBackupConfigs for the cluster still need cleanup.
+	EtcdBackupConfigCleanupFinalizer = "kubermatic.k8c.io/cleanup-etcdbackupconfigs"
+	// GatekeeperConstraintCleanupFinalizer indicates that gatkeeper constraints on the user cluster need cleanup.
+	GatekeeperConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-gatekeeper-constraints"
+	// KubermaticConstraintCleanupFinalizer indicates that Kubermatic constraints for the cluster need cleanup.
+	KubermaticConstraintCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-constraints"
+)
+
+const (
+	InitialMachineDeploymentRequestAnnotation        = "kubermatic.io/initial-machinedeployment-request"
+	InitialApplicationInstallationsRequestAnnotation = "kubermatic.io/initial-application-installations-request"
+)

--- a/pkg/clusterdeletion/clusterrolebindings.go
+++ b/pkg/clusterdeletion/clusterrolebindings.go
@@ -19,13 +19,18 @@ package clusterdeletion
 import (
 	"context"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+)
+
+const (
+	// clusterRoleBindingsCleanupFinalizer indicates that the cluster ClusterRoleBindings on the seed cluster need cleanup.
+	// This finalizer is deprecated and should not be used anymore since we migrated to using owner references for cleanup.
+	clusterRoleBindingsCleanupFinalizer = "kubermatic.k8c.io/cleanup-cluster-role-bindings"
 )
 
 // cleanupClusterRoleBindings is deprecated and should be removed in KKP 2.20+, because
 // nowadays we use owner references for cleanup and this manual step is not needed anymore.
 func (d *Deletion) cleanupClusterRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.ClusterRoleBindingsCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, clusterRoleBindingsCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/constraints.go
+++ b/pkg/clusterdeletion/constraints.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -31,7 +30,7 @@ import (
 )
 
 func (d *Deletion) cleanupConstraints(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, apiv1.KubermaticConstraintCleanupFinalizer) {
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.KubermaticConstraintCleanupFinalizer) {
 		return nil
 	}
 
@@ -53,7 +52,7 @@ func (d *Deletion) cleanupConstraints(ctx context.Context, log *zap.SugaredLogge
 		}
 
 		for _, constraint := range constraintList.Items {
-			if finalizer := apiv1.GatekeeperConstraintCleanupFinalizer; kuberneteshelper.HasFinalizer(&constraint, finalizer) {
+			if finalizer := kubermaticv1.GatekeeperConstraintCleanupFinalizer; kuberneteshelper.HasFinalizer(&constraint, finalizer) {
 				log.Infow("Garbage-collecting Constraint", "constraint", constraint.Name)
 
 				if err := kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, &constraint, finalizer); err != nil {
@@ -65,5 +64,5 @@ func (d *Deletion) cleanupConstraints(ctx context.Context, log *zap.SugaredLogge
 
 	d.recorder.Event(cluster, corev1.EventTypeNormal, "ConstraintCleanup", "Cleanup has been completed.")
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.KubermaticConstraintCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.KubermaticConstraintCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/deletion_test.go
+++ b/pkg/clusterdeletion/deletion_test.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
@@ -138,14 +137,14 @@ func TestNodesRemainUntilInClusterResourcesAreGone(t *testing.T) {
 	}{
 		{
 			name:    "Nodes remain because LB finalizer exists",
-			cluster: getClusterWithFinalizer(clusterName, apiv1.InClusterLBCleanupFinalizer),
+			cluster: getClusterWithFinalizer(clusterName, kubermaticv1.InClusterLBCleanupFinalizer),
 			objects: []ctrlruntimeclient.Object{&corev1.Service{
 				Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
 			}},
 		},
 		{
 			name:    "Nodes remain because PV finalizer exists",
-			cluster: getClusterWithFinalizer(clusterName, apiv1.InClusterPVCleanupFinalizer),
+			cluster: getClusterWithFinalizer(clusterName, kubermaticv1.InClusterPVCleanupFinalizer),
 			objects: []ctrlruntimeclient.Object{&corev1.PersistentVolume{}},
 		},
 	}

--- a/pkg/clusterdeletion/etcdbackupconfig.go
+++ b/pkg/clusterdeletion/etcdbackupconfig.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -29,7 +28,7 @@ import (
 )
 
 func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, apiv1.EtcdBackupConfigCleanupFinalizer) {
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.EtcdBackupConfigCleanupFinalizer) {
 		return nil
 	}
 
@@ -54,5 +53,5 @@ func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kuberm
 
 	d.recorder.Event(cluster, corev1.EventTypeNormal, "EtcdBackupConfigCleanup", "Cleanup has been completed.")
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.EtcdBackupConfigCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.EtcdBackupConfigCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/namespace.go
+++ b/pkg/clusterdeletion/namespace.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -33,7 +32,7 @@ import (
 )
 
 func (d *Deletion) cleanupNamespace(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, apiv1.NamespaceCleanupFinalizer) {
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.NamespaceCleanupFinalizer) {
 		return nil
 	}
 
@@ -78,5 +77,5 @@ func (d *Deletion) cleanupNamespace(ctx context.Context, log *zap.SugaredLogger,
 		}
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.NamespaceCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.NamespaceCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/node.go
+++ b/pkg/clusterdeletion/node.go
@@ -22,7 +22,6 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	eviction "github.com/kubermatic/machine-controller/pkg/node/eviction/types"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -33,12 +32,12 @@ import (
 )
 
 func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, apiv1.NodeDeletionFinalizer) {
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.NodeDeletionFinalizer) {
 		return nil
 	}
 
 	if cluster.Status.NamespaceName == "" {
-		return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.NodeDeletionFinalizer)
+		return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.NodeDeletionFinalizer)
 	}
 
 	userClusterClient, err := d.userClusterClientGetter()
@@ -115,5 +114,5 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 
 	d.recorder.Event(cluster, corev1.EventTypeNormal, "NodeCleanup", "Cleanup has been completed, all machines have been destroyed.")
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.NodeDeletionFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.NodeDeletionFinalizer)
 }

--- a/pkg/clusterdeletion/secret.go
+++ b/pkg/clusterdeletion/secret.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -35,7 +34,7 @@ func (d *Deletion) cleanupCredentialsSecrets(ctx context.Context, cluster *kuber
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 }
 
 func (d *Deletion) deleteSecret(ctx context.Context, cluster *kubermaticv1.Cluster) error {

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -160,7 +159,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(template, apiv1.CredentialsSecretsCleanupFinalizer) {
+	if kuberneteshelper.HasFinalizer(template, kubermaticv1.CredentialsSecretsCleanupFinalizer) {
 		if err := r.syncAllSeeds(log, template, func(seedClient ctrlruntimeclient.Client, template *kubermaticv1.ClusterTemplate) error {
 			err := seedClient.Delete(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -173,7 +172,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return err
 		}
 
-		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, template, apiv1.CredentialsSecretsCleanupFinalizer); err != nil {
+		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, template, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to remove credential secret finalizer %s: %w", template.Name, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -131,7 +130,7 @@ func generateClusterTemplate(name string, deleted bool) *kubermaticv1.ClusterTem
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		ct.DeletionTimestamp = &deleteTime
-		ct.Finalizers = append(ct.Finalizers, apiv1.ClusterTemplateSeedCleanupFinalizer)
+		ct.Finalizers = append(ct.Finalizers, cleanupFinalizer)
 	}
 	return ct
 }

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -94,13 +93,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if icl.DeletionTimestamp != nil {
-		if kuberneteshelper.HasFinalizer(icl, apiv1.ExternalClusterKubeconfigCleanupFinalizer) {
+		if kuberneteshelper.HasFinalizer(icl, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer) {
 			if err := r.cleanUpKubeconfigSecret(ctx, icl); err != nil {
 				log.Errorf("Could not delete kubeconfig secret, %v", err)
 				return reconcile.Result{}, err
 			}
 		}
-		if kuberneteshelper.HasFinalizer(icl, apiv1.CredentialsSecretsCleanupFinalizer) {
+		if kuberneteshelper.HasFinalizer(icl, kubermaticv1.CredentialsSecretsCleanupFinalizer) {
 			if err := r.cleanUpCredentialsSecret(ctx, icl); err != nil {
 				log.Errorf("Could not delete credentials secret, %v", err)
 				return reconcile.Result{}, err
@@ -194,7 +193,7 @@ func (r *Reconciler) cleanUpKubeconfigSecret(ctx context.Context, cluster *kuber
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer)
 }
 
 func (r *Reconciler) cleanUpCredentialsSecret(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
@@ -202,7 +201,7 @@ func (r *Reconciler) cleanUpCredentialsSecret(ctx context.Context, cluster *kube
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 }
 
 func (r *Reconciler) deleteSecret(ctx context.Context, secretName string) error {
@@ -330,7 +329,7 @@ func (r *Reconciler) updateKubeconfigSecret(ctx context.Context, config *api.Con
 		return err
 	}
 	cluster.Spec.KubeconfigReference = keyRef
-	kuberneteshelper.AddFinalizer(cluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(cluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer)
 
 	return r.Update(ctx, cluster)
 }

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller_test.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -118,7 +117,7 @@ func genExternalCluster(name string, deletionTimestamp metav1.Time) *kubermaticv
 		},
 	}
 
-	kuberneteshelper.AddFinalizer(cluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(cluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer)
 
 	cluster.Spec.KubeconfigReference = &providerconfig.GlobalSecretKeySelector{
 		ObjectReference: corev1.ObjectReference{

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -30,7 +30,6 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
 	"k8c.io/kubeone/pkg/fail"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -227,7 +226,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, err
 		}
 
-		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r, externalCluster, apiv1.ExternalClusterKubeOneNamespaceCleanupFinalizer); err != nil {
+		if err := kuberneteshelper.TryRemoveFinalizer(ctx, r, externalCluster, kubermaticv1.ExternalClusterKubeOneNamespaceCleanupFinalizer); err != nil {
 			log.Errorw("failed to remove kubeone namespace finalizer", zap.Error(err))
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -135,7 +134,7 @@ func genConstraint(name, namespace, kind string, deleted bool) *kubermaticv1.Con
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		constraint.DeletionTimestamp = &deleteTime
-		constraint.Finalizers = append(constraint.Finalizers, apiv1.GatekeeperSeedConstraintCleanupFinalizer)
+		constraint.Finalizers = append(constraint.Finalizers, cleanupFinalizer)
 	}
 
 	return constraint

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller_test.go
@@ -23,7 +23,6 @@ import (
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -137,7 +136,7 @@ func genConstraintTemplate(name string, deleted bool) *kubermaticv1.ConstraintTe
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		ct.DeletionTimestamp = &deleteTime
-		ct.Finalizers = append(ct.Finalizers, apiv1.GatekeeperSeedConstraintTemplateCleanupFinalizer)
+		ct.Finalizers = append(ct.Finalizers, cleanupFinalizer)
 	}
 
 	return ct

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -133,7 +132,7 @@ func generatePreset(name string, deleted bool) *kubermaticv1.Preset {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		pr.DeletionTimestamp = &deleteTime
-		pr.Finalizers = append(pr.Finalizers, apiv1.PresetSeedCleanupFinalizer)
+		pr.Finalizers = append(pr.Finalizers, cleanupFinalizer)
 	}
 	return pr
 }

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/apis/equality"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -43,6 +42,9 @@ import (
 
 const (
 	ControllerName = "kkp-project-synchronizer"
+
+	// cleanupFinalizer indicates that Kubermatic Projects on the seed clusters need cleanup.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-projects"
 )
 
 type reconciler struct {
@@ -112,7 +114,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, project, apiv1.SeedProjectCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, project, cleanupFinalizer); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -179,7 +181,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, project, apiv1.SeedProjectCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, project, cleanupFinalizer)
 }
 
 func (r *reconciler) syncAllSeeds(

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -139,7 +138,7 @@ func generateProject(name string, deleted bool) *kubermaticv1.Project {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		project.DeletionTimestamp = &deleteTime
-		project.Finalizers = append(project.Finalizers, apiv1.SeedProjectCleanupFinalizer)
+		project.Finalizers = append(project.Finalizers, cleanupFinalizer)
 	}
 	return project
 }

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -44,6 +43,9 @@ import (
 
 const (
 	ControllerName = "kkp-user-project-binding-synchronizer"
+
+	// cleanupFinalizer indicates that Kubermatic UserProjectBindings on the seed clusters need cleanup.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-user-project-bindings"
 )
 
 type reconciler struct {
@@ -115,7 +117,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, userProjectBinding, apiv1.SeedUserProjectBindingCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, userProjectBinding, cleanupFinalizer); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -155,7 +157,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, userProjectBinding, apiv1.SeedUserProjectBindingCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, userProjectBinding, cleanupFinalizer)
 }
 
 func (r *reconciler) syncAllSeeds(

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -138,7 +137,7 @@ func generateUserProjectBinding(name string, deleted bool) *kubermaticv1.UserPro
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		userProjectBinding.DeletionTimestamp = &deleteTime
-		userProjectBinding.Finalizers = append(userProjectBinding.Finalizers, apiv1.SeedUserProjectBindingCleanupFinalizer)
+		userProjectBinding.Finalizers = append(userProjectBinding.Finalizers, cleanupFinalizer)
 	}
 	return userProjectBinding
 }

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/apis/equality"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
@@ -44,6 +43,9 @@ import (
 
 const (
 	ControllerName = "kkp-user-synchronizer"
+
+	// cleanupFinalizer indicates that Kubermatic Users on the seed clusters need cleanup.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-users"
 )
 
 type reconciler struct {
@@ -128,7 +130,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, user, apiv1.SeedUserCleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.masterClient, user, cleanupFinalizer); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -183,7 +185,7 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		return err
 	}
 
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, user, apiv1.SeedUserCleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, user, cleanupFinalizer)
 }
 
 func (r *reconciler) syncAllSeeds(

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -134,7 +133,7 @@ func generateUser(name string, deleted bool) *kubermaticv1.User {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		user.DeletionTimestamp = &deleteTime
-		user.Finalizers = append(user.Finalizers, apiv1.SeedUserCleanupFinalizer)
+		user.Finalizers = append(user.Finalizers, cleanupFinalizer)
 	}
 	return user
 }

--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/zap"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
@@ -158,7 +157,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		log.Debug("Cleaning up cloud provider")
 
 		// in-cluster resources, like nodes, are still being cleaned up
-		if kuberneteshelper.HasAnyFinalizer(cluster, apiv1.InClusterLBCleanupFinalizer, apiv1.InClusterPVCleanupFinalizer, apiv1.NodeDeletionFinalizer) {
+		if kuberneteshelper.HasAnyFinalizer(cluster, kubermaticv1.InClusterLBCleanupFinalizer, kubermaticv1.InClusterPVCleanupFinalizer, kubermaticv1.NodeDeletionFinalizer) {
 			log.Debug("Cluster still has in-cluster cleanup finalizers, retrying later")
 			return &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -203,7 +202,7 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster); err != nil {
 		return err
 	}
-	kuberneteshelper.AddFinalizer(newCluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 
 	// re-use our reconciling framework, because this is a special place where right after the Cluster
 	// creation, we must set some status fields and this requires us to wait for the Cluster object

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"testing"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -118,7 +117,7 @@ func TestReconcile(t *testing.T) {
 				// ignore clusters that only have a deletion timestampa and
 				// the CredentialsSecretsCleanupFinalizer finalizer, as those
 				// would be cleaned up by another controller
-				if kuberneteshelper.HasOnlyFinalizer(&cluster, apiv1.CredentialsSecretsCleanupFinalizer) && !cluster.DeletionTimestamp.IsZero() {
+				if kuberneteshelper.HasOnlyFinalizer(&cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer) && !cluster.DeletionTimestamp.IsZero() {
 					continue
 				}
 
@@ -161,7 +160,7 @@ func genCluster(name, userEmail string, instance kubermaticv1.ClusterTemplateIns
 			Name:            name,
 			Labels:          map[string]string{kubermaticv1.ProjectIDLabelKey: instance.Spec.ProjectID, kubernetes.ClusterTemplateInstanceLabelKey: instance.Name},
 			ResourceVersion: "1",
-			Finalizers:      []string{apiv1.CredentialsSecretsCleanupFinalizer},
+			Finalizers:      []string{kubermaticv1.CredentialsSecretsCleanupFinalizer},
 			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail},
 		},
 		Spec: kubermaticv1.ClusterSpec{

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -49,10 +48,12 @@ import (
 const (
 	// This controller syncs the kubermatic constraints to constraint on the user cluster.
 	ControllerName = "kkp-constraint-synchronizer"
-	finalizer      = apiv1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer
 	Key            = "default"
 	AddAction      = "add"
 	RemoveAction   = "remove"
+
+	// cleanupFinalizer indicates that kubermatic constraints on the user cluster namespace need cleanup.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-usercluster-ns-default-constraints"
 )
 
 type reconciler struct {
@@ -208,9 +209,9 @@ func (r *reconciler) patchFinalizer(ctx context.Context, constraint *kubermaticv
 	oldconstraint := constraint.DeepCopy()
 
 	if action == AddAction {
-		kuberneteshelper.AddFinalizer(constraint, finalizer)
+		kuberneteshelper.AddFinalizer(constraint, cleanupFinalizer)
 	} else if action == RemoveAction {
-		kuberneteshelper.RemoveFinalizer(constraint, finalizer)
+		kuberneteshelper.RemoveFinalizer(constraint, cleanupFinalizer)
 	}
 
 	if err := r.seedClient.Patch(ctx, constraint, ctrlruntimeclient.MergeFrom(oldconstraint)); err != nil {
@@ -233,7 +234,7 @@ func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Con
 
 	// constraint deletion
 	if !constraint.DeletionTimestamp.IsZero() {
-		if !kuberneteshelper.HasFinalizer(constraint, finalizer) {
+		if !kuberneteshelper.HasFinalizer(constraint, cleanupFinalizer) {
 			return nil
 		}
 
@@ -249,7 +250,7 @@ func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Con
 	}
 
 	// constraint initialization
-	if !kuberneteshelper.HasFinalizer(constraint, finalizer) {
+	if !kuberneteshelper.HasFinalizer(constraint, cleanupFinalizer) {
 		if err := r.patchFinalizer(ctx, constraint, AddAction); err != nil {
 			return err
 		}

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -155,7 +154,7 @@ func genConstraint(name, namespace, kind string, label, deleted bool) *kubermati
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		constraint.DeletionTimestamp = &deleteTime
-		constraint.Finalizers = append(constraint.Finalizers, apiv1.KubermaticUserClusterNsDefaultConstraintCleanupFinalizer)
+		constraint.Finalizers = append(constraint.Finalizers, cleanupFinalizer)
 	}
 	return constraint
 }

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -23,7 +23,6 @@ import (
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -209,7 +208,7 @@ func genConstraintTemplate(name string, deleted bool) *kubermaticv1.ConstraintTe
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		ct.DeletionTimestamp = &deleteTime
-		ct.Finalizers = append(ct.Finalizers, apiv1.GatekeeperConstraintTemplateCleanupFinalizer)
+		ct.Finalizers = append(ct.Finalizers, cleanupFinalizer)
 	}
 
 	return ct

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -86,7 +86,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
 
-	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(apiv1.InitialApplicationInstallationsRequestAnnotation, "", false)); err != nil {
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(kubermaticv1.InitialApplicationInstallationsRequestAnnotation, "", false)); err != nil {
 		return fmt.Errorf("failed to create watch: %w", err)
 	}
 
@@ -132,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// there is no annotation anymore
-	request := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]
+	request := cluster.Annotations[kubermaticv1.InitialApplicationInstallationsRequestAnnotation]
 	if request == "" {
 		return nil, nil
 	}
@@ -223,6 +223,6 @@ func (r *Reconciler) parseApplications(cluster *kubermaticv1.Cluster, request st
 
 func (r *Reconciler) removeAnnotation(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	oldCluster := cluster.DeepCopy()
-	delete(cluster.Annotations, apiv1.InitialApplicationInstallationsRequestAnnotation)
+	delete(cluster.Annotations, kubermaticv1.InitialApplicationInstallationsRequestAnnotation)
 	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
@@ -76,7 +76,7 @@ func genCluster(annotation string) *kubermaticv1.Cluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testcluster",
 			Annotations: map[string]string{
-				apiv1.InitialApplicationInstallationsRequestAnnotation: annotation,
+				kubermaticv1.InitialApplicationInstallationsRequestAnnotation: annotation,
 			},
 			Labels: map[string]string{
 				kubermaticv1.ProjectIDLabelKey: projectID,
@@ -138,7 +138,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("reconciling should not have caused an error, but did: %w", reconcileErr)
 				}
 
-				if ann, ok := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[kubermaticv1.InitialApplicationInstallationsRequestAnnotation]; ok {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("reconciling should not have caused an error, but did: %w", reconcileErr)
 				}
 
-				if ann, ok := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[kubermaticv1.InitialApplicationInstallationsRequestAnnotation]; ok {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -196,7 +196,7 @@ func TestReconcile(t *testing.T) {
 					return errors.New("reconciling a bad annotation should have produced an error, but got nil")
 				}
 
-				if ann, ok := cluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[kubermaticv1.InitialApplicationInstallationsRequestAnnotation]; ok {
 					return fmt.Errorf("bad annotation should be have been removed, but found %q on the cluster", ann)
 				}
 

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
@@ -86,7 +86,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
 
-	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(apiv1.InitialMachineDeploymentRequestAnnotation, "", false)); err != nil {
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByAnnotation(kubermaticv1.InitialMachineDeploymentRequestAnnotation, "", false)); err != nil {
 		return fmt.Errorf("failed to create watch: %w", err)
 	}
 
@@ -126,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// there is no annotation anymore
-	request := cluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]
+	request := cluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]
 	if request == "" {
 		return nil, nil
 	}
@@ -255,6 +255,6 @@ func (r *Reconciler) getSSHKeys(ctx context.Context, cluster *kubermaticv1.Clust
 
 func (r *Reconciler) removeAnnotation(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	oldCluster := cluster.DeepCopy()
-	delete(cluster.Annotations, apiv1.InitialMachineDeploymentRequestAnnotation)
+	delete(cluster.Annotations, kubermaticv1.InitialMachineDeploymentRequestAnnotation)
 	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller_test.go
@@ -73,7 +73,7 @@ func genCluster(annotation string) *kubermaticv1.Cluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testcluster",
 			Annotations: map[string]string{
-				apiv1.InitialMachineDeploymentRequestAnnotation: annotation,
+				kubermaticv1.InitialMachineDeploymentRequestAnnotation: annotation,
 			},
 			Labels: map[string]string{
 				kubermaticv1.ProjectIDLabelKey: projectID,
@@ -156,7 +156,7 @@ func TestReconcile(t *testing.T) {
 					return fmt.Errorf("reconciling should not have caused an error, but did: %w", reconcileErr)
 				}
 
-				if ann, ok := cluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]; ok {
 					return fmt.Errorf("annotation should be have been removed, but found %q on the cluster", ann)
 				}
 
@@ -181,7 +181,7 @@ func TestReconcile(t *testing.T) {
 					return errors.New("reconciling a bad annotation should have produced an error, but got nil")
 				}
 
-				if ann, ok := cluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]; ok {
+				if ann, ok := cluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]; ok {
 					return fmt.Errorf("bad annotation should be have been removed, but found %q on the cluster", ann)
 				}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 
@@ -33,8 +32,8 @@ const (
 )
 
 func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, namespace *corev1.Namespace) (*reconcile.Result, error) {
-	if !kuberneteshelper.HasFinalizer(cluster, apiv1.EtcdBackupConfigCleanupFinalizer) {
-		res, err := r.AddFinalizers(ctx, cluster, apiv1.EtcdBackupConfigCleanupFinalizer)
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.EtcdBackupConfigCleanupFinalizer) {
+		res, err := r.AddFinalizers(ctx, cluster, kubermaticv1.EtcdBackupConfigCleanupFinalizer)
 		if err != nil {
 			return nil, err
 		}
@@ -71,13 +70,13 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 
 		// Only add the node deletion finalizer when the cluster is actually running
 		// Otherwise we fail to delete the nodes and are stuck in a loop
-		if !kuberneteshelper.HasFinalizer(cluster, apiv1.NodeDeletionFinalizer) {
-			finalizers = append(finalizers, apiv1.NodeDeletionFinalizer)
+		if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.NodeDeletionFinalizer) {
+			finalizers = append(finalizers, kubermaticv1.NodeDeletionFinalizer)
 		}
 	}
 
-	if !kuberneteshelper.HasFinalizer(cluster, apiv1.KubermaticConstraintCleanupFinalizer) {
-		finalizers = append(finalizers, apiv1.KubermaticConstraintCleanupFinalizer)
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticv1.KubermaticConstraintCleanupFinalizer) {
+		finalizers = append(finalizers, kubermaticv1.KubermaticConstraintCleanupFinalizer)
 	}
 
 	if len(finalizers) > 0 {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -27,7 +27,6 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -245,8 +244,8 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 // reconcileClusterNamespace will ensure that the cluster namespace is
 // correctly initialized and created.
 func (r *Reconciler) reconcileClusterNamespace(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*corev1.Namespace, error) {
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, apiv1.NamespaceCleanupFinalizer); err != nil {
-		return nil, fmt.Errorf("failed to set %q finalizer: %w", apiv1.NamespaceCleanupFinalizer, err)
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, kubermaticv1.NamespaceCleanupFinalizer); err != nil {
+		return nil, fmt.Errorf("failed to set %q finalizer: %w", kubermaticv1.NamespaceCleanupFinalizer, err)
 	}
 
 	namespace, err := r.ensureNamespaceExists(ctx, log, cluster)

--- a/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -131,7 +130,7 @@ func genCluster(name, userEmail, preset string) *kubermaticv1.Cluster {
 			Name:            name,
 			Labels:          map[string]string{kubermaticv1.IsCredentialPresetLabelKey: "true"},
 			ResourceVersion: "1",
-			Finalizers:      []string{apiv1.CredentialsSecretsCleanupFinalizer},
+			Finalizers:      []string{kubermaticv1.CredentialsSecretsCleanupFinalizer},
 			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail, kubermaticv1.PresetNameAnnotation: preset},
 		},
 		Spec: kubermaticv1.ClusterSpec{

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	apiv2 "k8c.io/kubermatic/v2/pkg/api/v2"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -101,7 +100,7 @@ func TestReconcile(t *testing.T) {
 					c := test.GenConstraint(constraintName, "namespace", kind)
 					deleteTime := metav1.NewTime(time.Now())
 					c.DeletionTimestamp = &deleteTime
-					c.Finalizers = []string{apiv1.GatekeeperConstraintCleanupFinalizer}
+					c.Finalizers = []string{kubermaticv1.GatekeeperConstraintCleanupFinalizer}
 					return c
 				}()).
 				Build(),
@@ -129,7 +128,7 @@ func TestReconcile(t *testing.T) {
 					c := test.GenConstraint(constraintName, "namespace", kind)
 					deleteTime := metav1.NewTime(time.Now())
 					c.DeletionTimestamp = &deleteTime
-					c.Finalizers = []string{apiv1.GatekeeperConstraintCleanupFinalizer}
+					c.Finalizers = []string{kubermaticv1.GatekeeperConstraintCleanupFinalizer}
 					return c
 				}()).
 				Build(),

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ce.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ce.go
@@ -24,13 +24,12 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 )
 
 func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
-	finalizer := apiv1.GatekeeperConstraintCleanupFinalizer
+	finalizer := kubermaticv1.GatekeeperConstraintCleanupFinalizer
 
 	// constraint deletion
 	if constraint.DeletionTimestamp != nil {

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ee.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/wrappers_ee.go
@@ -24,13 +24,12 @@ import (
 
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 )
 
 func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Constraint, log *zap.SugaredLogger) error {
-	finalizer := apiv1.GatekeeperConstraintCleanupFinalizer
+	finalizer := kubermaticv1.GatekeeperConstraintCleanupFinalizer
 
 	// constraint deletion
 	if constraint.Spec.Disabled {

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"testing"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
@@ -61,7 +60,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "view",
 						Namespace:         "kube-system",
-						Finalizers:        []string{apiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers:        []string{cleanupFinalizer},
 						Labels:            map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 						DeletionTimestamp: &nowTime,
 					},
@@ -100,7 +99,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{cleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 				},
@@ -145,7 +144,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{cleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -190,7 +189,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{cleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -235,7 +234,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{cleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -266,7 +265,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "view",
 						Namespace:  "kube-system",
-						Finalizers: []string{apiv1.UserClusterRoleCleanupFinalizer},
+						Finalizers: []string{cleanupFinalizer},
 						Labels:     map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterRoleComponentValue},
 					},
 					Rules: []rbacv1.PolicyRule{

--- a/pkg/ee/allowed-registry-controller/controller.go
+++ b/pkg/ee/allowed-registry-controller/controller.go
@@ -40,6 +40,9 @@ import (
 const (
 	// This controller creates corresponding OPA Constraint Templates and Default Constraints based on AllowedRegistry data.
 	ControllerName = "kkp-allowed-registry-controller"
+
+	// cleanupFinalizer indicates that allowed registry Constraints need to be cleaned up.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-allowed-registry"
 )
 
 func Add(mgr manager.Manager,

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -32,7 +32,6 @@ import (
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"go.uber.org/zap"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -91,7 +90,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, allowedRegistry *kubermaticv1.AllowedRegistry) error {
-	finalizer := apiv1.AllowedRegistryCleanupFinalizer
+	finalizer := cleanupFinalizer
 
 	regSet, err := r.getRegistrySet(ctx)
 	if err != nil {

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -32,7 +32,6 @@ import (
 
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	allowedregistrycontroller "k8c.io/kubermatic/v2/pkg/ee/allowed-registry-controller"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -237,7 +236,7 @@ func genAllowedRegistry(name, registry string, deleted bool) *kubermaticv1.Allow
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		wr.DeletionTimestamp = &deleteTime
-		wr.Finalizers = append(wr.Finalizers, apiv1.AllowedRegistryCleanupFinalizer)
+		wr.Finalizers = append(wr.Finalizers, cleanupFinalizer)
 	}
 
 	return wr

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -22,7 +22,7 @@
    END OF TERMS AND CONDITIONS
 */
 
-package allowedregistrycontroller_test
+package allowedregistrycontroller
 
 import (
 	"context"
@@ -33,7 +33,6 @@ import (
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	allowedregistrycontroller "k8c.io/kubermatic/v2/pkg/ee/allowed-registry-controller"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 
@@ -121,7 +120,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			r := allowedregistrycontroller.NewReconciler(
+			r := NewReconciler(
 				kubermaticlog.Logger,
 				&record.FakeRecorder{},
 				tc.masterClient,
@@ -192,17 +191,17 @@ func TestReconcile(t *testing.T) {
 func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 	ct := &kubermaticv1.ConstraintTemplate{}
 
-	ct.Name = allowedregistrycontroller.AllowedRegistryCTName
+	ct.Name = AllowedRegistryCTName
 	ct.Spec = kubermaticv1.ConstraintTemplateSpec{
 		CRD: constrainttemplatev1.CRD{
 			Spec: constrainttemplatev1.CRDSpec{
 				Names: constrainttemplatev1.Names{
-					Kind: allowedregistrycontroller.AllowedRegistryCTName,
+					Kind: AllowedRegistryCTName,
 				},
 				Validation: &constrainttemplatev1.Validation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
-							allowedregistrycontroller.AllowedRegistryField: {
+							AllowedRegistryField: {
 								Type: "array",
 								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 									Schema: &apiextensionsv1.JSONSchemaProps{
@@ -244,13 +243,13 @@ func genAllowedRegistry(name, registry string, deleted bool) *kubermaticv1.Allow
 
 func genWRConstraint(registrySet sets.String) *kubermaticv1.Constraint {
 	ct := &kubermaticv1.Constraint{}
-	ct.Name = allowedregistrycontroller.AllowedRegistryCTName
+	ct.Name = AllowedRegistryCTName
 	ct.Namespace = testNamespace
 
 	jsonRegSet, _ := json.Marshal(registrySet.List())
 
 	ct.Spec = kubermaticv1.ConstraintSpec{
-		ConstraintType: allowedregistrycontroller.AllowedRegistryCTName,
+		ConstraintType: AllowedRegistryCTName,
 		Match: kubermaticv1.Match{
 			Kinds: []kubermaticv1.Kind{
 				{
@@ -260,7 +259,7 @@ func genWRConstraint(registrySet sets.String) *kubermaticv1.Constraint {
 			},
 		},
 		Parameters: map[string]json.RawMessage{
-			allowedregistrycontroller.AllowedRegistryField: jsonRegSet,
+			AllowedRegistryField: jsonRegSet,
 		},
 		Disabled: registrySet.Len() == 0,
 	}

--- a/pkg/ee/group-project-binding/sync-controller/controller_test.go
+++ b/pkg/ee/group-project-binding/sync-controller/controller_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
@@ -158,7 +157,7 @@ func generateGroupProjectBinding(name string, deleted bool) *kubermaticv1.GroupP
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		groupProjectBinding.DeletionTimestamp = &deleteTime
-		groupProjectBinding.Finalizers = append(groupProjectBinding.Finalizers, apiv1.SeedGroupProjectBindingCleanupFinalizer)
+		groupProjectBinding.Finalizers = append(groupProjectBinding.Finalizers, cleanupFinalizer)
 	}
 	return groupProjectBinding
 }

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -180,7 +179,7 @@ func genResourceQuota(name string, deleted bool) *kubermaticv1.ResourceQuota {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		rq.DeletionTimestamp = &deleteTime
-		rq.Finalizers = append(rq.Finalizers, apiv1.ResourceQuotaSeedCleanupFinalizer)
+		rq.Finalizers = append(rq.Finalizers, cleanupFinalizer)
 	}
 
 	return rq

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -124,7 +124,7 @@ func CreateEndpoint(
 	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {
 		return nil, err
 	}
-	kuberneteshelper.AddFinalizer(partialCluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(partialCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 
 	newCluster, err := createNewCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, project, partialCluster)
 	if err != nil {
@@ -251,7 +251,7 @@ func GenerateCluster(
 			if err != nil {
 				return nil, fmt.Errorf("cannot marshal initial machine deployment: %w", err)
 			}
-			partialCluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation] = string(data)
+			partialCluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation] = string(data)
 		}
 	}
 
@@ -273,7 +273,7 @@ func GenerateCluster(
 		if err != nil {
 			return nil, fmt.Errorf("cannot marshal initial applications: %w", err)
 		}
-		partialCluster.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation] = string(data)
+		partialCluster.Annotations[kubermaticv1.InitialApplicationInstallationsRequestAnnotation] = string(data)
 	}
 
 	// Owning project ID must be set early, because it will be inherited by some child objects,
@@ -433,13 +433,13 @@ func DeleteEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
 
 	// Use the NodeDeletionFinalizer to determine if the cluster was ever up, the LB and PV finalizers
 	// will prevent cluster deletion if the APIserver was never created
-	wasUpOnce := kuberneteshelper.HasFinalizer(existingCluster, apiv1.NodeDeletionFinalizer)
+	wasUpOnce := kuberneteshelper.HasFinalizer(existingCluster, kubermaticv1.NodeDeletionFinalizer)
 	if wasUpOnce && (deleteVolumes || deleteLoadBalancers) {
 		if deleteLoadBalancers {
-			kuberneteshelper.AddFinalizer(existingCluster, apiv1.InClusterLBCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(existingCluster, kubermaticv1.InClusterLBCleanupFinalizer)
 		}
 		if deleteVolumes {
-			kuberneteshelper.AddFinalizer(existingCluster, apiv1.InClusterPVCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(existingCluster, kubermaticv1.InClusterPVCleanupFinalizer)
 		}
 	}
 

--- a/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/pkg/handler/v2/cluster_template/cluster_template.go
@@ -370,7 +370,7 @@ func createClusterTemplate(ctx context.Context, userInfoGetter provider.UserInfo
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 	if !isBYO {
-		kuberneteshelper.AddFinalizer(newClusterTemplate, apiv1.CredentialsSecretsCleanupFinalizer)
+		kuberneteshelper.AddFinalizer(newClusterTemplate, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 	}
 
 	// copy preset annotations
@@ -378,7 +378,7 @@ func createClusterTemplate(ctx context.Context, userInfoGetter provider.UserInfo
 		newClusterTemplate.Annotations = partialCluster.Annotations
 	}
 
-	newClusterTemplate.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation] = partialCluster.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]
+	newClusterTemplate.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation] = partialCluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]
 
 	newClusterTemplate.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey] = adminUserInfo.Email
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateProjectLabelKey] = project.Name
@@ -632,7 +632,7 @@ func DecodeExportReq(c context.Context, r *http.Request) (interface{}, error) {
 
 func convertInternalClusterTemplatetoExternal(template *kubermaticv1.ClusterTemplate) (*apiv2.ClusterTemplate, error) {
 	md := &apiv1.NodeDeployment{}
-	rawMachineDeployment, ok := template.Annotations[apiv1.InitialMachineDeploymentRequestAnnotation]
+	rawMachineDeployment, ok := template.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]
 	if ok && rawMachineDeployment != "" {
 		err := json.Unmarshal([]byte(rawMachineDeployment), md)
 		if err != nil {
@@ -641,7 +641,7 @@ func convertInternalClusterTemplatetoExternal(template *kubermaticv1.ClusterTemp
 	}
 
 	var apps []apiv1.Application
-	rawApplicationsRequest, ok := template.Annotations[apiv1.InitialApplicationInstallationsRequestAnnotation]
+	rawApplicationsRequest, ok := template.Annotations[kubermaticv1.InitialApplicationInstallationsRequestAnnotation]
 	if ok && rawApplicationsRequest != "" {
 		err := json.Unmarshal([]byte(rawApplicationsRequest), &apps)
 		if err != nil {

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -345,7 +345,7 @@ func createOrImportAKSCluster(ctx context.Context, name string, userInfoGetter p
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	kuberneteshelper.AddFinalizer(newCluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 	newCluster.Spec.CloudSpec.AKS.CredentialsReference = keyRef
 
 	return createNewCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, newCluster, project)

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -397,7 +397,7 @@ func createOrImportEKSCluster(ctx context.Context, name string, userInfoGetter p
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	kuberneteshelper.AddFinalizer(newCluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 	newCluster.Spec.CloudSpec.EKS.CredentialsReference = keyRef
 
 	return createNewCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, newCluster, project)

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -181,7 +181,7 @@ func CreateEndpoint(
 		// connect cluster by kubeconfig
 		if cloud == nil {
 			newCluster := genExternalCluster(req.Body.Name, project.Name)
-			kuberneteshelper.AddFinalizer(newCluster, apiv1.ExternalClusterKubeconfigCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer)
 			config, err := base64.StdEncoding.DecodeString(req.Body.Kubeconfig)
 			if err != nil {
 				return nil, utilerrors.NewBadRequest(err.Error())

--- a/pkg/handler/v2/external_cluster/gke.go
+++ b/pkg/handler/v2/external_cluster/gke.go
@@ -265,7 +265,7 @@ func createOrImportGKECluster(ctx context.Context, name string, userInfoGetter p
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	kuberneteshelper.AddFinalizer(newCluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 	newCluster.Spec.CloudSpec.GKE.CredentialsReference = keyRef
 
 	return createNewCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, newCluster, project)

--- a/pkg/handler/v2/external_cluster/kubeone.go
+++ b/pkg/handler/v2/external_cluster/kubeone.go
@@ -61,7 +61,7 @@ func importKubeOneCluster(ctx context.Context, name string, userInfoGetter func(
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	kuberneteshelper.AddFinalizer(newCluster, apiv1.ExternalClusterKubeOneNamespaceCleanupFinalizer)
+	kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.ExternalClusterKubeOneNamespaceCleanupFinalizer)
 
 	err = clusterProvider.CreateOrUpdateKubeOneSSHSecret(ctx, cloud.KubeOne.SSHKey, newCluster)
 	if err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
`pkg/api/` represents the types used in the KKP REST API, not to be confused with `pkg/apis/`, which is for the Kube API (i.e. our CRDs).

It therefore doesn't make sense to put finalizers that are "owned" by controllers into an API package.

Going further, it's questionable whether finalizers need to be even public. In most cases the finalizers are set and removed by a single controller. This turns them into an implementation detail and we should needlessly pretend like the finalizers are a public interface and that it would be by default okay for a controller to use another controller's finalizer.

So I moved all 1-time-use finalizers into the controller packages where they are handled. The remaining few finalizers, mostly those used in the `clusterdeletion` package, have been moved to `pkg/apis/kubermatic/v1/common.go`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
