### PR TITLE
Adding validations for GCP dual-stack network

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -26435,6 +26435,9 @@
           "type": "string",
           "x-go-name": "IPCidrRange"
         },
+        "ipFamily": {
+          "$ref": "#/definitions/IPFamily"
+        },
         "kind": {
           "type": "string",
           "x-go-name": "Kind"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -291,16 +291,17 @@ type GCPSubnetworkList []GCPSubnetwork
 // GCPSubnetwork represents a object of GCP subnetworks.
 // swagger:model GCPSubnetwork
 type GCPSubnetwork struct {
-	ID                    uint64 `json:"id"`
-	Name                  string `json:"name"`
-	Network               string `json:"network"`
-	IPCidrRange           string `json:"ipCidrRange"`
-	GatewayAddress        string `json:"gatewayAddress"`
-	Region                string `json:"region"`
-	SelfLink              string `json:"selfLink"`
-	PrivateIPGoogleAccess bool   `json:"privateIpGoogleAccess"`
-	Kind                  string `json:"kind"`
-	Path                  string `json:"path"`
+	ID                    uint64                `json:"id"`
+	Name                  string                `json:"name"`
+	Network               string                `json:"network"`
+	IPCidrRange           string                `json:"ipCidrRange"`
+	GatewayAddress        string                `json:"gatewayAddress"`
+	Region                string                `json:"region"`
+	SelfLink              string                `json:"selfLink"`
+	PrivateIPGoogleAccess bool                  `json:"privateIpGoogleAccess"`
+	Kind                  string                `json:"kind"`
+	Path                  string                `json:"path"`
+	IPFamily              kubermaticv1.IPFamily `json:"ipFamily"`
 }
 
 // DigitaloceanSizeList represents a object of digitalocean sizes.

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -215,27 +215,12 @@ func ListGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datace
 
 	req := computeService.Subnetworks.List(project, datacenter.Spec.GCP.Region)
 	err = req.Pages(ctx, func(page *compute.SubnetworkList) error {
-		subnetworkRegex := regexp.MustCompile(`(projects\/.+)$`)
 		for _, subnetwork := range page.Items {
 			// subnetworks.Network are a url e.g. https://www.googleapis.com/compute/v1/[...]/networks/default"
 			// we just get the path of the network, instead of the url
 			// therefore we can't use regular Filter function and need to check on our own
 			if strings.Contains(subnetwork.Network, networkName) {
-				subnetworkPath := subnetworkRegex.FindString(subnetwork.SelfLink)
-				net := apiv1.GCPSubnetwork{
-					ID:                    subnetwork.Id,
-					Name:                  subnetwork.Name,
-					Network:               subnetwork.Network,
-					IPCidrRange:           subnetwork.IpCidrRange,
-					GatewayAddress:        subnetwork.GatewayAddress,
-					Region:                subnetwork.Region,
-					SelfLink:              subnetwork.SelfLink,
-					PrivateIPGoogleAccess: subnetwork.PrivateIpGoogleAccess,
-					Kind:                  subnetwork.Kind,
-					Path:                  subnetworkPath,
-				}
-
-				subnetworks = append(subnetworks, net)
+				subnetworks = append(subnetworks, gcp.ToGCPSubnetworkAPIModel(subnetwork))
 			}
 		}
 		return nil

--- a/pkg/handler/common/provider/gcp.go
+++ b/pkg/handler/common/provider/gcp.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"google.golang.org/api/compute/v1"
@@ -239,20 +238,8 @@ func ListGCPNetworks(ctx context.Context, sa string) (apiv1.GCPNetworkList, erro
 
 	req := computeService.Networks.List(project)
 	err = req.Pages(ctx, func(page *compute.NetworkList) error {
-		networkRegex := regexp.MustCompile(`(global\/.+)$`)
 		for _, network := range page.Items {
-			networkPath := networkRegex.FindString(network.SelfLink)
-
-			net := apiv1.GCPNetwork{
-				ID:                    network.Id,
-				Name:                  network.Name,
-				AutoCreateSubnetworks: network.AutoCreateSubnetworks,
-				Subnetworks:           network.Subnetworks,
-				Kind:                  network.Kind,
-				Path:                  networkPath,
-			}
-
-			networks = append(networks, net)
+			networks = append(networks, gcp.ToGCPNetworkAPIModel(network))
 		}
 		return nil
 	})

--- a/pkg/provider/cloud/gcp/provider.go
+++ b/pkg/provider/cloud/gcp/provider.go
@@ -224,6 +224,9 @@ func isHTTPError(err error, status int) bool {
 	return errors.As(err, &gerr) && gerr.Code == status
 }
 
+// GCPSubnetworkGetter is a function to retrieve a single subnetwork.
+type GCPSubnetworkGetter = func(ctx context.Context, sa, region, subnetworkName string) (apiv1.GCPSubnetwork, error)
+
 func GetGCPSubnetwork(ctx context.Context, sa, region, subnetworkName string) (apiv1.GCPSubnetwork, error) {
 	computeService, project, err := ConnectToComputeService(ctx, sa)
 	if err != nil {

--- a/pkg/test/e2e/utils/apiclient/models/g_c_p_subnetwork.go
+++ b/pkg/test/e2e/utils/apiclient/models/g_c_p_subnetwork.go
@@ -8,6 +8,7 @@ package models
 import (
 	"context"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -46,15 +47,67 @@ type GCPSubnetwork struct {
 
 	// self link
 	SelfLink string `json:"selfLink,omitempty"`
+
+	// ip family
+	IPFamily IPFamily `json:"ipFamily,omitempty"`
 }
 
 // Validate validates this g c p subnetwork
 func (m *GCPSubnetwork) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateIPFamily(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 
-// ContextValidate validates this g c p subnetwork based on context it is used
+func (m *GCPSubnetwork) validateIPFamily(formats strfmt.Registry) error {
+	if swag.IsZero(m.IPFamily) { // not required
+		return nil
+	}
+
+	if err := m.IPFamily.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("ipFamily")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("ipFamily")
+		}
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this g c p subnetwork based on the context it is used
 func (m *GCPSubnetwork) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateIPFamily(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GCPSubnetwork) contextValidateIPFamily(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.IPFamily.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("ipFamily")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("ipFamily")
+		}
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -26,7 +26,6 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/coreos/locksmith/pkg/timeutil"
 
-	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/features"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
@@ -699,8 +698,7 @@ func validateAWSCloudSpec(spec *kubermaticv1.AWSCloudSpec) error {
 	return nil
 }
 
-func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec, dc *kubermaticv1.Datacenter, ipFamily kubermaticv1.IPFamily,
-	getGCPSubnetwork func(ctx context.Context, sa, region, subnetworkName string) (apiv1.GCPSubnetwork, error)) error {
+func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec, dc *kubermaticv1.Datacenter, ipFamily kubermaticv1.IPFamily, gcpSubnetworkGetter gcp.GCPSubnetworkGetter) error {
 	if spec.ServiceAccount == "" {
 		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.GCPServiceAccount); err != nil {
 			return err
@@ -730,7 +728,7 @@ func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec, dc *kubermaticv1.Data
 			return errors.New("GCP subnetwork should belong to same cluster region")
 		}
 
-		gcpSubnetwork, err := getGCPSubnetwork(context.Background(), spec.ServiceAccount, subnetworkRegion, subnetworkName)
+		gcpSubnetwork, err := gcpSubnetworkGetter(context.Background(), spec.ServiceAccount, subnetworkRegion, subnetworkName)
 		if err != nil {
 			return err
 		}

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/coreos/locksmith/pkg/timeutil"
@@ -29,6 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/features"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/version"
@@ -111,7 +113,7 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 	allErrs = append(allErrs, ValidateLeaderElectionSettings(&spec.ComponentsOverride.Scheduler.LeaderElectionSettings, parentFieldPath.Child("componentsOverride", "scheduler", "leaderElection"))...)
 
 	// general cloud spec logic
-	if errs := ValidateCloudSpec(spec.Cloud, dc, parentFieldPath.Child("cloud")); len(errs) > 0 {
+	if errs := ValidateCloudSpec(spec.Cloud, dc, spec.ClusterNetwork.IPFamily, parentFieldPath.Child("cloud")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
 
@@ -539,7 +541,7 @@ func ValidateCloudChange(newSpec, oldSpec kubermaticv1.CloudSpec) error {
 // ValidateCloudSpec validates if the cloud spec is valid
 // If this is not called from within another validation
 // routine, parentFieldPath can be nil.
-func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter, parentFieldPath *field.Path) field.ErrorList {
+func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter, ipFamily kubermaticv1.IPFamily, parentFieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if spec.DatacenterName == "" {
@@ -596,7 +598,7 @@ func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter,
 	case spec.Fake != nil:
 		providerErr = validateFakeCloudSpec(spec.Fake)
 	case spec.GCP != nil:
-		providerErr = validateGCPCloudSpec(spec.GCP)
+		providerErr = validateGCPCloudSpec(spec.GCP, dc, ipFamily)
 	case spec.Hetzner != nil:
 		providerErr = validateHetznerCloudSpec(spec.Hetzner)
 	case spec.Kubevirt != nil:
@@ -696,7 +698,7 @@ func validateAWSCloudSpec(spec *kubermaticv1.AWSCloudSpec) error {
 	return nil
 }
 
-func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec) error {
+func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec, dc *kubermaticv1.Datacenter, ipFamily kubermaticv1.IPFamily) error {
 	if spec.ServiceAccount == "" {
 		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.GCPServiceAccount); err != nil {
 			return err
@@ -709,6 +711,32 @@ func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec) error {
 	}
 	if err := spec.NodePortsAllowedIPRanges.Validate(); err != nil {
 		return err
+	}
+	if ipFamily == kubermaticv1.IPFamilyDualStack {
+		if spec.Network == "" || spec.Subnetwork == "" {
+			return errors.New("network and subnetwork should be defined for GCP dual-stack (IPv4 + IPv6) cluster")
+		}
+
+		subnetworkParts := strings.Split(spec.Subnetwork, "/")
+		if len(subnetworkParts) != 6 {
+			return errors.New("invalid GCP subnetwork path")
+		}
+		subnetworkRegion := subnetworkParts[3]
+		subnetworkName := subnetworkParts[5]
+
+		if dc.Spec.GCP.Region != subnetworkRegion {
+			return errors.New("GCP subnetwork should belong to same cluster region")
+		}
+
+		if spec.ServiceAccount != "" {
+			gcpSubnetwork, err := gcp.GetGCPSubnetwork(context.Background(), spec.ServiceAccount, subnetworkRegion, subnetworkName)
+			if err != nil {
+				return err
+			}
+			if ipFamily != gcpSubnetwork.IPFamily {
+				return errors.New("GCP subnetwork should belong to same cluster network stack type")
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -184,7 +184,7 @@ func TestValidateCloudSpec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidateCloudSpec(test.spec, dc, nil).ToAggregate()
+			err := ValidateCloudSpec(test.spec, dc, kubermaticv1.IPFamilyIPv4, nil).ToAggregate() // TODO
 
 			if (err == nil) != test.valid {
 				t.Errorf("Extected err to be %v, got %v", test.valid, err)

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package validation
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 
 	semverlib "github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
 
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/version"
@@ -184,7 +189,7 @@ func TestValidateCloudSpec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidateCloudSpec(test.spec, dc, kubermaticv1.IPFamilyIPv4, nil).ToAggregate() // TODO
+			err := ValidateCloudSpec(test.spec, dc, kubermaticv1.IPFamilyIPv4, nil).ToAggregate()
 
 			if (err == nil) != test.valid {
 				t.Errorf("Extected err to be %v, got %v", test.valid, err)
@@ -626,6 +631,258 @@ func TestValidateClusterNetworkingConfig(t *testing.T) {
 			if test.wantErr == (len(errs) == 0) {
 				t.Errorf("Want error: %t, but got: \"%v\"", test.wantErr, errs)
 			}
+		})
+	}
+}
+
+func TestValidateGCPCloudSpec(t *testing.T) {
+	testCases := []struct {
+		name              string
+		spec              *kubermaticv1.GCPCloudSpec
+		dc                *kubermaticv1.Datacenter
+		ipFamily          kubermaticv1.IPFamily
+		gcpSubnetworkResp apiv1.GCPSubnetwork
+		expectedError     error
+	}{
+		{
+			name: "valid ipv4 gcp spec",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily: kubermaticv1.IPFamilyIPv4,
+		},
+		{
+			name: "invalid gcp spec: service account cannot be empty",
+			spec: &kubermaticv1.GCPCloudSpec{
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyIPv4,
+			expectedError: errors.New("\"serviceAccount\" cannot be empty"),
+		},
+		{
+			name: "invalid gcp spec: NodePortsAllowedIPRange",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "invalid",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyIPv4,
+			expectedError: &net.ParseError{Type: "CIDR address", Text: "invalid"},
+		},
+		{
+			name: "invalid gcp spec: NodePortsAllowedIPRanges",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"invalid",
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyIPv4,
+			expectedError: fmt.Errorf("unable to parse CIDR \"invalid\": %w", &net.ParseError{Type: "CIDR address", Text: "invalid"}),
+		},
+		{
+			name: "invalid dual-stack gcp spec: empty network",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyDualStack,
+			expectedError: errors.New("network and subnetwork should be defined for GCP dual-stack (IPv4 + IPv6) cluster"),
+		},
+		{
+			name: "invalid dual-stack gcp spec: empty subnetwork",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+				Network: "global/networks/dualstack",
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyDualStack,
+			expectedError: errors.New("network and subnetwork should be defined for GCP dual-stack (IPv4 + IPv6) cluster"),
+		},
+		{
+			name: "invalid dual-stack gcp spec: invalid subnetwork path",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+				Network:    "global/networks/dualstack",
+				Subnetwork: "invalid",
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyDualStack,
+			expectedError: errors.New("invalid GCP subnetwork path"),
+		},
+		{
+			name: "invalid dual-stack gcp spec: wrong region",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+				Network:    "global/networks/dualstack",
+				Subnetwork: "projects/kubermatic-dev/regions/europe-west2/subnetworks/dualstack-europe-west2",
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west3",
+					},
+				},
+			},
+			ipFamily:      kubermaticv1.IPFamilyDualStack,
+			expectedError: errors.New("GCP subnetwork should belong to same cluster region"),
+		},
+		{
+			name: "valid gcp dual-stack spec",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+				Network:    "global/networks/dualstack",
+				Subnetwork: "projects/kubermatic-dev/regions/europe-west2/subnetworks/dualstack-europe-west2",
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west2",
+					},
+				},
+			},
+			ipFamily: kubermaticv1.IPFamilyDualStack,
+			gcpSubnetworkResp: apiv1.GCPSubnetwork{
+				IPFamily: kubermaticv1.IPFamilyDualStack,
+			},
+		},
+		{
+			name: "invalid gcp dual-stack spec: wrong network stack type",
+			spec: &kubermaticv1.GCPCloudSpec{
+				ServiceAccount:          "service-account",
+				NodePortsAllowedIPRange: "0.0.0.0/0",
+				NodePortsAllowedIPRanges: &kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{
+						"0.0.0.0/0",
+						"::/0",
+					},
+				},
+				Network:    "global/networks/default",
+				Subnetwork: "projects/kubermatic-dev/regions/europe-west2/subnetworks/default",
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					GCP: &kubermaticv1.DatacenterSpecGCP{
+						Region: "europe-west2",
+					},
+				},
+			},
+			ipFamily: kubermaticv1.IPFamilyDualStack,
+			gcpSubnetworkResp: apiv1.GCPSubnetwork{
+				IPFamily: kubermaticv1.IPFamilyIPv4,
+			},
+			expectedError: errors.New("GCP subnetwork should belong to same cluster network stack type"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateGCPCloudSpec(tc.spec, tc.dc, tc.ipFamily, func(ctx context.Context, sa, region, subnetworkName string) (apiv1.GCPSubnetwork, error) {
+				return tc.gcpSubnetworkResp, nil
+			})
+			assert.Equal(t, tc.expectedError, err)
 		})
 	}
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We need to improve the validation of GCP dual-stack cluster creation, because, for custom networks (dual-stack case), GCP requires that the subnetwork is specified. Besides that, we cannot use the default network because it's IPv4 only and the node deployment instance subnetwork should have the same cluster IP stack (i.e. dual-stack IPv4 + IPv6). Also, the node deployment instance must be in same cluster region.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10343

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
