### PR TITLE
ipam-controller: Skip clusters in deletion process

### DIFF
--- a/pkg/controller/seed-controller-manager/ipam/controller.go
+++ b/pkg/controller/seed-controller-manager/ipam/controller.go
@@ -135,6 +135,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
+	if cluster.DeletionTimestamp != nil {
+		log.Debug("Cluster is in deletion, skipping")
+		return reconcile.Result{}, nil
+	}
+
 	// Add a wrapping here so we can emit an event on error
 	result, err := kubermaticv1helper.ClusterReconcileWrapper(
 		ctx,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The `kkp-ipam-controller` already skips `Cluster` objects with unset namespace, but I observed it trying to reconcile IPAM allocations during cluster deletion, presumably when the `IPAMAllocation` resource in the cluster namespace was already deleted by the cluster namespace cleanup process. Cleanup behaviour was recently changed in #10359, so this situation (cluster still exists but namespace is cleaned up) did not happen before. This adjusts the ipam-controller a tiny bit to account for that.

My understanding of the controller logic is that if the cluster is being deleted, we don't want to continue reconciling the cluster. There doesn't seem to be any cleanup logic in the controller as far as I can say.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
