### PR TITLE
[release/v2.19] Add `--skip-dependencies` flag to kubermatic-installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -111,6 +111,10 @@ var (
 		Name:  "disable-telemetry",
 		Usage: "disable telemetry agents",
 	}
+	skipDependenciesFlag = cli.BoolFlag{
+		Name:  "skip-dependencies",
+		Usage: "skip pulling Helm chart dependencies (requires chart dependencies to be already downloaded)",
+	}
 )
 
 func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) cli.Command {
@@ -134,6 +138,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) c
 			migrateOpenstackCSIdriversFlag,
 			migrateLogrotateFlag,
 			disableTelemetryFlag,
+			skipDependenciesFlag,
 		},
 	}
 }
@@ -217,6 +222,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			EnableOpenstackCSIDriverMigration:  ctx.Bool(migrateOpenstackCSIdriversFlag.Name),
 			EnableLogrotateMigration:           ctx.Bool(migrateLogrotateFlag.Name),
 			DisableTelemetry:                   ctx.Bool(disableTelemetryFlag.Name),
+			DisableDependencyUpdate:            ctx.Bool(skipDependenciesFlag.Name),
 		}
 
 		// validate the configuration

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -119,8 +119,8 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 		return fmt.Errorf("failed to check to Helm release: %v", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, CertManagerNamespace, CertManagerReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
-		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, CertManagerNamespace, CertManagerReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
 	if err := waitForCertManagerWebhook(ctx, sublogger, kubeClient); err != nil {

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -87,7 +87,7 @@ func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kub
 	// get an IP and this can require manual intervention based on the target environment
 	sublogger.Info("Deploying Helm chart…")
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, NginxIngressControllerNamespace, NginxIngressControllerReleaseName, opt.HelmValues, false, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, NginxIngressControllerNamespace, NginxIngressControllerReleaseName, opt.HelmValues, false, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		if isUpgrading {
 			return fmt.Errorf("failed to deploy Helm release: %v\n\nuse backup file to restore the deployment or re-try the installation after fixing any errors.", err)
 		}

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -148,7 +148,7 @@ func deployTelemetry(ctx context.Context, logger *logrus.Entry, kubeClient ctrlr
 		return fmt.Errorf("failed to check to Helm release: %v", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, TelemetryNamespace, TelemetryReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, TelemetryNamespace, TelemetryReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
 		return fmt.Errorf("failed to deploy Helm release: %v", err)
 	}
 
@@ -226,8 +226,8 @@ func deployDex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntime
 		return fmt.Errorf("failed to check to Helm release: %v", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, DexNamespace, DexReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
-		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, DexNamespace, DexReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
 	logger.Info("✅ Success.")
@@ -259,8 +259,8 @@ func (s *MasterStack) deployKubermaticOperator(ctx context.Context, logger *logr
 		return fmt.Errorf("failed to check to Helm release: %v", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, KubermaticOperatorNamespace, KubermaticOperatorReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
-		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, KubermaticOperatorNamespace, KubermaticOperatorReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
 	logger.Info("✅ Success.")

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -191,8 +191,8 @@ func deployMinio(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunti
 		return fmt.Errorf("failed to check to Helm release: %v", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, MinioNamespace, MinioReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
-		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, MinioNamespace, MinioReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
 	logger.Info("✅ Success.")
@@ -218,8 +218,8 @@ func deployS3Exporter(ctx context.Context, logger *logrus.Entry, kubeClient ctrl
 		return fmt.Errorf("failed to check to Helm release: %v", err)
 	}
 
-	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, S3ExporterNamespace, S3ExporterReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
-		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, S3ExporterNamespace, S3ExporterReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, opt.DisableDependencyUpdate, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %w", err)
 	}
 
 	logger.Info("✅ Success.")

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -64,6 +64,7 @@ type DeployOptions struct {
 	EnableOpenstackCSIDriverMigration  bool
 	EnableLogrotateMigration           bool
 	DisableTelemetry                   bool
+	DisableDependencyUpdate            bool
 }
 
 type Stack interface {

--- a/pkg/install/util/helm.go
+++ b/pkg/install/util/helm.go
@@ -71,7 +71,19 @@ func CheckHelmRelease(ctx context.Context, log logrus.FieldLogger, helmClient he
 	return release, nil
 }
 
-func DeployHelmChart(ctx context.Context, log logrus.FieldLogger, helmClient helm.Client, chart *helm.Chart, namespace string, releaseName string, values *yamled.Document, atomic bool, force bool, release *helm.Release) error {
+func DeployHelmChart(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	helmClient helm.Client,
+	chart *helm.Chart,
+	namespace string,
+	releaseName string,
+	values *yamled.Document,
+	atomic bool,
+	force bool,
+	skipDeps bool,
+	release *helm.Release,
+) error {
 	switch {
 	case release == nil:
 		log.Debug("Installing…")
@@ -114,8 +126,10 @@ func DeployHelmChart(ctx context.Context, log logrus.FieldLogger, helmClient hel
 		flags = append(flags, "--atomic")
 	}
 
-	if err := helmClient.BuildChartDependencies(chart.Directory, flags); err != nil {
-		return fmt.Errorf("failed to download dependencies: %v", err)
+	if !skipDeps {
+		if err := helmClient.BuildChartDependencies(chart.Directory, flags); err != nil {
+			return fmt.Errorf("failed to download dependencies: %v", err)
+		}
 	}
 
 	if err := helmClient.InstallChart(namespace, releaseName, chart.Directory, helmValues, nil, flags); err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/10348. Adds a `--skip-dependencies` flag to kubermatic-installer that allows skipping Helm chart dependency fetching.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--skip-dependencies` flag to kubermatic-installer that skips downloading Helm chart dependencies (requires chart dependencies to be downloaded already)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
