### PR TITLE
fix update controller

### DIFF
--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -115,6 +115,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if cluster.DeletionTimestamp != nil {
+		log.Debug("Cluster is in deletion, no further reconciling.")
+		return reconcile.Result{}, nil
+	}
+
+	if cluster.Status.NamespaceName == "" {
+		log.Debug("Cluster has no namespace yet, cannot reconcile.")
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Without a namespace, the controller would accidentally list *all* ReplicaSets across all namespaces. This would make thhe oldest available cluster the leader and lead to weird, seemingly nonsensical downgrades of other clusters.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @xmudrii 