### PR TITLE
update Prometheus to 2.37

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: blackbox-exporter
 version: v9.9.9-dev
-appVersion: v0.21.0
+appVersion: v0.21.1
 description: Deploys the Prometheus Blackbox Exporter
 keywords:
   - kubermatic

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -15,7 +15,7 @@
 blackboxExporter:
   image:
     repository: quay.io/prometheus/blackbox-exporter
-    tag: v0.21.0
+    tag: v0.21.1
     pullPolicy: IfNotPresent
 
   containers:

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: prometheus
 version: v9.9.9-dev
-appVersion: v2.36.2
+appVersion: v2.37.0
 description: Prometheus Monitoring for Kubernetes
 keywords:
   - kubermatic

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -16,7 +16,7 @@ prometheus:
   replicas: 2
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.36.2
+    tag: v2.37.0
     pullPolicy: IfNotPresent
 
   host: ''

--- a/hack/update-prometheus-rules.sh
+++ b/hack/update-prometheus-rules.sh
@@ -23,7 +23,7 @@ containerize ./hack/update-prometheus-rules.sh
 
 promtool=promtool
 if ! [ -x "$(command -v $promtool)" ]; then
-  version=2.36.2
+  version=2.37.0
   url="https://github.com/prometheus/prometheus/releases/download/v$version/prometheus-$version.linux-amd64.tar.gz"
   promtool=/tmp/promtool
 

--- a/hack/verify-prometheus-rules.sh
+++ b/hack/verify-prometheus-rules.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/..
 source hack/lib.sh
 
 if ! [ -x "$(command -v promtool)" ]; then
-  version=2.36.2
+  version=2.37.0
 
   echodate "Downloading promtool v$version..."
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/prometheus/deployment.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	imageName     = "prometheus/prometheus"
-	tag           = "v2.36.2"
+	tag           = "v2.37.0"
 	appName       = "mla-prometheus"
 	containerName = "prometheus"
 

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.36.2"
+	tag  = "v2.37.0"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
@@ -33,7 +33,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.36.2
+        image: quay.io/prometheus/prometheus:v2.37.0
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
What it says on the tin. 2.37 is an LTS release.

**Does this PR introduce a user-facing change?**:
```release-note
Update Prometheus to 2.37
Update blackbox exporter to 0.21.1
```
