### PR TITLE
Fix operations on GroupProjectBindings

### DIFF
--- a/pkg/provider/kubernetes/member.go
+++ b/pkg/provider/kubernetes/member.go
@@ -204,7 +204,7 @@ func (p *ProjectMemberProvider) MapUserToGroups(ctx context.Context, user *kuber
 	return nil, apierrors.NewForbidden(
 		schema.GroupResource{},
 		projectID,
-		fmt.Errorf("there is no binding between %q user and %s project", user.Spec.Email, projectID),
+		fmt.Errorf("%q doesn't belong to project %s", user.Spec.Email, projectID),
 	)
 }
 

--- a/pkg/provider/kubernetes/member.go
+++ b/pkg/provider/kubernetes/member.go
@@ -166,7 +166,7 @@ func (p *ProjectMemberProvider) MapUserToGroup(ctx context.Context, userEmail st
 		return "", err
 	}
 	if group == "" {
-		return "", apierrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("%q doesn't belong to project %s", userEmail, projectID))
+		return "", apierrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("there is no user binding between %q user and %s project", userEmail, projectID))
 	}
 	return group, nil
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -437,6 +437,11 @@ type ProjectMemberMapper interface {
 	// project bindings for the user and returns the roles.
 	// This function is unsafe in a sense that it uses privileged account to list all userProjectBindings and groupProjectBindings in the system.
 	MapUserToRoles(ctx context.Context, user *kubermaticv1.User, projectID string) (sets.String, error)
+
+	// MapUserToGroups returns the groups of the user in the project. It combines identity provider groups with
+	// group from UserProjectBinding (if exists).
+	// This function is unsafe in a sense that it uses privileged account to list all userProjectBindings in the system.
+	MapUserToGroups(ctx context.Context, user *kubermaticv1.User, projectID string) (sets.String, error)
 }
 
 // ExternalClusterCloudProviderName returns the provider name for the given ExternalClusterCloudSpec.

--- a/pkg/provider/userinfo.go
+++ b/pkg/provider/userinfo.go
@@ -19,8 +19,10 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -98,7 +98,7 @@ func NewAlreadyExists(kind, name string) error {
 	return HTTPError{http.StatusConflict, fmt.Sprintf("%s %q already exists", kind, name), nil}
 }
 
-// IsStatus verifies if api error is of a given status
+// IsStatus verifies if api error is of a given status.
 func IsStatus(err error, status int32) bool {
 	var statusErr *apierrors.StatusError
 

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -17,11 +17,8 @@ limitations under the License.
 package errors
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // HTTPError represents an HTTP server error.
@@ -96,11 +93,4 @@ func NewNotImplemented() error {
 // NewAlreadyExists creates a HTTP 409 already exists error.
 func NewAlreadyExists(kind, name string) error {
 	return HTTPError{http.StatusConflict, fmt.Sprintf("%s %q already exists", kind, name), nil}
-}
-
-// IsStatus verifies if api error is of a given status.
-func IsStatus(err error, status int32) bool {
-	var statusErr *apierrors.StatusError
-
-	return errors.As(err, &statusErr) && status == statusErr.Status().Code
 }

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -17,8 +17,11 @@ limitations under the License.
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // HTTPError represents an HTTP server error.
@@ -93,4 +96,11 @@ func NewNotImplemented() error {
 // NewAlreadyExists creates a HTTP 409 already exists error.
 func NewAlreadyExists(kind, name string) error {
 	return HTTPError{http.StatusConflict, fmt.Sprintf("%s %q already exists", kind, name), nil}
+}
+
+// IsStatus verifies if api error is of a given status
+func IsStatus(err error, status int32) bool {
+	var statusErr *apierrors.StatusError
+
+	return errors.As(err, &statusErr) && status == statusErr.Status().Code
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Add dedicated method for retrieving groups for the user in a specific project.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
