### PR TITLE
do not log client-side errors in KKP API

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -61,13 +61,22 @@ type ErrorDetails struct {
 // swagger:response empty
 type EmptyResponse struct{}
 
+func AsHTTPError(err error) *utilerrors.HTTPError {
+	var httpErr utilerrors.HTTPError
+	if errors.As(err, &httpErr) {
+		return &httpErr
+	}
+
+	return nil
+}
+
 func ErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var additional []string
+
 	errorCode := http.StatusInternalServerError
 	msg := err.Error()
 
-	var httpErr utilerrors.HTTPError
-	if errors.As(err, &httpErr) {
+	if httpErr := AsHTTPError(err); httpErr != nil {
 		errorCode = httpErr.StatusCode()
 		msg = httpErr.Error()
 		additional = httpErr.Details()

--- a/pkg/handler/v2/routing.go
+++ b/pkg/handler/v2/routing.go
@@ -171,12 +171,18 @@ func NewV2Routing(routingParams handler.RoutingParams) Routing {
 func (r Routing) defaultServerOptions() []httptransport.ServerOption {
 	var req *http.Request
 
+	// wrap the request variable so that we do not hand a stable
+	// "req" variable to NewRequestErrorHandler()
+	provider := func() *http.Request {
+		return req
+	}
+
 	return []httptransport.ServerOption{
 		httptransport.ServerBefore(func(c context.Context, r *http.Request) context.Context {
 			req = r
 			return c
 		}),
-		httptransport.ServerErrorHandler(handler.NewRequestErrorHandler(r.log, req)),
+		httptransport.ServerErrorHandler(handler.NewRequestErrorHandler(r.log, provider)),
 		httptransport.ServerErrorEncoder(handler.ErrorEncoder),
 		httptransport.ServerBefore(middleware.TokenExtractor(r.tokenExtractors)),
 		httptransport.ServerBefore(middleware.SetSeedsGetter(r.seedsGetter)),

--- a/pkg/handler/v2/routing.go
+++ b/pkg/handler/v2/routing.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/go-kit/kit/transport"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/go-kit/log"
 	prometheusapi "github.com/prometheus/client_golang/api"
@@ -177,9 +176,7 @@ func (r Routing) defaultServerOptions() []httptransport.ServerOption {
 			req = r
 			return c
 		}),
-		httptransport.ServerErrorHandler(transport.ErrorHandlerFunc(func(ctx context.Context, err error) {
-			r.log.Errorw(err.Error(), "request", req.URL.String())
-		})),
+		httptransport.ServerErrorHandler(handler.NewRequestErrorHandler(r.log, req)),
 		httptransport.ServerErrorEncoder(handler.ErrorEncoder),
 		httptransport.ServerBefore(middleware.TokenExtractor(r.tokenExtractors)),
 		httptransport.ServerBefore(middleware.SetSeedsGetter(r.seedsGetter)),


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
I have observed a high number of seemingly irrelevant errors in the KKP API logs, like

> {"level":"error","time":"2022-07-19T14:03:26.292Z","caller":"handler/routing.go:146","msg":"failed to list clusters: Get \"https://35.198.89.109/apis/kubermatic.k8c.io/v1/clusters?labelSelector=project-id%3Dsv8qtp9pn5\": context canceled","request":"/api/v1/projects?displayAll=false"}
> {"level":"error","time":"2022-07-19T14:03:27.490Z","caller":"handler/routing.go:146","msg":"failed to get some projects, please examine details field for more info","request":"/api/v1/projects?displayAll=false"}

Looking at the nginx logs, I can see some requests ending in HTTP 499, which is nginx's catch-all for clients canceling a request. This makes me think that it's clients that are canceling requests, leading to these contexts being canceled.

This does not happen at all during e2e tests, but happens often on the KKP dashboard. I presume this happens as browsers move back and forth between views and requests and preflights and whatnot are firing all over the place, some getting canceled along the way?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
