### PR TITLE
Fix nil pointer return in resource validation when Openstack app credentials are used

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -425,7 +425,6 @@ func getOpenstackResourceRequirements(ctx context.Context,
 		if err != nil {
 			return nil, fmt.Errorf("failed to get the value of openstack \"applicationCredentialSecret\" field, error: %w", err)
 		}
-		return nil, nil
 	}
 	creds.Domain, err = configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.DomainName, envOSDomain)
 	if err != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

When creating a user cluster with Openstack app credentials, the `user-cluster-controller-manager` is crashing because it hits a nil pointer:

```
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x25fd0e0, 0x51d6e00})
	runtime/panic.go:838 +0x207
k8c.io/kubermatic/v2/pkg/ee/validation/machine.(*ResourceDetails).Cpu(...)
	k8c.io/kubermatic/v2/pkg/ee/validation/machine/resourcequota.go:115
k8c.io/kubermatic/v2/pkg/ee/resource-usage-controller.(*reconciler).reconcile(0xc0018168a0, {0x325cf88, 0xc002813500}, 0xc002772000, 0xc000525880)
	k8c.io/kubermatic/v2/pkg/ee/resource-usage-controller/controller.go:135 +0x39d
k8c.io/kubermatic/v2/pkg/ee/resource-usage-controller.(*reconciler).Reconcile(0xc0018168a0, {0x325cf88, 0xc002813500}, {{{0xc001cac170?, 0x10?}, {0xc001aee600?, 0x40d987?}}})
	k8c.io/kubermatic/v2/pkg/ee/resource-usage-controller/controller.go:119 +0x389
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x325cee0?, {0x325cf88?, 0xc002813500?}, {{{0xc001cac170?, 0x2a04f00?}, {0xc001aee600?, 0x4041f4?}}})
	sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:121 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00114d860, {0x325cee0, 0xc001449340}, {0x27609a0?, 0xc0020f97c0?})
	sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:320 +0x33c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00114d860, {0x325cee0, 0xc001449340})
	sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:234 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:230 +0x325
```

This happens because when using application credentials with Openstack, the `getOpenstackResourceRequirements` func returns early with `return nil, nil`, thus producing no error but also not returning a reference to a `ResourceDetails` object.

It seems to be from the logic of the func that just dropping this return should fix it.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>