### PR TITLE
[release/v2.20] Improve etcd backup filenames (#10143)

### DIFF
--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -418,7 +418,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		backupConfig.Status.CurrentBackups = []kubermaticv1.BackupStatus{{}}
 		backupToSchedule = &backupConfig.Status.CurrentBackups[0]
 		backupToSchedule.ScheduledTime = metav1.NewTime(r.clock.Now())
-		backupToSchedule.BackupName = backupConfig.Name
+		backupToSchedule.BackupName = fmt.Sprintf("%s.db", backupConfig.Name)
 		requeueAfter = 0
 	} else {
 		// compute the pending (i.e. latest past) and the next (i.e. earliest future) backup time,
@@ -451,7 +451,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		backupConfig.Status.CurrentBackups = append(backupConfig.Status.CurrentBackups, kubermaticv1.BackupStatus{})
 		backupToSchedule = &backupConfig.Status.CurrentBackups[len(backupConfig.Status.CurrentBackups)-1]
 		backupToSchedule.ScheduledTime = metav1.NewTime(pendingBackupTime)
-		backupToSchedule.BackupName = fmt.Sprintf("%s-%s", backupConfig.Name, backupToSchedule.ScheduledTime.UTC().Format("2006-01-02t15-04-05"))
+		backupToSchedule.BackupName = fmt.Sprintf("%s-%s.db", backupConfig.Name, backupToSchedule.ScheduledTime.UTC().Format("2006-01-02t15-04-05"))
 		requeueAfter = nextBackupTime.Sub(now)
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -253,7 +253,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(10, 0).UTC()),
-					BackupName:    "testbackup",
+					BackupName:    "testbackup.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -270,7 +270,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(100, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-40",
+					BackupName:    "testbackup-1970-01-01t00-01-40.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -278,7 +278,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(100, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-40",
+					BackupName:    "testbackup-1970-01-01t00-01-40.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -320,7 +320,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -328,7 +328,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -346,7 +346,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -354,13 +354,13 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(600, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-10-00",
+					BackupName:    "testbackup-1970-01-01t00-10-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(1200, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-20-00",
+					BackupName:    "testbackup-1970-01-01t00-20-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -379,7 +379,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(3600*24*15, 0).UTC()),
-					BackupName:    "testbackup-1970-01-16t00-00-00",
+					BackupName:    "testbackup-1970-01-16t00-00-00.db",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -398,7 +398,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(10, 0).UTC()),
-					BackupName:    "long-backup-config-name-abcdefghijk",
+					BackupName:    "long-backup-config-name-abcdefghijk.db",
 					JobName:       "testcluster-backup-long-backup-config-name-abcdefghijk-creaxxxx",
 					DeleteJobName: "testcluster-backup-long-backup-config-name-abcdefghijk-delexxxx",
 				},
@@ -478,13 +478,13 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-bbbb",
 					DeleteJobName: "testcluster-backup-testbackup-delete-bbbb",
 				},
@@ -493,14 +493,14 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-bbbb",
 					DeleteJobName: "testcluster-backup-testbackup-delete-bbbb",
 				},
@@ -516,21 +516,21 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(70, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-10",
+					BackupName:    "testbackup-1970-01-01t00-01-10.db",
 					JobName:       "testcluster-backup-testbackup-create-bbbb",
 					DeleteJobName: "testcluster-backup-testbackup-delete-bbbb",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -544,7 +544,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -553,7 +553,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(70, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-10",
+					BackupName:         "testbackup-1970-01-01t00-01-10.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(80, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -562,7 +562,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-02-00",
+					BackupName:    "testbackup-1970-01-01t00-02-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -581,7 +581,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
@@ -593,7 +593,7 @@ func TestStartPendingBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-01-00",
+					BackupName:    "testbackup-1970-01-01t00-01-00.db",
 					JobName:       "testcluster-backup-testbackup-create-aaaa",
 					DeleteJobName: "testcluster-backup-testbackup-delete-aaaa",
 					BackupPhase:   kubermaticv1.BackupStatusPhaseRunning,
@@ -684,7 +684,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -693,7 +693,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -702,7 +702,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-03-00",
+					BackupName:    "testbackup-1970-01-01t00-03-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -711,7 +711,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -721,7 +721,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -730,7 +730,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-03-00",
+					BackupName:    "testbackup-1970-01-01t00-03-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -747,7 +747,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -759,7 +759,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -780,7 +780,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -790,7 +790,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -799,7 +799,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -811,7 +811,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -821,7 +821,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -831,7 +831,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -851,7 +851,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -867,7 +867,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				// unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -888,7 +888,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			existingBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				return kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-testbackup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(90+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -900,7 +900,7 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 			expectedBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				result := kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-testbackup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(90+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -997,7 +997,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// 3 backups with deletions marked as running, a 4th backup is only scheduled
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1007,7 +1007,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1017,7 +1017,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1027,7 +1027,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -1044,7 +1044,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// result: 1st backup's deletion marked as completed, 2nd one's restarted, 3rd and 4th unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1056,7 +1056,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1067,7 +1067,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1077,7 +1077,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -1091,7 +1091,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// 2 backups with deletions marked as running
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1101,7 +1101,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1121,7 +1121,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				// result: both backups' deletions marked as completed, and we reconcile after the retention period
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1133,7 +1133,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1152,7 +1152,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 			existingBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				return kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(150+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1170,7 +1170,7 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 			expectedBackups: genBackupStatusList(maxSimultaneousDeleteJobsPerConfig+2, func(i int) kubermaticv1.BackupStatus {
 				result := kubermaticv1.BackupStatus{
 					ScheduledTime:      metav1.NewTime(time.Unix(60+int64(i)*60, 0).UTC()),
-					BackupName:         fmt.Sprintf("testbackup-%v", i),
+					BackupName:         fmt.Sprintf("testbackup-%v.db", i),
 					JobName:            fmt.Sprintf("testcluster-backup-%v-create", i),
 					BackupFinishedTime: metav1.NewTime(time.Unix(150+int64(i)*60, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1260,7 +1260,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// 2 backups with backup jobs marked as completed
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1269,7 +1269,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1281,7 +1281,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// (just so we can test them with the same current time)
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-cccc",
 					BackupFinishedTime: metav1.NewTime(time.Unix(80, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1293,7 +1293,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-dddd",
 					BackupFinishedTime: metav1.NewTime(time.Unix(140, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1321,7 +1321,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1330,7 +1330,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1339,7 +1339,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-dddd",
 					BackupFinishedTime: metav1.NewTime(time.Unix(140, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1365,7 +1365,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// 2 backups with backup jobs marked as failed
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1374,7 +1374,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1394,7 +1394,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// backups unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1403,7 +1403,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(120, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-02-00",
+					BackupName:         "testbackup-1970-01-01t00-02-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(150, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseFailed,
@@ -1424,7 +1424,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// one backup with deletion marked as completed, one with deletion marked as running, a 3rd backup is only scheduled
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(60, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-01-00",
+					BackupName:         "testbackup-1970-01-01t00-01-00.db",
 					JobName:            "testcluster-backup-testbackup-create-aaaa",
 					BackupFinishedTime: metav1.NewTime(time.Unix(90, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1436,7 +1436,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1446,7 +1446,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},
@@ -1463,7 +1463,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				// result: 1st backup's job and status entry are deleted, other two unchanged
 				{
 					ScheduledTime:      metav1.NewTime(time.Unix(180, 0).UTC()),
-					BackupName:         "testbackup-1970-01-01t00-03-00",
+					BackupName:         "testbackup-1970-01-01t00-03-00.db",
 					JobName:            "testcluster-backup-testbackup-create-bbbb",
 					BackupFinishedTime: metav1.NewTime(time.Unix(210, 0).UTC()),
 					BackupPhase:        kubermaticv1.BackupStatusPhaseCompleted,
@@ -1473,7 +1473,7 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(240, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-04-00",
+					BackupName:    "testbackup-1970-01-01t00-04-00.db",
 					JobName:       "testcluster-backup-testbackup-create-cccc",
 					DeleteJobName: "testcluster-backup-testbackup-delete-cccc",
 				},

--- a/pkg/storeuploader/storeuploader.go
+++ b/pkg/storeuploader/storeuploader.go
@@ -85,14 +85,14 @@ func (u *StoreUploader) Store(file, bucket, prefix string, createBucket bool) er
 			return err
 		}
 		if !exists {
-			logger.Infow("Creating bucket")
+			logger.Info("Creating bucket")
 			if err := u.client.MakeBucket(bucket, ""); err != nil {
 				return err
 			}
 		}
 	}
 
-	objectName := fmt.Sprintf("%s-%s-%s-%s", prefix, prefixSeparator, time.Now().Format("2006-01-02T15:04:05"), path.Base(file))
+	objectName := fmt.Sprintf("%s-%s-%s-%s", prefix, prefixSeparator, time.Now().Format("2006-01-02T150405"), path.Base(file))
 	logger.Infow("Uploading file", "src", file, "dst", objectName)
 
 	_, err := u.client.FPutObject(bucket, objectName, file, minio.PutObjectOptions{})


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
@dharapvj requested this manual backport.

**Does this PR introduce a user-facing change?**:
```release-note
etcd backup files are named differently (`foo-YYYY-MM-DDThh:mm:ss` to `foo-YYYY-MM-DDThhmmss.db`) to improve compatibility with different storage solutions
```
