### PR TITLE
added rq machine validating webhook configuration to reconciling

### DIFF
--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -127,7 +127,7 @@ func main() {
 	if err != nil {
 		log.Fatalw("Failed to setup Machine validator", zap.Error(err))
 	}
-	if err := builder.WebhookManagedBy(seedMgr).For(&clusterv1alpha1.Machine{}).WithValidator(machineValidator).Complete(); err != nil {
+	if err := builder.WebhookManagedBy(userMgr).For(&clusterv1alpha1.Machine{}).WithValidator(machineValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup Machine validation webhook", zap.Error(err))
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -43,6 +43,7 @@ import (
 	kubernetesresources "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine"
 	machinecontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
 	metricsserver "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla"
@@ -667,6 +668,7 @@ func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context,
 func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Context, data reconcileData) error {
 	creators := []reconciling.NamedValidatingWebhookConfigurationCreatorGetter{
 		applications.ApplicationInstallationValidatingWebhookConfigurationCreator(data.caCert.Cert, r.namespace),
+		machine.ValidatingWebhookConfigurationCreator(data.caCert.Cert, r.namespace),
 	}
 	if r.opaIntegration {
 		creators = append(creators, gatekeeper.ValidatingWebhookConfigurationCreator(r.opaWebhookTimeout))

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -31,21 +31,23 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const machineValidatingWebhookConfigurationName = "kubermatic-machine-validation"
+
 // ValidatingWebhookConfigurationCreator returns the ValidatingWebhookConfiguration for the machine CRD.
 func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
-		return resources.MachineValidatingWebhookConfigurationName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+		return machineValidatingWebhookConfigurationName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
 			// TODO - change to Fail when the resource quotas are fully implemented and tested
 			failurePolicy := admissionregistrationv1.Ignore
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.NamespacedScope
 
-			url := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1-machine", resources.UserClusterWebhookServiceName, namespace)
+			url := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1alpha1-machine", resources.UserClusterWebhookServiceName, namespace)
 
 			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name:                    resources.MachineValidatingWebhookConfigurationName, // this should be a FQDN
+					Name:                    "machines.cluster.k8c.io", // this should be a FQDN
 					AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
 					MatchPolicy:             &matchPolicy,
 					FailurePolicy:           &failurePolicy,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -37,7 +37,7 @@ const (
 func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
 		return resources.MachineValidatingWebhookConfigurationName, func(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
-			// TODO - change to Fail when the resource quotas are fully implemented
+			// TODO - change to Fail when the resource quotas are fully implemented and tested
 			failurePolicy := admissionregistrationv1.Ignore
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			mURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1-machine", resources.UserClusterWebhookServiceName, namespace)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -57,7 +57,7 @@ func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace s
 			validatingWebhookConfiguration.Webhooks[0].FailurePolicy = &failurePolicy
 			validatingWebhookConfiguration.Webhooks[0].AdmissionReviewVersions = reviewVersions
 			validatingWebhookConfiguration.Webhooks[0].Rules = []admissionregistrationv1.RuleWithOperations{{
-				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 				Rule: admissionregistrationv1.Rule{
 					APIGroups:   []string{clusterAPIGroup},
 					APIVersions: []string{clusterAPIVersion},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -20,57 +20,59 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	clusterAPIGroup   = "cluster.k8s.io"
-	clusterAPIVersion = "v1alpha1"
+	"k8s.io/utils/pointer"
 )
 
 // ValidatingWebhookConfigurationCreator returns the ValidatingWebhookConfiguration for the machine CRD.
 func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
-		return resources.MachineValidatingWebhookConfigurationName, func(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+		return resources.MachineValidatingWebhookConfigurationName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+			matchPolicy := admissionregistrationv1.Exact
 			// TODO - change to Fail when the resource quotas are fully implemented and tested
 			failurePolicy := admissionregistrationv1.Ignore
 			sideEffects := admissionregistrationv1.SideEffectClassNone
-			mURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1-machine", resources.UserClusterWebhookServiceName, namespace)
-			reviewVersions := []string{"v1", "v1beta1"}
+			scope := admissionregistrationv1.NamespacedScope
 
-			// This only gets set when the APIServer supports it, so carry it over
-			var scope *admissionregistrationv1.ScopeType
-			if len(validatingWebhookConfiguration.Webhooks) != 1 {
-				validatingWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{{}, {}}
-			} else if len(validatingWebhookConfiguration.Webhooks[0].Rules) > 0 {
-				scope = validatingWebhookConfiguration.Webhooks[0].Rules[0].Scope
-			}
+			url := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1-machine", resources.UserClusterWebhookServiceName, namespace)
 
-			validatingWebhookConfiguration.Webhooks[0].Name = fmt.Sprintf("%s-machines", resources.MachineValidatingWebhookConfigurationName)
-			validatingWebhookConfiguration.Webhooks[0].NamespaceSelector = &metav1.LabelSelector{}
-			validatingWebhookConfiguration.Webhooks[0].SideEffects = &sideEffects
-			validatingWebhookConfiguration.Webhooks[0].FailurePolicy = &failurePolicy
-			validatingWebhookConfiguration.Webhooks[0].AdmissionReviewVersions = reviewVersions
-			validatingWebhookConfiguration.Webhooks[0].Rules = []admissionregistrationv1.RuleWithOperations{{
-				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-				Rule: admissionregistrationv1.Rule{
-					APIGroups:   []string{clusterAPIGroup},
-					APIVersions: []string{clusterAPIVersion},
-					Resources:   []string{"machines"},
-					Scope:       scope,
+			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
+				{
+					Name:                    resources.MachineValidatingWebhookConfigurationName, // this should be a FQDN
+					AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
+					MatchPolicy:             &matchPolicy,
+					FailurePolicy:           &failurePolicy,
+					SideEffects:             &sideEffects,
+					TimeoutSeconds:          pointer.Int32Ptr(3),
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
+						CABundle: triple.EncodeCertPEM(caCert),
+						URL:      &url,
+					},
+					ObjectSelector:    &metav1.LabelSelector{},
+					NamespaceSelector: &metav1.LabelSelector{},
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{clusterv1alpha1.SchemeGroupVersion.Group},
+								APIVersions: []string{clusterv1alpha1.SchemeGroupVersion.Version},
+								Resources:   []string{"machines"},
+								Scope:       &scope,
+							},
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+							},
+						},
+					},
 				},
-			}}
-			validatingWebhookConfiguration.Webhooks[0].ClientConfig = admissionregistrationv1.WebhookClientConfig{
-				URL:      &mURL,
-				CABundle: triple.EncodeCertPEM(caCert),
 			}
-
-			return validatingWebhookConfiguration, nil
+			return hook, nil
 		}
 	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -444,7 +444,7 @@ const (
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
 
 	// MachineValidatingWebhookConfigurationName is the name for the machine validating webhook.
-	MachineValidatingWebhookConfigurationName = "machine.kubermatic.k8c.io"
+	MachineValidatingWebhookConfigurationName = "machines.cluster.k8c.io"
 
 	// GatekeeperValidatingWebhookConfigurationName is the name of the gatekeeper validating webhook
 	// configuration.

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -443,9 +443,6 @@ const (
 	// configuration.
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
 
-	// MachineValidatingWebhookConfigurationName is the name for the machine validating webhook.
-	MachineValidatingWebhookConfigurationName = "machines.cluster.k8c.io"
-
 	// GatekeeperValidatingWebhookConfigurationName is the name of the gatekeeper validating webhook
 	// configuration.
 	GatekeeperValidatingWebhookConfigurationName = "gatekeeper-validating-webhook-configuration"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds the ResourceQuotas Machine ValidatingWebhookConfiguration to the reconciling for the user cluster.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
