### PR TITLE
Clarify message of cleanup events

### DIFF
--- a/pkg/clusterdeletion/constraints.go
+++ b/pkg/clusterdeletion/constraints.go
@@ -62,7 +62,7 @@ func (d *Deletion) cleanupConstraints(ctx context.Context, log *zap.SugaredLogge
 		}
 	}
 
-	d.recorder.Event(cluster, corev1.EventTypeNormal, "ConstraintCleanup", "Cleanup has been completed.")
+	d.recorder.Event(cluster, corev1.EventTypeNormal, "ConstraintCleanup", "Cleanup has been completed, all constraints have been deleted.")
 
 	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.KubermaticConstraintCleanupFinalizer)
 }

--- a/pkg/clusterdeletion/etcdbackupconfig.go
+++ b/pkg/clusterdeletion/etcdbackupconfig.go
@@ -51,7 +51,7 @@ func (d *Deletion) cleanupEtcdBackupConfigs(ctx context.Context, cluster *kuberm
 		}
 	}
 
-	d.recorder.Event(cluster, corev1.EventTypeNormal, "EtcdBackupConfigCleanup", "Cleanup has been completed.")
+	d.recorder.Event(cluster, corev1.EventTypeNormal, "EtcdBackupConfigCleanup", "Cleanup has been completed, all EtcdBackupConfigs have been deleted.")
 
 	return kuberneteshelper.TryRemoveFinalizer(ctx, d.seedClient, cluster, kubermaticv1.EtcdBackupConfigCleanupFinalizer)
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The cleanup message for nodes includes a little sugar that explains what has been cleaned up, this PR adds that kind of information to the other "Cleanup has been completed" events as well. There's a limitation in the UI that does not display event reasons, but this will reduce confusion for dashboard users for the time being. I'll raise a follow up to have event reasons in kubermatic/dashboard.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
