### PR TITLE
remove validation for externalcluster providername

### DIFF
--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -32,8 +32,6 @@ const (
 	ExternalClusterKind = "ExternalCluster"
 )
 
-// +kubebuilder:validation:Enum=gke;aks;eks;kubeone
-
 type ExternalClusterProvider string
 
 const (

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -368,11 +368,6 @@ spec:
                     - sshReference
                     type: object
                   providerName:
-                    enum:
-                    - gke
-                    - aks
-                    - eks
-                    - kubeone
                     type: string
                 required:
                 - providerName


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What does this PR do / Why do we need it**:
remove validation for externalclsuter providername.
Since ExternalCluster ProviderName possible values are not determined.
Temporarily removing the validation to avoid issues specificaly for clsuters where providerName cannot be determined as we only have access of cluster kubeconfig

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
