### PR TITLE
Remove human-readable name label from ResourceQuotas

### DIFF
--- a/pkg/apis/kubermatic/v1/resource_quota.go
+++ b/pkg/apis/kubermatic/v1/resource_quota.go
@@ -25,9 +25,8 @@ const (
 	// ResourceQuotaKindName represents "Kind" defined in Kubernetes.
 	ResourceQuotaKindName = "ResourceQuota"
 
-	ResourceQuotaSubjectNameLabelKey              = "subject-name"
-	ResourceQuotaSubjectKindLabelKey              = "subject-kind"
-	ResourceQuotaSubjectHumanReadableNameLabelKey = "subject-human-readable-name"
+	ResourceQuotaSubjectNameLabelKey = "subject-name"
+	ResourceQuotaSubjectKindLabelKey = "subject-kind"
 
 	ProjectSubjectKind = "project"
 )

--- a/pkg/ee/mutation/resourcequota/mutation.go
+++ b/pkg/ee/mutation/resourcequota/mutation.go
@@ -62,7 +62,7 @@ func Handle(ctx context.Context, req webhook.AdmissionRequest, decoder *admissio
 		})
 
 		if strings.EqualFold(resourceQuota.Spec.Subject.Kind, kubermaticv1.ProjectSubjectKind) {
-			err := ensureProjectOwnershipRefAndLabel(ctx, client, resourceQuota)
+			err := ensureProjectOwnershipRef(ctx, client, resourceQuota)
 			if err != nil {
 				logger.Info("ResourceQuota mutation failed", "error", err)
 				return admission.Errored(http.StatusBadRequest, err)
@@ -99,7 +99,7 @@ func Handle(ctx context.Context, req webhook.AdmissionRequest, decoder *admissio
 	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedResourceQuota)
 }
 
-func ensureProjectOwnershipRefAndLabel(ctx context.Context, client ctrlruntimeclient.Client, resourceQuota *kubermaticv1.ResourceQuota) error {
+func ensureProjectOwnershipRef(ctx context.Context, client ctrlruntimeclient.Client, resourceQuota *kubermaticv1.ResourceQuota) error {
 	subjectName := resourceQuota.Spec.Subject.Name
 	ownRefs := resourceQuota.OwnerReferences
 
@@ -120,8 +120,6 @@ func ensureProjectOwnershipRefAndLabel(ctx context.Context, client ctrlruntimecl
 	projectRef := resources.GetProjectRef(project)
 	ownRefs = append(ownRefs, projectRef)
 	resourceQuota.SetOwnerReferences(ownRefs)
-
-	kubernetes.EnsureLabels(resourceQuota, map[string]string{kubermaticv1.ResourceQuotaSubjectHumanReadableNameLabelKey: project.Spec.Name})
 
 	return nil
 }

--- a/pkg/ee/mutation/resourcequota/mutation_test.go
+++ b/pkg/ee/mutation/resourcequota/mutation_test.go
@@ -176,11 +176,6 @@ func TestHandle(t *testing.T) {
 					"/metadata/labels/subject-kind",
 					"project",
 				),
-				jsonpatch.NewOperation(
-					"replace",
-					"/metadata/labels/subject-human-readable-name",
-					"boo",
-				),
 			},
 		},
 		{

--- a/pkg/ee/mutation/resourcequota/mutation_test.go
+++ b/pkg/ee/mutation/resourcequota/mutation_test.go
@@ -112,9 +112,8 @@ func TestHandle(t *testing.T) {
 					"add",
 					"/metadata/labels",
 					map[string]interface{}{
-						kubermaticv1.ResourceQuotaSubjectKindLabelKey:              kubermaticv1.ProjectSubjectKind,
-						kubermaticv1.ResourceQuotaSubjectNameLabelKey:              "xxtestxx",
-						kubermaticv1.ResourceQuotaSubjectHumanReadableNameLabelKey: "boo",
+						kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
+						kubermaticv1.ResourceQuotaSubjectNameLabelKey: "xxtestxx",
 					},
 				),
 			},
@@ -135,9 +134,8 @@ func TestHandle(t *testing.T) {
 							Name:        "project-xxtestxx",
 							ProjectName: "xxtestxx",
 							Labels: map[string]string{
-								kubermaticv1.ResourceQuotaSubjectKindLabelKey:              "NOT-project",
-								kubermaticv1.ResourceQuotaSubjectNameLabelKey:              "WRONG-name",
-								kubermaticv1.ResourceQuotaSubjectHumanReadableNameLabelKey: "ROBOT-name",
+								kubermaticv1.ResourceQuotaSubjectKindLabelKey: "NOT-project",
+								kubermaticv1.ResourceQuotaSubjectNameLabelKey: "WRONG-name",
 							},
 						}.Do(),
 					},

--- a/pkg/ee/resource-quota/provider_test.go
+++ b/pkg/ee/resource-quota/provider_test.go
@@ -43,7 +43,8 @@ import (
 )
 
 const (
-	projectName = "my-first-project-ID"
+	projectName        = "my-first-project-ID"
+	anotherProjectName = "my-second-project-ID"
 )
 
 func createResourceProviderHelper(existingObjects []ctrlruntimeclient.Object) *resourcequotas.ResourceQuotaProvider {

--- a/pkg/handler/v2/resource_quota/resourequota.go
+++ b/pkg/handler/v2/resource_quota/resourequota.go
@@ -35,7 +35,7 @@ func GetForProjectEndpoint(projectProvider provider.ProjectProvider, privilegedP
 	}
 }
 
-func GetResourceQuotaEndpoint(userInfoGetter provider.UserInfoGetter, provider provider.ResourceQuotaProvider) endpoint.Endpoint {
+func GetResourceQuotaEndpoint(userInfoGetter provider.UserInfoGetter, provider provider.ResourceQuotaProvider, projectProvider provider.PrivilegedProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -45,7 +45,7 @@ func GetResourceQuotaEndpoint(userInfoGetter provider.UserInfoGetter, provider p
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%s doesn't have admin rights", userInfo.Email))
 		}
 
-		resp, err := getResourceQuota(ctx, req, provider)
+		resp, err := getResourceQuota(ctx, req, provider, projectProvider)
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +54,7 @@ func GetResourceQuotaEndpoint(userInfoGetter provider.UserInfoGetter, provider p
 	}
 }
 
-func ListResourceQuotasEndpoint(userInfoGetter provider.UserInfoGetter, provider provider.ResourceQuotaProvider) endpoint.Endpoint {
+func ListResourceQuotasEndpoint(userInfoGetter provider.UserInfoGetter, provider provider.ResourceQuotaProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -64,7 +64,7 @@ func ListResourceQuotasEndpoint(userInfoGetter provider.UserInfoGetter, provider
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%s doesn't have admin rights", userInfo.Email))
 		}
 
-		resp, err := listResourceQuotas(ctx, req, provider)
+		resp, err := listResourceQuotas(ctx, req, provider, projectProvider)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/handler/v2/resource_quota/wrappers_ce.go
+++ b/pkg/handler/v2/resource_quota/wrappers_ce.go
@@ -30,11 +30,11 @@ func getResourceQuotaForProject(_ context.Context, _ interface{}, _ provider.Pro
 	_ provider.PrivilegedProjectProvider, _ provider.UserInfoGetter, _ provider.ResourceQuotaProvider) (*apiv2.ResourceQuota, error) {
 	return nil, nil
 }
-func getResourceQuota(_ context.Context, _ interface{}, _ provider.ResourceQuotaProvider) (*apiv2.ResourceQuota, error) {
+func getResourceQuota(_ context.Context, _ interface{}, _ provider.ResourceQuotaProvider, _ provider.PrivilegedProjectProvider) (*apiv2.ResourceQuota, error) {
 	return nil, nil
 }
 
-func listResourceQuotas(_ context.Context, _ interface{}, _ provider.ResourceQuotaProvider) ([]apiv2.ResourceQuota, error) {
+func listResourceQuotas(_ context.Context, _ interface{}, _ provider.ResourceQuotaProvider, _ provider.ProjectProvider) ([]apiv2.ResourceQuota, error) {
 	return nil, nil
 }
 

--- a/pkg/handler/v2/resource_quota/wrappers_ee.go
+++ b/pkg/handler/v2/resource_quota/wrappers_ee.go
@@ -33,12 +33,12 @@ func getResourceQuotaForProject(ctx context.Context, request interface{}, projec
 	return resourcequota.GetResourceQuotaForProject(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
 }
 
-func getResourceQuota(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider) (*apiv2.ResourceQuota, error) {
-	return resourcequota.GetResourceQuota(ctx, request, provider)
+func getResourceQuota(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider, projectProvider provider.PrivilegedProjectProvider) (*apiv2.ResourceQuota, error) {
+	return resourcequota.GetResourceQuota(ctx, request, provider, projectProvider)
 }
 
-func listResourceQuotas(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider) ([]*apiv2.ResourceQuota, error) {
-	return resourcequota.ListResourceQuotas(ctx, request, provider)
+func listResourceQuotas(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider, projectProvider provider.ProjectProvider) ([]*apiv2.ResourceQuota, error) {
+	return resourcequota.ListResourceQuotas(ctx, request, provider, projectProvider)
 }
 
 func createResourceQuota(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider) error {

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -6896,7 +6896,7 @@ func (r Routing) getResourceQuota() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(resourcequota.GetResourceQuotaEndpoint(r.userInfoGetter, r.resourceQuotaProvider)),
+		)(resourcequota.GetResourceQuotaEndpoint(r.userInfoGetter, r.resourceQuotaProvider, r.privilegedProjectProvider)),
 		resourcequota.DecodeResourceQuotasReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,
@@ -6920,7 +6920,7 @@ func (r Routing) listResourceQuotas() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(resourcequota.ListResourceQuotasEndpoint(r.userInfoGetter, r.resourceQuotaProvider)),
+		)(resourcequota.ListResourceQuotasEndpoint(r.userInfoGetter, r.resourceQuotaProvider, r.projectProvider)),
 		resourcequota.DecodeListResourceQuotasReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Unfortunately label keys are strict and cannot contain some of characters that we allow in human-readable project names.  

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
