### PR TITLE
Increase TestDeleteClusterBeforeIsUp timeout to five minutes

### DIFF
--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -274,7 +274,7 @@ func (r *TestClient) CleanupCluster(t *testing.T, projectID, dc, clusterID strin
 		t.Fatalf("Failed to delete cluster: %v", err)
 	}
 
-	timeout := 3 * time.Minute
+	timeout := 5 * time.Minute
 	t.Logf("Waiting %v for cluster to be gone...", timeout)
 
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
I think #10359 sent the `pre-kubermatic-api-e2e` test over the edge as clusters now remain longer (until everything is cleaned up). A lot of tests are currently failing with this error in `TestDeleteClusterBeforeIsUp/delete_cluster_before_is_up`:

```
client.go:285: Failed to wait for cluster to be gone: timed out waiting for the condition
```

This was occasionally happening before, but the situation has become much worse than before.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>