### PR TITLE
migrate scripts to yq4

### DIFF
--- a/charts/backup/velero/crd/backups.yaml
+++ b/charts/backup/velero/crd/backups.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/backupstoragelocations.yaml
+++ b/charts/backup/velero/crd/backupstoragelocations.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/deletebackuprequests.yaml
+++ b/charts/backup/velero/crd/deletebackuprequests.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/downloadrequests.yaml
+++ b/charts/backup/velero/crd/downloadrequests.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/podvolumebackups.yaml
+++ b/charts/backup/velero/crd/podvolumebackups.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/podvolumerestores.yaml
+++ b/charts/backup/velero/crd/podvolumerestores.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/resticrepositories.yaml
+++ b/charts/backup/velero/crd/resticrepositories.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/restores.yaml
+++ b/charts/backup/velero/crd/restores.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/schedules.yaml
+++ b/charts/backup/velero/crd/schedules.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/serverstatusrequests.yaml
+++ b/charts/backup/velero/crd/serverstatusrequests.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/backup/velero/crd/volumesnapshotlocations.yaml
+++ b/charts/backup/velero/crd/volumesnapshotlocations.yaml
@@ -1,4 +1,5 @@
 # This file has been generated with Velero v1.9.0. Do not edit.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/monitoring/prometheus/rules/general-blackbox-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-blackbox-exporter.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: blackbox-exporter
     rules:

--- a/charts/monitoring/prometheus/rules/general-cadvisor.yaml
+++ b/charts/monitoring/prometheus/rules/general-cadvisor.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: cadvisor
     rules:

--- a/charts/monitoring/prometheus/rules/general-cadvisor.yaml
+++ b/charts/monitoring/prometheus/rules/general-cadvisor.yaml
@@ -39,18 +39,3 @@ groups:
           sum by (namespace, pod, container) (
             rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])
           )
-
-# triggered by kernel bug, see issue kubermatic#2367
-
-# - alert: CPUThrottlingHigh
-#   annotations:
-#     message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container }}.'
-#     runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-cputhrottlinghigh
-#   expr: |
-#     100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container, pod, namespace)
-#       /
-#     sum(increase(container_cpu_cfs_periods_total[5m])) by (container, pod, namespace)
-#       > 25
-#   for: 15m
-#   labels:
-#     severity: warning

--- a/charts/monitoring/prometheus/rules/general-cert-manager.yaml
+++ b/charts/monitoring/prometheus/rules/general-cert-manager.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: cert-manager
     rules:

--- a/charts/monitoring/prometheus/rules/general-helm-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-helm-exporter.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: helm-exporter
     rules:

--- a/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kube-apiserver
     rules:

--- a/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kube-kubelet
     rules:

--- a/charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kube-state-metrics
     rules:

--- a/charts/monitoring/prometheus/rules/general-node-exporter.yaml
+++ b/charts/monitoring/prometheus/rules/general-node-exporter.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: node-exporter
     rules:

--- a/charts/monitoring/prometheus/rules/general-prometheus.yaml
+++ b/charts/monitoring/prometheus/rules/general-prometheus.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: prometheus
     rules:

--- a/charts/monitoring/prometheus/rules/general-thanos.yaml
+++ b/charts/monitoring/prometheus/rules/general-thanos.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: thanos
     rules:

--- a/charts/monitoring/prometheus/rules/general-velero.yaml
+++ b/charts/monitoring/prometheus/rules/general-velero.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: velero
     rules:

--- a/charts/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
+++ b/charts/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: vertical-pod-autoscaler
     rules:

--- a/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kubermatic
     rules:

--- a/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kubermatic
     rules:

--- a/charts/monitoring/prometheus/rules/managed-kube-controller-manager.yaml
+++ b/charts/monitoring/prometheus/rules/managed-kube-controller-manager.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kube-controller-manager
     rules:

--- a/charts/monitoring/prometheus/rules/managed-kube-scheduler.yaml
+++ b/charts/monitoring/prometheus/rules/managed-kube-scheduler.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: kube-scheduler
     rules:

--- a/charts/monitoring/prometheus/rules/src/general/cadvisor.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/cadvisor.yaml
@@ -41,18 +41,3 @@ groups:
       sum by (namespace, pod, container) (
         rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])
       )
-
-  # triggered by kernel bug, see issue kubermatic#2367
-
-  # - alert: CPUThrottlingHigh
-  #   annotations:
-  #     message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container }}.'
-  #     runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat_sheets/alerting_runbook/#alert-cputhrottlinghigh
-  #   expr: |
-  #     100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container, pod, namespace)
-  #       /
-  #     sum(increase(container_cpu_cfs_periods_total[5m])) by (container, pod, namespace)
-  #       > 25
-  #   for: 15m
-  #   labels:
-  #     severity: warning

--- a/charts/monitoring/prometheus/rules/usercluster-mla-cortex.yaml
+++ b/charts/monitoring/prometheus/rules/usercluster-mla-cortex.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: cortex
     rules:

--- a/charts/monitoring/prometheus/rules/usercluster-mla-loki-distributed.yaml
+++ b/charts/monitoring/prometheus/rules/usercluster-mla-loki-distributed.yaml
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 groups:
   - name: loki-distributed
     rules:

--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -119,7 +119,7 @@ logging)
 
 kubermatic)
   if [ -n "${IMAGE_PULL_SECRET:-}" ]; then
-    yq write --inplace charts/kubermatic-operator/values.yaml 'kubermaticOperator.imagePullSecret' "$(cat $IMAGE_PULL_SECRET)"
+    yq4 --inplace ".kubermaticOperator.imagePullSecret = \"$(cat $IMAGE_PULL_SECRET)\"" charts/kubermatic-operator/values.yaml
   fi
 
   # Kubermatic
@@ -138,7 +138,7 @@ kubermatic)
   if [[ "$clusterType" = "master" ]]; then
     # We might have not configured IAP, which results in nothing being deployed. This triggers
     # https://github.com/helm/helm/issues/4295 and marks this as failed.
-    if [ $(yq read "$VALUES_FILE" --length 'iap.deployments') -gt 0 ]; then
+    if [ $(yq4 '.iap.deployments | length' "$VALUES_FILE") -gt 0 ]; then
       deploy "iap" "iap" charts/iap/
     else
       echodate "Skipping IAP chart because no deployments are defined in Helm values file."

--- a/hack/ci/fetch-chart-dependencies.sh
+++ b/hack/ci/fetch-chart-dependencies.sh
@@ -32,7 +32,7 @@ charts=$(find charts/ -name Chart.yaml | sort)
   echodate "Fetching dependencies for ${chartname}..."
 
   i=0
-  for url in $(yq4 '.dependencies.[].repository' Chart.yaml); do
+  for url in $(yq4 '.dependencies.[].repository' "$chartYAML"); do
     i=$((i + 1))
     helm repo add ${chartname}-dep-${i} ${url}
   done

--- a/hack/ci/fetch-chart-dependencies.sh
+++ b/hack/ci/fetch-chart-dependencies.sh
@@ -28,11 +28,11 @@ charts=$(find charts/ -name Chart.yaml | sort)
 
 [ -n "$charts" ] && while read -r chartYAML; do
   dirname="$(dirname $(echo "$chartYAML"))"
-  chartname=$(yq read "$chartYAML" name)
+  chartname=$(yq4 '.name' "$chartYAML")
   echodate "Fetching dependencies for ${chartname}..."
 
   i=0
-  for url in $(yq r "$chartYAML" dependencies --tojson | jq -r .[].repository); do
+  for url in $(yq4 '.dependencies.[].repository' Chart.yaml); do
     i=$((i + 1))
     helm repo add ${chartname}-dep-${i} ${url}
   done

--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -236,7 +236,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
   echodate "Creating CE archive..."
 
   # switch Docker repository used by the operator to the CE repository
-  yq write --inplace charts/kubermatic-operator/values.yaml 'kubermaticOperator.image.repository' 'quay.io/kubermatic/kubermatic'
+  yq4 --inplace '.kubermaticOperator.image.repository = "quay.io/kubermatic/kubermatic"' charts/kubermatic-operator/values.yaml
 
   archive="_dist/kubermatic-ce-$RELEASE_NAME-$buildTarget.tar.gz"
   # GNU tar is required
@@ -271,7 +271,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
   echodate "Creating EE archive..."
 
   # switch Docker repository used by the operator to the EE repository
-  yq write --inplace charts/kubermatic-operator/values.yaml 'kubermaticOperator.image.repository' 'quay.io/kubermatic/kubermatic-ee'
+  yq4 --inplace '.kubermaticOperator.image.repository = "quay.io/kubermatic/kubermatic-ee"' charts/kubermatic-operator/values.yaml
 
   archive="_dist/kubermatic-ee-$RELEASE_NAME-$buildTarget.tar.gz"
   # GNU tar is required

--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -41,12 +41,12 @@ git clone "$URL" "$tempdir"
 
   # due to the anti affinities, getting more than 1 replica can take forever in kind,
   # so we reduce the replica count for all those components
-  yq write --inplace config/cortex/values.yaml cortex.ingester.replicas 1
-  yq write --inplace config/cortex/values.yaml cortex.distributor.replicas 1
-  yq write --inplace config/cortex/values.yaml cortex.alertmanager.replicas 1
+  yq4 --inplace '.cortex.ingester.replicas = 1' config/cortex/values.yaml
+  yq4 --inplace '.cortex.distributor.replicas = 1' config/cortex/values.yaml
+  yq4 --inplace '.cortex.alertmanager.replicas = 1' config/cortex/values.yaml
 
-  yq write --inplace config/loki/values.yaml loki-distributed.ingester.replicas 1
-  yq write --inplace config/loki/values.yaml loki-distributed.distributor.replicas 1
+  yq4 --inplace '.loki-distributed.ingester.replicas = 1' config/loki/values.yaml
+  yq4 --inplace '.loki-distributed.distributor.replicas = 1' config/loki/values.yaml
 
   # ensure that dependencies are fetched and stored in the corresponding charts dir
   echodate "Fetching dependencies for the charts"

--- a/hack/ci/verify-user-cluster-prometheus-configs.sh
+++ b/hack/ci/verify-user-cluster-prometheus-configs.sh
@@ -35,8 +35,8 @@ touch /etc/kubernetes/prometheus-client.key
 for configMap in pkg/resources/test/fixtures/configmap-*-prometheus.yaml; do
   echodate "Checking $configMap ..."
 
-  yq read "$configMap" 'data."rules.yaml"' > rules.yaml
-  yq read "$configMap" 'data."prometheus.yaml"' > prometheus.yaml
+  yq4 '.data."rules.yaml"' "$configMap" > rules.yaml
+  yq4 '.data."prometheus.yaml"' "$configMap" > prometheus.yaml
 
   promtool check rules rules.yaml
   promtool check config prometheus.yaml

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -424,10 +424,10 @@ set_helm_charts_version() {
   while IFS= read -r -d '' chartFile; do
     chart="$(basename $(dirname "$chartFile"))"
 
-    yq write --inplace "$chartFile" version "$version"
+    yq4 --inplace ".version = \"$version\"" "$chartFile"
     if [ "$chart" = "kubermatic-operator" ]; then
-      yq write --inplace "$chartFile" appVersion "$version"
-      yq write --inplace "$(dirname "$chartFile")/values.yaml" kubermaticOperator.image.tag "$dockerTag"
+      yq4 --inplace ".appVersion = \"$version\"" "$chartFile"
+      yq4 --inplace ".kubermaticOperator.image.tag = \"$dockerTag\"" "$(dirname "$chartFile")/values.yaml"
     fi
   done < <(find charts -name 'Chart.yaml' -print0 | sort --zero-terminated)
 }
@@ -456,7 +456,7 @@ set_crds_version_annotation() {
   fi
 
   while IFS= read -r -d '' filename; do
-    yq write --inplace --doc '*' "$filename" metadata.annotations.'"app.kubernetes.io/version"' "$version"
+    yq4 --inplace ".metadata.annotations.\"app.kubernetes.io/version\" = \"$version\"" "$filename"
   done < <(find "$directory" -name '*.yaml' -print0 | sort --zero-terminated)
 }
 

--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -41,11 +41,9 @@ fi
 # the one creating it in case of openshift. So we just use the internal kubeconfig and replace
 # the apiserver url
 KUBECONFIG_USERCLUSTER_CONTROLLER_FILE=$(mktemp)
-kubectl --namespace "$NAMESPACE" get secret internal-admin-kubeconfig -o json |
+kubectl --namespace "$NAMESPACE" get secret admin-kubeconfig --output json |
   jq '.data.kubeconfig' -r |
-  base64 -d |
-  yq -o=json - |
-  jq --arg url "$CLUSTER_URL" '.clusters[0].cluster.server = $url' \
+  base64 -d \
     > $KUBECONFIG_USERCLUSTER_CONTROLLER_FILE
 echo "Using kubeconfig $KUBECONFIG_USERCLUSTER_CONTROLLER_FILE"
 

--- a/hack/test-chart-rendering.sh
+++ b/hack/test-chart-rendering.sh
@@ -28,7 +28,7 @@ REALDIR="$(cd "$(dirname $(readlink -f "${BASH_SOURCE[0]}"))" && pwd)"
 source ${REALDIR}/lib.sh
 
 cd ${BASEDIR}
-chartname=$(yq read Chart.yaml name)
+chartname=$(yq4 '.name' Chart.yaml)
 echodate "(Golden master) Testing ${chartname}..."
 exitCode=0
 
@@ -36,7 +36,7 @@ set +o errexit
 helm version
 echodate "Fetching dependencies..."
 i=0
-for url in $(yq r Chart.yaml dependencies --tojson | jq -r .[].repository); do
+for url in $(yq4 '.dependencies.[].repository' Chart.yaml); do
   i=$((i + 1))
   helm repo add ${chartname}-dep-${i} ${url}
 done

--- a/hack/update-cert-manager-crds.sh
+++ b/hack/update-cert-manager-crds.sh
@@ -23,7 +23,7 @@ containerize ./hack/update-cert-manager-crds.sh
 
 cd charts/cert-manager/
 
-version=$(yq r Chart.yaml appVersion)
+version=$(yq4 '.appVersion' Chart.yaml)
 source=https://github.com/cert-manager/cert-manager/releases/download/$version/cert-manager.crds.yaml
 # do not use "crds/" or else Helm will try to install the
 # CRDs and then never ever touch them again
@@ -34,7 +34,3 @@ echo "" >> $file
 
 set -x
 curl -sLo - $source >> $file
-
-# remove misleading labels
-yq delete -i -d'*' $file 'metadata.labels."helm.sh/chart"'
-yq delete -i -d'*' $file 'metadata.labels."app.kubernetes.io/managed-by"'

--- a/hack/update-prometheus-rules.sh
+++ b/hack/update-prometheus-rules.sh
@@ -45,7 +45,7 @@ for file in */*.yaml; do
   echo "$file => $newfile"
 
   echo -e "# This file has been generated, DO NOT EDIT.\n" > "../$newfile"
-  yq d "$file" 'groups.*.rules.*.runbook' >> "../$newfile"
+  yq4 'del(.groups.[].rules.[].runbook)' "$file" >> "../$newfile"
 done
 
 cd ..

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -43,11 +43,11 @@ while IFS= read -r crd; do
   name=$(echo "$crd" | jq -r '.spec.names.plural')
   filename="crd/$name.yaml"
 
-  pretty=$(echo "$crd" | yq -P r -)
+  pretty=$(echo "$crd" | yq4 --prettyPrint)
 
   echo "# This file has been generated with Velero $version. Do not edit." > $filename
   echo -e "---\n$pretty" >> $filename
 
   # remove misleading values
-  yq delete -i -d'*' $filename 'metadata.creationTimestamp'
+  yq4 --inplace 'del(.metadata.creationTimestamp)' $filename
 done <<< "$crds"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It's time to migrate to yq4. See https://mikefarah.gitbook.io/yq/upgrading-from-v3 for more information.

I chose to make it explicit what version we're using for now, in order to slowly get rid of yq3 over the next few PRs. It is a bit annoying that devs would need a  `yq4` binary on their machines, but I suspect many have v3 and v4 around, like I do.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
