### PR TITLE
Add dual-stack e2e tests for vsphere

### DIFF
--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -67,6 +67,9 @@ export DO_TOKEN="${DO_TOKEN:-$(vault kv get -field=token dev/e2e-digitalocean)}"
 export METAL_AUTH_TOKEN="${METAL_AUTH_TOKEN:-$(vault kv get -field=METAL_AUTH_TOKEN dev/e2e-equinix-metal)}"
 export METAL_PROJECT_ID="${METAL_PROJECT_ID:-$(vault kv get -field=METAL_PROJECT_ID dev/e2e-equinix-metal)}"
 
+export VSPHERE_USERNAME="${VSPHERE_USERNAME:-$(vault kv get -field=username dev/e2e-vsphere)}"
+export VSPHERE_PASSWORD="${VSPHERE_PASSWORD:-$(vault kv get -field=password dev/e2e-vsphere)}"
+
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running dualstack tests..."
 

--- a/hack/ci/testdata/kubermatic_dualstack.yaml
+++ b/hack/ci/testdata/kubermatic_dualstack.yaml
@@ -24,8 +24,6 @@ spec:
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   userCluster:
     apiserverReplicas: 2
-    machineController:
-      imageTag: "32c8ec0998445a664938d2f7783a9d12168adf7b"
   api:
     replicas: 1
     debugLog: true

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -93,6 +93,7 @@ spec:
           datacenter: Hamburg
           datastore: alpha1
           endpoint: https://vcenter.dc.k8c.io
+          ipv6Enabled: true
           rootPath: /Hamburg/vm/Kubermatic-dev
           templates:
             centos: centos-7

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -414,7 +414,7 @@ func (a vsphere) NodeSpec() models.NodeCloudSpec {
 
 func (a vsphere) CloudSpec() models.CloudSpec {
 	return models.CloudSpec{
-		DatacenterName: "vsphere-hamburg",
+		DatacenterName: "vsphere-ger",
 		Vsphere: &models.VSphereCloudSpec{
 			Username: "VSPHERE_USERNAME",
 			Password: "VSPHERE_PASSWORD",

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -359,7 +359,6 @@ func (a do) NodeSpec() models.NodeCloudSpec {
 	return models.NodeCloudSpec{
 		Digitalocean: &models.DigitaloceanNodeSpec{
 			Backups:    false,
-			IPV6:       true, // TODO: Could be set to false once MC is fixed.
 			Monitoring: false,
 			Size:       pointer.String("c-2"),
 		},

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -397,6 +397,35 @@ func (a equinix) CloudSpec() models.CloudSpec {
 	}
 }
 
+type vsphere struct{}
+
+var _ clusterSpec = vsphere{}
+
+func (a vsphere) NodeSpec() models.NodeCloudSpec {
+	return models.NodeCloudSpec{
+		Vsphere: &models.VSphereNodeSpec{
+			Template:   "ubuntu-20.04",
+			CPUs:       2,
+			Memory:     4096,
+			DiskSizeGB: 10,
+		},
+	}
+}
+
+func (a vsphere) CloudSpec() models.CloudSpec {
+	return models.CloudSpec{
+		DatacenterName: "vsphere-hamburg",
+		Vsphere: &models.VSphereCloudSpec{
+			Username: "VSPHERE_USERNAME",
+			Password: "VSPHERE_PASSWORD",
+			InfraManagementUser: &models.VSphereCredentials{
+				Username: "VSPHERE_USERNAME",
+				Password: "VSPHERE_PASSWORD",
+			},
+		},
+	}
+}
+
 // operating systems
 
 func ubuntu() models.OperatingSystemSpec {

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -416,11 +416,11 @@ func (a vsphere) CloudSpec() models.CloudSpec {
 	return models.CloudSpec{
 		DatacenterName: "vsphere-ger",
 		Vsphere: &models.VSphereCloudSpec{
-			Username: "VSPHERE_USERNAME",
-			Password: "VSPHERE_PASSWORD",
+			Username: os.Getenv("VSPHERE_USERNAME"),
+			Password: os.Getenv("VSPHERE_PASSWORD"),
 			InfraManagementUser: &models.VSphereCredentials{
-				Username: "VSPHERE_USERNAME",
-				Password: "VSPHERE_PASSWORD",
+				Username: os.Getenv("VSPHERE_USERNAME"),
+				Password: os.Getenv("VSPHERE_PASSWORD"),
 			},
 		},
 	}

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -62,6 +62,7 @@ var cloudProviders = map[string]clusterSpec{
 	"hetzner":   hetzner{},
 	"do":        do{},
 	"equinix":   equinix{},
+	"vsphere":   vsphere{},
 }
 
 var cnis = map[string]models.CNIPluginSettings{
@@ -215,6 +216,22 @@ func TestCloudClusterIPFamily(t *testing.T) {
 		},
 		{
 			cloudName: "equinix",
+			osNames: []string{
+				"ubuntu",
+			},
+			cni:      "cilium",
+			ipFamily: util.DualStack,
+		},
+		{
+			cloudName: "vsphere",
+			osNames: []string{
+				"ubuntu",
+			},
+			cni:      "canal",
+			ipFamily: util.DualStack,
+		},
+		{
+			cloudName: "vsphere",
 			osNames: []string{
 				"ubuntu",
 			},

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -89,12 +89,13 @@ func TestCloudClusterIPFamily(t *testing.T) {
 	apicli := utils.NewTestClient(token, t)
 
 	type testCase struct {
-		cloudName           string
-		osNames             []string
-		cni                 string
-		ipFamily            util.IPFamily
-		skipNodes           bool
-		skipHostNetworkPods bool
+		cloudName              string
+		osNames                []string
+		cni                    string
+		ipFamily               util.IPFamily
+		skipNodes              bool
+		skipHostNetworkPods    bool
+		skipEgressConnectivity bool
 	}
 
 	tests := []testCase{
@@ -227,16 +228,18 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			osNames: []string{
 				"ubuntu",
 			},
-			cni:      "canal",
-			ipFamily: util.DualStack,
+			cni:                    "canal",
+			ipFamily:               util.DualStack,
+			skipEgressConnectivity: true, // TODO: remove once public IPv6 is available in Kubermatic DC
 		},
 		{
 			cloudName: "vsphere",
 			osNames: []string{
 				"ubuntu",
 			},
-			cni:      "cilium",
-			ipFamily: util.DualStack,
+			cni:                    "cilium",
+			ipFamily:               util.DualStack,
+			skipEgressConnectivity: true, // TODO: remove once public IPv6 is available in Kubermatic DC
 		},
 	}
 
@@ -362,7 +365,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 				t.Fatalf("pods never became ready: %v", err)
 			}
 
-			testUserCluster(t, userclusterClient, test.ipFamily, test.skipNodes, test.skipHostNetworkPods)
+			testUserCluster(t, userclusterClient, test.ipFamily, test.skipNodes, test.skipHostNetworkPods, test.skipEgressConnectivity)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
Adds dual-stack e2e tests for vsphere.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
Just e2e test, no new functionality.
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
