### PR TITLE
Fix for cluster admission webhook (GCP dual-stack validation)

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -728,12 +728,14 @@ func validateGCPCloudSpec(spec *kubermaticv1.GCPCloudSpec, dc *kubermaticv1.Data
 			return errors.New("GCP subnetwork should belong to same cluster region")
 		}
 
-		gcpSubnetwork, err := gcpSubnetworkGetter(context.Background(), spec.ServiceAccount, subnetworkRegion, subnetworkName)
-		if err != nil {
-			return err
-		}
-		if ipFamily != gcpSubnetwork.IPFamily {
-			return errors.New("GCP subnetwork should belong to same cluster network stack type")
+		if spec.ServiceAccount != "" {
+			gcpSubnetwork, err := gcpSubnetworkGetter(context.Background(), spec.ServiceAccount, subnetworkRegion, subnetworkName)
+			if err != nil {
+				return err
+			}
+			if ipFamily != gcpSubnetwork.IPFamily {
+				return errors.New("GCP subnetwork should belong to same cluster network stack type")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
GCP service account is empty in the cluster admission webhook. So, for simplification, it's better to avoid the IP family match validation there.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
