### PR TITLE
remove bogus securityContext default config for cert-manager

### DIFF
--- a/charts/cert-manager/values.yaml
+++ b/charts/cert-manager/values.yaml
@@ -21,7 +21,7 @@ cert-manager:
   fullnameOverride: cert-manager
   nameOverride: cert-manager
 
-  startupapicheck: 
+  startupapicheck:
     enabled: false
 
   controller:
@@ -95,11 +95,6 @@ cert-manager:
     nodeSelector: {}
     affinity: {}
     tolerations: []
-
-  securityContext:
-    enabled: false
-    fsGroup: 1001
-    runAsUser: 1001
 
   ingressShim: {}
     # defaultIssuerName: ""


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The securityContext is copied 1:1 into Deployments and Kubernets does not define an "enabled" field, leading to

> failed to deploy cert-manager: failed to deploy Helm release: failed to install: Error: UPGRADE FAILED: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field \"enabled\" in io.k8s.api.core.v1.PodSecurityContext.

As cert-manager enables the security context by default now, it's time to remove our customizations.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
