### PR TITLE
application: move template method to spec level

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -22810,6 +22810,9 @@
           "type": "string",
           "x-go-name": "Description"
         },
+        "method": {
+          "$ref": "#/definitions/TemplateMethod"
+        },
         "versions": {
           "description": "available version for this application",
           "type": "array",
@@ -22936,9 +22939,6 @@
             "$ref": "#/definitions/FormField"
           },
           "x-go-name": "FormSpec"
-        },
-        "method": {
-          "$ref": "#/definitions/TemplateMethod"
         },
         "source": {
           "$ref": "#/definitions/ApplicationSource"

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -172,9 +172,6 @@ type ApplicationTemplate struct {
 	// Defined how the source of the application (e.g Helm chart) is retrieved
 	Source ApplicationSource `json:"source"`
 
-	// Method used to install the application
-	Method TemplateMethod `json:"method"`
-
 	// Define the valued that can be override for the installation
 	FormSpec []FormField `json:"formSpec,omitempty"`
 }
@@ -212,6 +209,9 @@ type ApplicationVersion struct {
 type ApplicationDefinitionSpec struct {
 	// Description of the application. what is its purpose
 	Description string `json:"description"`
+
+	// Method used to install the application
+	Method TemplateMethod `json:"method"`
 
 	// available version for this application
 	Versions []ApplicationVersion `json:"versions"`

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -131,6 +131,9 @@ type ApplicationInstallationStatus struct {
 	// ApplicationVersion contains information installing / removing application
 	ApplicationVersion *ApplicationVersion `json:"applicationVersion,omitempty"`
 
+	// Method used to install the application
+	Method TemplateMethod `json:"method"`
+
 	// HelmRelease holds the information about the helm release installed by this application. This field is only filled if template method is 'helm'.
 	HelmRelease *HelmRelease `json:"helmRelease,omitempty"`
 }

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -71,7 +71,7 @@ func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, 
 		}
 	}()
 
-	templateProvider, err := providers.NewTemplateProvider(ctx, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, applicationInstallation.Status.ApplicationVersion.Template.Method)
+	templateProvider, err := providers.NewTemplateProvider(ctx, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, applicationInstallation.Status.Method)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
@@ -91,7 +91,7 @@ func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, 
 
 // Delete uninstalls the application where the application was installed if necessary.
 func (a *ApplicationManager) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, applicationInstallation.Status.ApplicationVersion.Template.Method)
+	templateProvider, err := providers.NewTemplateProvider(ctx, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, applicationInstallation.Status.Method)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize template provider: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -186,9 +186,10 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, appI
 		}
 	}
 
-	if !equality.Semantic.DeepEqual(appVersion, appInstallation.Status.ApplicationVersion) {
+	if !equality.Semantic.DeepEqual(appVersion, appInstallation.Status.ApplicationVersion) || appInstallation.Status.Method != applicationDef.Spec.Method {
 		oldAppInstallation := appInstallation.DeepCopy()
 		appInstallation.Status.ApplicationVersion = appVersion
+		appInstallation.Status.Method = applicationDef.Spec.Method
 
 		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
 			return fmt.Errorf("failed to update status with applicationVersion: %w", err)

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -183,7 +183,6 @@ var _ = Describe("application Installation controller", func() {
 								Credentials:  nil,
 							},
 						},
-						Method:   "helm",
 						FormSpec: nil,
 					},
 				}}
@@ -205,7 +204,7 @@ var _ = Describe("application Installation controller", func() {
 func createApplicationDef(appDefName string) *appskubermaticv1.ApplicationDefinition {
 	Expect(userClient.Create(ctx, genApplicationDefinition(appDefName))).To(Succeed())
 
-	def := &appskubermaticv1.ApplicationDefinition{}
+	def := &appskubermaticv1.ApplicationDefinition{Spec: appskubermaticv1.ApplicationDefinitionSpec{Method: appskubermaticv1.HelmTemplateMethod}}
 	EventuallyWithOffset(1, func(g Gomega) {
 		g.Expect(userClient.Get(ctx, types.NamespacedName{Name: appDefName}, def)).To(Succeed())
 	}, timeout, interval).Should(Succeed())

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -104,6 +104,7 @@ func genApplicationDefinition(name string) *appskubermaticv1.ApplicationDefiniti
 			Name: name,
 		},
 		Spec: appskubermaticv1.ApplicationDefinitionSpec{
+			Method: appskubermaticv1.HelmTemplateMethod,
 			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: "1.0.0",
@@ -120,7 +121,6 @@ func genApplicationDefinition(name string) *appskubermaticv1.ApplicationDefiniti
 								Credentials:  nil,
 							},
 						},
-						Method:   "helm",
 						FormSpec: nil,
 					},
 				},
@@ -139,7 +139,6 @@ func genApplicationDefinition(name string) *appskubermaticv1.ApplicationDefiniti
 								Credentials: nil,
 							},
 						},
-						Method:   "helm",
 						FormSpec: nil,
 					},
 				},

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -39,6 +39,11 @@ spec:
               description:
                 description: Description of the application. what is its purpose
                 type: string
+              method:
+                description: Method used to install the application
+                enum:
+                - helm
+                type: string
               versions:
                 description: available version for this application
                 items:
@@ -98,11 +103,6 @@ spec:
                             - type
                             type: object
                           type: array
-                        method:
-                          description: Method used to install the application
-                          enum:
-                          - helm
-                          type: string
                         source:
                           description: Defined how the source of the application (e.g
                             Helm chart) is retrieved
@@ -333,7 +333,6 @@ spec:
                               type: object
                           type: object
                       required:
-                      - method
                       - source
                       type: object
                     version:
@@ -346,6 +345,7 @@ spec:
                 type: array
             required:
             - description
+            - method
             - versions
             type: object
         type: object

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -154,11 +154,6 @@ spec:
                           - type
                           type: object
                         type: array
-                      method:
-                        description: Method used to install the application
-                        enum:
-                        - helm
-                        type: string
                       source:
                         description: Defined how the source of the application (e.g
                           Helm chart) is retrieved
@@ -384,7 +379,6 @@ spec:
                             type: object
                         type: object
                     required:
-                    - method
                     - source
                     type: object
                   version:
@@ -467,6 +461,13 @@ spec:
               lastUpdated:
                 format: date-time
                 type: string
+              method:
+                description: Method used to install the application
+                enum:
+                - helm
+                type: string
+            required:
+            - method
             type: object
         type: object
     served: true

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -2179,11 +2179,12 @@ func GenApplicationDefinition(name string) *appskubermaticv1.ApplicationDefiniti
 			APIVersion: appskubermaticv1.SchemeGroupVersion.String(),
 		},
 		Spec: appskubermaticv1.ApplicationDefinitionSpec{
+			Method: appskubermaticv1.HelmTemplateMethod,
 			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: "v1.0.0",
 					Template: appskubermaticv1.ApplicationTemplate{
-						Method: appskubermaticv1.HelmTemplateMethod,
+
 						Source: appskubermaticv1.ApplicationSource{
 							Helm: &appskubermaticv1.HelmSource{
 								URL:          "https://charts.example.com",
@@ -2196,7 +2197,6 @@ func GenApplicationDefinition(name string) *appskubermaticv1.ApplicationDefiniti
 				{
 					Version: "v1.1.0",
 					Template: appskubermaticv1.ApplicationTemplate{
-						Method: appskubermaticv1.HelmTemplateMethod,
 						Source: appskubermaticv1.ApplicationSource{
 							Git: &appskubermaticv1.GitSource{
 								Remote: "https://git.example.com",
@@ -2219,11 +2219,12 @@ func GenApiApplicationDefinition(name string) apiv2.ApplicationDefinition {
 			Name: name,
 		},
 		Spec: &appskubermaticv1.ApplicationDefinitionSpec{
+			Method: appskubermaticv1.HelmTemplateMethod,
 			Versions: []appskubermaticv1.ApplicationVersion{
 				{
 					Version: "v1.0.0",
 					Template: appskubermaticv1.ApplicationTemplate{
-						Method: appskubermaticv1.HelmTemplateMethod,
+
 						Source: appskubermaticv1.ApplicationSource{
 							Helm: &appskubermaticv1.HelmSource{
 								URL:          "https://charts.example.com",
@@ -2236,7 +2237,6 @@ func GenApiApplicationDefinition(name string) apiv2.ApplicationDefinition {
 				{
 					Version: "v1.1.0",
 					Template: appskubermaticv1.ApplicationTemplate{
-						Method: appskubermaticv1.HelmTemplateMethod,
 						Source: appskubermaticv1.ApplicationSource{
 							Git: &appskubermaticv1.GitSource{
 								Remote: "https://git.example.com",

--- a/pkg/test/e2e/utils/apiclient/models/application_definition_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/application_definition_spec.go
@@ -24,6 +24,9 @@ type ApplicationDefinitionSpec struct {
 
 	// available version for this application
 	Versions []*ApplicationVersion `json:"versions"`
+
+	// method
+	Method TemplateMethod `json:"method,omitempty"`
 }
 
 // Validate validates this application definition spec
@@ -31,6 +34,10 @@ func (m *ApplicationDefinitionSpec) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateVersions(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateMethod(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -66,11 +73,32 @@ func (m *ApplicationDefinitionSpec) validateVersions(formats strfmt.Registry) er
 	return nil
 }
 
+func (m *ApplicationDefinitionSpec) validateMethod(formats strfmt.Registry) error {
+	if swag.IsZero(m.Method) { // not required
+		return nil
+	}
+
+	if err := m.Method.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("method")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("method")
+		}
+		return err
+	}
+
+	return nil
+}
+
 // ContextValidate validate this application definition spec based on the context it is used
 func (m *ApplicationDefinitionSpec) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.contextValidateVersions(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateMethod(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -95,6 +123,20 @@ func (m *ApplicationDefinitionSpec) contextValidateVersions(ctx context.Context,
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *ApplicationDefinitionSpec) contextValidateMethod(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.Method.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("method")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("method")
+		}
+		return err
 	}
 
 	return nil

--- a/pkg/test/e2e/utils/apiclient/models/application_template.go
+++ b/pkg/test/e2e/utils/apiclient/models/application_template.go
@@ -22,9 +22,6 @@ type ApplicationTemplate struct {
 	// Define the valued that can be override for the installation
 	FormSpec []*FormField `json:"formSpec"`
 
-	// method
-	Method TemplateMethod `json:"method,omitempty"`
-
 	// source
 	Source *ApplicationSource `json:"source,omitempty"`
 }
@@ -34,10 +31,6 @@ func (m *ApplicationTemplate) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateFormSpec(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateMethod(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -77,23 +70,6 @@ func (m *ApplicationTemplate) validateFormSpec(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *ApplicationTemplate) validateMethod(formats strfmt.Registry) error {
-	if swag.IsZero(m.Method) { // not required
-		return nil
-	}
-
-	if err := m.Method.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("method")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("method")
-		}
-		return err
-	}
-
-	return nil
-}
-
 func (m *ApplicationTemplate) validateSource(formats strfmt.Registry) error {
 	if swag.IsZero(m.Source) { // not required
 		return nil
@@ -118,10 +94,6 @@ func (m *ApplicationTemplate) ContextValidate(ctx context.Context, formats strfm
 	var res []error
 
 	if err := m.contextValidateFormSpec(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateMethod(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -150,20 +122,6 @@ func (m *ApplicationTemplate) contextValidateFormSpec(ctx context.Context, forma
 			}
 		}
 
-	}
-
-	return nil
-}
-
-func (m *ApplicationTemplate) contextValidateMethod(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := m.Method.ContextValidate(ctx, formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("method")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("method")
-		}
-		return err
 	}
 
 	return nil

--- a/pkg/validation/applicationdefinition_test.go
+++ b/pkg/validation/applicationdefinition_test.go
@@ -28,9 +28,9 @@ import (
 var (
 	cs                = appskubermaticv1.ApplicationConstraints{K8sVersion: ">1.0.0", KKPVersion: ">1.0.0"}
 	secretKeySelector = &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "git-cred"}, Key: "thekey"}
-	helmv             = appskubermaticv1.ApplicationVersion{Version: "v1", Constraints: cs, Template: appskubermaticv1.ApplicationTemplate{Method: appskubermaticv1.HelmTemplateMethod, Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}}}
-	gitv              = appskubermaticv1.ApplicationVersion{Version: "v2", Constraints: cs, Template: appskubermaticv1.ApplicationTemplate{Method: appskubermaticv1.HelmTemplateMethod, Source: appskubermaticv1.ApplicationSource{Git: validGitSource()}}}
-	spec              = appskubermaticv1.ApplicationDefinitionSpec{Versions: []appskubermaticv1.ApplicationVersion{helmv, gitv}}
+	helmv             = appskubermaticv1.ApplicationVersion{Version: "v1", Constraints: cs, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}}}
+	gitv              = appskubermaticv1.ApplicationVersion{Version: "v2", Constraints: cs, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Git: validGitSource()}}}
+	spec              = appskubermaticv1.ApplicationDefinitionSpec{Method: appskubermaticv1.HelmTemplateMethod, Versions: []appskubermaticv1.ApplicationVersion{helmv, gitv}}
 )
 
 func validHelmSource() *appskubermaticv1.HelmSource {
@@ -53,7 +53,7 @@ func validGitSource() *appskubermaticv1.GitSource {
 	}
 }
 
-func TestValidateApplicationDefinition(t *testing.T) {
+func TestValidateApplicationDefinitionSpec(t *testing.T) {
 	tt := map[string]struct {
 		ad        appskubermaticv1.ApplicationDefinition
 		expErrLen int
@@ -83,7 +83,7 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = "invalid"
+					s.Method = "invalid"
 					return *s
 				}(),
 			},
@@ -93,7 +93,7 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
+					s.Method = appskubermaticv1.HelmTemplateMethod
 					return *s
 				}(),
 			},
@@ -103,7 +103,6 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{}
 					return *s
 				}(),
@@ -114,7 +113,6 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: validGitSource(), Helm: validHelmSource()}
 					return *s
 				}(),
@@ -125,7 +123,6 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "",
 						Ref:         appskubermaticv1.GitReference{Branch: "master"},
@@ -141,7 +138,6 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "",
 						ChartName:    "chartname",
@@ -157,7 +153,6 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "https://localhost/myrepo",
 						ChartName:    "",
@@ -173,7 +168,6 @@ func TestValidateApplicationDefinition(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "https://localhost/myrepo",
 						ChartName:    "chartname",
@@ -190,7 +184,7 @@ func TestValidateApplicationDefinition(t *testing.T) {
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
 			tc.ad.TypeMeta = metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
-			errl := ValidateApplicationDefinition(tc.ad)
+			errl := ValidateApplicationDefinitionSpec(tc.ad)
 
 			if len(errl) != tc.expErrLen {
 				t.Errorf("expected errLen %d, got %d. Errors are %q", tc.expErrLen, len(errl), errl)
@@ -208,7 +202,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "http://localhost/myrepo",
 						ChartName:    "chartname",
@@ -224,7 +217,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "https://localhost/myrepo",
 						ChartName:    "chartname",
@@ -240,7 +232,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "oci://localhost:5000/myrepo",
 						ChartName:    "chartname",
@@ -256,7 +247,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "",
 						ChartName:    "chartname",
@@ -272,7 +262,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "ssh://localhost:5000/myrepo",
 						ChartName:    "chartname",
@@ -288,7 +277,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "http://",
 						ChartName:    "chartname",
@@ -304,7 +292,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "https://",
 						ChartName:    "chartname",
@@ -320,7 +307,6 @@ func TestValidateHelmUrl(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{
 						URL:          "oci://",
 						ChartName:    "chartname",
@@ -337,7 +323,7 @@ func TestValidateHelmUrl(t *testing.T) {
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
 			tc.ad.TypeMeta = metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
-			errl := ValidateApplicationDefinition(tc.ad)
+			errl := ValidateApplicationDefinitionSpec(tc.ad)
 
 			if len(errl) != tc.expErrLen {
 				t.Errorf("expected errLen %d, got %d. Errors are %q", tc.expErrLen, len(errl), errl)
@@ -355,7 +341,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Branch: "master"},
@@ -371,7 +356,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Tag: "v1.0"},
@@ -387,7 +371,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Commit: "bad9725e1b225d152074fce24997c5d3d2503794"},
@@ -403,7 +386,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Branch: "master", Commit: "bad9725e1b225d152074fce24997c5d3d2503794"},
@@ -419,7 +401,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{},
@@ -435,7 +416,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Tag: "v1.0", Commit: "bad9725e1b225d152074fce24997c5d3d2503794"},
@@ -451,7 +431,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Tag: "v1.0", Branch: "master"},
@@ -467,7 +446,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Branch: ""},
@@ -483,7 +461,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Tag: ""},
@@ -499,7 +476,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Commit: ""},
@@ -515,7 +491,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Commit: "abc"},
@@ -531,7 +506,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Commit: "bad9725e1b225d152074fce24997c5d3d2503794toolong"},
@@ -547,7 +521,6 @@ func TestValidateGitRef(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[0].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Git: &appskubermaticv1.GitSource{
 						Remote:      "https://localhost/repo.git",
 						Ref:         appskubermaticv1.GitReference{Commit: "bad9725e1b225d152074fce249###5d3d2503794"},
@@ -564,7 +537,7 @@ func TestValidateGitRef(t *testing.T) {
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
 			tc.ad.TypeMeta = metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
-			errl := ValidateApplicationDefinition(tc.ad)
+			errl := ValidateApplicationDefinitionSpec(tc.ad)
 
 			if len(errl) != tc.expErrLen {
 				t.Errorf("expected errLen %d, got %d. Errors are %q", tc.expErrLen, len(errl), errl)
@@ -582,7 +555,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodToken, Token: secretKeySelector}
 					return *s
 				}(),
@@ -593,7 +565,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodPassword, Username: secretKeySelector, Password: secretKeySelector}
 					return *s
 				}(),
@@ -604,7 +575,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodSSHKey, SSHKey: secretKeySelector}
 					return *s
 				}(),
@@ -615,7 +585,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodToken, Token: nil}
 					return *s
 				}(),
@@ -626,7 +595,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodPassword, Username: nil, Password: secretKeySelector}
 					return *s
 				}(),
@@ -637,7 +605,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodPassword, Username: secretKeySelector, Password: nil}
 					return *s
 				}(),
@@ -648,7 +615,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodPassword, Username: nil, Password: nil}
 					return *s
 				}(),
@@ -659,7 +625,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: appskubermaticv1.GitAuthMethodSSHKey, SSHKey: nil}
 					return *s
 				}(),
@@ -670,7 +635,6 @@ func TestValidateGitCredentials(t *testing.T) {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
-					s.Versions[1].Template.Method = appskubermaticv1.HelmTemplateMethod
 					s.Versions[1].Template.Source.Git.Credentials = &appskubermaticv1.GitCredentials{Method: "unknown"}
 					return *s
 				}(),
@@ -682,7 +646,7 @@ func TestValidateGitCredentials(t *testing.T) {
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
 			tc.ad.TypeMeta = metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
-			errl := ValidateApplicationDefinition(tc.ad)
+			errl := ValidateApplicationDefinitionSpec(tc.ad)
 
 			if len(errl) != tc.expErrLen {
 				t.Errorf("expected errLen %d, got %d. Errors are %q", tc.expErrLen, len(errl), errl)
@@ -698,20 +662,20 @@ func TestValidateApplicationVersions(t *testing.T) {
 	}{
 		"duplicate version": {
 			[]appskubermaticv1.ApplicationVersion{
-				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}, Method: appskubermaticv1.HelmTemplateMethod}},
-				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}, Method: appskubermaticv1.HelmTemplateMethod}},
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}}},
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "1"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}}},
 			},
 			1,
 		},
 		"invalid kkp version": {
 			[]appskubermaticv1.ApplicationVersion{
-				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "not-semver"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}, Method: appskubermaticv1.HelmTemplateMethod}},
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "1", KKPVersion: "not-semver"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}}},
 			},
 			1,
 		},
 		"invalid k8s version": {
 			[]appskubermaticv1.ApplicationVersion{
-				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "not-semver", KKPVersion: "1"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}, Method: appskubermaticv1.HelmTemplateMethod}},
+				{Version: "v1", Constraints: appskubermaticv1.ApplicationConstraints{K8sVersion: "not-semver", KKPVersion: "1"}, Template: appskubermaticv1.ApplicationTemplate{Source: appskubermaticv1.ApplicationSource{Helm: validHelmSource()}}},
 			},
 			1,
 		},
@@ -719,6 +683,60 @@ func TestValidateApplicationVersions(t *testing.T) {
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
 			errl := ValidateApplicationVersions(tc.vs, nil)
+			if len(errl) != tc.expErrLen {
+				t.Errorf("expected errLen %d, got %d. Errors are %q", tc.expErrLen, len(errl), errl)
+			}
+		})
+	}
+}
+
+func TestValidateApplicationDefinitionUpdate(t *testing.T) {
+	appDef := appskubermaticv1.ApplicationDefinition{
+		Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+			s := spec.DeepCopy()
+			s.Versions[0].Template.Source = appskubermaticv1.ApplicationSource{Helm: &appskubermaticv1.HelmSource{URL: "https://kubermatic.io", ChartName: "test", ChartVersion: "1.0.0"}}
+			return *s
+		}(),
+	}
+
+	tt := map[string]struct {
+		oldAd     appskubermaticv1.ApplicationDefinition
+		newAd     appskubermaticv1.ApplicationDefinition
+		expErrLen int
+	}{
+		"Update ApplicationDefinition Success": {
+			oldAd: appDef,
+			newAd: appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					spec := appDef.Spec.DeepCopy()
+					spec.Description = "new description"
+					return *spec
+				}(),
+			},
+			expErrLen: 0,
+		},
+		"Update ApplicationDefinition failure - .Spec.Method is immutable": {
+			oldAd: appDef,
+			newAd: appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					spec := appDef.Spec.DeepCopy()
+					spec.Method = "foo"
+					return *spec
+				}(),
+			},
+			// Current we only support one Method which is helm. So we got 2 errors:
+			//  1) spec.method: Unsupported value "foo"
+			//  2) spec.method: Invalid value: "foo": field is immutable
+			expErrLen: 2,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.oldAd.TypeMeta = metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
+			tc.newAd.TypeMeta = metav1.TypeMeta{Kind: "ApplicationDefinition", APIVersion: "apps.kubermatic.k8c.io/v1"}
+			errl := ValidateApplicationDefinitionUpdate(tc.newAd, tc.oldAd)
+
 			if len(errl) != tc.expErrLen {
 				t.Errorf("expected errLen %d, got %d. Errors are %q", tc.expErrLen, len(errl), errl)
 			}

--- a/pkg/validation/applicationinstallation.go
+++ b/pkg/validation/applicationinstallation.go
@@ -85,13 +85,6 @@ func ValidateApplicationInstallationUpdate(ctx context.Context, client ctrlrunti
 		specPath.Child("namespace", "name"),
 	)...)
 
-	// Validate .Spec.ApplicationRef.Version for immutability
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
-		newAI.Spec.ApplicationRef.Version.Version.String(),
-		oldAI.Spec.ApplicationRef.Version.Version.String(),
-		specPath.Child("applicationRef", "version"),
-	)...)
-
 	// Validate .Spec.ApplicationRef.Name for immutability
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
 		newAI.Spec.ApplicationRef.Name,

--- a/pkg/validation/applicationinstallation_test.go
+++ b/pkg/validation/applicationinstallation_test.go
@@ -126,6 +126,7 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
 					spec := ai.Spec.DeepCopy()
 					spec.Namespace.Labels = map[string]string{"key": "value"}
+					spec.ApplicationRef.Version = appskubermaticv1.Version{Version: *semverlib.MustParse(defaultAppSecondaryVersion)}
 					return *spec
 				}(),
 			},
@@ -154,18 +155,6 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 				}(),
 			},
 			expectedError: `[spec.applicationRef.name: Invalid value: "app": field is immutable]`,
-		},
-		{
-			name: "Update ApplicationInstallation Failure - .ApplicationRef.Version is immutable",
-			ai:   ai,
-			updatedAI: &appskubermaticv1.ApplicationInstallation{
-				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
-					spec := ai.Spec.DeepCopy()
-					spec.ApplicationRef.Version = appskubermaticv1.Version{Version: *semverlib.MustParse(defaultAppSecondaryVersion)}
-					return *spec
-				}(),
-			},
-			expectedError: `[spec.applicationRef.version: Invalid value: "1.2.3": field is immutable]`,
 		},
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This pr  moves the field `ApplicationDefinition.spec.versions[].template.method` to `ApplicationDefinition.spec.method` and make it immutable.  It also makes the field `ApplicationDefinition.spec.versions[].version` mutable in order to allow update of an applicationInstallation.


**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10463

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
