### PR TITLE
wait for MC webhook before creating initial MD

### DIFF
--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -148,7 +148,7 @@ func New(debug bool, format Format) *zap.Logger {
 	var enc zapcore.Encoder
 	if format == FormatJSON {
 		enc = zapcore.NewJSONEncoder(encCfg)
-	} else if format == FormatConsole {
+	} else {
 		enc = zapcore.NewConsoleEncoder(encCfg)
 	}
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is supposed to fix

> {"level":"error","time":"2022-07-25T11:37:46.039Z","caller":"controller/controller.go:273","msg":"Reconciler error","controller":"kkp-initial-machinedeployment-controller","object":{"name":"xpwmtcw6d6"},"namespace":"","name":"xpwmtcw6d6","reconcileID":"af858fcb-db87-4d05-b748-0fa5e90ea4fc","error":"failed to create initial MachineDeployment: Internal error occurred: failed calling webhook \"machine-controller.kubermatic.io-machinedeployments\": failed to call webhook: Post \"https://machine-controller-webhook.cluster-xpwmtcw6d6.svc.cluster.local./machinedeployments?timeout=10s\": dial tcp 10.47.240.89:443: connect: connection refused","errorCauses":[{"error":"failed to create initial MachineDeployment: Internal error occurred: failed calling webhook \"machine-controller.kubermatic.io-machinedeployments\": failed to call webhook: Post \"https://machine-controller-webhook.cluster-xpwmtcw6d6.svc.cluster.local./machinedeployments?timeout=10s\": dial tcp 10.47.240.89:443: connect: connection refused"}]}

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
