### PR TITLE
allow users to not specify .spec.pause for Clusters

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -265,7 +265,7 @@ type ClusterSpec struct {
 	// If this is set to true, the cluster will not be reconciled by KKP.
 	// This indicates that the user needs to do some action to resolve the pause.
 	// +kubebuilder:default=false
-	Pause bool `json:"pause"`
+	Pause bool `json:"pause,omitempty"`
 	// PauseReason is the reason why the cluster is not being managed. This field is for informational
 	// purpose only and can be set by a user or a controller to communicate the reason for pausing the cluster.
 	PauseReason string `json:"pauseReason,omitempty"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -2336,7 +2336,6 @@ spec:
             - clusterNetwork
             - exposeStrategy
             - humanReadableName
-            - pause
             - version
             type: object
           status:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -2304,7 +2304,6 @@ spec:
             - clusterNetwork
             - exposeStrategy
             - humanReadableName
-            - pause
             - version
             type: object
           userSSHKeys:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Previously, when creating a cluster from YAML, you had to specify `spec: { pause: false }`, which is just annoying. This PR makes the field optional, as it is defaulted to false anyway.

**Does this PR introduce a user-facing change?**:
```release-note
`spec.pause` does not need to be set for Clusters anymore (defaults to `false`)
```
