### PR TITLE
kkp-application-secret-synchronizer controller: fix synchronization

### DIFF
--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -63,6 +63,7 @@ func Add(
 		recorder:     masterManager.GetEventRecorderFor(ControllerName),
 		masterClient: masterManager.GetClient(),
 		seedClients:  kuberneteshelper.SeedClientMap{},
+		namespace:    namespace,
 	}
 
 	for seedName, seedManager := range seedManagers {
@@ -144,7 +145,10 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, secr
 func secretCreator(s *corev1.Secret) reconciling.NamedSecretCreatorGetter {
 	return func() (name string, create reconciling.SecretCreator) {
 		return s.Name, func(existing *corev1.Secret) (*corev1.Secret, error) {
-			return s, nil
+			existing.Labels = s.Labels
+			existing.Annotations = s.Annotations
+			existing.Data = s.Data
+			return existing, nil
 		}
 	}
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This controller sync application Secret in kubermatic namespace from master to seed.  Howerver there were 2 problems:

1.  secrets were watched with `predicate.ByNamespace(r.namespace)`  but `r.namespace` was never set. So predicated never matched.
2. the `secretCreator` function was returning the all  object from the master, which tries to override immutable fields (e.g. `UUID`, generating a lot of errors like:
```
{
  "level": "error",
  "ts": 1658749197.320152,
  "msg": "Reconciler error",
  "controller": "kkp-application-secret-synchronizer",
  "object": {
    "name": "app-secret",
    "namespace": "kubermatic"
  },
  "namespace": "kubermatic",
  "name": "app-secret",
  "reconcileID": "5247244c-ca7c-46be-a652-9632900e4ac1",
  "error": "reconciling secret app-secret failed: failed processing Seed kind-cluster: failed to ensure Secret kubermatic/app-secret: failed to update object *v1.Secret \"kubermatic/app-secret\": Operation cannot be fulfilled on secrets \"app-secret\": StorageError: invalid object, Code: 4, Key: /registry/secrets/kubermatic/app-secret, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 8d34eed2-f9f4-4305-8a07-16ba7804f4e3, UID in object meta: d762af0a-2f37-439c-9cf6-277c1a4f8234",
  "stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234"
}
```

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
