### PR TITLE
Update kubevirt-csi-driver-operator version

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -338,7 +338,7 @@ spec:
             - /manager
           args:
             - --leader-elect
-          image: quay.io/kubermatic/kubevirt-csi-driver-operator:v0.1.0
+          image: quay.io/kubermatic/kubevirt-csi-driver-operator:v0.1.1
           imagePullPolicy: Always
           name: manager
           securityContext:


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR updates kubevirt-csi-driver-operator version from `v0.1.0` to `v0.1.1`.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


Signed-off-by: Sankalp Rangare <sankalprangare786@gmail.com>
