### PR TITLE
Cloud Credential Controller

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -27,6 +27,7 @@ import (
 	autoupdatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/auto-update-controller"
 	backupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/backup"
 	cloudcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
+	clustercredentialscontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-credentials-controller"
 	clusterphasecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-phase-controller"
 	clusterstuckcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-stuck-controller"
 	clustertemplatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-template-controller"
@@ -77,6 +78,7 @@ var AllControllers = map[string]controllerCreator{
 	encryptionatrestcontroller.ControllerName:               createEncryptionAtRestController,
 	ipam.ControllerName:                                     createIPAMController,
 	clusterstuckcontroller.ControllerName:                   createClusterStuckController,
+	clustercredentialscontroller.ControllerName:             createClusterCredentialsController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -437,5 +439,15 @@ func createClusterStuckController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.log,
+	)
+}
+
+func createClusterCredentialsController(ctrlCtx *controllerContext) error {
+	return clustercredentialscontroller.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.runOptions.workerCount,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.log,
+		ctrlCtx.versions,
 	)
 }

--- a/pkg/controller/seed-controller-manager/cluster-credentials-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-credentials-controller/controller.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercredentialscontroller
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/apis/equality"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kkp-cluster-credentials-controller"
+)
+
+type Reconciler struct {
+	ctrlruntimeclient.Client
+
+	workerName string
+	recorder   record.EventRecorder
+	log        *zap.SugaredLogger
+	versions   kubermatic.Versions
+}
+
+// Add creates a new cluster-credentials controller.
+func Add(
+	mgr manager.Manager,
+	numWorkers int,
+	workerName string,
+	log *zap.SugaredLogger,
+	versions kubermatic.Versions,
+) error {
+	reconciler := &Reconciler{
+		Client: mgr.GetClient(),
+
+		workerName: workerName,
+		recorder:   mgr.GetEventRecorderFor(ControllerName),
+		log:        log,
+		versions:   versions,
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: numWorkers,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request.Name)
+	log.Debug("Reconciling")
+
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// do not migrate a cluster in deletion
+	if cluster.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
+	// Add a wrapping here so we can emit an event on error
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
+		ctx,
+		r.Client,
+		r.workerName,
+		cluster,
+		r.versions,
+		kubermaticv1.ClusterConditionNone,
+		func() (*reconcile.Result, error) {
+			return r.reconcile(ctx, log, cluster)
+		},
+	)
+	if err != nil {
+		log.Errorw("Failed to reconcile cluster", zap.Error(err))
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+	if result == nil {
+		result = &reconcile.Result{}
+	}
+	return *result, err
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+	oldCluster := cluster.DeepCopy()
+
+	// patch in the cleanup finalizer first (the pkg/clusterdeletion takes care of cleaning up)
+	kuberneteshelper.AddFinalizer(cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
+
+	if !equality.Semantic.DeepEqual(oldCluster.Finalizers, cluster.Finalizers) {
+		if err := r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+			return nil, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+
+		return &reconcile.Result{Requeue: true}, nil
+	}
+
+	// make sure cluster credentials are placed in a dedicated Secret in the KKP namespace
+	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r, cluster); err != nil {
+		return nil, fmt.Errorf("failed to migrate Cluster credentials: %w", err)
+	}
+
+	// if the function above performed some magic, we need to persist the change and requeue
+	if !equality.Semantic.DeepEqual(oldCluster.Spec.Cloud, cluster.Spec.Cloud) {
+		if err := r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+			return nil, fmt.Errorf("failed to patch cluster with credentials secret: %w", err)
+		}
+
+		return &reconcile.Result{Requeue: true}, nil
+	}
+
+	// Now that a Secret was created in the KKP namespace, duplicate it into the
+	// cluster namespace so that Deployments like the kube-apiserver can reference
+	// it.
+
+	// We need a cluster namespace to mirror the Secret.
+	if cluster.Status.NamespaceName == "" {
+		return nil, nil
+	}
+
+	reference, err := resources.GetCredentialsReference(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine cluster credentials: %w", err)
+	}
+
+	secret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{Name: reference.Name, Namespace: reference.Namespace}, secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve credentials secret: %w", err)
+	}
+
+	creators := []reconciling.NamedSecretCreatorGetter{
+		secretCreator(secret),
+	}
+
+	if err := reconciling.ReconcileSecrets(ctx, creators, cluster.Status.NamespaceName, r); err != nil {
+		return nil, fmt.Errorf("failed to ensure credentials secret: %w", err)
+	}
+
+	return nil, nil
+}
+
+func secretCreator(original *corev1.Secret) reconciling.NamedSecretCreatorGetter {
+	return func() (name string, create reconciling.SecretCreator) {
+		return resources.ClusterCloudCredentialsSecretName, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			existing.Data = original.Data
+
+			return existing, nil
+		}
+	}
+}

--- a/pkg/controller/seed-controller-manager/cluster-credentials-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/cluster-credentials-controller/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package clustercredentialscontroller contains a controller that watches Cluster
+objects and is responsible for moving inline credentials (from the CloudSpec)
+into dedicated Kubernetes Secrets.
+
+In a perfect future, we would not even ever create a Cluster with inline credentials,
+but for historical reasons it's the safest method to handle credentials for now.
+It is also super convenient that users do not have to manually create a Secret
+somewhere themselves.
+*/
+package clustercredentialscontroller

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -25,7 +25,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
-	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -199,10 +198,6 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 	if err != nil {
 		return fmt.Errorf("failed to get credentials: %w", err)
 	}
-	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, r.seedClient, newCluster); err != nil {
-		return err
-	}
-	kuberneteshelper.AddFinalizer(newCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
 
 	// re-use our reconciling framework, because this is a special place where right after the Cluster
 	// creation, we must set some status fields and this requires us to wait for the Cluster object

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller_test.go
@@ -160,7 +160,6 @@ func genCluster(name, userEmail string, instance kubermaticv1.ClusterTemplateIns
 			Name:            name,
 			Labels:          map[string]string{kubermaticv1.ProjectIDLabelKey: instance.Spec.ProjectID, kubernetes.ClusterTemplateInstanceLabelKey: instance.Name},
 			ResourceVersion: "1",
-			Finalizers:      []string{kubermaticv1.CredentialsSecretsCleanupFinalizer},
 			Annotations:     map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail},
 		},
 		Spec: kubermaticv1.ClusterSpec{

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -121,11 +121,6 @@ func CreateEndpoint(
 		return nil, utilerrors.NewAlreadyExists("cluster", partialCluster.Spec.HumanReadableName)
 	}
 
-	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {
-		return nil, err
-	}
-	kuberneteshelper.AddFinalizer(partialCluster, kubermaticv1.CredentialsSecretsCleanupFinalizer)
-
 	newCluster, err := createNewCluster(ctx, userInfoGetter, clusterProvider, privilegedClusterProvider, project, partialCluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -160,6 +161,50 @@ func (cd *credentialsData) Cluster() *kubermaticv1.Cluster {
 
 func (cd *credentialsData) GetGlobalSecretKeySelectorValue(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error) {
 	return cd.globalSecretKeySelectorValueFunc(configVar, key)
+}
+
+func GetCredentialsReference(cluster *kubermaticv1.Cluster) (*providerconfig.GlobalSecretKeySelector, error) {
+	if cluster.Spec.Cloud.AWS != nil {
+		return cluster.Spec.Cloud.AWS.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Azure != nil {
+		return cluster.Spec.Cloud.Azure.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Digitalocean != nil {
+		return cluster.Spec.Cloud.Digitalocean.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.GCP != nil {
+		return cluster.Spec.Cloud.GCP.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Hetzner != nil {
+		return cluster.Spec.Cloud.Hetzner.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Openstack != nil {
+		return cluster.Spec.Cloud.Openstack.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Packet != nil {
+		return cluster.Spec.Cloud.Packet.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Kubevirt != nil {
+		return cluster.Spec.Cloud.Kubevirt.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.VSphere != nil {
+		return cluster.Spec.Cloud.VSphere.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Alibaba != nil {
+		return cluster.Spec.Cloud.Alibaba.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Anexia != nil {
+		return cluster.Spec.Cloud.Anexia.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.Nutanix != nil {
+		return cluster.Spec.Cloud.Nutanix.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
+		return cluster.Spec.Cloud.VMwareCloudDirector.CredentialsReference, nil
+	}
+
+	return nil, errors.New("cluster has no known cloud provider spec set")
 }
 
 func GetCredentials(data CredentialsData) (Credentials, error) {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -374,6 +374,10 @@ const (
 	ConstraintViolationsLimit = 20
 	// GatekeeperExemptNamespaceLabel label key for exempting namespaces from Gatekeeper checks.
 	GatekeeperExemptNamespaceLabel = "admission.gatekeeper.sh/ignore"
+	// ClusterCloudCredentialsSecretName is the name the Secret in the cluster namespace that contains
+	// the cloud provider credentials. This Secret is a copy of the credentials secret from the KKP
+	// namespace (which has a dynamic name).
+	ClusterCloudCredentialsSecretName = "cloud-credentials"
 
 	// CloudInitSettingsNamespace are used in order to reach, authenticate and be authorized by the api server, to fetch
 	// the machine  provisioning cloud-init.

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -465,9 +465,7 @@ func (j *ClusterJig) applyPreset(ctx context.Context, cluster *kubermaticv1.Clus
 		return nil, fmt.Errorf("provider %q is not yet supported, please implement", cluster.Spec.Cloud.ProviderName)
 	}
 
-	err := kubernetes.CreateOrUpdateCredentialSecretForCluster(ctx, j.client, cluster)
-
-	return cluster, err
+	return cluster, nil
 }
 
 func (j *ClusterJig) getClusterProvider() (*kubernetes.ClusterProvider, error) {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
For a long time we have planned to remove the cloud provider credentials from the various Deployments in the cluster namespace. It's just plain wrong to have an `AWS_ACCESS_KEY=supersecret` env on the kube-apiserver Deployment.

To achieve this, this PR mirrors the credentials Secret for a usercluster from the `kubermatic` namespace into the cluster namespace. A new controller takes care of this simple procedure. This new controller also migrates cluster credentials (i.e. creates the Secret in the kubermatic Namespace and remove credentials from `.spec.cloud` in the Cluster object), something that previously was only done when a Cluster was created via the KKP API.

The new Secret is called `cloud-credentials` and will in the future be consumed by the various Deployments.

**Does this PR introduce a user-facing change?**:
```release-note
Cloud provider credentials (`.spec.cloud` in a Cluster object) are transferred into a Secret by a controller, something previously only done during cluster creation when using the KKP dashboard. Now this procedure affects every Cluster object.
The cluster credentials are now also mirrored into the usercluster namespace.
```
