### PR TITLE
Use cloud credential secret for Deployments

### DIFF
--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -777,15 +777,11 @@ func getVolumes(isKonnectivityEnabled, isEncryptionEnabled, isAuditEnabled bool)
 }
 
 type kubeAPIServerEnvData interface {
-	resources.CredentialsData
+	Cluster() *kubermaticv1.Cluster
 	Seed() *kubermaticv1.Seed
 }
 
 func GetEnvVars(data kubeAPIServerEnvData) ([]corev1.EnvVar, error) {
-	credentials, err := resources.GetCredentials(data)
-	if err != nil {
-		return nil, err
-	}
 	cluster := data.Cluster()
 
 	vars := []corev1.EnvVar{
@@ -795,9 +791,20 @@ func GetEnvVars(data kubeAPIServerEnvData) ([]corev1.EnvVar, error) {
 		},
 	}
 
+	refTo := func(key string) *corev1.EnvVarSource {
+		return &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: resources.ClusterCloudCredentialsSecretName,
+				},
+				Key: key,
+			},
+		}
+	}
+
 	if cluster.Spec.Cloud.AWS != nil {
-		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
+		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", ValueFrom: refTo(resources.AWSAccessKeyID)})
+		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: refTo(resources.AWSSecretAccessKey)})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_VPC_ID", Value: cluster.Spec.Cloud.AWS.VPCID})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ASSUME_ROLE_ARN", Value: cluster.Spec.Cloud.AWS.AssumeRoleARN})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ASSUME_ROLE_EXTERNAL_ID", Value: cluster.Spec.Cloud.AWS.AssumeRoleExternalID})

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -781,7 +781,6 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		ref := refTo(NutanixProxyURL)
 		ref.SecretKeyRef.Optional = pointer.Bool(true)
 		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PROXY_URL", ValueFrom: ref})
-
 	}
 	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
 		vars = append(vars, corev1.EnvVar{Name: "VCD_URL", Value: dc.Spec.VMwareCloudDirector.URL})

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -712,6 +712,13 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		}
 	}
 
+	optionalRefTo := func(key string) *corev1.EnvVarSource {
+		ref := refTo(key)
+		ref.SecretKeyRef.Optional = pointer.Bool(true)
+
+		return ref
+	}
+
 	var vars []corev1.EnvVar
 	if cluster.Spec.Cloud.AWS != nil {
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", ValueFrom: refTo(AWSAccessKeyID)})
@@ -730,10 +737,10 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", ValueFrom: refTo(OpenstackUsername)})
 		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", ValueFrom: refTo(OpenstackPassword)})
 		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", ValueFrom: refTo(OpenstackDomain)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_NAME", ValueFrom: refTo(OpenstackProject)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_ID", ValueFrom: refTo(OpenstackProjectID)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", ValueFrom: refTo(OpenstackApplicationCredentialID)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", ValueFrom: refTo(OpenstackApplicationCredentialSecret)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_NAME", ValueFrom: optionalRefTo(OpenstackProject)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_ID", ValueFrom: optionalRefTo(OpenstackProjectID)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", ValueFrom: optionalRefTo(OpenstackApplicationCredentialID)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", ValueFrom: optionalRefTo(OpenstackApplicationCredentialSecret)})
 	}
 	if cluster.Spec.Cloud.Hetzner != nil {
 		vars = append(vars, corev1.EnvVar{Name: "HZ_TOKEN", ValueFrom: refTo(HetznerToken)})
@@ -776,11 +783,7 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 
 		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_USERNAME", ValueFrom: refTo(NutanixUsername)})
 		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PASSWORD", ValueFrom: refTo(NutanixPassword)})
-
-		// proxy URL can be empty
-		ref := refTo(NutanixProxyURL)
-		ref.SecretKeyRef.Optional = pointer.Bool(true)
-		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PROXY_URL", ValueFrom: ref})
+		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PROXY_URL", ValueFrom: optionalRefTo(NutanixProxyURL)}) // proxy URL can be empty
 	}
 	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
 		vars = append(vars, corev1.EnvVar{Name: "VCD_URL", Value: dc.Spec.VMwareCloudDirector.URL})

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubenetutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -697,92 +698,103 @@ func (d *TemplateData) KubermaticConfiguration() *kubermaticv1.KubermaticConfigu
 }
 
 func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
-	credentials, err := GetCredentials(data)
-	if err != nil {
-		return nil, err
+	cluster := data.Cluster()
+	dc := data.DC()
+
+	refTo := func(key string) *corev1.EnvVarSource {
+		return &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: ClusterCloudCredentialsSecretName,
+				},
+				Key: key,
+			},
+		}
 	}
 
 	var vars []corev1.EnvVar
-	if data.Cluster().Spec.Cloud.AWS != nil {
-		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_ASSUME_ROLE_ARN", Value: credentials.AWS.AssumeRoleARN})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_ASSUME_ROLE_EXTERNAL_ID", Value: credentials.AWS.AssumeRoleExternalID})
+	if cluster.Spec.Cloud.AWS != nil {
+		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", ValueFrom: refTo(AWSAccessKeyID)})
+		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: refTo(AWSSecretAccessKey)})
+		vars = append(vars, corev1.EnvVar{Name: "AWS_ASSUME_ROLE_ARN", Value: cluster.Spec.Cloud.AWS.AssumeRoleARN})
+		vars = append(vars, corev1.EnvVar{Name: "AWS_ASSUME_ROLE_EXTERNAL_ID", Value: cluster.Spec.Cloud.AWS.AssumeRoleExternalID})
 	}
-	if data.Cluster().Spec.Cloud.Azure != nil {
-		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_ID", Value: credentials.Azure.ClientID})
-		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_SECRET", Value: credentials.Azure.ClientSecret})
-		vars = append(vars, corev1.EnvVar{Name: "AZURE_TENANT_ID", Value: credentials.Azure.TenantID})
-		vars = append(vars, corev1.EnvVar{Name: "AZURE_SUBSCRIPTION_ID", Value: credentials.Azure.SubscriptionID})
+	if cluster.Spec.Cloud.Azure != nil {
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_ID", ValueFrom: refTo(AzureClientID)})
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_SECRET", ValueFrom: refTo(AzureClientSecret)})
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_TENANT_ID", ValueFrom: refTo(AzureTenantID)})
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_SUBSCRIPTION_ID", ValueFrom: refTo(AzureSubscriptionID)})
 	}
-	if data.Cluster().Spec.Cloud.Openstack != nil {
-		vars = append(vars, corev1.EnvVar{Name: "OS_AUTH_URL", Value: data.DC().Spec.Openstack.AuthURL})
-		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", Value: credentials.Openstack.Username})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", Value: credentials.Openstack.Password})
-		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", Value: credentials.Openstack.Domain})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_NAME", Value: credentials.Openstack.Project})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_ID", Value: credentials.Openstack.ProjectID})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", Value: credentials.Openstack.ApplicationCredentialID})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", Value: credentials.Openstack.ApplicationCredentialSecret})
+	if cluster.Spec.Cloud.Openstack != nil {
+		vars = append(vars, corev1.EnvVar{Name: "OS_AUTH_URL", Value: dc.Spec.Openstack.AuthURL})
+		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", ValueFrom: refTo(OpenstackUsername)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", ValueFrom: refTo(OpenstackPassword)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", ValueFrom: refTo(OpenstackDomain)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_NAME", ValueFrom: refTo(OpenstackProject)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_ID", ValueFrom: refTo(OpenstackProjectID)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", ValueFrom: refTo(OpenstackApplicationCredentialID)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", ValueFrom: refTo(OpenstackApplicationCredentialSecret)})
 	}
-	if data.Cluster().Spec.Cloud.Hetzner != nil {
-		vars = append(vars, corev1.EnvVar{Name: "HZ_TOKEN", Value: credentials.Hetzner.Token})
+	if cluster.Spec.Cloud.Hetzner != nil {
+		vars = append(vars, corev1.EnvVar{Name: "HZ_TOKEN", ValueFrom: refTo(HetznerToken)})
 	}
-	if data.Cluster().Spec.Cloud.Digitalocean != nil {
-		vars = append(vars, corev1.EnvVar{Name: "DO_TOKEN", Value: credentials.Digitalocean.Token})
+	if cluster.Spec.Cloud.Digitalocean != nil {
+		vars = append(vars, corev1.EnvVar{Name: "DO_TOKEN", ValueFrom: refTo(DigitaloceanToken)})
 	}
-	if data.Cluster().Spec.Cloud.VSphere != nil {
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: data.DC().Spec.VSphere.Endpoint})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", Value: credentials.VSphere.Username})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", Value: credentials.VSphere.Password})
+	if cluster.Spec.Cloud.VSphere != nil {
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: dc.Spec.VSphere.Endpoint})
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", ValueFrom: refTo(VsphereUsername)})
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", ValueFrom: refTo(VspherePassword)})
 	}
-	if data.Cluster().Spec.Cloud.Packet != nil {
-		vars = append(vars, corev1.EnvVar{Name: "PACKET_API_KEY", Value: credentials.Packet.APIKey})
-		vars = append(vars, corev1.EnvVar{Name: "PACKET_PROJECT_ID", Value: credentials.Packet.ProjectID})
+	if cluster.Spec.Cloud.Packet != nil {
+		vars = append(vars, corev1.EnvVar{Name: "PACKET_API_KEY", ValueFrom: refTo(PacketAPIKey)})
+		vars = append(vars, corev1.EnvVar{Name: "PACKET_PROJECT_ID", ValueFrom: refTo(PacketProjectID)})
 	}
-	if data.Cluster().Spec.Cloud.GCP != nil {
-		vars = append(vars, corev1.EnvVar{Name: "GOOGLE_SERVICE_ACCOUNT", Value: credentials.GCP.ServiceAccount})
+	if cluster.Spec.Cloud.GCP != nil {
+		vars = append(vars, corev1.EnvVar{Name: "GOOGLE_SERVICE_ACCOUNT", ValueFrom: refTo(GCPServiceAccount)})
 	}
-	if data.Cluster().Spec.Cloud.Kubevirt != nil {
-		vars = append(vars, corev1.EnvVar{Name: "KUBEVIRT_KUBECONFIG", Value: credentials.Kubevirt.KubeConfig})
+	if cluster.Spec.Cloud.Kubevirt != nil {
+		vars = append(vars, corev1.EnvVar{Name: "KUBEVIRT_KUBECONFIG", ValueFrom: refTo(KubevirtKubeConfig)})
 	}
-	if data.Cluster().Spec.Cloud.Alibaba != nil {
-		vars = append(vars, corev1.EnvVar{Name: "ALIBABA_ACCESS_KEY_ID", Value: credentials.Alibaba.AccessKeyID})
-		vars = append(vars, corev1.EnvVar{Name: "ALIBABA_ACCESS_KEY_SECRET", Value: credentials.Alibaba.AccessKeySecret})
+	if cluster.Spec.Cloud.Alibaba != nil {
+		vars = append(vars, corev1.EnvVar{Name: "ALIBABA_ACCESS_KEY_ID", ValueFrom: refTo(AlibabaAccessKeyID)})
+		vars = append(vars, corev1.EnvVar{Name: "ALIBABA_ACCESS_KEY_SECRET", ValueFrom: refTo(AlibabaAccessKeySecret)})
 	}
-	if data.Cluster().Spec.Cloud.Anexia != nil {
-		vars = append(vars, corev1.EnvVar{Name: "ANEXIA_TOKEN", Value: credentials.Anexia.Token})
+	if cluster.Spec.Cloud.Anexia != nil {
+		vars = append(vars, corev1.EnvVar{Name: "ANEXIA_TOKEN", ValueFrom: refTo(AnexiaToken)})
 	}
-	if data.Cluster().Spec.Cloud.Nutanix != nil {
-		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_ENDPOINT", Value: data.DC().Spec.Nutanix.Endpoint})
-		if port := data.DC().Spec.Nutanix.Port; port != nil {
+	if cluster.Spec.Cloud.Nutanix != nil {
+		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_CLUSTER_NAME", Value: cluster.Spec.Cloud.Nutanix.ClusterName})
+		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_ENDPOINT", Value: dc.Spec.Nutanix.Endpoint})
+
+		if port := dc.Spec.Nutanix.Port; port != nil {
 			vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PORT", Value: strconv.Itoa(int(*port))})
 		}
-		if data.DC().Spec.Nutanix.AllowInsecure {
+		if dc.Spec.Nutanix.AllowInsecure {
 			vars = append(vars, corev1.EnvVar{Name: "NUTANIX_INSECURE", Value: "true"})
 		}
 
-		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_USERNAME", Value: credentials.Nutanix.Username})
-		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PASSWORD", Value: credentials.Nutanix.Password})
-		if proxyURL := credentials.Nutanix.ProxyURL; proxyURL != "" {
-			vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PROXY_URL", Value: proxyURL})
-		}
+		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_USERNAME", ValueFrom: refTo(NutanixUsername)})
+		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PASSWORD", ValueFrom: refTo(NutanixPassword)})
 
-		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_CLUSTER_NAME", Value: data.Cluster().Spec.Cloud.Nutanix.ClusterName})
+		// proxy URL can be empty
+		ref := refTo(NutanixProxyURL)
+		ref.SecretKeyRef.Optional = pointer.Bool(true)
+		vars = append(vars, corev1.EnvVar{Name: "NUTANIX_PROXY_URL", ValueFrom: ref})
+
 	}
-	if data.Cluster().Spec.Cloud.VMwareCloudDirector != nil {
-		vars = append(vars, corev1.EnvVar{Name: "VCD_URL", Value: data.DC().Spec.VMwareCloudDirector.URL})
+	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
+		vars = append(vars, corev1.EnvVar{Name: "VCD_URL", Value: dc.Spec.VMwareCloudDirector.URL})
+		vars = append(vars, corev1.EnvVar{Name: "VCD_USER", ValueFrom: refTo(VMwareCloudDirectorUsername)})
+		vars = append(vars, corev1.EnvVar{Name: "VCD_PASSWORD", ValueFrom: refTo(VMwareCloudDirectorPassword)})
+		vars = append(vars, corev1.EnvVar{Name: "VCD_ORG", ValueFrom: refTo(VMwareCloudDirectorOrganization)})
+		vars = append(vars, corev1.EnvVar{Name: "VCD_VDC", ValueFrom: refTo(VMwareCloudDirectorVDC)})
 
-		if data.DC().Spec.VMwareCloudDirector.AllowInsecure {
+		if dc.Spec.VMwareCloudDirector.AllowInsecure {
 			vars = append(vars, corev1.EnvVar{Name: "VCD_ALLOW_UNVERIFIED_SSL", Value: "true"})
 		}
-
-		vars = append(vars, corev1.EnvVar{Name: "VCD_USER", Value: credentials.VMwareCloudDirector.Username})
-		vars = append(vars, corev1.EnvVar{Name: "VCD_PASSWORD", Value: credentials.VMwareCloudDirector.Password})
-		vars = append(vars, corev1.EnvVar{Name: "VCD_ORG", Value: credentials.VMwareCloudDirector.Organization})
-		vars = append(vars, corev1.EnvVar{Name: "VCD_VDC", Value: credentials.VMwareCloudDirector.VDC})
 	}
-	vars = append(vars, GetHTTPProxyEnvVarsFromSeed(data.Seed(), data.Cluster().GetAddress().InternalName)...)
+	vars = append(vars, GetHTTPProxyEnvVarsFromSeed(data.Seed(), cluster.GetAddress().InternalName)...)
 
 	vars = SanitizeEnvVars(vars)
 	vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}})

--- a/pkg/resources/environment.go
+++ b/pkg/resources/environment.go
@@ -25,14 +25,9 @@ import (
 // SanitizeEnvVar will take the value of an environment variable and sanitize it.
 // the need for this comes from github.com/kubermatic/kubermatic/issues/7960.
 func SanitizeEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
-	sanitizedEnvVars := make([]corev1.EnvVar, len(envVars))
-
-	for idx, envVar := range envVars {
-		sanitizedEnvVars[idx] = corev1.EnvVar{
-			Name:  envVar.Name,
-			Value: strings.ReplaceAll(envVar.Value, "$", "$$"),
-		}
+	for idx := range envVars {
+		envVars[idx].Value = strings.ReplaceAll(envVars[idx].Value, "$", "$$")
 	}
 
-	return sanitizedEnvVars
+	return envVars
 }

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -290,6 +291,13 @@ func getEnvVars(data operatingSystemManagerData) ([]corev1.EnvVar, error) {
 		}
 	}
 
+	optionalRefTo := func(key string) *corev1.EnvVarSource {
+		ref := refTo(key)
+		ref.SecretKeyRef.Optional = pointer.Bool(true)
+
+		return ref
+	}
+
 	var vars []corev1.EnvVar
 	if data.Cluster().Spec.Cloud.Azure != nil {
 		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_ID", ValueFrom: refTo(resources.AzureClientID)})
@@ -302,10 +310,10 @@ func getEnvVars(data operatingSystemManagerData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", ValueFrom: refTo(resources.OpenstackUsername)})
 		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", ValueFrom: refTo(resources.OpenstackPassword)})
 		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", ValueFrom: refTo(resources.OpenstackDomain)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_NAME", ValueFrom: refTo(resources.OpenstackProject)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_ID", ValueFrom: refTo(resources.OpenstackProjectID)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", ValueFrom: refTo(resources.OpenstackApplicationCredentialID)})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", ValueFrom: refTo(resources.OpenstackApplicationCredentialSecret)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_NAME", ValueFrom: optionalRefTo(resources.OpenstackProject)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PROJECT_ID", ValueFrom: optionalRefTo(resources.OpenstackProjectID)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", ValueFrom: optionalRefTo(resources.OpenstackApplicationCredentialID)})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", ValueFrom: optionalRefTo(resources.OpenstackApplicationCredentialSecret)})
 	}
 	if data.Cluster().Spec.Cloud.VSphere != nil {
 		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: data.DC().Spec.VSphere.Endpoint})

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -238,9 +238,15 @@ spec:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_VPC_ID
           value: aws-vpn-id
         - name: AWS_ASSUME_ROLE_ARN

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -64,9 +64,15 @@ spec:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_VPC_ID
           value: aws-vpn-id
         - name: AWS_ASSUME_ROLE_ARN

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
@@ -40,9 +40,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
@@ -43,9 +43,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-controller.yaml
@@ -45,9 +45,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
@@ -33,9 +33,15 @@ spec:
         - user-cluster-webhook
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-apiserver.yaml
@@ -240,9 +240,15 @@ spec:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_VPC_ID
           value: aws-vpn-id
         - name: AWS_ASSUME_ROLE_ARN

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-controller-manager.yaml
@@ -64,9 +64,15 @@ spec:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_VPC_ID
           value: aws-vpn-id
         - name: AWS_ASSUME_ROLE_ARN

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
@@ -40,9 +40,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
@@ -43,9 +43,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-controller.yaml
@@ -45,9 +45,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
@@ -33,9 +33,15 @@ spec:
         - user-cluster-webhook
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
@@ -240,9 +240,15 @@ spec:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_VPC_ID
           value: aws-vpn-id
         - name: AWS_ASSUME_ROLE_ARN

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
@@ -64,9 +64,15 @@ spec:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_VPC_ID
           value: aws-vpn-id
         - name: AWS_ASSUME_ROLE_ARN

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
@@ -40,9 +40,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
@@ -43,9 +43,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-controller.yaml
@@ -45,9 +45,15 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
@@ -33,9 +33,15 @@ spec:
         - user-cluster-webhook
         env:
         - name: AWS_ACCESS_KEY_ID
-          value: aws-access-key-id
+          valueFrom:
+            secretKeyRef:
+              key: accessKeyId
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
-          value: aws-secret-access-key
+          valueFrom:
+            secretKeyRef:
+              key: secretAccessKey
+              name: cloud-credentials
         - name: AWS_ASSUME_ROLE_ARN
           value: aws-assume-role-arn
         - name: AWS_ASSUME_ROLE_EXTERNAL_ID

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -43,13 +43,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -40,13 +40,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
@@ -40,13 +40,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
@@ -43,13 +43,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -45,13 +45,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller.yaml
@@ -45,13 +45,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -33,13 +33,25 @@ spec:
         - user-cluster-webhook
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
@@ -33,13 +33,25 @@ spec:
         - user-cluster-webhook
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -43,13 +43,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -40,13 +40,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
@@ -40,13 +40,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
@@ -43,13 +43,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller-externalCloudProvider.yaml
@@ -45,13 +45,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller.yaml
@@ -45,13 +45,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -33,13 +33,25 @@ spec:
         - user-cluster-webhook
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
@@ -33,13 +33,25 @@ spec:
         - user-cluster-webhook
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -43,13 +43,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -40,13 +40,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
@@ -40,13 +40,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
@@ -43,13 +43,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller-externalCloudProvider.yaml
@@ -45,13 +45,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller.yaml
@@ -45,13 +45,25 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -33,13 +33,25 @@ spec:
         - user-cluster-webhook
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
@@ -33,13 +33,25 @@ spec:
         - user-cluster-webhook
         env:
         - name: AZURE_CLIENT_ID
-          value: az-client-id
+          valueFrom:
+            secretKeyRef:
+              key: clientID
+              name: cloud-credentials
         - name: AZURE_CLIENT_SECRET
-          value: az-client-secret
+          valueFrom:
+            secretKeyRef:
+              key: clientSecret
+              name: cloud-credentials
         - name: AZURE_TENANT_ID
-          value: az-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenantID
+              name: cloud-credentials
         - name: AZURE_SUBSCRIPTION_ID
-          value: az-subscription-id
+          valueFrom:
+            secretKeyRef:
+              key: subscriptionID
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -40,7 +40,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
@@ -43,7 +43,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-controller.yaml
@@ -45,7 +45,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -33,7 +33,10 @@ spec:
         - user-cluster-webhook
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
@@ -40,7 +40,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
@@ -43,7 +43,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-controller.yaml
@@ -45,7 +45,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -33,7 +33,10 @@ spec:
         - user-cluster-webhook
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
@@ -40,7 +40,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
@@ -43,7 +43,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-controller.yaml
@@ -45,7 +45,10 @@ spec:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -33,7 +33,10 @@ spec:
         - user-cluster-webhook
         env:
         - name: DO_TOKEN
-          value: do-token
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -45,16 +45,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -42,16 +42,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
@@ -42,16 +42,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
@@ -45,16 +45,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -47,16 +47,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller.yaml
@@ -47,16 +47,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -35,16 +35,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
@@ -35,16 +35,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -45,16 +45,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -42,16 +42,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
@@ -42,16 +42,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
@@ -45,16 +45,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller-externalCloudProvider.yaml
@@ -47,16 +47,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller.yaml
@@ -47,16 +47,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -35,16 +35,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
@@ -35,16 +35,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -45,16 +45,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -42,16 +42,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
@@ -42,16 +42,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
@@ -45,16 +45,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller-externalCloudProvider.yaml
@@ -47,16 +47,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller.yaml
@@ -47,16 +47,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -35,16 +35,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
@@ -35,16 +35,44 @@ spec:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
         - name: OS_USER_NAME
-          value: openstack-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: OS_PASSWORD
-          value: openstack-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: OS_DOMAIN_NAME
-          value: openstack-domain
+          valueFrom:
+            secretKeyRef:
+              key: domain
+              name: cloud-credentials
         - name: OS_PROJECT_NAME
-          value: openstack-project
+          valueFrom:
+            secretKeyRef:
+              key: project
+              name: cloud-credentials
+              optional: true
         - name: OS_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              key: projectID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_ID
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialID
+              name: cloud-credentials
+              optional: true
         - name: OS_APPLICATION_CREDENTIAL_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: applicationCredentialSecret
+              name: cloud-credentials
+              optional: true
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -45,9 +45,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -42,9 +42,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -42,9 +42,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
@@ -45,9 +45,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -47,9 +47,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller.yaml
@@ -47,9 +47,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -35,9 +35,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
@@ -35,9 +35,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -45,9 +45,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -42,9 +42,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
@@ -42,9 +42,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
@@ -45,9 +45,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller-externalCloudProvider.yaml
@@ -47,9 +47,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller.yaml
@@ -47,9 +47,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -35,9 +35,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
@@ -35,9 +35,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -45,9 +45,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -42,9 +42,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
@@ -42,9 +42,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
@@ -45,9 +45,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller-externalCloudProvider.yaml
@@ -47,9 +47,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller.yaml
@@ -47,9 +47,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -35,9 +35,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
@@ -35,9 +35,15 @@ spec:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
-          value: vs-username
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloud-credentials
         - name: VSPHERE_PASSWORD
-          value: vs-password
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloud-credentials
         - name: HTTP_PROXY
           value: http://my-corp
         - name: HTTPS_PROXY


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR refactors all Deployments that get cloud credentials injected to take those from a Secret instead of inline (so no more sensitive data is put into Deployment objects).

**Does this PR introduce a user-facing change?**:
```release-note
Cloud provider credentials are not put into environment variables for Deployments anymore, but instead Deployments reference Secrets.
```
