### PR TITLE
Add controller to synchronize custom OSPs to user-cluster namespaces

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -41,6 +41,7 @@ import (
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
+	operatingsystemprofilesynchronizer "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer"
 	presetcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/preset-controller"
 	projectcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/project"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/pvwatcher"
@@ -77,6 +78,7 @@ var AllControllers = map[string]controllerCreator{
 	encryptionatrestcontroller.ControllerName:               createEncryptionAtRestController,
 	ipam.ControllerName:                                     createIPAMController,
 	clusterstuckcontroller.ControllerName:                   createClusterStuckController,
+	operatingsystemprofilesynchronizer.ControllerName:       createOperatingSystemProfileController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -437,5 +439,15 @@ func createClusterStuckController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.log,
+	)
+}
+
+func createOperatingSystemProfileController(ctrlCtx *controllerContext) error {
+	return operatingsystemprofilesynchronizer.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.namespace,
+		ctrlCtx.runOptions.workerCount,
 	)
 }

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -173,6 +173,11 @@ func main() {
 				ResourceImportPath: "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1",
 			},
 			{
+				ResourceName:       "OperatingSystemProfile",
+				ImportAlias:        "osmv1alpha1",
+				ResourceImportPath: "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1",
+			},
+			{
 				ResourceName:     "ConstraintTemplate",
 				ImportAlias:      "kubermaticv1",
 				APIVersionPrefix: "KubermaticV1",

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemprofilesynchronizer
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kkp-operating-system-profile-synchronizer"
+
+	// cleanupFinalizer indicates that the OperatingSystemProfile needs to be removed from all the user-cluster namespaces.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-operating-system-profiles"
+)
+
+type Reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	workerName              string
+	recorder                record.EventRecorder
+	namespace               string
+	seedClient              ctrlruntimeclient.Client
+}
+
+func Add(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	namespace string,
+	numWorkers int,
+) error {
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &Reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		workerName:              workerName,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		namespace:               namespace,
+		seedClient:              mgr.GetClient(),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	// Watch changes for OSPs.
+	if err := c.Watch(
+		&source.Kind{Type: &osmv1alpha1.OperatingSystemProfile{}},
+		&handler.EnqueueRequestForObject{},
+		kubermaticpred.ByNamespace(namespace),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for operatingSystemProfiles: %w", err)
+	}
+
+	// Watch changes for OSPs and then enqueue all the clusters where OSM is enabled.
+	if err := c.Watch(
+		&source.Kind{Type: &kubermaticv1.Cluster{}},
+		enqueueOperatingSystemProfiles(reconciler.seedClient, reconciler.log, namespace),
+		workerlabel.Predicates(workerName),
+		withEventFilter(),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for clusters: %w", err)
+	}
+	return nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("operatingsystemprofile", request.NamespacedName.String())
+	log.Debug("Reconciling")
+
+	osp := &osmv1alpha1.OperatingSystemProfile{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, osp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// OperatingSystemProfile is marked for deletion.
+	if osp.DeletionTimestamp != nil {
+		log.Debug("Deletion timestamp found for operatingSystemProfile")
+		if kuberneteshelper.HasFinalizer(osp, cleanupFinalizer) {
+			if err := r.handleDeletion(ctx, log, osp); err != nil {
+				err = fmt.Errorf("failed to delete operatingSystemProfile: %w", err)
+
+				log.Errorw("ReconcilingError", zap.Error(err))
+				r.recorder.Event(osp, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{}, nil
+		}
+		// Finalizer doesn't exist so clean up is already done.
+		return reconcile.Result{}, nil
+	}
+
+	err := r.reconcile(ctx, log, osp)
+	if err != nil {
+		log.Errorw("Reconciling failed", zap.Error(err))
+		r.recorder.Event(osp, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, osp *osmv1alpha1.OperatingSystemProfile) error {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.seedClient, osp, cleanupFinalizer); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
+	}
+	return r.syncAllUserClusterNamespaces(ctx, log, osp)
+}
+
+func (r *Reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, osp *osmv1alpha1.OperatingSystemProfile) error {
+	err := r.syncAllUserClusterNamespaces(ctx, log, osp)
+	if err != nil {
+		return err
+	}
+
+	// Remove the finalizer
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.seedClient, osp, cleanupFinalizer)
+}
+
+func (r *Reconciler) syncAllUserClusterNamespaces(ctx context.Context, log *zap.SugaredLogger, osp *osmv1alpha1.OperatingSystemProfile) error {
+	clusters := &kubermaticv1.ClusterList{}
+	if err := r.seedClient.List(context.Background(), clusters); err != nil {
+		log.Error(err)
+		utilruntime.HandleError(fmt.Errorf("failed to list clusters: %w", err))
+	}
+
+	var errors []error
+	for _, cluster := range clusters.Items {
+		// Ensure that this is a reconcilable cluster
+		if cluster.Spec.EnableOperatingSystemManager && cluster.DeletionTimestamp == nil && !cluster.Spec.Pause {
+			// We want to avoid changes to the original object.
+			currentOSP := osp.DeepCopy()
+			err := r.syncOperatingSystemProfile(ctx, log, currentOSP, cluster.Status.NamespaceName)
+			if err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+	return kerrors.NewAggregate(errors)
+}
+
+func (r *Reconciler) syncOperatingSystemProfile(ctx context.Context, log *zap.SugaredLogger, osp *osmv1alpha1.OperatingSystemProfile, namespace string) error {
+	// We want to perform actions on the user-cluster namespace.
+	osp.Namespace = namespace
+
+	// If OSP is marked for deletion then remove it from the user-cluster namespace.
+	if osp.DeletionTimestamp != nil {
+		err := r.seedClient.Delete(ctx, osp)
+		return ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	existingOSP := &osmv1alpha1.OperatingSystemProfile{}
+	err := r.seedClient.Get(ctx, types.NamespacedName{Name: osp.Name, Namespace: osp.Namespace}, existingOSP)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get operatingSystemProfile %s/%s: %w", osp.Namespace, osp.Name, err)
+	}
+
+	// We need to create the OperatingSystemProfile.
+	if apierrors.IsNotFound(err) {
+		// set resource version to empty.
+		osp.ResourceVersion = ""
+		osp.Finalizers = nil
+		if err := r.seedClient.Create(ctx, osp); err != nil {
+			return fmt.Errorf("failed to create operatingSystemProfile: %w", err)
+		}
+		return nil
+	}
+
+	// We need to check if the existing OperatingSystemProfile can be updated.
+	// OSP is immutable by nature and to make modifications a version bump is mandatory
+	if equal := apiequality.Semantic.DeepEqual(existingOSP.Spec, osp.Spec); !equal && existingOSP.Spec.Version == osp.Spec.Version {
+		log.Debug("OperatingSystemProfile is immutable. For updates .spec.version needs to be updated")
+		return nil
+	}
+
+	existingOSP.Spec = osp.Spec
+	existingOSP.Annotations = osp.Annotations
+	existingOSP.Labels = osp.Labels
+
+	// We need to update the existing OperatingSystemProfile.
+	if err := r.seedClient.Update(ctx, existingOSP); err != nil {
+		return fmt.Errorf("failed to update operatingSystemProfile: %w", err)
+	}
+	return nil
+}
+
+func withEventFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			cluster, ok := e.Object.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			return cluster.Spec.EnableOperatingSystemManager && cluster.DeletionTimestamp == nil
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, ok := e.ObjectOld.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			newCluster, ok := e.ObjectNew.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			// We might need to install or delete custom OSPs from the user cluster namespace.
+			if oldCluster.Spec.EnableOperatingSystemManager != newCluster.Spec.EnableOperatingSystemManager && newCluster.DeletionTimestamp == nil {
+				return true
+			}
+
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func enqueueOperatingSystemProfiles(client ctrlruntimeclient.Client, log *zap.SugaredLogger, namespace string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a ctrlruntimeclient.Object) []reconcile.Request {
+		var requests []reconcile.Request
+
+		ospList := &osmv1alpha1.OperatingSystemProfileList{}
+
+		if err := client.List(context.Background(), ospList, &ctrlruntimeclient.ListOptions{Namespace: namespace}); err != nil {
+			log.Error(err)
+			utilruntime.HandleError(fmt.Errorf("failed to list operatingSystemProfiles: %w", err))
+		}
+
+		for _, osp := range ospList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      osp.Name,
+				Namespace: osp.Namespace,
+			}})
+		}
+		return requests
+	})
+}

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller_test.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemprofilesynchronizer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/test/diff"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/utils/pointer"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func init() {
+	utilruntime.Must(osmv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(kubermaticv1.AddToScheme(scheme.Scheme))
+}
+
+func TestReconcile(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	testCases := []struct {
+		name                            string
+		namespacedName                  types.NamespacedName
+		existingClusters                []*kubermaticv1.Cluster
+		existingOperatingSystemProfiles []*osmv1alpha1.OperatingSystemProfile
+		expectedOperatingSystemProfiles []*osmv1alpha1.OperatingSystemProfile
+	}{
+		{
+			name: "scenario 1: sync OSP to user cluster namespace",
+			existingClusters: []*kubermaticv1.Cluster{
+				genCluster("cluster-1", true),
+			},
+			namespacedName: types.NamespacedName{Name: "osp", Namespace: "kubermatic"},
+			existingOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, false),
+			},
+			expectedOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-1", "v1.0.0", false, false),
+			},
+		},
+		{
+			name: "scenario 2: sync OSP to multiple user cluster namespaces",
+			existingClusters: []*kubermaticv1.Cluster{
+				genCluster("cluster-1", true),
+				genCluster("cluster-2", true),
+				genCluster("cluster-3", true),
+				genCluster("cluster-4", false),
+			},
+			namespacedName: types.NamespacedName{Name: "osp", Namespace: "kubermatic"},
+			existingOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, false),
+			},
+			expectedOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-1", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-2", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-3", "v1.0.0", false, false),
+			},
+		},
+		{
+			name: "scenario 3: deleting OSP from kubermatic namespace should delete it from the cluster namespace",
+			existingClusters: []*kubermaticv1.Cluster{
+				genCluster("cluster-1", true),
+			},
+			namespacedName: types.NamespacedName{Name: "osp", Namespace: "kubermatic"},
+			existingOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", true, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-1", "v1.0.0", false, false),
+			},
+			expectedOperatingSystemProfiles: nil,
+		},
+		{
+			name: "scenario 4: deleting OSP from kubermatic namespace should delete it from multiple user cluster namespaces",
+			existingClusters: []*kubermaticv1.Cluster{
+				genCluster("cluster-1", true),
+				genCluster("cluster-2", true),
+				genCluster("cluster-3", true),
+				genCluster("cluster-4", false),
+			},
+			namespacedName: types.NamespacedName{Name: "osp", Namespace: "kubermatic"},
+			existingOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", true, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-1", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-2", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-3", "v1.0.0", false, false),
+			},
+			expectedOperatingSystemProfiles: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var (
+				obj []ctrlruntimeclient.Object
+				err error
+			)
+
+			for _, c := range tc.existingClusters {
+				obj = append(obj, c)
+			}
+
+			for _, c := range tc.existingOperatingSystemProfiles {
+				obj = append(obj, c)
+			}
+
+			seedClient := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(obj...).
+				Build()
+
+			r := &Reconciler{
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				recorder:                &record.FakeRecorder{},
+				seedClient:              seedClient,
+				namespace:               "kubermatic",
+			}
+
+			request := reconcile.Request{NamespacedName: tc.namespacedName}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			ospList := &osmv1alpha1.OperatingSystemProfileList{}
+			err = seedClient.List(context.Background(), ospList)
+			if err != nil {
+				t.Fatalf("failed to list operatingSystemProfiles: %v", err)
+			}
+
+			if len(ospList.Items) != len(tc.expectedOperatingSystemProfiles) {
+				t.Fatalf("expected count %d differs from the observed count %d for operatingSystemProfiles", len(tc.expectedOperatingSystemProfiles), len(ospList.Items))
+			}
+
+			for _, observedOSP := range ospList.Items {
+				for _, expectedOSP := range tc.expectedOperatingSystemProfiles {
+					if expectedOSP.Name == observedOSP.Name && expectedOSP.Namespace == observedOSP.Namespace {
+						if !diff.SemanticallyEqual(expectedOSP.Spec, observedOSP.Spec) {
+							t.Fatalf("Objects differ:\n%v", diff.ObjectDiff(expectedOSP.Spec, observedOSP.Spec))
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileForUpdate(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	testCases := []struct {
+		name                            string
+		namespacedName                  types.NamespacedName
+		updatedVersion                  *string
+		existingClusters                []*kubermaticv1.Cluster
+		existingOperatingSystemProfile  *osmv1alpha1.OperatingSystemProfile
+		expectedOperatingSystemProfiles []*osmv1alpha1.OperatingSystemProfile
+	}{
+		{
+			name: "scenario 1: updating custom OSP should update OSPs in user clusters",
+			existingClusters: []*kubermaticv1.Cluster{
+				genCluster("cluster-1", true),
+				genCluster("cluster-2", true),
+				genCluster("cluster-3", true),
+			},
+			namespacedName:                 types.NamespacedName{Name: "osp", Namespace: "kubermatic"},
+			updatedVersion:                 pointer.String("v1.2.3"),
+			existingOperatingSystemProfile: getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, false),
+			expectedOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.2.3", false, true),
+				getOperatingSystemProfile("osp", "cluster-cluster-1", "v1.2.3", false, true),
+				getOperatingSystemProfile("osp", "cluster-cluster-2", "v1.2.3", false, true),
+				getOperatingSystemProfile("osp", "cluster-cluster-3", "v1.2.3", false, true),
+			},
+		},
+		{
+			name: "scenario 2: updating custom OSP without version update should result in no update",
+			existingClusters: []*kubermaticv1.Cluster{
+				genCluster("cluster-1", true),
+				genCluster("cluster-2", true),
+				genCluster("cluster-3", true),
+			},
+			namespacedName:                 types.NamespacedName{Name: "osp", Namespace: "kubermatic"},
+			existingOperatingSystemProfile: getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, false),
+			expectedOperatingSystemProfiles: []*osmv1alpha1.OperatingSystemProfile{
+				getOperatingSystemProfile("osp", "kubermatic", "v1.0.0", false, true),
+				getOperatingSystemProfile("osp", "cluster-cluster-1", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-2", "v1.0.0", false, false),
+				getOperatingSystemProfile("osp", "cluster-cluster-3", "v1.0.0", false, false),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var (
+				obj []ctrlruntimeclient.Object
+				err error
+			)
+
+			for _, c := range tc.existingClusters {
+				obj = append(obj, c)
+			}
+
+			obj = append(obj, tc.existingOperatingSystemProfile)
+
+			seedClient := fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(obj...).
+				Build()
+
+			r := &Reconciler{
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				recorder:                &record.FakeRecorder{},
+				seedClient:              seedClient,
+				namespace:               "kubermatic",
+			}
+
+			request := reconcile.Request{NamespacedName: tc.namespacedName}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			osp := &osmv1alpha1.OperatingSystemProfile{}
+			err = seedClient.Get(context.Background(), tc.namespacedName, osp)
+			if err != nil {
+				t.Fatalf("failed to get operatingSystemProfile: %v", err)
+			}
+
+			osp.Spec.OSVersion = "2.0"
+			if tc.updatedVersion != nil {
+				osp.Spec.Version = *tc.updatedVersion
+			}
+
+			err = seedClient.Update(context.Background(), osp)
+			if err != nil {
+				t.Fatalf("failed to update operatingSystemProfile: %v", err)
+			}
+
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			ospList := &osmv1alpha1.OperatingSystemProfileList{}
+			err = seedClient.List(context.Background(), ospList)
+			if err != nil {
+				t.Fatalf("failed to list operatingSystemProfiles: %v", err)
+			}
+
+			if len(ospList.Items) != len(tc.expectedOperatingSystemProfiles) {
+				t.Fatalf("expected count %d differs from the observed count %d for operatingSystemProfiles", len(tc.expectedOperatingSystemProfiles), len(ospList.Items))
+			}
+
+			for _, observedOSP := range ospList.Items {
+				for _, expectedOSP := range tc.expectedOperatingSystemProfiles {
+					if expectedOSP.Name == observedOSP.Name && expectedOSP.Namespace == observedOSP.Namespace {
+						if !diff.SemanticallyEqual(expectedOSP.Spec, observedOSP.Spec) {
+							t.Fatalf("Objects differ:\n%v", diff.ObjectDiff(expectedOSP.Spec, observedOSP.Spec))
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func genCluster(name string, osmEnabled bool) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			EnableOperatingSystemManager: osmEnabled,
+			HumanReadableName:            name,
+		},
+		Status: kubermaticv1.ClusterStatus{
+			NamespaceName: kubernetes.NamespaceName(name),
+			ExtendedHealth: kubermaticv1.ExtendedClusterHealth{
+				Etcd:       kubermaticv1.HealthStatusUp,
+				Apiserver:  kubermaticv1.HealthStatusUp,
+				Controller: kubermaticv1.HealthStatusUp,
+				Scheduler:  kubermaticv1.HealthStatusUp,
+			},
+		},
+	}
+}
+
+func getOperatingSystemProfile(name string, namespace string, version string, markedForDeletion bool, update bool) *osmv1alpha1.OperatingSystemProfile {
+	var (
+		deletionTimestamp *metav1.Time
+		finalizers        []string
+	)
+	if markedForDeletion {
+		deletionTimestamp = &metav1.Time{Time: time.Now()}
+		finalizers = []string{cleanupFinalizer}
+	}
+
+	osVersion := "1.0"
+	if update {
+		osVersion = "2.0"
+	}
+
+	return &osmv1alpha1.OperatingSystemProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			DeletionTimestamp: deletionTimestamp,
+			Finalizers:        finalizers,
+		},
+		Spec: osmv1alpha1.OperatingSystemProfileSpec{
+			OSName:    "ubuntu",
+			OSVersion: osVersion,
+			Version:   version,
+			SupportedCloudProviders: []osmv1alpha1.CloudProviderSpec{
+				{
+					Name: "aws",
+				},
+			},
+			ProvisioningConfig: osmv1alpha1.OSPConfig{
+				SupportedContainerRuntimes: []osmv1alpha1.ContainerRuntimeSpec{
+					{
+						Name: "containerd",
+					},
+				},
+				Files: []osmv1alpha1.File{
+					{
+						Path: "/etc/systemd/journald.conf.d/max_disk_use.conf",
+						Content: osmv1alpha1.FileContent{
+							Inline: &osmv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data:     "test",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/doc.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package operatingsystemprofilesynchronizer contains a controller that is responsible for ensuring that
+OperatingSystemProfiles are synced from the seed namespace to the user cluster namespace.
+*/
+package operatingsystemprofilesynchronizer


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
We consider the seed namespace as the place where all the custom OperatingSystemProfiles should be installed. This PR introduces a new controller that will synchronize those OSPs to the user-cluster namespaces.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
