### PR TITLE
bring back support for 1.22.5 to allow for smooth KKP upgrades

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -516,6 +516,7 @@ spec:
         to: 1.24.*
     # Versions lists the available versions.
     versions:
+      - v1.22.5
       - v1.22.9
       - v1.22.12
       - v1.23.6

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -214,6 +214,7 @@ var (
 		Default: semver.NewSemverOrDie("v1.23.9"),
 		Versions: []semver.Semver{
 			// Kubernetes 1.22
+			newSemver("v1.22.5"),
 			newSemver("v1.22.9"),
 			newSemver("v1.22.12"),
 			// Kubernetes 1.23


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Removing support for a single patch release would just cause trouble during upgrades, so we should not just remove it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
