### PR TITLE
allow to not specify --config when upgrading KKP

### DIFF
--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -295,6 +295,15 @@ func (*MasterStack) InstallKubermaticCRDs(ctx context.Context, client ctrlruntim
 }
 
 func applyKubermaticConfiguration(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, opt stack.DeployOptions) error {
+	// if no --config was given, no opt.RawKubermaticConfiguration is set and we
+	// auto-detected the configuration; in this case we do not want to update
+	// the config in the cluster (which would be bad because an auto-detected
+	// KubermaticConfiguration is also defaulted and we do not want to persist
+	// the defaulted values).
+	if opt.RawKubermaticConfiguration == nil {
+		return nil
+	}
+
 	logger.Info("📝 Applying Kubermatic Configuration…")
 
 	existingConfig := &kubermaticv1.KubermaticConfiguration{}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This makes the installer easier to use during upgrades. The config already exists in the cluster anyway, so we can just load it from there instead of forcing the admins to have it handy all the time. We could even do this for the Helm values, but one step at a time. :grin: 

**Does this PR introduce a user-facing change?**:
```release-note
When updating an existing KKP installation, `--config` must not be specified for the kubermatic-installer. Instead the current configuration is loaded from the KKP master cluster.
```
