### PR TITLE
Fix finalizers getting overwritten by cloud & cluster credentials controller

### DIFF
--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -273,7 +273,7 @@ func (r *Reconciler) migrateICMP(ctx context.Context, log *zap.SugaredLogger, cl
 	return nil
 }
 
-func (r *Reconciler) clusterUpdater(ctx context.Context, name string, modify func(*kubermaticv1.Cluster), options ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+func (r *Reconciler) clusterUpdater(ctx context.Context, name string, modify func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: name}, cluster); err != nil {
 		return nil, err
@@ -289,15 +289,16 @@ func (r *Reconciler) clusterUpdater(ctx context.Context, name string, modify fun
 		return nil, errors.New("updateCluster must not change cluster status")
 	}
 
-	opts := (&provider.UpdaterOptions{}).Apply(options...)
-	var patch ctrlruntimeclient.Patch
-	if opts.OptimisticLock {
-		patch = ctrlruntimeclient.MergeFromWithOptions(oldCluster, ctrlruntimeclient.MergeFromWithOptimisticLock{})
-	} else {
-		patch = ctrlruntimeclient.MergeFrom(oldCluster)
+	// When finalizers were changed, we must force optimistic locking,
+	// as we do not exclusively own the metadata.finalizers field and do not
+	// want to risk overwriting other finalizers. Labels and annotations are
+	// maps and so not affected.
+	var opts []ctrlruntimeclient.MergeFromOption
+	if !reflect.DeepEqual(oldCluster.Finalizers, cluster.Finalizers) {
+		opts = append(opts, ctrlruntimeclient.MergeFromWithOptimisticLock{})
 	}
 
-	if err := r.Patch(ctx, cluster, patch); err != nil {
+	if err := r.Patch(ctx, cluster, ctrlruntimeclient.MergeFromWithOptions(oldCluster, opts...)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -94,6 +94,8 @@ func TryRemoveFinalizer(ctx context.Context, client ctrlruntimeclient.Client, ob
 			return err
 		}
 
+		original := obj.DeepCopyObject().(ctrlruntimeclient.Object)
+
 		// modify it
 		previous := sets.NewString(obj.GetFinalizers()...)
 		RemoveFinalizer(obj, finalizers...)
@@ -105,7 +107,7 @@ func TryRemoveFinalizer(ctx context.Context, client ctrlruntimeclient.Client, ob
 		}
 
 		// update the object
-		return client.Update(ctx, obj)
+		return client.Patch(ctx, obj, ctrlruntimeclient.MergeFromWithOptions(original, ctrlruntimeclient.MergeFromWithOptimisticLock{}))
 	})
 
 	if err != nil {
@@ -137,6 +139,8 @@ func TryAddFinalizer(ctx context.Context, client ctrlruntimeclient.Client, obj c
 			return nil
 		}
 
+		original := obj.DeepCopyObject().(ctrlruntimeclient.Object)
+
 		// modify it
 		previous := sets.NewString(obj.GetFinalizers()...)
 		AddFinalizer(obj, finalizers...)
@@ -148,7 +152,7 @@ func TryAddFinalizer(ctx context.Context, client ctrlruntimeclient.Client, obj c
 		}
 
 		// update the object
-		return client.Update(ctx, obj)
+		return client.Patch(ctx, obj, ctrlruntimeclient.MergeFromWithOptions(original, ctrlruntimeclient.MergeFromWithOptimisticLock{}))
 	})
 
 	if err != nil {

--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -74,7 +74,7 @@ func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {
 }
 
 func testClusterUpdater(cluster *kubermaticv1.Cluster) provider.ClusterUpdater {
-	return func(_ context.Context, clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+	return func(_ context.Context, clusterName string, patcher func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 		patcher(cluster)
 		return cluster, nil
 	}

--- a/pkg/provider/cloud/azure/utils_test.go
+++ b/pkg/provider/cloud/azure/utils_test.go
@@ -87,7 +87,7 @@ func makeCluster(name string, cloudSpec *kubermaticv1.AzureCloudSpec, credential
 }
 
 func testClusterUpdater(cluster *kubermaticv1.Cluster) provider.ClusterUpdater {
-	return func(_ context.Context, clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+	return func(_ context.Context, clusterName string, patcher func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 		patcher(cluster)
 		return cluster, nil
 	}

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -192,7 +192,7 @@ func ensureFinalizers(ctx context.Context, cluster *kubermaticv1.Cluster, finali
 	if len(finalizers) > 0 {
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kubernetes.AddFinalizer(cluster, finalizers...)
-		}, provider.UpdaterOptionOptimisticLock)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -487,7 +487,7 @@ func (os *Provider) CleanUpCloudProvider(ctx context.Context, cluster *kubermati
 			RouterCleanupFinalizer,
 			OldNetworkCleanupFinalizer,
 		)
-	}, provider.UpdaterOptionOptimisticLock)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -588,7 +588,7 @@ type fakeClusterUpdater struct {
 	c *kubermaticv1.Cluster
 }
 
-func (f *fakeClusterUpdater) update(_ context.Context, _ string, updateFn func(c *kubermaticv1.Cluster), _ ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+func (f *fakeClusterUpdater) update(_ context.Context, _ string, updateFn func(c *kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 	updateFn(f.c)
 	return f.c, nil
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -71,34 +71,8 @@ type ReconcilingCloudProvider interface {
 	ReconcileCluster(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
 }
 
-// UpdaterOption represent an option for the updater function.
-type UpdaterOption string
-
-const (
-	// UpdaterOptionOptimisticLock enables optimistic lock, to fail in case of
-	// potential conflict.
-	UpdaterOptionOptimisticLock UpdaterOption = "OptimisticLock"
-)
-
-// UpdaterOptions holds the options for the updater function.
-type UpdaterOptions struct {
-	OptimisticLock bool
-}
-
-func (c *UpdaterOptions) Apply(opts ...UpdaterOption) *UpdaterOptions {
-	for _, o := range opts {
-		switch o {
-		case UpdaterOptionOptimisticLock:
-			c.OptimisticLock = true
-		default:
-			panic(fmt.Sprintf("unrecognised cluster updater option: %s", o))
-		}
-	}
-	return c
-}
-
 // ClusterUpdater defines a function to persist an update to a cluster.
-type ClusterUpdater func(context.Context, string, func(*kubermaticv1.Cluster), ...UpdaterOption) (*kubermaticv1.Cluster, error)
+type ClusterUpdater func(context.Context, string, func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error)
 
 // ClusterListOptions allows to set filters that will be applied to filter the result.
 type ClusterListOptions struct {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Recently in #10359 I introduced a change where the AWS cloud provider would only cleanup if its finalizer is set. This was done to save on API calls, as during the cluster deletion the cloud controller might reconcile frequently.

This change has unearthed another problem: Sometimes the AWS cleanup finalizer got missing, leading to orphaned tags during e2e tests. We noticed once we ran into the max-tag limit for subnets multiple times a day.

This PR fixes that problem by changing the ClusterUpdater to use optimistic locking when finalizers are involved. Most providers forgot to specify the optimistic locking option, so I see this as prove that relying on the provider will lead to issues and and automatic selection is more reliable.

Additionally I changed the Try*Finalizer() functions to also use patching with optimistic locking, just as a minor optimizations now that I was sure how to properly handle finalizers with patches and since I saw that asserting `.DeepCopyObject().(ctrlruntimeclient.Object)` is not so uncommon.

The cloud provider part also affects 2.20. The credential secret stuff is 2.21+ only. So I expect a manual cherrypick.

**Does this PR introduce a user-facing change?**:
```release-note
Fix finalizers on clusters sometimes getting overwritten by the cloud controller or cluster-credentials controller.
```
