### PR TITLE
fix RELEASES_TO_TEST not being optional enough

### DIFF
--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -134,7 +134,7 @@ timeout -s 9 "${maxDuration}m" ./_build/conformance-tester $EXTRA_ARGS \
   -reports-root="$ARTIFACTS/conformance" \
   -log-directory="$ARTIFACTS/logs" \
   -create-oidc-token=true \
-  -releases="$RELEASES_TO_TEST" \
+  -releases="${RELEASES_TO_TEST:-}" \
   -providers=$provider \
   -node-ssh-pub-key="$E2E_SSH_PUBKEY" \
   -distributions="${DISTRIBUTIONS:-}" \


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This makes sure that jobs can run with an automatic version selection, as originally intended in #10500.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
