### PR TITLE
[release/v2.20] use optimistic locking when finalizers are involved (#10536)

### DIFF
--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -65,7 +65,7 @@ func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {
 }
 
 func testClusterUpdater(cluster *kubermaticv1.Cluster) provider.ClusterUpdater {
-	return func(clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+	return func(clusterName string, patcher func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 		patcher(cluster)
 		return cluster, nil
 	}

--- a/pkg/provider/cloud/azure/utils_test.go
+++ b/pkg/provider/cloud/azure/utils_test.go
@@ -85,7 +85,7 @@ func makeCluster(name string, cloudSpec *kubermaticv1.AzureCloudSpec, credential
 }
 
 func testClusterUpdater(cluster *kubermaticv1.Cluster) provider.ClusterUpdater {
-	return func(clusterName string, patcher func(*kubermaticv1.Cluster), opts ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+	return func(clusterName string, patcher func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 		patcher(cluster)
 		return cluster, nil
 	}

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -177,7 +177,7 @@ func ensureFinalizers(cluster *kubermaticv1.Cluster, finalizers []string, update
 	if len(finalizers) > 0 {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kubernetes.AddFinalizer(cluster, finalizers...)
-		}, provider.UpdaterOptionOptimisticLock)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -408,7 +408,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 			RouterCleanupFinalizer,
 			OldNetworkCleanupFinalizer,
 		)
-	}, provider.UpdaterOptionOptimisticLock)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -500,7 +500,7 @@ type fakeClusterUpdater struct {
 	c *kubermaticv1.Cluster
 }
 
-func (f *fakeClusterUpdater) update(_ string, updateFn func(c *kubermaticv1.Cluster), _ ...provider.UpdaterOption) (*kubermaticv1.Cluster, error) {
+func (f *fakeClusterUpdater) update(_ string, updateFn func(c *kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
 	updateFn(f.c)
 	return f.c, nil
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -68,34 +68,8 @@ type ReconcilingCloudProvider interface {
 	ReconcileCluster(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
 }
 
-// UpdaterOption represent an option for the updater function.
-type UpdaterOption string
-
-const (
-	// UpdaterOptionOptimisticLock enables optimistic lock, to fail in case of
-	// potential conflict.
-	UpdaterOptionOptimisticLock UpdaterOption = "OptimisticLock"
-)
-
-// UpdaterOptions holds the options for the updater function.
-type UpdaterOptions struct {
-	OptimisticLock bool
-}
-
-func (c *UpdaterOptions) Apply(opts ...UpdaterOption) *UpdaterOptions {
-	for _, o := range opts {
-		switch o {
-		case UpdaterOptionOptimisticLock:
-			c.OptimisticLock = true
-		default:
-			panic(fmt.Sprintf("unrecognised cluster updater option: %s", o))
-		}
-	}
-	return c
-}
-
 // ClusterUpdater defines a function to persist an update to a cluster.
-type ClusterUpdater func(string, func(*kubermaticv1.Cluster), ...UpdaterOption) (*kubermaticv1.Cluster, error)
+type ClusterUpdater func(string, func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error)
 
 // ClusterListOptions allows to set filters that will be applied to filter the result.
 type ClusterListOptions struct {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a manual cherrypick of #10536.

**Does this PR introduce a user-facing change?**:
```release-note
Fix finalizers on clusters sometimes getting overwritten by the cloud controller.
```
