### PR TITLE
[release/v2.20] Freeze kubermatic/mla commit to v0.2.2

### DIFF
--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -28,6 +28,9 @@ source hack/lib.sh
 
 URL="https://github.com/kubermatic/mla.git"
 
+# Frozen for KKP v2.20.x
+REF="v0.2.2"
+
 # Ensure Github's host key is available and disable IP checking.
 # ensure_github_host_pubkey
 
@@ -35,7 +38,7 @@ echodate "Cloning MLA repo"
 # clone the target and pick the right branch
 tempdir="$(mktemp -d)"
 trap "rm -rf '$tempdir'" EXIT
-git clone "$URL" "$tempdir"
+git clone --branch "$REF" "$URL" "$tempdir"
 (
   cd "$tempdir"
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
kubermatic/mla has been changed in ci non-backwards-compatible-way. This freezes on the last working release of mla.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
