### PR TITLE
Add ApiserverIsRunning wrapper to the usercluster-webhook

### DIFF
--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -96,8 +99,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -109,4 +125,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -96,8 +99,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -109,4 +125,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -96,8 +99,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -109,4 +125,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:
@@ -102,8 +105,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -115,4 +131,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:
@@ -102,8 +105,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -115,4 +131,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:
@@ -102,8 +105,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -115,4 +131,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:
@@ -102,8 +105,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -115,4 +131,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:
@@ -102,8 +105,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -115,4 +131,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:
@@ -102,8 +105,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -115,4 +131,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: HTTP_PROXY
           value: http://my-corp
@@ -82,8 +85,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -95,4 +111,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: HTTP_PROXY
           value: http://my-corp
@@ -82,8 +85,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -95,4 +111,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: HTTP_PROXY
           value: http://my-corp
@@ -82,8 +85,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -95,4 +111,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           valueFrom:
@@ -87,8 +90,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -100,4 +116,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           valueFrom:
@@ -87,8 +90,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -100,4 +116,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           valueFrom:
@@ -87,8 +90,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -100,4 +116,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -123,8 +126,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -136,4 +152,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -123,8 +126,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -136,4 +152,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -123,8 +126,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -136,4 +152,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -123,8 +126,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -136,4 +152,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -123,8 +126,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -136,4 +152,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -123,8 +126,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -136,4 +152,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -94,8 +97,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -107,4 +123,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -94,8 +97,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -107,4 +123,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -94,8 +97,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -107,4 +123,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -94,8 +97,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -107,4 +123,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -94,8 +97,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -107,4 +123,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
@@ -21,16 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -webhook-cert-dir=/opt/webhook-serving-cert/
-        - -webhook-cert-name=serving.crt
-        - -webhook-key-name=serving.key
-        - -ca-bundle=/opt/ca-bundle/ca-bundle.pem
-        - -project-id=my-project
-        - -v=2
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
-        - user-cluster-webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -94,8 +97,21 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert
@@ -107,4 +123,6 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This prevents the webhook from going into CrashLoops while the cluster is being created.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
