### PR TITLE
Fix empty response for missing resource quota for a particular project

### DIFF
--- a/pkg/ee/resource-quota/handler.go
+++ b/pkg/ee/resource-quota/handler.go
@@ -195,6 +195,11 @@ func GetResourceQuotaForProject(ctx context.Context, request interface{}, projec
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
+	if projectResourceQuota == nil {
+		// ResourceQuota not found. Return an empty response.
+		return nil, nil
+	}
+
 	return convertToAPIStruct(projectResourceQuota, kubermaticProject.Spec.Name), nil
 }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This change fixes controller crush caused by passing `nil` to the convert function.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
