### PR TITLE
Applications: helms support registry with autentification

### DIFF
--- a/pkg/applications/helmclient/testdata/examplechart2/.helmignore
+++ b/pkg/applications/helmclient/testdata/examplechart2/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/pkg/applications/helmclient/testdata/examplechart2/Chart.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart2/Chart.yaml
@@ -1,0 +1,17 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: examplechart2
+version: 0.1.0

--- a/pkg/applications/helmclient/testdata/examplechart2/templates/configmap.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart2/templates/configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testcm-2
+  labels:
+{{ if .Values.versionLabel }}
+    versionLabel: {{ .Values.versionLabel | quote}}
+{{ end }}
+data:
+{{ if .Values.cmData }}
+{{ toYaml .Values.cmData | nindent 2 }}
+{{ end }}

--- a/pkg/applications/helmclient/testdata/examplechart2/values.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart2/values.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for examplechart.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+cmData:
+  foo: bar
+
+versionLabel: "1.0"

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -64,7 +64,7 @@ func (a *ApplicationManager) GetAppCache() string {
 
 // DonwloadSource the application's source using the appropriate provider into downloadDest and returns the full path to the sources.
 func (a *ApplicationManager) DonwloadSource(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation, downloadDest string) (string, error) {
-	sourceProvider, err := providers.NewSourceProvider(ctx, log, seedClient, a.Kubeconfig, a.ApplicationCache, applicationInstallation, &applicationInstallation.Status.ApplicationVersion.Template.Source, a.SecretNamespace)
+	sourceProvider, err := providers.NewSourceProvider(ctx, log, seedClient, a.Kubeconfig, a.ApplicationCache, &applicationInstallation.Status.ApplicationVersion.Template.Source, a.SecretNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize source provider: %w", err)
 	}
@@ -79,7 +79,7 @@ func (a *ApplicationManager) DonwloadSource(ctx context.Context, log *zap.Sugare
 
 // Apply creates the namespace where the application will be installed (if necessary) and installs the application.
 func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, applicationInstallation.Status.Method)
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
@@ -93,7 +93,7 @@ func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, 
 
 // Delete uninstalls the application where the application was installed if necessary.
 func (a *ApplicationManager) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, applicationInstallation.Status.Method)
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize template provider: %w", err)
 	}

--- a/pkg/applications/providers/source/git.go
+++ b/pkg/applications/providers/source/git.go
@@ -39,8 +39,8 @@ import (
 type GitSource struct {
 	Ctx context.Context
 
-	// Client to seed cluster.
-	Client ctrlruntimeclient.Client
+	// SeedClient to seed cluster.
+	SeedClient ctrlruntimeclient.Client
 
 	Source *appskubermaticv1.GitSource
 
@@ -112,7 +112,7 @@ func (g GitSource) authFromCredentials() (gogittransport.AuthMethod, error) {
 
 func (g GitSource) getCredentialFromSecret(name string, key string) (string, error) {
 	secret := &corev1.Secret{}
-	if err := g.Client.Get(g.Ctx, types.NamespacedName{Namespace: g.SecretNamespace, Name: name}, secret); err != nil {
+	if err := g.SeedClient.Get(g.Ctx, types.NamespacedName{Namespace: g.SecretNamespace, Name: name}, secret); err != nil {
 		return "", fmt.Errorf("failed to get git credential: %w", err)
 	}
 

--- a/pkg/applications/providers/source/git.go
+++ b/pkg/applications/providers/source/git.go
@@ -29,9 +29,8 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/applications/providers/util"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -71,12 +70,12 @@ func (g GitSource) authFromCredentials() (gogittransport.AuthMethod, error) {
 	if credentials != nil {
 		switch credentials.Method {
 		case appskubermaticv1.GitAuthMethodPassword:
-			username, err := g.getCredentialFromSecret(credentials.Username.Name, credentials.Username.Key)
+			username, err := util.GetCredentialFromSecret(g.Ctx, g.SeedClient, g.SecretNamespace, credentials.Username.Name, credentials.Username.Key)
 			if err != nil {
 				return nil, err
 			}
 
-			password, err := g.getCredentialFromSecret(credentials.Password.Name, credentials.Password.Key)
+			password, err := util.GetCredentialFromSecret(g.Ctx, g.SeedClient, g.SecretNamespace, credentials.Password.Name, credentials.Password.Key)
 			if err != nil {
 				return nil, err
 			}
@@ -84,14 +83,14 @@ func (g GitSource) authFromCredentials() (gogittransport.AuthMethod, error) {
 			auth = &gogithttp.BasicAuth{Username: username, Password: password}
 
 		case appskubermaticv1.GitAuthMethodToken:
-			token, err := g.getCredentialFromSecret(credentials.Token.Name, credentials.Token.Key)
+			token, err := util.GetCredentialFromSecret(g.Ctx, g.SeedClient, g.SecretNamespace, credentials.Token.Name, credentials.Token.Key)
 			if err != nil {
 				return nil, err
 			}
 
 			auth = &gogithttp.TokenAuth{Token: token}
 		case appskubermaticv1.GitAuthMethodSSHKey:
-			privateKey, err := g.getCredentialFromSecret(credentials.SSHKey.Name, credentials.SSHKey.Key)
+			privateKey, err := util.GetCredentialFromSecret(g.Ctx, g.SeedClient, g.SecretNamespace, credentials.SSHKey.Name, credentials.SSHKey.Key)
 			if err != nil {
 				return nil, err
 			}
@@ -108,19 +107,6 @@ func (g GitSource) authFromCredentials() (gogittransport.AuthMethod, error) {
 		}
 	}
 	return auth, nil
-}
-
-func (g GitSource) getCredentialFromSecret(name string, key string) (string, error) {
-	secret := &corev1.Secret{}
-	if err := g.SeedClient.Get(g.Ctx, types.NamespacedName{Namespace: g.SecretNamespace, Name: name}, secret); err != nil {
-		return "", fmt.Errorf("failed to get git credential: %w", err)
-	}
-
-	cred, found := secret.Data[key]
-	if !found {
-		return "", fmt.Errorf("key '%s' does not exist in secret '%s'", key, fmt.Sprintf("%s/%s", secret.GetNamespace(), secret.GetName()))
-	}
-	return string(cred), nil
 }
 
 // getCheckoutStrategy returns the checkoutFunc according to the GitSource.

--- a/pkg/applications/providers/source/git_test.go
+++ b/pkg/applications/providers/source/git_test.go
@@ -351,7 +351,7 @@ func TestDownloadGitSource(t *testing.T) {
 
 			source := GitSource{
 				Ctx:             context.Background(),
-				Client:          tc.client,
+				SeedClient:      tc.client,
 				Source:          tc.source,
 				SecretNamespace: "kubermatic",
 			}

--- a/pkg/applications/providers/template/helm_integration_test.go
+++ b/pkg/applications/providers/template/helm_integration_test.go
@@ -83,6 +83,21 @@ var _ = Describe("helm template", func() {
 				},
 				Values: runtime.RawExtension{},
 			},
+			Status: appskubermaticv1.ApplicationInstallationStatus{
+				Method: appskubermaticv1.HelmTemplateMethod,
+				ApplicationVersion: &appskubermaticv1.ApplicationVersion{
+					Version: "0.1.0",
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
+								URL:          "localhost",
+								ChartName:    "example",
+								ChartVersion: "0.1.0",
+							},
+						},
+					},
+				},
+			},
 		}
 	})
 
@@ -100,6 +115,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err := template.InstallOrUpgrade(chartLoc, app)
@@ -135,6 +152,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err := template.InstallOrUpgrade(chartLoc, app)
@@ -171,6 +190,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err := template.InstallOrUpgrade(chartLoc, app)
@@ -205,6 +226,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err := template.InstallOrUpgrade(chartLoc, app)
@@ -236,6 +259,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err = template.InstallOrUpgrade(chartLoc, app)
@@ -268,6 +293,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err := template.InstallOrUpgrade(chartLoc, app)
@@ -297,6 +324,8 @@ var _ = Describe("helm template", func() {
 				CacheDir:                helmCacheDir,
 				Log:                     kubermaticlog.Logger,
 				ApplicationInstallation: app,
+				SecretNamespace:         "abc",
+				SeedClient:              userClient,
 			}
 
 			statusUpdater, err = template.Uninstall(app)

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -43,7 +43,7 @@ type SourceProvider interface {
 func NewSourceProvider(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubeconfig string, cacheDir string, appSource *appskubermaticv1.ApplicationSource, secretNamespace string) (SourceProvider, error) {
 	switch {
 	case appSource.Helm != nil:
-		return source.HelmSource{Ctx: ctx, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, Source: appSource.Helm}, nil
+		return source.HelmSource{Ctx: ctx, SeedClient: client, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, Source: appSource.Helm, SecretNamespace: secretNamespace}, nil
 	case appSource.Git != nil:
 		return source.GitSource{Ctx: ctx, SeedClient: client, Source: appSource.Git, SecretNamespace: secretNamespace}, nil
 	default: // This should not happen. The admission webhook prevents that.
@@ -62,11 +62,11 @@ type TemplateProvider interface {
 }
 
 // NewTemplateProvider return the concrete implementation of TemplateProvider according to the templateMethod.
-func NewTemplateProvider(ctx context.Context, kubeconfig string, cacheDir string, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation, templateMethod appskubermaticv1.TemplateMethod) (TemplateProvider, error) {
-	switch templateMethod {
+func NewTemplateProvider(ctx context.Context, seedClient ctrlruntimeclient.Client, kubeconfig string, cacheDir string, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation, secretNamespace string) (TemplateProvider, error) {
+	switch appInstallation.Status.Method {
 	case appskubermaticv1.HelmTemplateMethod:
-		return template.HelmTemplate{Ctx: ctx, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, ApplicationInstallation: appInstallation}, nil
+		return template.HelmTemplate{Ctx: ctx, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, ApplicationInstallation: appInstallation, SecretNamespace: secretNamespace, SeedClient: seedClient}, nil
 	default:
-		return nil, fmt.Errorf("template method '%v' not implemented", templateMethod)
+		return nil, fmt.Errorf("template method '%v' not implemented", appInstallation.Status.Method)
 	}
 }

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -40,12 +40,12 @@ type SourceProvider interface {
 }
 
 // NewSourceProvider returns the concrete implementation of SourceProvider according to source defined in appSource.
-func NewSourceProvider(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubeconfig string, cacheDir string, appInstallation *appskubermaticv1.ApplicationInstallation, appSource *appskubermaticv1.ApplicationSource, secretNamespace string) (SourceProvider, error) {
+func NewSourceProvider(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubeconfig string, cacheDir string, appSource *appskubermaticv1.ApplicationSource, secretNamespace string) (SourceProvider, error) {
 	switch {
 	case appSource.Helm != nil:
 		return source.HelmSource{Ctx: ctx, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, Source: appSource.Helm}, nil
 	case appSource.Git != nil:
-		return source.GitSource{Ctx: ctx, Client: client, Source: appSource.Git, SecretNamespace: secretNamespace}, nil
+		return source.GitSource{Ctx: ctx, SeedClient: client, Source: appSource.Git, SecretNamespace: secretNamespace}, nil
 	default: // This should not happen. The admission webhook prevents that.
 		return nil, errors.New("no source found")
 	}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds support for Helm registry with authentication. There is 2 kinds of auth method:

- basic (user /password) for HTTP repository
- registryConfigFile for oci repository ( registryConfigFile is a dockercfg file that follows the same format rules as ~/.docker/config.json)

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #9550 
Fixes #9776

**Special notes for your reviewer**:
I recommend a first review by commit because some commits are just refactoring.

Test of HelmTemplate could be improved with authentification tests. But I think I would be better to do it in another PR, it would be the opportunity to switch from ginko to go test

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
