### PR TITLE
API: allow updates for EnableOperatingSystemManager and KubernetesDashboard

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -28234,7 +28234,7 @@
       "title": "KubernetesDashboard contains settings for the kubernetes-dashboard component as part of the cluster control plane.",
       "properties": {
         "enabled": {
-          "description": "Controls whether kubernetes-dashboard is deployed to the user cluster or not.",
+          "description": "Controls whether kubernetes-dashboard is deployed to the user cluster or not.\nEnabled by default.",
           "type": "boolean",
           "x-go-name": "Enabled"
         }

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -280,9 +280,8 @@ func (c ClusterSpec) IsOperatingSystemManagerEnabled() bool {
 
 // KubernetesDashboard contains settings for the kubernetes-dashboard component as part of the cluster control plane.
 type KubernetesDashboard struct {
-	// +kubebuilder:default=true
-
 	// Controls whether kubernetes-dashboard is deployed to the user cluster or not.
+	// Enabled by default.
 	Enabled bool `json:"enabled,omitempty"`
 }
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -2067,9 +2067,8 @@ spec:
                   component.
                 properties:
                   enabled:
-                    default: true
                     description: Controls whether kubernetes-dashboard is deployed
-                      to the user cluster or not.
+                      to the user cluster or not. Enabled by default.
                     type: boolean
                 type: object
               machineNetworks:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -2035,9 +2035,8 @@ spec:
                   component.
                 properties:
                   enabled:
-                    default: true
                     description: Controls whether kubernetes-dashboard is deployed
-                      to the user cluster or not.
+                      to the user cluster or not. Enabled by default.
                     type: boolean
                 type: object
               machineNetworks:

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -540,6 +540,8 @@ func PatchEndpoint(
 	newInternalCluster.Spec.ContainerRuntime = patchedCluster.Spec.ContainerRuntime
 	newInternalCluster.Spec.ClusterNetwork.KonnectivityEnabled = patchedCluster.Spec.ClusterNetwork.KonnectivityEnabled
 	newInternalCluster.Spec.CNIPlugin = patchedCluster.Spec.CNIPlugin
+	newInternalCluster.Spec.EnableOperatingSystemManager = patchedCluster.Spec.EnableOperatingSystemManager
+	newInternalCluster.Spec.KubernetesDashboard = patchedCluster.Spec.KubernetesDashboard
 
 	incompatibleKubelets, err := common.CheckClusterVersionSkew(ctx, userInfoGetter, clusterProvider, newInternalCluster, projectID)
 	if err != nil {

--- a/pkg/test/e2e/utils/apiclient/models/kubernetes_dashboard.go
+++ b/pkg/test/e2e/utils/apiclient/models/kubernetes_dashboard.go
@@ -18,6 +18,7 @@ import (
 type KubernetesDashboard struct {
 
 	// Controls whether kubernetes-dashboard is deployed to the user cluster or not.
+	// Enabled by default.
 	Enabled bool `json:"enabled,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
Allows updates for EnableOperatingSystemManager and KubernetesDashboard via API endpoint to patch cluster.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
