### PR TITLE
Group alertmanager support

### DIFF
--- a/cmd/alertmanager-authorization-server/main.go
+++ b/cmd/alertmanager-authorization-server/main.go
@@ -184,16 +184,14 @@ func (a *authorizationServer) authorize(ctx context.Context, userEmail, clusterI
 
 	// authorize through group project bindings
 	allGroupBindings := &kubermaticv1.GroupProjectBindingList{}
-	if err := a.client.List(ctx, allGroupBindings); err != nil {
+	if err := a.client.List(ctx, allGroupBindings, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID}); err != nil {
 		return false, fmt.Errorf("listing groupProjectBinding: %w", err)
 	}
 
 	groupSet := sets.NewString()
 	for _, gpb := range allGroupBindings.Items {
-		if gpb.Spec.ProjectID == projectID {
-			a.log.Debugf("found group project binding %q for project %q with group %q", gpb.Name, projectID, gpb.Spec.Group)
-			groupSet.Insert(gpb.Spec.Group)
-		}
+		a.log.Debugf("found group project binding %q for project %q with group %q", gpb.Name, projectID, gpb.Spec.Group)
+		groupSet.Insert(gpb.Spec.Group)
 	}
 
 	if groupSet.Len() == 0 {

--- a/cmd/alertmanager-authorization-server/main.go
+++ b/cmd/alertmanager-authorization-server/main.go
@@ -23,13 +23,14 @@ import (
 	"net"
 	"strings"
 
-	coreV3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-	typeV3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+
+	coreV3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	typeV3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/cmd/alertmanager-authorization-server/main_test.go
+++ b/cmd/alertmanager-authorization-server/main_test.go
@@ -90,6 +90,18 @@ func TestAuthorize(t *testing.T) {
 			expectedError:      false,
 			expectedAuthorized: true,
 		},
+		{
+			name:      "user is authorized to access alertmanager through group project bindings",
+			userEmail: "john@acme.com",
+			clusterID: test.DefaultClusterID,
+			existingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenDefaultCluster(),
+				test.GenUserWithGroups("user", "John", "john@acme.com", []string{"projectgroup"}),
+				test.GenGroupBinding(test.GenDefaultProject().Name, "projectgroup", "viewers"),
+			),
+			expectedError:      false,
+			expectedAuthorized: true,
+		},
 	}
 
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Adds support for GroupProjectBindings in MLA alertmanager authorization

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10572 


**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds support for GroupProjectBindings in alertmanager authorization server.
```
