### PR TITLE
Forbid users from disabling OSM after it has been enabled

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -235,6 +235,12 @@ func ValidateClusterUpdate(ctx context.Context, newCluster, oldCluster *kubermat
 		allErrs = append(allErrs, field.Invalid(path, *newCluster.Spec.EnableUserSSHKeyAgent, "UserSSHKey agent is enabled by default for user clusters created prior KKP 2.16 version"))
 	}
 
+	// OperatingSystemManager cannot be disabled once it's enabled.
+	if !newCluster.Spec.IsOperatingSystemManagerEnabled() && oldCluster.Spec.IsKubernetesDashboardEnabled() {
+		path := field.NewPath("cluster", "spec", "enableOperatingSystemManager")
+		allErrs = append(allErrs, field.Invalid(path, newCluster.Spec.IsOperatingSystemManagerEnabled(), "OperatingSystemManager cannot be disabled once it's enabled"))
+	}
+
 	allErrs = append(allErrs, validateClusterNetworkingConfigUpdateImmutability(&newCluster.Spec.ClusterNetwork, &oldCluster.Spec.ClusterNetwork, specPath.Child("clusterNetwork"))...)
 
 	// even though ErrorList later in ToAggregate() will filter out nil errors, it does so by


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
OSM is enabled by default for new clusters but existing clusters have to migrate to OSM manually. Due to this, we allow users to modify this field in the Cluster Spec so that they can enable OSM for existing clusters.

Although, disabling OSM after it has been enabled should never be allowed. Since machine deployments will have finalizers that will not get removed and the clusters will get stuck in deletion. Other resources,  created and managed by OSM like OSPs, OSCs, and secrets are not removed as well.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
