### PR TITLE
Inject BUILD_ID and test name into cluster names again

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -50,7 +50,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-ccm-migration-vsphere-e2e
     run_if_changed: "(pkg/provider/cloud/vsphere/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/|.prow/ccm-migrations.yaml)"
@@ -89,7 +89,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-ccm-migration-azure-e2e
     run_if_changed: "(addons/azure-cloud-node-manager/|pkg/provider/cloud/azure/|pkg/resources/cloudcontroller/|pkg/test/e2e/ccm-migration/|.prow/ccm-migrations.yaml)"
@@ -128,4 +128,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -433,4 +433,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -57,4 +57,4 @@ presubmits:
             memory: 4Gi
             cpu: 3.5
           limits:
-            memory: 4Gi
+            memory: 6Gi

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -53,7 +53,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-aws-ubuntu-1.23
     decorate: true
@@ -95,7 +95,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-aws-ubuntu-1.24
     decorate: true
@@ -137,7 +137,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
 
   - name: pre-kubermatic-e2e-aws-ubuntu-1.24-ce
@@ -182,7 +182,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-aws-ubuntu-1.24-headless
     decorate: true
@@ -226,6 +226,6 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
 

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -56,4 +56,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -55,4 +55,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -55,7 +55,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-gcp-ubuntu-1.24-psp
     decorate: true
@@ -102,7 +102,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-gcp-offline
     decorate: true
@@ -127,5 +127,5 @@ presubmits:
               memory: 2.5Gi
               cpu: 500m
             limits:
-              memory: 4Gi
+              memory: 6Gi
               cpu: 2

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -56,4 +56,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -54,7 +54,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-kubevirt-ubuntu-1.24
     decorate: true
@@ -97,4 +97,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -56,7 +56,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-nutanix-centos-1.24
     decorate: true
@@ -101,4 +101,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -56,7 +56,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-openstack-centos-1.24
     decorate: true
@@ -101,4 +101,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -54,4 +54,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -55,4 +55,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -55,7 +55,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.24-customfolder
     decorate: true
@@ -101,7 +101,7 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi
 
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.24-datastore-cluster
     decorate: true
@@ -147,4 +147,4 @@ presubmits:
               memory: 4Gi
               cpu: 3.5
             limits:
-              memory: 4Gi
+              memory: 6Gi

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -125,7 +125,7 @@ appendTrap copy_junit EXIT
 
 timeout -s 9 "${maxDuration}m" ./_build/conformance-tester $EXTRA_ARGS \
   -client="${SETUP_MODE:-api}" \
-  -name-prefix=prow-e2e \
+  -name-prefix="kkp-$BUILD_ID" \
   -kubeconfig=$KUBECONFIG \
   -kubermatic-seed-cluster="$SEED_NAME" \
   -kubermatic-endpoint="$KUBERMATIC_API_ENDPOINT" \

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -1154,11 +1154,12 @@ func (r *reconciler) ensureOPAExperimentalMutationWebhookIsRemoved(ctx context.C
 }
 
 func (r *reconciler) getCluster(ctx context.Context) (*kubermaticv1.Cluster, error) {
-	key := types.NamespacedName{Name: kubernetes.ClusterNameFromNamespace(r.namespace)}
-
-	cluster := &kubermaticv1.Cluster{}
-	if err := r.seedClient.Get(ctx, key, cluster); err != nil {
+	cluster, err := kubernetes.ClusterFromNamespace(ctx, r, r.namespace)
+	if err != nil {
 		return nil, err
+	}
+	if cluster == nil {
+		return nil, fmt.Errorf("no cluster exists for namespace %q", r.namespace)
 	}
 
 	return cluster, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -1154,7 +1154,7 @@ func (r *reconciler) ensureOPAExperimentalMutationWebhookIsRemoved(ctx context.C
 }
 
 func (r *reconciler) getCluster(ctx context.Context) (*kubermaticv1.Cluster, error) {
-	cluster, err := kubernetes.ClusterFromNamespace(ctx, r, r.namespace)
+	cluster, err := kubernetes.ClusterFromNamespace(ctx, r.seedClient, r.namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -163,6 +163,9 @@ func (cd *credentialsData) GetGlobalSecretKeySelectorValue(configVar *providerco
 	return cd.globalSecretKeySelectorValueFunc(configVar, key)
 }
 
+// GetCredentialsReference returns the CredentialsReference for the cluster's chosen
+// cloud provider (or nil if the provider is BYO). If an unknown provider is used, an
+// error is returned.
 func GetCredentialsReference(cluster *kubermaticv1.Cluster) (*providerconfig.GlobalSecretKeySelector, error) {
 	if cluster.Spec.Cloud.AWS != nil {
 		return cluster.Spec.Cloud.AWS.CredentialsReference, nil
@@ -202,6 +205,9 @@ func GetCredentialsReference(cluster *kubermaticv1.Cluster) (*providerconfig.Glo
 	}
 	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
 		return cluster.Spec.Cloud.VMwareCloudDirector.CredentialsReference, nil
+	}
+	if cluster.Spec.Cloud.BringYourOwn != nil {
+		return nil, nil
 	}
 
 	return nil, errors.New("cluster has no known cloud provider spec set")

--- a/pkg/resources/etcd/statefulset_test.go
+++ b/pkg/resources/etcd/statefulset_test.go
@@ -22,7 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	testhelper "k8c.io/kubermatic/v2/pkg/test"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -30,23 +33,34 @@ var update = flag.Bool("update", false, "update .golden files")
 func TestGetEtcdCommand(t *testing.T) {
 	tests := []struct {
 		name                  string
-		clusterName           string
-		clusterNamespace      string
+		cluster               *kubermaticv1.Cluster
 		enableCorruptionCheck bool
 		launcherEnabled       bool
 		expectedArgs          int
 	}{
 		{
-			name:             "with-launcher",
-			clusterName:      "62m9k9tqlm",
-			clusterNamespace: "cluster-62m9k9tqlm",
-			launcherEnabled:  true,
-			expectedArgs:     11,
+			name: "with-launcher",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "62m9k9tqlm",
+				},
+				Status: kubermaticv1.ClusterStatus{
+					NamespaceName: "cluster-62m9k9tqlm",
+				},
+			},
+			launcherEnabled: true,
+			expectedArgs:    11,
 		},
 		{
-			name:                  "with-corruption-flags",
-			clusterName:           "lg69pmx8wf",
-			clusterNamespace:      "cluster-lg69pmx8wf",
+			name: "with-corruption-flags",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "lg69pmx8wf",
+				},
+				Status: kubermaticv1.ClusterStatus{
+					NamespaceName: "cluster-lg69pmx8wf",
+				},
+			},
 			enableCorruptionCheck: true,
 			launcherEnabled:       false,
 			expectedArgs:          3,
@@ -55,7 +69,7 @@ func TestGetEtcdCommand(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			args, err := getEtcdCommand(test.clusterName, test.clusterNamespace, test.enableCorruptionCheck, test.launcherEnabled)
+			args, err := getEtcdCommand(test.cluster, test.enableCorruptionCheck, test.launcherEnabled)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/resources/etcd/testdata/etcd-command-with-launcher.golden.sh
+++ b/pkg/resources/etcd/testdata/etcd-command-with-launcher.golden.sh
@@ -1,1 +1,1 @@
-/opt/bin/etcd-launcher -namespace $(NAMESPACE) -pod-name $(POD_NAME) -pod-ip $(POD_IP) -api-version $(ETCDCTL_API) -token $(TOKEN)
+/opt/bin/etcd-launcher -cluster 62m9k9tqlm -pod-name $(POD_NAME) -pod-ip $(POD_IP) -api-version $(ETCDCTL_API) -token $(TOKEN)

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -444,6 +444,7 @@ func createUserCluster(
 	testJig := jig.NewAWSCluster(masterClient, log, accessKeyID, secretAccessKey, 2)
 	testJig.ProjectJig.WithHumanReadableName(projectName)
 	testJig.ClusterJig.
+		WithTestName("cilium").
 		WithAddons(jig.Addon{Name: "hubble"}).
 		WithProxyMode(proxyMode).
 		WithKonnectivity(true).

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -71,6 +71,7 @@ func TestBackup(t *testing.T) {
 
 	// create test environment
 	testJig := jig.NewBYOCluster(client, logger)
+	testJig.ClusterJig.WithTestName("etcd-backup")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForNothing)
 	defer testJig.Cleanup(ctx, t, false)
@@ -146,6 +147,7 @@ func TestScaling(t *testing.T) {
 
 	// create test environment
 	testJig := jig.NewBYOCluster(client, logger)
+	testJig.ClusterJig.WithTestName("etcd-scaling")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForNothing)
 	defer testJig.Cleanup(ctx, t, false)
@@ -194,6 +196,7 @@ func TestRecovery(t *testing.T) {
 
 	// create test environment
 	testJig := jig.NewBYOCluster(client, logger)
+	testJig.ClusterJig.WithTestName("etcd-recovery")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForNothing)
 	defer testJig.Cleanup(ctx, t, false)

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -56,6 +56,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 	// create test environment
 	testJig := jig.NewBYOCluster(seedClient, logger)
 	testJig.ClusterJig.
+		WithTestName("expose-strategy").
 		WithExposeStrategy(kubermaticv1.ExposeStrategyTunneling).
 		WithPatch(func(cs *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
 			cs.ComponentsOverride.Apiserver.EndpointReconcilingDisabled = pointer.Bool(true)

--- a/pkg/test/e2e/ipam/ipam_test.go
+++ b/pkg/test/e2e/ipam/ipam_test.go
@@ -64,7 +64,7 @@ func TestIPAM(t *testing.T) {
 	}
 
 	log.Info("Creating first user cluster...")
-	cluster1, userClient1, cleanupUserCluster1, err := createUserCluster(ctx, t, log, seedClient)
+	cluster1, userClient1, cleanupUserCluster1, err := createUserCluster(ctx, t, log, seedClient, "ipam1")
 	if err != nil {
 		t.Fatalf("failed to create user cluster: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestIPAM(t *testing.T) {
 	}
 
 	log.Info("Creating second user cluster...")
-	cluster2, userClient2, cleanupUserCluster2, err := createUserCluster(ctx, t, log, seedClient)
+	cluster2, userClient2, cleanupUserCluster2, err := createUserCluster(ctx, t, log, seedClient, "ipam2")
 	if err != nil {
 		t.Fatalf("failed to create user cluster: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestIPAM(t *testing.T) {
 	}
 
 	log.Info("Creating third user cluster...")
-	cluster3, userClient3, cleanupUserCluster3, err := createUserCluster(ctx, t, log, seedClient)
+	cluster3, userClient3, cleanupUserCluster3, err := createUserCluster(ctx, t, log, seedClient, "ipam3")
 	if err != nil {
 		t.Fatalf("failed to create user cluster: %v", err)
 	}
@@ -219,10 +219,12 @@ func createUserCluster(
 	t *testing.T,
 	log *zap.SugaredLogger,
 	seedClient ctrlruntimeclient.Client,
+	name string,
 ) (*kubermaticv1.Cluster, ctrlruntimeclient.Client, func(), error) {
 	testJig := jig.NewHetznerCluster(seedClient, log, 1)
 	testJig.ProjectJig.WithHumanReadableName("IPAM test")
 	testJig.ClusterJig.
+		WithTestName(name).
 		WithPreset(preset).
 		WithAddons(jig.Addon{
 			Name: "metallb",

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -78,7 +78,7 @@ func NewClusterJig(client ctrlruntimeclient.Client, log *zap.SugaredLogger) *Clu
 		ownerEmail: "e2e@test.kubermatic.com",
 		addons:     []Addon{},
 	}
-	
+
 	jig.WithTestName("e2e")
 
 	if version := ClusterVersion(log); version != "" {

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -52,6 +52,7 @@ type ClusterJig struct {
 	projectName  string
 	spec         *kubermaticv1.ClusterSpec
 	generateName string
+	desiredName  string
 	ownerEmail   string
 	labels       map[string]string
 	presetSecret string
@@ -69,15 +70,16 @@ type Addon struct {
 
 func NewClusterJig(client ctrlruntimeclient.Client, log *zap.SugaredLogger) *ClusterJig {
 	jig := &ClusterJig{
-		client:       client,
-		log:          log,
-		versions:     kubermatic.NewFakeVersions(),
-		spec:         &kubermaticv1.ClusterSpec{},
-		labels:       map[string]string{},
-		generateName: "e2e-",
-		ownerEmail:   "e2e@test.kubermatic.com",
-		addons:       []Addon{},
+		client:     client,
+		log:        log,
+		versions:   kubermatic.NewFakeVersions(),
+		spec:       &kubermaticv1.ClusterSpec{},
+		labels:     map[string]string{},
+		ownerEmail: "e2e@test.kubermatic.com",
+		addons:     []Addon{},
 	}
+	
+	jig.WithTestName("e2e")
 
 	if version := ClusterVersion(log); version != "" {
 		jig.WithVersion(version)
@@ -100,7 +102,20 @@ func (j *ClusterJig) WithExistingCluster(clusterName string) *ClusterJig {
 	return j
 }
 
+// WithTestName injects the test name into the cluster name. The name should
+// be less than 18 characters in length.
+func (j *ClusterJig) WithTestName(name string) *ClusterJig {
+	return j.WithName(fmt.Sprintf("kkp-%s-%s", name, BuildID()))
+}
+
+func (j *ClusterJig) WithName(name string) *ClusterJig {
+	j.desiredName = name
+	j.generateName = ""
+	return j
+}
+
 func (j *ClusterJig) WithGenerateName(prefix string) *ClusterJig {
+	j.desiredName = ""
 	j.generateName = prefix
 	return j
 }
@@ -270,6 +285,7 @@ func (j *ClusterJig) Create(ctx context.Context, waitForHealthy bool) (*kubermat
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: j.generateName,
+			Name:         j.desiredName,
 			Labels:       j.labels,
 		},
 		Spec: *j.spec,

--- a/pkg/test/e2e/jig/flags.go
+++ b/pkg/test/e2e/jig/flags.go
@@ -21,7 +21,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math/big"
 	"os"
+	"strconv"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -29,21 +32,53 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/defaults"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	kkpNamespace = "kubermatic"
+	buildID      string
 	datacenter   string
 	project      string
 	version      string
+
+	// once is for goroutine-safe defaulting of the build ID.
+	once = &sync.Once{}
 )
 
 func AddFlags(fs *flag.FlagSet) {
+	flag.StringVar(&buildID, "build-id", buildID, "unique identifier for this test (defaults to $BUILD_ID)")
 	flag.StringVar(&kkpNamespace, "namespace", kkpNamespace, "namespace where KKP is installed into")
 	flag.StringVar(&datacenter, "datacenter", datacenter, "KKP datacenter to use (must match whatever is used in the tests to run)")
 	flag.StringVar(&project, "project", project, "KKP project to use (if not given, a new project might be created)")
 	flag.StringVar(&version, "cluster-version", version, "Kubernetes version of the new user cluster (defaults to $VERSION_TO_TEST or the default version compiled into KKP)")
+}
+
+func BuildID() string {
+	once.Do(func() {
+		if buildID == "" {
+			buildID = os.Getenv("BUILD_ID")
+
+			// Space is precious in cluster names and the build ID
+			// is a super long 64 bit value (e.g. 1552957086332096512, or 19 digits).
+			// To give us more room without losing context, we convert from
+			// base 10 to base35 ([0-9a-z], i.e. lowercased alphanumeric)
+			// (resulting in "g2xnbutsi0sw", 12 characters).
+			if buildID != "" {
+				id, err := strconv.ParseInt(buildID, 10, 64)
+				if err == nil {
+					buildID = big.NewInt(id).Text(35)
+				}
+			}
+		}
+
+		if buildID == "" {
+			buildID = rand.String(8)
+		}
+	})
+
+	return buildID
 }
 
 func KubermaticNamespace() string {

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -100,7 +100,6 @@ func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, acce
 	projectJig := NewProjectJig(client, log)
 
 	clusterJig := NewClusterJig(client, log).
-		WithGenerateName("e2e-").
 		WithHumanReadableName("e2e test cluster").
 		WithSSHKeyAgent(false).
 		WithCloudSpec(&kubermaticv1.CloudSpec{
@@ -128,7 +127,6 @@ func NewHetznerCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, 
 	projectJig := NewProjectJig(client, log)
 
 	clusterJig := NewClusterJig(client, log).
-		WithGenerateName("e2e-").
 		WithHumanReadableName("e2e test cluster").
 		WithSSHKeyAgent(false).
 		WithCloudSpec(&kubermaticv1.CloudSpec{
@@ -153,7 +151,6 @@ func NewBYOCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger) *Tes
 	projectJig := NewProjectJig(client, log)
 
 	clusterJig := NewClusterJig(client, log).
-		WithGenerateName("e2e-").
 		WithHumanReadableName("e2e test cluster").
 		WithSSHKeyAgent(false).
 		WithCloudSpec(&kubermaticv1.CloudSpec{

--- a/pkg/test/e2e/konnectivity/konnectivity_test.go
+++ b/pkg/test/e2e/konnectivity/konnectivity_test.go
@@ -339,7 +339,7 @@ func createUserCluster(
 ) (*kubermaticv1.Cluster, ctrlruntimeclient.Client, *rest.Config, func(), *zap.SugaredLogger, error) {
 	testJig := jig.NewAWSCluster(masterClient, log, accessKeyID, secretAccessKey, 1)
 	testJig.ProjectJig.WithHumanReadableName(projectName)
-	testJig.ClusterJig.WithKonnectivity(true)
+	testJig.ClusterJig.WithKonnectivity(true).WithTestName("konnectivity")
 
 	cleanup := func() {
 		testJig.Cleanup(ctx, t, true)

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -89,7 +89,7 @@ func TestMLAIntegration(t *testing.T) {
 
 	// create test environment
 	testJig := jig.NewHetznerCluster(seedClient, logger, 1)
-	testJig.ClusterJig.WithPreset(preset)
+	testJig.ClusterJig.WithPreset(preset).WithTestName("mla")
 
 	project, cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)
 	defer testJig.Cleanup(ctx, t, true)

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -77,7 +77,7 @@ func TestOPAIntegration(t *testing.T) {
 
 	// create test environment
 	testJig := jig.NewHetznerCluster(seedClient, logger, 1)
-	testJig.ClusterJig.WithPreset(preset)
+	testJig.ClusterJig.WithPreset(preset).WithTestName("opa")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)
 	defer testJig.Cleanup(ctx, t, true)

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -52,6 +52,15 @@ var (
 	UnsafeCNIUpgradeLabel = "unsafe-cni-upgrade"
 	// UnsafeCNIMigrationLabel allows unsafe CNI type migration.
 	UnsafeCNIMigrationLabel = "unsafe-cni-migration"
+
+	// MaxClusterNameLength is the maximum allowed length for cluster names.
+	// This is restricted by the many uses of cluster names, from embedding
+	// them in namespace names (and prefixing them) to using them in role
+	// names (when using AWS).
+	// AWS role names have a max length of 64 characters, "kubernetes-" and
+	// "-control-plane" being added by KKP. This leaves 39 usable characters
+	// and to give some wiggle room, we define the max length to be 36.
+	MaxClusterNameLength = 36
 )
 
 // ValidateClusterSpec validates the given cluster spec. If this is not called from within another validation

--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -27,6 +27,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -128,17 +129,9 @@ func (h *AdmissionHandler) ensureClusterReference(ctx context.Context, addon *ku
 		return fmt.Errorf("failed to get Seed client: %w", err)
 	}
 
-	clusters := kubermaticv1.ClusterList{}
-	if err := client.List(ctx, &clusters); err != nil {
+	cluster, err := kubernetes.ClusterFromNamespace(ctx, client, addon.Namespace)
+	if err != nil {
 		return fmt.Errorf("failed to list Cluster objects: %w", err)
-	}
-
-	var cluster *kubermaticv1.Cluster
-	for i, c := range clusters.Items {
-		if c.Status.NamespaceName == addon.Namespace {
-			cluster = &clusters.Items[i]
-			break
-		}
 	}
 
 	if cluster == nil {

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -28,7 +28,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud"
-	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version"
 
@@ -78,11 +77,8 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) erro
 		return fmt.Errorf("cluster name must be valid rfc1035 label: %s", strings.Join(errs, ","))
 	}
 
-	// We prepend "cluster-" to the cluster name to get the namespace name,
-	// so we need to ensure there is enough room to fit in the prefix
-	maxNameLength := k8svalidation.DNS1035LabelMaxLength - len(kubernetes.NamespacePrefix)
-	if len(cluster.Name) > maxNameLength {
-		return fmt.Errorf("cluster name exceeds maximum allowed length of %d characters", maxNameLength)
+	if len(cluster.Name) > validation.MaxClusterNameLength {
+		return fmt.Errorf("cluster name exceeds maximum allowed length of %d characters", validation.MaxClusterNameLength)
 	}
 
 	datacenter, cloudProvider, err := v.buildValidationDependencies(ctx, cluster)

--- a/pkg/webhook/mlaadminsetting/mutation/mutation.go
+++ b/pkg/webhook/mlaadminsetting/mutation/mutation.go
@@ -27,6 +27,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -127,17 +128,9 @@ func (h *AdmissionHandler) ensureClusterReference(ctx context.Context, adminSett
 		return fmt.Errorf("failed to get Seed client: %w", err)
 	}
 
-	clusters := kubermaticv1.ClusterList{}
-	if err := client.List(ctx, &clusters); err != nil {
+	cluster, err := kubernetes.ClusterFromNamespace(ctx, client, adminSetting.Namespace)
+	if err != nil {
 		return fmt.Errorf("failed to list Cluster objects: %w", err)
-	}
-
-	var cluster *kubermaticv1.Cluster
-	for i, c := range clusters.Items {
-		if c.Status.NamespaceName == adminSetting.Namespace {
-			cluster = &clusters.Items[i]
-			break
-		}
 	}
 
 	if cluster == nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is something we already did maaany years ago, but in some refactoring craze, I removed the build ID from cluster names. After that, we could not easily identify whether for example the AWS tags belong to a "real" usercluster or are from some e2e test.

This PR brings back the build ID and also gives each cluster a more descriptive name. During this exercise I learned that since we prepend and append things to cluster names, we must restrict cluster names to be much shorter than anyone would think. While a DNS label can be 63 characters or so, due to the way AWS restrict tag lengths and us prepending "kubernetes-" and appending "-role-name", the effective max length for a cluster name is around 37 characters. I therefore adjusted our webhook to enforce this and had to be a bit more creative when naming the test ("etcd-recovery" instead of "etcd-launcher-recovery").

The Prow jobs got a higher memory limit because they started to get OOMKilled during compilations.

Since this PR focussed my on the cluster namespace handling, I also refactored the ClusterNameFromNamespace function, which previously was built assuming that a cluster namespace is ALWAYS `cluster-.....` But I do not want to make this assumption, there is a reason why we store the namespace name in the ClusterStatus and do not constantly rebuild it. To ensure that this logic ("deducing the cluster from the namespace name") doesn't grow like cancer, I refactored the function to list all Clusters and loop through them, finding the matching one. So this tiny refactoring is also part of this PR.

This tiny refactoring however showed that the etcd-launcher doesn't have permissions to LIST cluster objects, only to GET one specific cluster object. Since rewriting the rbac controller is too dangerous for me, @embik and me decided that it would be easier to just change the etcd-launcher to not have `-namespace` but `-cluster`. So that is all the change I did to the etcd-launcher's `main.go`. Looks horribly complicated in the diff, though.

And on this I noticed that we had a few event handlers that basically reimplemented `EnqueueClusterForNamespacedObject`, so I updated those controllers as well.

And lastly, there is a tiny bugfix to handle BYO cluster credentials, which I recently broke in #10505.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
