### PR TITLE
Simplify metallb addon: render only one IPAddressPool for IPAMPool "metallb"

### DIFF
--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- range $ipamPool, $allocation := .Cluster.Network.IPAMAllocations }}
+{{- if .Cluster.Network.IPAMAllocations.metallb }}
+{{- $allocation := .Cluster.Network.IPAMAllocations.metallb }}
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: {{ $ipamPool }}
+  name: kkp-managed-pool
   namespace: metallb-system
-spec: 
-  {{- if eq $allocation.Type "prefix" }}
-  addresses: 
+spec:
+  addresses:
+  {{- if eq $allocation.Type "prefix" }} 
     - {{ $allocation.CIDR }}
   {{- end }}
   {{- if eq $allocation.Type "range" }}
-  addresses:
     {{- range $allocation.Addresses }}
     - {{ . }}
     {{- end }}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
There is a limitation in the addon controller: it doesn't delete old resources. So, when the user deletes an IPAMPool, the old IPAddressPool was not being deleted, even it wasn't being rendered anymore in the metallb addon manifests. The solution is to make the metallb addon manage only one IPAddressPool for the IPAMPool with name "metallb".

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
