### PR TITLE
Remove enforcing of cloud-init for flatcar on AWS

### DIFF
--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -685,9 +685,8 @@ func getFlatcarOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtensi
 
 		ProvisioningUtility: flatcar.Ignition,
 	}
-	// set cloud init only for anexia and aws(due to the userdata size limit on aws, ignition increases the size drastically).
-	// This should be temporary until the new operating system manager is added to KKP.
-	if nodeSpec.Cloud.Anexia != nil || nodeSpec.Cloud.AWS != nil {
+	// Force cloud-init on Anexia since it doesn't have support for ignition
+	if nodeSpec.Cloud.Anexia != nil {
 		config.ProvisioningUtility = flatcar.CloudInit
 	}
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Flatcar on AWS will default to ignition as the provisioning utility
```
