### PR TITLE
Add project_info, project_labels and cluster_labels metrics

### DIFF
--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -194,6 +194,9 @@ func main() {
 	log.Debug("Starting external clusters collector")
 	collectors.MustRegisterExternalClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 
+	log.Debug("Starting projects collector")
+	collectors.MustRegisterProjectCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
+
 	if err := createAllControllers(ctrlCtx); err != nil {
 		log.Fatalw("could not create all controllers", zap.Error(err))
 	}

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -246,6 +246,10 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 	collectors.MustRegisterClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 	log.Debug("Starting addons collector")
 	collectors.MustRegisterAddonCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
+	// The canonical source of projects is the master cluster, but since they are replicated onto
+	// seeds, we start the project collctor on seed clusters as well, just for convenience for the admin.
+	log.Debug("Starting projects collector")
+	collectors.MustRegisterProjectCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 
 	if err := mgr.Add(metricserver.New(options.internalAddr)); err != nil {
 		log.Fatalw("failed to add metrics server", zap.Error(err))

--- a/pkg/collectors/cluster.go
+++ b/pkg/collectors/cluster.go
@@ -70,6 +70,7 @@ func MustRegisterClusterCollector(registry prometheus.Registerer, client ctrlrun
 				"cloud_provider",
 				"datacenter",
 				"pause",
+				"project",
 				"phase",
 			},
 			nil,
@@ -127,6 +128,10 @@ func (cc *ClusterCollector) collectCluster(ch chan<- prometheus.Metric, c *kuber
 			labels...,
 		)
 	}
+
+	kubernetesLabels := convertKubernetesLabels(c.Labels)
+	desc := prometheus.NewDesc(clusterPrefix+"labels", "Kubernetes labels on Cluster resources", nil, kubernetesLabels)
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1)
 }
 
 func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]string, error) {
@@ -149,6 +154,7 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 		provider,
 		cluster.Spec.Cloud.DatacenterName,
 		pause,
+		cluster.Labels[kubermaticv1.ProjectIDLabelKey],
 		string(cluster.Status.Phase),
 	}, nil
 }

--- a/pkg/collectors/project.go
+++ b/pkg/collectors/project.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	projectPrefix = "kubermatic_project_"
+)
+
+// ProjectCollector exports metrics for project resources.
+type ProjectCollector struct {
+	client ctrlruntimeclient.Reader
+
+	projectInfo *prometheus.Desc
+}
+
+// MustRegisterProjectCollector registers the project collector at the given prometheus registry.
+func MustRegisterProjectCollector(registry prometheus.Registerer, client ctrlruntimeclient.Reader) {
+	cc := &ProjectCollector{
+		client: client,
+		projectInfo: prometheus.NewDesc(
+			projectPrefix+"info",
+			"Additional project information",
+			[]string{
+				"name",
+				"display_name",
+				"owner",
+				"phase",
+			},
+			nil,
+		),
+	}
+
+	registry.MustRegister(cc)
+}
+
+// Describe returns the metrics descriptors.
+func (cc ProjectCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(cc, ch)
+}
+
+// Collect gets called by prometheus to collect the metrics.
+func (cc ProjectCollector) Collect(ch chan<- prometheus.Metric) {
+	projects := &kubermaticv1.ProjectList{}
+	if err := cc.client.List(context.Background(), projects); err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list projects in ProjectCollector: %w", err))
+		return
+	}
+
+	for _, project := range projects.Items {
+		cc.collectProject(ch, &project)
+	}
+}
+
+func (cc *ProjectCollector) collectProject(ch chan<- prometheus.Metric, p *kubermaticv1.Project) {
+	owner := ""
+	for _, ref := range p.OwnerReferences {
+		if ref.APIVersion == kubermaticv1.SchemeGroupVersion.String() && ref.Kind == "User" {
+			owner = ref.Name
+			break
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		cc.projectInfo,
+		prometheus.GaugeValue,
+		1,
+		p.Name,
+		p.Spec.Name,
+		owner,
+		string(p.Status.Phase),
+	)
+
+	kubernetesLabels := convertKubernetesLabels(p.Labels)
+	desc := prometheus.NewDesc(projectPrefix+"labels", "Kubernetes labels on Project resources", nil, kubernetesLabels)
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1)
+}

--- a/pkg/collectors/util.go
+++ b/pkg/collectors/util.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"strings"
+)
+
+func convertKubernetesLabels(labels map[string]string) map[string]string {
+	promLabels := map[string]string{}
+	for k, v := range labels {
+		k := "label_" + strings.ReplaceAll(k, "-", "_")
+		promLabels[k] = v
+	}
+
+	return promLabels
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This extends our metrics, primarily because the new metering implementation needs some more meta info and will rely on Prometheus metrics. This PR therefore

* adds a `kubermatic_cluster_labels` metric that contains all Kubernetes labels on Cluster objects (similar to kube-state-metrics),
* adds a `kubermatic_project_labels` metric that contains all Kubernetes labels on Projects objects,
* adds a `kubermatic_project_info` metric with `name`, `display_name`, `owner` and `phase` labels.
* adds a `project` label to the `kubermatic_cluster_info` metric, containing the project name for which the cluster belongs to.

The label labels (sic) are, just like in kube-state-metrics, prefixed with `label_` (e.g. the label `project-id` in Kubernetes i `label_project_id` in Prometheus).

**Does this PR introduce a user-facing change?**:
```release-note
* adds a `kubermatic_cluster_labels` metric that contains all Kubernetes labels on Cluster objects (similar to kube-state-metrics),
* adds a `kubermatic_project_labels` metric that contains all Kubernetes labels on Projects objects,
* adds a `kubermatic_project_info` metric with `name`, `display_name`, `owner` and `phase` labels.
* adds a `project` label to the `kubermatic_cluster_info` metric, containing the project name for which the cluster belongs to.
```
