### PR TITLE
AddonConfig Disable/Enable KKP auto assign IPAddressPool

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -358,7 +358,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-ipam-e2e
-    run_if_changed: "(pkg/controller/seed-controller-manager/ipam/|pkg/webhook/ipampool/|pkg/test/e2e/ipam/)"
+    run_if_changed: "(pkg/controller/seed-controller-manager/ipam/|pkg/webhook/ipampool/|addons/metallb/|pkg/test/e2e/ipam/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Variables.autoIPAddressPool }}
+{{- if .Variables.disableAutoIPAMAllocation }}
 {{- if .Cluster.Network.IPAMAllocations.metallb }}
 {{- $allocation := .Cluster.Network.IPAMAllocations.metallb }}
 ---

--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if ne .Variables.disableAutoIPAMAllocation true }}
+{{- if not .Variables.disableAutoIPAMAllocation }}
 {{- if .Cluster.Network.IPAMAllocations.metallb }}
 {{- $allocation := .Cluster.Network.IPAMAllocations.metallb }}
 ---

--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Variables.autoIPAddressPool }}
 {{- if .Cluster.Network.IPAMAllocations.metallb }}
 {{- $allocation := .Cluster.Network.IPAMAllocations.metallb }}
 ---
@@ -30,6 +31,7 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 
 {{- if .Variables.addressPoolYaml }}

--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Variables.disableAutoIPAMAllocation }}
+{{- if ne .Variables.disableAutoIPAMAllocation true }}
 {{- if .Cluster.Network.IPAMAllocations.metallb }}
 {{- $allocation := .Cluster.Network.IPAMAllocations.metallb }}
 ---


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We added a new feature to enable and disable auto assign IPAddressPool for metallb.
**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10547

**Special notes for your reviewer**:
This is important for the metallb addon coming in the next release for issue: #10547, it fixes the bug for users to be enable/disable IPAddressPool from the KKP IPAMPool on a cluster, some clusters might need the automatic IPAMPool while some might not need the IPAMPool.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
