### PR TITLE
Dual-stack e2e tests: Do not pin CNI versions

### DIFF
--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -467,14 +467,12 @@ func rockyLinux() models.OperatingSystemSpec {
 
 func cilium() models.CNIPluginSettings {
 	return models.CNIPluginSettings{
-		Version: "v1.11",
-		Type:    "cilium",
+		Type: "cilium",
 	}
 }
 
 func canal() models.CNIPluginSettings {
 	return models.CNIPluginSettings{
-		Type:    "canal",
-		Version: "v3.22",
+		Type: "canal",
 	}
 }


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What does this PR do / Why do we need it**:
We should not pin e2e tests to a certain CNI version, so that we always test the latest version of our CNIs and can use the job to test the CNI upgrade PRs.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
Not needed, just an e2e update.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
