### PR TITLE
fix _labels metrics

### DIFF
--- a/pkg/collectors/util.go
+++ b/pkg/collectors/util.go
@@ -17,15 +17,23 @@ limitations under the License.
 package collectors
 
 import (
+	"regexp"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func convertKubernetesLabels(labels map[string]string) map[string]string {
-	promLabels := map[string]string{}
-	for k, v := range labels {
-		k := "label_" + strings.ReplaceAll(k, "-", "_")
-		promLabels[k] = v
+func convertKubernetesLabels(labelKeys sets.String) []string {
+	promLabels := make([]string, labelKeys.Len())
+	for i, key := range labelKeys.List() {
+		promLabels[i] = convertKubernetesLabel(key)
 	}
 
 	return promLabels
+}
+
+var validMetricLabel = regexp.MustCompile(`[^a-z0-9_]`)
+
+func convertKubernetesLabel(label string) string {
+	return "label_" + validMetricLabel.ReplaceAllString(strings.ToLower(label), "_")
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This fixes the broken metrics introduced in #10605. Prometheus does not allow multiple metrics with the same name to have different labels. A restriction I thought couldn't possibly be real, as kube-state-metrics demonstrates it, but then I learned that KSM back in the day simply did hacks like https://github.com/kubernetes/kube-state-metrics/pull/194 to work around this.

So this PR does a number of things:

* it fixes the broken Describe() of the cluster collector, which forgot the _labels metric.
* it fixes the broken label sanitisation.
* it fixes the missing "name" label on those _labels metrics, making them effectively useless.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
