### PR TITLE
make rbac resources controller not reconcile deleted objects

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
@@ -128,6 +128,10 @@ func (c *resourcesController) Reconcile(ctx context.Context, req reconcile.Reque
 		return reconcile.Result{}, err
 	}
 
+	if obj.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, nil
+	}
+
 	err := c.reconcile(ctx, obj)
 	if err != nil {
 		kind := obj.GetObjectKind().GroupVersionKind().Kind

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -159,6 +159,11 @@ func (c *resourcesController) syncClusterResource(ctx context.Context, obj ctrlr
 		return nil
 	}
 
+	// do not reconcile anyone once a cluster is in deletion
+	if cluster.DeletionTimestamp != nil {
+		return nil
+	}
+
 	rmapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
The RBAC controllers never clean up or delete anything. So they do not need to react to objects being deleted. Therefore I added this blanket if statement to reject all events for deleted objects, in order to fix errors like

> {"level":"error","time":"2022-08-02T09:13:37.567Z","caller":"controller/controller.go:273","msg":"Reconciler error","controller":"rbac_generator_resources_europe-west3-c","object":{"name":"rj6z4j49qs"},"namespace":"","name":"rj6z4j49qs","reconcileID":"04b34e44-12bb-4312-a576-a1c14f8474af","error":"failed to reconcile Cluster /rj6z4j49qs in europe-west3-c cluster: failed to sync Cluster resource: failed to sync RBAC Role: roles.rbac.authorization.k8s.io \"kubermatic:addon:owners\" is forbidden: unable to create new content in namespace cluster-rj6z4j49qs because it is being terminated"}

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
