### PR TITLE
[EE] fix reconcile loop in allowed-registry controller

### DIFF
--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -41,6 +41,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -152,6 +153,7 @@ func allowedRegistryCTCreatorGetter() reconciling.NamedKubermaticV1ConstraintTem
 							Kind: AllowedRegistryCTName,
 						},
 						Validation: &constrainttemplatev1.Validation{
+							LegacySchema: pointer.Bool(false),
 							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									AllowedRegistryField: {

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -199,6 +200,7 @@ func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 					Kind: AllowedRegistryCTName,
 				},
 				Validation: &constrainttemplatev1.Validation{
+					LegacySchema: pointer.Bool(false),
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							AllowedRegistryField: {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This fixes the reconciling loop in the controller. When running with `-log-debug`, one can see that

> {"level":"error","time":"2022-08-02T08:16:06.452Z","caller":"controller/controller.go:273","msg":"Reconciler error","controller":"kkp-allowed-registry-controller","object":{"name":"ahmd-test"},"namespace":"","name":"ahmd-test","reconcileID":"7a54f8d8-99cc-430f-98e2-92e47f8e53b0","error":"error ensuring AllowedRegistry Constraint Template: failed to ensure ConstraintTemplate /allowedregistry: failed waiting for the cache to contain our latest changes: timed out waiting for the condition"}

is ultimately caused by 

> 2022-08-02T11:41:05.382+0200    debug   reconciling/compare.go:60       Object differs from generated one       {"type": "*v1.ConstraintTemplate", "namespace": "", "name": "allowedregistry", "diff": ["Spec.CRD.Spec.Validation.LegacySchema: <nil pointer> != bool"]}

**Does this PR introduce a user-facing change?**:
```release-note
Fix reconcile loop in AllowedRegistry controller
```
