### PR TITLE
[release/v2.20] [EE] fix reconcile loop in allowed-registry controller (#10644)

### DIFF
--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -42,7 +42,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -161,7 +160,7 @@ func allowedRegistryCTCreatorGetter() reconciling.NamedKubermaticV1ConstraintTem
 							Kind: AllowedRegistryCTName,
 						},
 						Validation: &constrainttemplatev1beta1.Validation{
-							LegacySchema: pointer.Bool(false),
+							LegacySchema: true,
 							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									AllowedRegistryField: {

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -42,6 +42,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -160,6 +161,7 @@ func allowedRegistryCTCreatorGetter() reconciling.NamedKubermaticV1ConstraintTem
 							Kind: AllowedRegistryCTName,
 						},
 						Validation: &constrainttemplatev1beta1.Validation{
+							LegacySchema: pointer.Bool(false),
 							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									AllowedRegistryField: {

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -204,7 +203,7 @@ func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 					Kind: allowedregistrycontroller.AllowedRegistryCTName,
 				},
 				Validation: &constrainttemplatev1beta1.Validation{
-					LegacySchema: pointer.Bool(false),
+					LegacySchema: true,
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							allowedregistrycontroller.AllowedRegistryField: {

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -203,6 +204,7 @@ func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 					Kind: allowedregistrycontroller.AllowedRegistryCTName,
 				},
 				Validation: &constrainttemplatev1beta1.Validation{
+					LegacySchema: pointer.Bool(false),
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							allowedregistrycontroller.AllowedRegistryField: {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a manual backport of #10644 because in KKP 2.20, we still use v1beta1 of the Gatekeeper APIs. I checked and both v1 and v1beta1 use the same pointer for this field.

**Does this PR introduce a user-facing change?**:
```release-note
Fix reconcile loop in AllowedRegistry controller
```
