### PR TITLE
applicationInstallationController: fix infinite reconciling loop

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -87,7 +88,10 @@ func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.M
 		return fmt.Errorf("failed to create controller %s: %w", controllerName, err)
 	}
 
-	if err = c.Watch(&source.Kind{Type: &appskubermaticv1.ApplicationInstallation{}}, &handler.EnqueueRequestForObject{}); err != nil {
+	// update of the status with conditions or HelmInfo triggers an update event. To avoid reconciling in loop, we filter
+	// update event on generation. We also allow update events if annotations have changed so that the user can force a
+	// reconciliation without changing the spec.
+	if err = c.Watch(&source.Kind{Type: &appskubermaticv1.ApplicationInstallation{}}, &handler.EnqueueRequestForObject{}, predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})); err != nil {
 		return fmt.Errorf("failed to create watch for ApplicationInstallation: %w", err)
 	}
 


### PR DESCRIPTION
# What does this PR do / Why do we need it
When we create an application installation, the status is set with the Helm information and the conditions (e.g. Ready). These changes to the status trigger an Update Event so the application is "re-installed", the status is updated and so on and so on...

Fixes #10639 

# Special notes for your reviewer
As a consequence of using the predicate filter, the ReSync period of the controller, which is 10h (default value) is ignored. 
So the application will not force to be reconciled after 10h anymore. 

**Do we want to keep this behavior?**

It can esaly implemented by using `reconcile.Result{RequeueAfter: 10 * time.Hour}`


# Does this PR introduce a user-facing change?
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
