### PR TITLE
Applications fix panic in HelmClient.DonwloadChart when version is empty or  non semver

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -93,18 +93,18 @@ func (a *AuthSettings) newRegistryClient() (*registry.Client, error) {
 	return registry.NewClient(registry.ClientOptCredentialsFile(a.RegistryConfigFile))
 }
 
-// getterOptions return authentication options for Getter.
-func (a AuthSettings) getterOptions() ([]getter.Option, error) {
+// registryClientAndGetterOptions return registry.Client and authentication options for Getter.
+func (a *AuthSettings) registryClientAndGetterOptions() (*registry.Client, []getter.Option, error) {
 	regClient, err := a.newRegistryClient()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	options := []getter.Option{getter.WithRegistryClient(regClient)}
 
 	if a.Username != "" && a.Password != "" {
 		options = append(options, getter.WithBasicAuth(a.Username, a.Password))
 	}
-	return options, nil
+	return regClient, options, nil
 }
 
 // HelmClient is a client that allows interacting with Helm.
@@ -172,7 +172,7 @@ func (h HelmClient) DownloadChart(url string, chartName string, version string, 
 		}
 	}
 
-	options, err := auth.getterOptions()
+	regClient, options, err := auth.registryClientAndGetterOptions()
 	if err != nil {
 		return "", err
 	}
@@ -183,6 +183,7 @@ func (h HelmClient) DownloadChart(url string, chartName string, version string, 
 		RepositoryConfig: h.settings.RepositoryConfig,
 		RepositoryCache:  h.settings.RepositoryCache,
 		Getters:          h.getterProviders,
+		RegistryClient:   regClient,
 		Options:          options,
 	}
 

--- a/pkg/applications/helmclient/testdata/examplechart-v2/.helmignore
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/pkg/applications/helmclient/testdata/examplechart-v2/Chart.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/Chart.yaml
@@ -1,0 +1,17 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: examplechart
+version: 0.2.0

--- a/pkg/applications/helmclient/testdata/examplechart-v2/templates/configmap.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/templates/configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testcm
+  labels:
+{{ if .Values.versionLabel }}
+    versionLabel: {{ .Values.versionLabel | quote}}
+{{ end }}
+data:
+{{ if .Values.cmData }}
+{{ toYaml .Values.cmData | nindent 2 }}
+{{ end }}

--- a/pkg/applications/helmclient/testdata/examplechart-v2/values.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/values.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for examplechart.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+cmData:
+  foo: bar
+
+versionLabel: "1.0"

--- a/pkg/applications/providers/source/helm.go
+++ b/pkg/applications/providers/source/helm.go
@@ -54,7 +54,7 @@ func (h HelmSource) DownloadSource(destination string) (string, error) {
 	}
 	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
 
-	auth, err := util.AuthFromCredentials(h.Ctx, h.SeedClient, path.Join(helmCacheDir, "reg-creg"), h.SecretNamespace, h.Source)
+	auth, err := util.HelmAuthFromCredentials(h.Ctx, h.SeedClient, path.Join(helmCacheDir, "reg-creg"), h.SecretNamespace, h.Source)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -63,7 +63,7 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, applicationInstallation 
 	}
 	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
 
-	auth, err := util.AuthFromCredentials(h.Ctx, h.SeedClient, path.Join(helmCacheDir, "reg-creg"), h.SecretNamespace, h.ApplicationInstallation.Status.ApplicationVersion.Template.Source.Helm)
+	auth, err := util.HelmAuthFromCredentials(h.Ctx, h.SeedClient, path.Join(helmCacheDir, "reg-creg"), h.SecretNamespace, h.ApplicationInstallation.Status.ApplicationVersion.Template.Source.Helm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applications/providers/util/util.go
+++ b/pkg/applications/providers/util/util.go
@@ -65,8 +65,8 @@ func GetCredentialFromSecret(ctx context.Context, client ctrlruntimeclient.Clien
 	return string(cred), nil
 }
 
-// AuthFromCredentials builds helmclient.AuthSettings from source.Credentials. registryConfigFilePath is the path of the file that stores credentials for OCI registry.
-func AuthFromCredentials(ctx context.Context, client ctrlruntimeclient.Client, registryConfigFilePath string, secretNamespace string, source *appskubermaticv1.HelmSource) (helmclient.AuthSettings, error) {
+// HelmAuthFromCredentials builds helmclient.AuthSettings from source.Credentials. registryConfigFilePath is the path of the file that stores credentials for OCI registry.
+func HelmAuthFromCredentials(ctx context.Context, client ctrlruntimeclient.Client, registryConfigFilePath string, secretNamespace string, source *appskubermaticv1.HelmSource) (helmclient.AuthSettings, error) {
 	auth := helmclient.AuthSettings{}
 	if source.Credentials != nil {
 		if source.Credentials.Username != nil {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

The problem was that when the version is not a semVersion, Helm will list tag using `ChartDownloader.RegistryClient` and not the client set in `GetterOptions`. As we set only the client in `GetterOptions`, we got a NPE.

According to [helm/v3/pkg/downloader/chart_downloader.go.ResolveChartVersion(reg, version string)](https://github.com/helm/helm/blob/v3.9.1/pkg/downloader/chart_downloader.go#L185-L192) version must be a semVersion or an empty string. If it's an empty string then the last chart version is returned.
So we have adapted tests accordingly.


This PR also rename `pkg/applications/providers/util/util.go::AuthFromCredentials` to `HelmAuthFromCredentials` as requested [here](https://github.com/kubermatic/kubermatic/pull/10570#discussion_r933033653)


**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10661

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
