### PR TITLE
Unified PR template update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,11 +28,14 @@ Optionally add one or more of the following kinds if applicable:
 <!--
 Please do one of the following options:
 - Add a link to the existing documentation
-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request.
-- If no documentation change is applicable, then a brief explanation about the reasoning (like “not user-facing change”, “Will be updated along with the next PR” etc.)
+- Add a link to the kubermatic/docs pull request
+- If no documentation change is applicable then add:
+  - TBD (documentation will be added later)
+  - NONE (no documentation needed for this PR)
 -->
+```documentation
 
-Documentation link / PR link / Explanation
+```
 
 **Does this PR introduce a user-facing change? Then add your Release Note here**:
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,16 @@ Optionally add one or more of the following kinds if applicable:
 
 **Special notes for your reviewer**:
 
+**Does this PR introduce a user-facing change? Then add your Release Note here**:
+<!--
+Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, just write "NONE".
+-->
+```release-note
+
+```
+
 **Documentation**:
 <!--
 Please do one of the following options:
@@ -35,14 +45,4 @@ Please do one of the following options:
 -->
 ```documentation
 
-```
-
-**Does this PR introduce a user-facing change? Then add your Release Note here**:
-<!--
-Write your release note:
-1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
-2. If no release note is required, just write "NONE".
--->
-```release-note
-NONE
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,6 @@ Optionally add one or more of the following kinds if applicable:
 /kind failing-test
 /kind flake
 /kind regression
-/kind question
 -->
 
 **Special notes for your reviewer**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,45 @@
-**What does this PR do / Why do we need it**:
+**What this PR does / why we need it**:
 
-**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
+**Which issue(s) this PR fixes**:
+<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
 Fixes #
+
+**What type of PR is this?**
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+/kind question
+-->
 
 **Special notes for your reviewer**:
 
 **Documentation**:
-<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
+<!--
+Please do one of the following options:
+- Add a link to the existing documentation
+- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request.
+- If no documentation change is applicable, then a brief explanation about the reasoning (like “not user-facing change”, “Will be updated along with the next PR” etc.)
+-->
 
-**Does this PR introduce a user-facing change?**:
-<!-- Write your release note:
+Documentation link / PR link / Explanation
+
+**Does this PR introduce a user-facing change? Then add your Release Note here**:
+<!--
+Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
 2. If no release note is required, just write "NONE".
 -->
 ```release-note
+NONE
 ```


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Unified PR template with emphasising documentation

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

This is not a user facing change, therefore no need for change in public documentation.

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
