### PR TITLE
applicationInstallationController: update status.HelmRelease even if an error occurred

### DIFF
--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -28,10 +28,6 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var noStatusUodate util.StatusUpdater = func(status *appskubermaticv1.ApplicationInstallationStatus) {
-	// NO OP
-}
-
 // ApplicationInstallerRecorder is a fake ApplicationInstaller that records calls to apply and delete for testing assertions.
 type ApplicationInstallerRecorder struct {
 	// DownloadEvents stores the call to download function. Key is the name of the applicationInstallation.
@@ -55,12 +51,12 @@ func (a *ApplicationInstallerRecorder) DonwloadSource(ctx context.Context, log *
 
 func (a *ApplicationInstallerRecorder) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
 	a.ApplyEvents.Store(applicationInstallation.Name, *applicationInstallation.DeepCopy())
-	return noStatusUodate, nil
+	return util.NoStatusUpdate, nil
 }
 
 func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
 	a.DeleteEvents.Store(applicationInstallation.Name, *applicationInstallation.DeepCopy())
-	return noStatusUodate, nil
+	return util.NoStatusUpdate, nil
 }
 
 // ApplicationInstallerLogger is a fake ApplicationInstaller that just logs actions. it's used for the development of the controller.
@@ -77,10 +73,10 @@ func (a ApplicationInstallerLogger) DonwloadSource(ctx context.Context, log *zap
 }
 func (a ApplicationInstallerLogger) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
 	log.Debugf("Install application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
-	return noStatusUodate, nil
+	return util.NoStatusUpdate, nil
 }
 
 func (a ApplicationInstallerLogger) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
 	log.Debugf("Uninstall application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
-	return noStatusUodate, nil
+	return util.NoStatusUpdate, nil
 }

--- a/pkg/applications/providers/util/util.go
+++ b/pkg/applications/providers/util/util.go
@@ -49,7 +49,14 @@ func CleanUpHelmTempDir(cacheDir string, logger *zap.SugaredLogger) {
 }
 
 // StatusUpdater is a function that postpone the update of the applicationInstallation.
+// It used to set status's filed of a specific template Porvider (eg status.HelmRelease).
 type StatusUpdater func(status *appskubermaticv1.ApplicationInstallationStatus)
+
+// NoStatusUpdate is a StatusUpdater that does not update the status.
+// It useful in case an error happens and we don't have information to update the status.
+var NoStatusUpdate StatusUpdater = func(status *appskubermaticv1.ApplicationInstallationStatus) {
+	// NO OP
+}
 
 // GetCredentialFromSecret get the secret and returns secret.Data[key].
 func GetCredentialFromSecret(ctx context.Context, client ctrlruntimeclient.Client, namespce string, name string, key string) (string, error) {

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -255,8 +255,8 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		r.setCondition(appInstallation, appskubermaticv1.Ready, corev1.ConditionFalse, "InstallationFailed", installErr.Error())
 	} else {
 		r.setCondition(appInstallation, appskubermaticv1.Ready, corev1.ConditionTrue, "InstallationSuccessful", "application successfully installed or upgraded")
-		statusUpdater(&appInstallation.Status)
 	}
+	statusUpdater(&appInstallation.Status)
 
 	// we set condition in every case and condition update the LastHeartbeatTime. So patch will not be empty.
 	if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
@@ -273,9 +273,9 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 		oldAppInstallation := appInstallation.DeepCopy()
 		if uninstallErr != nil {
 			r.setCondition(appInstallation, appskubermaticv1.Ready, corev1.ConditionFalse, "UninstallFailed", uninstallErr.Error())
-		} else {
-			statusUpdater(&appInstallation.Status)
 		}
+		statusUpdater(&appInstallation.Status)
+
 		if !equality.Semantic.DeepEqual(oldAppInstallation.Status, appInstallation.Status) { // avoid to send empty patch
 			if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
 				return fmt.Errorf("failed to update status: %w", err)


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Depending on the error the HelmRelease Info may be or not be nil. If it's not nil, we should set the HelmRelease Info in the status. 

For example, if the resources created by helm do not satisfy a validation webhook, the application is partially installed and HelmRelease Info is not nil.



**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #10681 

**Special notes for your reviewer**:
The installer now always returns a non-nil `StatusUpdater` in order to simplify logic in the controller.


**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
