### PR TITLE
fix missing Registry overwrite in Canal 3.23 addon

### DIFF
--- a/addons/canal/canal_v3.23.yaml
+++ b/addons/canal/canal_v3.23.yaml
@@ -4171,7 +4171,7 @@ rules:
     resources:
       - endpointslices
     verbs:
-      - watch 
+      - watch
       - list
   - apiGroups: [""]
     resources:
@@ -4429,7 +4429,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.23.3
+          image: '{{ Registry "quay.io" }}/calico/node:v3.23.3'
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
             - mountPath: /sys/fs


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It seems to be an oversight that we didn't use `Registry` in the 3.23 manifests. I also switched to quay.io, like we did in #10305. The `calico/node:v3.23.0` image is available as multiarch on quay.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
