### PR TITLE
pull konnectivity images only if not present

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -78,7 +78,7 @@ func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrit
 				{
 					Name:            resources.KonnectivityAgentContainer,
 					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryEUGCR), name, version),
-					ImagePullPolicy: corev1.PullAlways,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/proxy-agent"},
 					Args: []string{
 						"--logtostderr=true",

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -49,7 +49,7 @@ func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Cont
 	return &corev1.Container{
 		Name:            resources.KonnectivityServerContainer,
 		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryEUGCR), name, version),
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/proxy-server",
 		},


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
We always pull konnectivity images. This fixes the image pull policy to pull only if not present.  

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
