### PR TITLE
Fix project list endpoint after introducing group suffixes

### DIFF
--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -284,6 +284,9 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 		for _, group := range groupMappings {
 			projectID := group.Spec.ProjectID
 
+			// Append user info with projectId-suffixed group name to allow for get project request.
+			userInfo.Groups = append(userInfo.Groups, fmt.Sprintf("%s-%s", group.Spec.Group, projectID))
+
 			if projectIDSet.Has(projectID) {
 				// The project has been already added either from user or other group bindings.
 				continue


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Extend impersonated client with projectId-suffixed group names for list projects endpoint.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
