### PR TITLE
fix typo in conformance-tester

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters:
     - tenv
     - unconvert
     - unused
+    - usestdlibvars
     - varcheck
     - wastedassign
     - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     - tenv
     - unconvert
     - unused
-    - usestdlibvars
     - varcheck
     - wastedassign
     - whitespace

--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -153,7 +153,7 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 	hostURL := fmt.Sprintf("http://%s", net.JoinHostPort(host, "80"))
 	log.Debug("Waiting until the pod is available via the LoadBalancer...")
 	err = wait.Poll(ctx, 3*time.Second, opts.CustomTestTimeout, func() (transient error, terminal error) {
-		request, err := http.NewRequestWithContext(ctx, "GET", hostURL, nil)
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, hostURL, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -215,8 +215,8 @@ func (o *Options) ParseFlags(log *zap.SugaredLogger) error {
 	// periodics do not specify a version at all and just rely on us auto-determining
 	// the most recent stable (stable = latest-1) supported Kubernetes version
 	if len(o.Versions) == 0 {
-		log.Infow("No -releases specified, defaulting to latest stable Kubernetes version", "version", o.Versions[0])
 		o.Versions = append(o.Versions, test.LatestStableKubernetesVersion(nil))
+		log.Infow("No -releases specified, defaulting to latest stable Kubernetes version", "version", o.Versions[0])
 	}
 
 	o.Distributions, err = o.effectiveDistributions()

--- a/cmd/http-prober/main.go
+++ b/cmd/http-prober/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", e.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.String(), nil)
 	if err != nil {
 		log.Fatalw("Failed to build request", zap.Error(err))
 	}

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/controller-tools v0.9.2
 	sigs.k8s.io/yaml v1.3.0
-
 )
 
 replace (

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -137,7 +137,7 @@ func NewTemplateData(
 			Labels:            cluster.Labels,
 			Annotations:       cluster.Annotations,
 			Kubeconfig:        kubeconfig,
-			// nolint:staticcheck
+			//nolint:staticcheck
 			OwnerName:         cluster.Status.UserName,
 			OwnerEmail:        cluster.Status.UserEmail,
 			Address:           cluster.GetAddress(),

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -202,7 +202,7 @@ func (r *userGrafanaController) handleDeletion(ctx context.Context, user *kuberm
 }
 
 func (r *userGrafanaController) ensureGrafanaUser(ctx context.Context, user *kubermaticv1.User, grafanaClient *grafanasdk.Client) error {
-	req, err := http.NewRequestWithContext(ctx, "GET", r.grafanaURL+"/api/user", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.grafanaURL+"/api/user", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/ee/group-project-binding/handler/handler_test.go
+++ b/pkg/ee/group-project-binding/handler/handler_test.go
@@ -27,6 +27,7 @@ package handler_test
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -56,7 +57,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 	}{
 		{
 			name:            "scenario 1: list GroupProjectBindings in a project",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/projects/foo-ID/groupbindings",
 			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 			existingObjects: []ctrlruntimeclient.Object{
@@ -83,7 +84,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:            "scenario 2: list GroupProjectBindings in an illicit project",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/projects/foo-ID/groupbindings",
 			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 			existingObjects: []ctrlruntimeclient.Object{
@@ -100,7 +101,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:            "scenario 3: get an existing GroupProjectBinding",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/projects/boo-ID/groupbindings/boo-ID-xxxxxxxxxx",
 			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 			existingObjects: []ctrlruntimeclient.Object{
@@ -124,7 +125,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:            "scenario 4: get a non-existing GroupProjectBinding",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/projects/boo-ID/groupbindings/boo-ID-DoesNotExist",
 			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 			existingObjects: []ctrlruntimeclient.Object{
@@ -138,7 +139,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:            "scenario 5: get an illicit GroupProjectBinding",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-xxxxxxxxxx",
 			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 			existingObjects: []ctrlruntimeclient.Object{
@@ -154,7 +155,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:   "scenario 6: create a new GroupProjectBinding",
-			method: "POST",
+			method: http.MethodPost,
 			url:    "/api/v2/projects/foo-ID/groupbindings",
 			body: `{
 				"role": "viewers",
@@ -172,7 +173,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:   "scenario 7: create a new GroupProjectBinding with invalid role name",
-			method: "POST",
+			method: http.MethodPost,
 			url:    "/api/v2/projects/foo-ID/groupbindings",
 			body: `{
 				"role": "invalid",
@@ -190,7 +191,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:            "scenario 8: delete an existing GroupProjectBinding",
-			method:          "DELETE",
+			method:          http.MethodDelete,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-xxxxxxxxxx",
 			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 			existingObjects: []ctrlruntimeclient.Object{
@@ -205,7 +206,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:   "scenario 9: patch an existing GroupProjectBinding",
-			method: "PATCH",
+			method: http.MethodPatch,
 			body: `{
 				"group": "testGroup",
 				"role": "owners"
@@ -224,7 +225,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:   "scenario 10: patch a non-existing GroupProjectBinding",
-			method: "PATCH",
+			method: http.MethodPatch,
 			body: `{
 				"group": "testGroup",
 				"role": "owners"
@@ -243,7 +244,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 		},
 		{
 			name:   "scenario 11: patch an existing GroupProjectBinding with illicit role",
-			method: "PATCH",
+			method: http.MethodPatch,
 			body: `{
 				"role": "invalid"
 			}`,

--- a/pkg/ee/group-project-binding/handler/handler_test.go
+++ b/pkg/ee/group-project-binding/handler/handler_test.go
@@ -67,7 +67,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenGroupBinding("foo-ID", "TestGroup", "owners"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
 			},
-			httpStatus: 200,
+			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				bindingList := &[]apiv2.GroupProjectBinding{}
 				err := json.Unmarshal(resp.Body.Bytes(), bindingList)
@@ -94,7 +94,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenGroupBinding("foo-ID", "TestGroup", "owners"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
 			},
-			httpStatus: 403,
+			httpStatus: http.StatusForbidden,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -109,7 +109,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
 			},
-			httpStatus: 200,
+			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				binding := &apiv2.GroupProjectBinding{}
 				err := json.Unmarshal(resp.Body.Bytes(), binding)
@@ -132,7 +132,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenProject("boo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
 			},
-			httpStatus: 404,
+			httpStatus: http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -148,7 +148,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
 			},
-			httpStatus: 403,
+			httpStatus: http.StatusForbidden,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -166,7 +166,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 			},
-			httpStatus: 201,
+			httpStatus: http.StatusCreated,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -184,7 +184,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 			},
-			httpStatus: 400,
+			httpStatus: http.StatusBadRequest,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -199,7 +199,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
 			},
-			httpStatus: 200,
+			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -218,7 +218,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
 			},
-			httpStatus: 200,
+			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -237,7 +237,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
 			},
-			httpStatus: 404,
+			httpStatus: http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -255,7 +255,7 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
 			},
-			httpStatus: 400,
+			httpStatus: http.StatusBadRequest,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},

--- a/pkg/ee/metering/report_config_handler_test.go
+++ b/pkg/ee/metering/report_config_handler_test.go
@@ -118,7 +118,7 @@ func TestGetMeteringReportConfigEndpoint(t *testing.T) {
 		if tc.reportName != "" {
 			reqURL += "/" + tc.reportName
 		}
-		req := httptest.NewRequest("GET", reqURL, strings.NewReader(""))
+		req := httptest.NewRequest(http.MethodGet, reqURL, strings.NewReader(""))
 		res := httptest.NewRecorder()
 
 		router, err := test.CreateTestEndpoint(*tc.existingAPIUser, nil, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -261,7 +261,7 @@ func TestCreateMeteringReportConfigEndpoint(t *testing.T) {
 		if tc.reportName != "" {
 			reqURL += "/" + tc.reportName
 		}
-		req := httptest.NewRequest("POST", reqURL, strings.NewReader(tc.body))
+		req := httptest.NewRequest(http.MethodPost, reqURL, strings.NewReader(tc.body))
 		res := httptest.NewRecorder()
 
 		router, err := test.CreateTestEndpoint(*tc.existingAPIUser, nil, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -385,7 +385,7 @@ func TestUpdateMeteringReportConfigEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		reqURL := fmt.Sprintf("/api/v1/admin/metering/configurations/reports/%s", tc.reportName)
-		req := httptest.NewRequest("PUT", reqURL, strings.NewReader(tc.body))
+		req := httptest.NewRequest(http.MethodPut, reqURL, strings.NewReader(tc.body))
 		res := httptest.NewRecorder()
 
 		router, err := test.CreateTestEndpoint(*tc.existingAPIUser, nil, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -449,7 +449,7 @@ func TestDeleteMeteringReportConfigEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		reqURL := fmt.Sprintf("/api/v1/admin/metering/configurations/reports/%s", tc.reportName)
-		req := httptest.NewRequest("DELETE", reqURL, strings.NewReader(""))
+		req := httptest.NewRequest(http.MethodDelete, reqURL, strings.NewReader(""))
 		res := httptest.NewRecorder()
 
 		router, err := test.CreateTestEndpoint(*tc.existingAPIUser, nil, tc.existingKubermaticObjs, nil, hack.NewTestRouting)

--- a/pkg/ee/metering/report_handler.go
+++ b/pkg/ee/metering/report_handler.go
@@ -137,7 +137,7 @@ func GetReport(ctx context.Context, req interface{}, seedsGetter provider.SeedsG
 		return urlString, nil
 	}
 
-	return "", utilerrors.New(404, "report not found")
+	return "", utilerrors.New(http.StatusNotFound, "report not found")
 }
 
 func DeleteReport(ctx context.Context, req interface{}, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) error {
@@ -179,7 +179,7 @@ func DeleteReport(ctx context.Context, req interface{}, seedsGetter provider.See
 		return nil
 	}
 
-	return utilerrors.New(404, "report not found")
+	return utilerrors.New(http.StatusNotFound, "report not found")
 }
 
 func getReportsForSeed(ctx context.Context, options minio.ListObjectsOptions, seedClient ctrlruntimeclient.Client) ([]apiv1.MeteringReport, error) {

--- a/pkg/ee/resource-quota/handler_test.go
+++ b/pkg/ee/resource-quota/handler_test.go
@@ -27,6 +27,7 @@ package resourcequota_test
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -96,7 +97,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 	}{
 		{
 			name:            "scenario 1: list all resource quotas with proper quota conversion",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/quotas",
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
@@ -134,7 +135,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 2: list filtered resource quotas",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             fmt.Sprintf("/api/v2/quotas?subjectName=%s", projectName),
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
@@ -155,7 +156,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 3: get a single resource quota",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             fmt.Sprintf("/api/v2/quotas/project-%s", projectName),
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
@@ -183,7 +184,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 4: get a non-existing single resource quota",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             "/api/v2/quotas/project-non-existing",
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
@@ -194,7 +195,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:   "scenario 5: create an existing resource quota",
-			method: "POST",
+			method: http.MethodPost,
 			url:    "/api/v2/quotas",
 			body: `{
 		      "subjectKind": "project",
@@ -209,7 +210,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:   "scenario 6: create a new resource quota",
-			method: "POST",
+			method: http.MethodPost,
 			url:    "/api/v2/quotas",
 			body: `{
 		      "subjectKind": "project",
@@ -229,7 +230,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:   "scenario 7: update an existing resource quota",
-			method: "PATCH",
+			method: http.MethodPatch,
 			url:    fmt.Sprintf("/api/v2/quotas/project-%s", projectName),
 			body: `{
 				"cpu": 10,
@@ -245,7 +246,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:   "scenario 8: update a non-existing resource quota",
-			method: "PATCH",
+			method: http.MethodPatch,
 			url:    "/api/v2/quotas/project-non-existing",
 			body: `{
 				"cpu": 10,
@@ -261,7 +262,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 9: delete an existing resource quota",
-			method:          "DELETE",
+			method:          http.MethodDelete,
 			url:             fmt.Sprintf("/api/v2/quotas/project-%s", projectName),
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
@@ -272,7 +273,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 10: delete a non-existing resource quota",
-			method:          "DELETE",
+			method:          http.MethodDelete,
 			url:             "/api/v2/quotas/project-non-existing",
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
@@ -283,7 +284,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 11: get a project resource quota",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             fmt.Sprintf("/api/v2/projects/%s/quota", projectName),
 			existingAPIUser: test.GenDefaultAPIUser(),
 			existingObjects: existingObjects,
@@ -307,7 +308,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 		},
 		{
 			name:            "scenario 12: user bob can't get a project resource quota from a project he doesn't belong to",
-			method:          "GET",
+			method:          http.MethodGet,
 			url:             fmt.Sprintf("/api/v2/projects/%s-2/quota", projectName),
 			existingAPIUser: test.GenDefaultAPIUser(),
 			existingObjects: append(existingObjects, func() *kubermaticv1.Project {

--- a/pkg/ee/resource-quota/handler_test.go
+++ b/pkg/ee/resource-quota/handler_test.go
@@ -101,7 +101,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             "/api/v2/quotas",
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      200,
+			httpStatus:      http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				resourceQuotaList := &[]apiv2.ResourceQuota{}
 				err := json.Unmarshal(resp.Body.Bytes(), resourceQuotaList)
@@ -139,7 +139,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             fmt.Sprintf("/api/v2/quotas?subjectName=%s", projectName),
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      200,
+			httpStatus:      http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				resourceQuotaList := &[]apiv2.ResourceQuota{}
 				err := json.Unmarshal(resp.Body.Bytes(), resourceQuotaList)
@@ -160,7 +160,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             fmt.Sprintf("/api/v2/quotas/project-%s", projectName),
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      200,
+			httpStatus:      http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				resourceQuota := &apiv2.ResourceQuota{}
 				err := json.Unmarshal(resp.Body.Bytes(), resourceQuota)
@@ -188,7 +188,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             "/api/v2/quotas/project-non-existing",
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      404,
+			httpStatus:      http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -203,7 +203,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			}`,
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      409,
+			httpStatus:      http.StatusConflict,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -223,7 +223,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			}`,
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      201,
+			httpStatus:      http.StatusCreated,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -239,7 +239,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			}`,
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      200,
+			httpStatus:      http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -255,7 +255,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			}`,
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      404,
+			httpStatus:      http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -266,7 +266,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             fmt.Sprintf("/api/v2/quotas/project-%s", projectName),
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      200,
+			httpStatus:      http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -277,7 +277,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             "/api/v2/quotas/project-non-existing",
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			existingObjects: existingObjects,
-			httpStatus:      404,
+			httpStatus:      http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},
@@ -288,7 +288,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 			url:             fmt.Sprintf("/api/v2/projects/%s/quota", projectName),
 			existingAPIUser: test.GenDefaultAPIUser(),
 			existingObjects: existingObjects,
-			httpStatus:      200,
+			httpStatus:      http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				resourceQuota := &apiv2.ResourceQuota{}
 				err := json.Unmarshal(resp.Body.Bytes(), resourceQuota)
@@ -316,7 +316,7 @@ func TestHandlerResourceQuotas(t *testing.T) {
 				p.Name = fmt.Sprintf("%s-2", projectName)
 				return p
 			}()),
-			httpStatus: 403,
+			httpStatus: http.StatusForbidden,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
 				return nil
 			},

--- a/pkg/handler/common/provider/packet.go
+++ b/pkg/handler/common/provider/packet.go
@@ -82,7 +82,7 @@ func PacketSizes(apiKey, projectID string, quota kubermaticv1.MachineDeploymentV
 	}
 
 	client := packngo.NewClientWithAuth("kubermatic", apiKey, nil)
-	req, err := client.NewRequest("GET", "/projects/"+projectID+"/plans", nil)
+	req, err := client.NewRequest(http.MethodGet, "/projects/"+projectID+"/plans", nil)
 	if err != nil {
 		return sizes, err
 	}
@@ -112,7 +112,7 @@ func DescribePacketSize(apiKey, projectID, instanceType string) (packngo.Plan, e
 	}
 
 	packetclient := packngo.NewClientWithAuth("kubermatic", apiKey, nil)
-	req, err := packetclient.NewRequest("GET", "/projects/"+projectID+"/plans", nil)
+	req, err := packetclient.NewRequest(http.MethodGet, "/projects/"+projectID+"/plans", nil)
 	if err != nil {
 		return plan, err
 	}

--- a/pkg/handler/v1/addon/addon_test.go
+++ b/pkg/handler/v1/addon/addon_test.go
@@ -143,7 +143,7 @@ func TestGetAddon(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.AddonToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.AddonToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var machineObj []ctrlruntimeclient.Object
 			var kubernetesObj []ctrlruntimeclient.Object
@@ -307,7 +307,7 @@ func TestListAddons(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj := []ctrlruntimeclient.Object{test.GenTestSeed()}
@@ -461,7 +461,7 @@ func TestCreateAddon(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj := []ctrlruntimeclient.Object{test.GenTestSeed()}
@@ -637,7 +637,7 @@ func TestCreatePatchGetAddon(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.CreateBody))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.CreateBody))
 			res := httptest.NewRecorder()
 
 			kubermaticObj := []ctrlruntimeclient.Object{test.GenTestSeed()}
@@ -657,7 +657,7 @@ func TestCreatePatchGetAddon(t *testing.T) {
 				return
 			}
 
-			req = httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToPatch), strings.NewReader(tc.PatchBody))
+			req = httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToPatch), strings.NewReader(tc.PatchBody))
 			res = httptest.NewRecorder()
 
 			ep.ServeHTTP(res, req)
@@ -670,7 +670,7 @@ func TestCreatePatchGetAddon(t *testing.T) {
 				return
 			}
 
-			req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToGet), strings.NewReader(""))
+			req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToGet), strings.NewReader(""))
 			res = httptest.NewRecorder()
 
 			if res.Code != tc.ExpectedGetHTTPStatus {

--- a/pkg/handler/v1/admin/admin_test.go
+++ b/pkg/handler/v1/admin/admin_test.go
@@ -68,7 +68,7 @@ func TestGetAdmins(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("GET", "/api/v1/admin", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin", strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj := []ctrlruntimeclient.Object{test.GenTestSeed()}
@@ -142,7 +142,7 @@ func TestSetAdmin(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("PUT", "/api/v1/admin", strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/admin", strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj := []ctrlruntimeclient.Object{test.GenTestSeed()}

--- a/pkg/handler/v1/admin/admission_plugin_test.go
+++ b/pkg/handler/v1/admin/admission_plugin_test.go
@@ -93,7 +93,7 @@ func TestListAdmissionPluginEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("GET", "/api/v1/admin/admission/plugins", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/admission/plugins", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -177,7 +177,7 @@ func TestGetAdmissionPluginEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/admin/admission/plugins/%s", tc.plugin), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/admission/plugins/%s", tc.plugin), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -261,7 +261,7 @@ func TestDeleteAdmissionPluginEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/admin/admission/plugins/%s", tc.plugin), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/admission/plugins/%s", tc.plugin), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -376,7 +376,7 @@ func TestUpdateAdmissionPluginEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/admin/admission/plugins/%s", tc.plugin), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/admin/admission/plugins/%s", tc.plugin), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v1/admin/backupdestination_test.go
+++ b/pkg/handler/v1/admin/backupdestination_test.go
@@ -86,7 +86,7 @@ func TestDeleteBackupDestinationEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/admin/seeds/%s/backupdestinations/%s",
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/seeds/%s/backupdestinations/%s",
 				test.GenTestSeed().Name, tc.backupDestinationName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object

--- a/pkg/handler/v1/admin/seed_test.go
+++ b/pkg/handler/v1/admin/seed_test.go
@@ -61,7 +61,7 @@ func TestListSeedsEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("GET", "/api/v1/admin/seeds", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/seeds", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -123,7 +123,7 @@ func TestGetSeedEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/admin/seeds/%s", tc.seedName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/seeds/%s", tc.seedName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -220,7 +220,7 @@ func TestUpdateSeedEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/admin/seeds/%s", tc.seedName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/admin/seeds/%s", tc.seedName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -283,7 +283,7 @@ func TestDeleteSeedEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/admin/seeds/%s", tc.seedName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/seeds/%s", tc.seedName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -337,7 +337,7 @@ func TestCreateSeedEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("POST", "/api/v1/admin/seeds", strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/seeds", strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v1/admin/settings_test.go
+++ b/pkg/handler/v1/admin/settings_test.go
@@ -63,7 +63,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("GET", "/api/v1/admin/settings", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -128,7 +128,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("PATCH", "/api/v1/admin/settings", strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v1/admission-plugin/admission_plugin_test.go
+++ b/pkg/handler/v1/admission-plugin/admission_plugin_test.go
@@ -120,7 +120,7 @@ func TestCredentialEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/admission/plugins/%s", tc.version), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admission/plugins/%s", tc.version), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			apiUser := test.GenDefaultAPIUser()

--- a/pkg/handler/v1/cluster/binding_test.go
+++ b/pkg/handler/v1/cluster/binding_test.go
@@ -258,7 +258,7 @@ func TestBindUserToRole(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -374,7 +374,7 @@ func TestUnbindUserFromRoleBinding(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -479,7 +479,7 @@ func TestListRoleBinding(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/bindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/bindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -718,7 +718,7 @@ func TestBindUserToClusterRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -835,7 +835,7 @@ func TestUnbindUserFromClusterRoleBinding(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -936,7 +936,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterbindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterbindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v1/cluster/cluster_test.go
+++ b/pkg/handler/v1/cluster/cluster_test.go
@@ -176,7 +176,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -193,7 +193,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 			test.CompareWithResult(t, res, tc.ExpectedResponse)
 
 			// validate if the cluster was deleted
-			req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/abcd/sshkeys", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/abcd/sshkeys", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res = httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
 			if res.Code != tc.ExpectedListClusterKeysStatus {
@@ -342,7 +342,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 			var ep http.Handler
 			{
 				var err error
-				req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.KeyToDelete), strings.NewReader(tc.Body))
+				req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.KeyToDelete), strings.NewReader(tc.Body))
 				res := httptest.NewRecorder()
 				var kubermaticObj []ctrlruntimeclient.Object
 				kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -441,7 +441,7 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/sshkeys", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/sshkeys", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -586,7 +586,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.SSHKeyID), nil)
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.SSHKeyID), nil)
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -827,7 +827,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			if tc.ExistingProject != nil {
@@ -1105,7 +1105,7 @@ func TestGetClusterHealth(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/health", tc.ProjectToSync, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/health", tc.ProjectToSync, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -1399,7 +1399,7 @@ func TestGetCluster(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -1705,7 +1705,7 @@ func TestListClusters(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters", test.ProjectName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters", test.ProjectName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -1939,7 +1939,7 @@ func TestListClustersForProject(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/clusters", test.ProjectName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/clusters", test.ProjectName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -2027,7 +2027,7 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 
 			// perform test
 			res := httptest.NewRecorder()
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/token", test.ProjectName, tc.clusterToGet.Name), nil)
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/token", test.ProjectName, tc.clusterToGet.Name), nil)
 			ep.ServeHTTP(res, req)
 
 			// check assertions
@@ -2159,7 +2159,7 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.QueryParams), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.QueryParams), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := make([]ctrlruntimeclient.Object, 0)
 			machineObj := make([]ctrlruntimeclient.Object, 0)
@@ -2355,7 +2355,7 @@ func TestGetClusterMetrics(t *testing.T) {
 			for _, node := range tc.ExistingNodes {
 				kubeObj = append(kubeObj, node)
 			}
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/metrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/metrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -2456,7 +2456,7 @@ func TestListNamespace(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/namespaces", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/namespaces", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v1/cluster/kubeconfig_test.go
+++ b/pkg/handler/v1/cluster/kubeconfig_test.go
@@ -209,7 +209,7 @@ func TestCreateOIDCKubeconfig(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			reqURL := fmt.Sprintf("/api/v1/kubeconfig?cluster_id=%s&project_id=%s&user_id=%s&datacenter=%s", tc.ClusterID, tc.ProjectID, tc.UserID, tc.Datacenter)
-			req := httptest.NewRequest("GET", reqURL, strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, reqURL, strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, tc.ExistingObjects, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -271,7 +271,7 @@ func TestCreateOIDCKubeconfig(t *testing.T) {
 
 				// call kubeconfig endpoint after authentication
 				// exchange code phase
-				req = httptest.NewRequest("GET", urlExchangeCodePhase, strings.NewReader(""))
+				req = httptest.NewRequest(http.MethodGet, urlExchangeCodePhase, strings.NewReader(""))
 				res = httptest.NewRecorder()
 
 				// create secure cookie
@@ -436,7 +436,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/kubeconfig", tc.ProjectToGet, tc.ClusterToGet), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/kubeconfig", tc.ProjectToGet, tc.ClusterToGet), nil)
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v1/cluster/role_test.go
+++ b/pkg/handler/v1/cluster/role_test.go
@@ -61,7 +61,7 @@ func TestCreateClusterRole(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -125,7 +125,7 @@ func TestCreateRole(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -182,7 +182,7 @@ func TestListRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -238,7 +238,7 @@ func TestListClusterRole(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -299,7 +299,7 @@ func TestGetRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -357,7 +357,7 @@ func TestGetClusterRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -440,7 +440,7 @@ func TestPatchRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/roles/%s/%s", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -520,7 +520,7 @@ func TestPatchClusterRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterroles/%s", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -588,7 +588,7 @@ func TestListRoleNmaes(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/rolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/rolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -664,7 +664,7 @@ func TestListClusterRoleNames(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterrolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/clusterrolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v1/cluster/upgrade_test.go
+++ b/pkg/handler/v1/cluster/upgrade_test.go
@@ -268,7 +268,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 			}
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/foo/upgrades", test.ProjectName), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/foo/upgrades", test.ProjectName), nil)
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{testStruct.cluster}
 			kubermaticObj = append(kubermaticObj, testStruct.existingKubermaticObjs...)
@@ -383,7 +383,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("entering")
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodes/upgrades",
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodes/upgrades",
 				tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
@@ -498,7 +498,7 @@ func TestGetNodeUpgrades(t *testing.T) {
 				},
 			}
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/upgrades/node?control_plane_version=%s", testStruct.controlPlaneVersion), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/upgrades/node?control_plane_version=%s", testStruct.controlPlaneVersion), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(testStruct.apiUser, nil, testStruct.existingKubermaticObjs, &dummyKubermaticConfiguration, hack.NewTestRouting)
 			if err != nil {
@@ -569,7 +569,7 @@ func TestGetMasterVersionsEndpoint(t *testing.T) {
 			if len(testStruct.clusterType) > 0 {
 				testStruct.clusterType = fmt.Sprintf("?type=%s", testStruct.clusterType)
 			}
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/upgrades/cluster%s", testStruct.clusterType), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/upgrades/cluster%s", testStruct.clusterType), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(testStruct.apiUser, nil, testStruct.existingKubermaticObjs, &dummyKubermaticConfiguration, hack.NewTestRouting)
 			if err != nil {

--- a/pkg/handler/v1/dc/datacenter_test.go
+++ b/pkg/handler/v1/dc/datacenter_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -61,7 +62,7 @@ func TestDatacentersListEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v1/dc", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/dc", nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -126,7 +127,7 @@ func TestDatacenterGetEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/dc/%s", tc.dc), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/dc/%s", tc.dc), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -177,7 +178,7 @@ func TestDatacenterListForProviderEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/providers/%s/dc", tc.provider), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/providers/%s/dc", tc.provider), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -256,7 +257,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/providers/%s/dc/%s", tc.provider, tc.dc), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/providers/%s/dc/%s", tc.provider, tc.dc), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -307,7 +308,7 @@ func TestDatacenterListForSeedEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/seed/%s/dc", tc.seed), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/seed/%s/dc", tc.seed), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -386,7 +387,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/seed/%s/dc/%s", tc.seed, tc.dc), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/seed/%s/dc/%s", tc.seed, tc.dc), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -515,7 +516,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error marshalling body into json: %v", err)
 			}
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/seed/%s/dc", tc.seedName), bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/seed/%s/dc", tc.seedName), bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)
@@ -709,7 +710,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error marshalling body into json: %v", err)
 			}
-			req := httptest.NewRequest("PUT",
+			req := httptest.NewRequest(http.MethodPut,
 				fmt.Sprintf("/api/v1/seed/%s/dc/%s", tc.seedName, tc.dcPathName), bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
@@ -823,7 +824,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("PATCH",
+			req := httptest.NewRequest(http.MethodPatch,
 				fmt.Sprintf("/api/v1/seed/%s/dc/%s", tc.seedName, tc.dcPathName), strings.NewReader(tc.patch))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
@@ -887,7 +888,7 @@ func TestDatacenterDeleteEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE",
+			req := httptest.NewRequest(http.MethodDelete,
 				fmt.Sprintf("/api/v1/seed/%s/dc/%s", tc.seedName, tc.dcName), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},

--- a/pkg/handler/v1/dc/datacenter_test.go
+++ b/pkg/handler/v1/dc/datacenter_test.go
@@ -50,13 +50,13 @@ func TestDatacentersListEndpoint(t *testing.T) {
 		{
 			name:             "admin should be able to list dc without email filtering",
 			expectedResponse: `[{"metadata":{"name":"audited-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","fake":{},"node":{},"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"fake-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Henrik's basement","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"node-dc"},"spec":{"seed":"us-central1","country":"Chile","location":"Santiago","provider":"fake","fake":{},"node":{"httpProxy":"HTTPProxy","insecureRegistries":["incsecure-registry"],"registryMirrors":["http://127.0.0.1:5001"],"pauseImage":"pause-image"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"private-do1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{"pauseImage":"image-pause"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":true}},{"metadata":{"name":"psp-dc"},"spec":{"seed":"us-central1","country":"Egypt","location":"Alexandria","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":false}},{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}},{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"restricted-fake-dc2"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["23f67weuc.com","example.com","12noifsdsd.org"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
 			name:             "regular user should be able to list dc with email filtering",
 			expectedResponse: `[{"metadata":{"name":"audited-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","fake":{},"node":{},"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"fake-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Henrik's basement","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"node-dc"},"spec":{"seed":"us-central1","country":"Chile","location":"Santiago","provider":"fake","fake":{},"node":{"httpProxy":"HTTPProxy","insecureRegistries":["incsecure-registry"],"registryMirrors":["http://127.0.0.1:5001"],"pauseImage":"pause-image"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"private-do1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{"pauseImage":"image-pause"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":true}},{"metadata":{"name":"psp-dc"},"spec":{"seed":"us-central1","country":"Egypt","location":"Alexandria","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":false}},{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}}]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}
@@ -93,35 +93,35 @@ func TestDatacenterGetEndpoint(t *testing.T) {
 			name:             "admin should be able to get email restricted dc",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
 			name:             "regular user should not be able to get restricted dc if his email domain is restricted",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
 			name:             "regular user should be able to get restricted dc if his email domain is allowed",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenAPIUser(test.UserName2, test.UserEmail2),
 		},
 		{
 			name:             "should get 404 for non-existent dc",
 			dc:               "idontexist",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"idontexist\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
 			name:             "should find dc",
 			dc:               "regular-do1",
 			expectedResponse: `{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}
@@ -158,21 +158,21 @@ func TestDatacenterListForProviderEndpoint(t *testing.T) {
 			name:             "admin should be able to list dc per provider without email filtering",
 			provider:         "fake",
 			expectedResponse: `[{"metadata":{"name":"audited-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","fake":{},"node":{},"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"fake-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Henrik's basement","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"node-dc"},"spec":{"seed":"us-central1","country":"Chile","location":"Santiago","provider":"fake","fake":{},"node":{"httpProxy":"HTTPProxy","insecureRegistries":["incsecure-registry"],"registryMirrors":["http://127.0.0.1:5001"],"pauseImage":"pause-image"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"psp-dc"},"spec":{"seed":"us-central1","country":"Egypt","location":"Alexandria","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":false}},{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"restricted-fake-dc2"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["23f67weuc.com","example.com","12noifsdsd.org"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
 			name:             "regular user should be able to list dc per provider with email filtering",
 			provider:         "fake",
 			expectedResponse: `[{"metadata":{"name":"audited-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","fake":{},"node":{},"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"fake-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Henrik's basement","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"node-dc"},"spec":{"seed":"us-central1","country":"Chile","location":"Santiago","provider":"fake","fake":{},"node":{"httpProxy":"HTTPProxy","insecureRegistries":["incsecure-registry"],"registryMirrors":["http://127.0.0.1:5001"],"pauseImage":"pause-image"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"psp-dc"},"spec":{"seed":"us-central1","country":"Egypt","location":"Alexandria","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":false}}]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
 			name:             "should receive empty list for non-existent provider",
 			provider:         "idontexist",
 			expectedResponse: `[]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}
@@ -211,7 +211,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 			provider:         "fake",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -219,7 +219,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 			provider:         "fake",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -227,7 +227,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 			provider:         "fake",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenAPIUser(test.UserName2, test.UserEmail2),
 		},
 		{
@@ -235,7 +235,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 			provider:         "fake",
 			dc:               "idontexist",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"idontexist\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -243,7 +243,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 			provider:         "idontexist",
 			dc:               "regular-do1",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"regular-do1\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -251,7 +251,7 @@ func TestDatacenterGetForProviderEndpoint(t *testing.T) {
 			provider:         "digitalocean",
 			dc:               "regular-do1",
 			expectedResponse: `{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}
@@ -288,21 +288,21 @@ func TestDatacenterListForSeedEndpoint(t *testing.T) {
 			name:             "admin should be able to list dc per seed without email filtering",
 			seed:             "us-central1",
 			expectedResponse: `[{"metadata":{"name":"audited-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","fake":{},"node":{},"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"fake-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Henrik's basement","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"node-dc"},"spec":{"seed":"us-central1","country":"Chile","location":"Santiago","provider":"fake","fake":{},"node":{"httpProxy":"HTTPProxy","insecureRegistries":["incsecure-registry"],"registryMirrors":["http://127.0.0.1:5001"],"pauseImage":"pause-image"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"private-do1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{"pauseImage":"image-pause"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":true}},{"metadata":{"name":"psp-dc"},"spec":{"seed":"us-central1","country":"Egypt","location":"Alexandria","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":false}},{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}},{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"restricted-fake-dc2"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["23f67weuc.com","example.com","12noifsdsd.org"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
 			name:             "regular user should be able to list dc per seed with email filtering",
 			seed:             "us-central1",
 			expectedResponse: `[{"metadata":{"name":"audited-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","fake":{},"node":{},"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"fake-dc"},"spec":{"seed":"us-central1","country":"Germany","location":"Henrik's basement","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"node-dc"},"spec":{"seed":"us-central1","country":"Chile","location":"Santiago","provider":"fake","fake":{},"node":{"httpProxy":"HTTPProxy","insecureRegistries":["incsecure-registry"],"registryMirrors":["http://127.0.0.1:5001"],"pauseImage":"pause-image"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}},{"metadata":{"name":"private-do1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{"pauseImage":"image-pause"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":true}},{"metadata":{"name":"psp-dc"},"spec":{"seed":"us-central1","country":"Egypt","location":"Alexandria","provider":"fake","fake":{},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":false}},{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}}]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
 			name:             "should receive 404 for non-existing seed",
 			seed:             "idontexist",
 			expectedResponse: `{"error":{"code":404,"message":"seed \"idontexist\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}
@@ -341,7 +341,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 			seed:             "us-central1",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -349,7 +349,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 			seed:             "us-central1",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"restricted-fake-dc\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -357,7 +357,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 			seed:             "us-central1",
 			dc:               "restricted-fake-dc",
 			expectedResponse: `{"metadata":{"name":"restricted-fake-dc"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","fake":{},"node":{},"requiredEmails":["example.com"],"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenAPIUser(test.UserName2, test.UserEmail2),
 		},
 		{
@@ -365,7 +365,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 			seed:             "us-central1",
 			dc:               "idontexist",
 			expectedResponse: `{"error":{"code":404,"message":"datacenter \"idontexist\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -373,7 +373,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 			seed:             "idontexist",
 			dc:               "regular-do1",
 			expectedResponse: `{"error":{"code":404,"message":"seed \"idontexist\" not found"}}`,
-			httpStatus:       404,
+			httpStatus:       http.StatusNotFound,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -381,7 +381,7 @@ func TestDatacenterGetForSeedEndpoint(t *testing.T) {
 			seed:             "us-central1",
 			dc:               "regular-do1",
 			expectedResponse: `{"metadata":{"name":"regular-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":true}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}
@@ -427,7 +427,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "do-correct",
 			seedName:         "us-central1",
 			expectedResponse: `{"metadata":{"name":"do-correct"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","digitalocean":{"region":""},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       201,
+			httpStatus:       http.StatusCreated,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -439,7 +439,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "do-correct",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
-			httpStatus:       403,
+			httpStatus:       http.StatusForbidden,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -451,7 +451,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: datacenter \"private-do1\" already exists"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -463,7 +463,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "idontexist",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: seed \"idontexist\" does not exist"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -474,7 +474,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Validation error: one DC provider should be specified, got: []"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -487,7 +487,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Validation error: one DC provider should be specified, got: [digitalocean aws]"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -499,7 +499,7 @@ func TestDatacenterCreateEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "different",
 			expectedResponse: `{"error":{"code":400,"message":"Validation error: path seed \"different\" and request seed \"us-central1\" not equal"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 	}
@@ -566,7 +566,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"metadata":{"name":"private-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","digitalocean":{"region":"EU"},"node":{"pauseImage":"pause-image"},"requiredEmails":["example.com","pleaseno.org"],"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -589,7 +589,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"metadata":{"name":"private-do1-updated"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","digitalocean":{"region":"EU"},"node":{"pauseImage":"pause-image"},"requiredEmails":["example.com","pleaseno.org"],"enforceAuditLogging":true,"enforcePodSecurityPolicy":false,"ipv6Enabled":false}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -604,7 +604,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "do-correct",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
-			httpStatus:       403,
+			httpStatus:       http.StatusForbidden,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -619,7 +619,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "idontexist",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: datacenter \"idontexist\" does not exists"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -634,7 +634,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "regular-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: cannot change \"regular-do1\" datacenter name to \"private-do1\" as it already exists"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -649,7 +649,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "idontexist",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: seed \"idontexist\" does not exist"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -661,7 +661,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Validation error: one DC provider should be specified, got: []"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -679,7 +679,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Validation error: one DC provider should be specified, got: [digitalocean aws]"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -694,7 +694,7 @@ func TestDatacenterUpdateEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "different",
 			expectedResponse: `{"error":{"code":400,"message":"Validation error: path seed \"different\" and request seed \"us-central1\" not equal"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 	}
@@ -746,7 +746,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"metadata":{"name":"private-do1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"aws","aws":{"region":"EU"},"node":{},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":true}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -755,7 +755,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"metadata":{"name":"private-do1-updated"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"node":{"pauseImage":"image-pause"},"enforceAuditLogging":false,"enforcePodSecurityPolicy":true,"ipv6Enabled":true}}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -764,7 +764,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "do-correct",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
-			httpStatus:       403,
+			httpStatus:       http.StatusForbidden,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -773,7 +773,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "idontexist",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: datacenter \"idontexist\" does not exists"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -782,7 +782,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "regular-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: cannot change \"regular-do1\" datacenter name to \"private-do1\" as it already exists"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -791,7 +791,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "idontexist",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: seed \"idontexist\" does not exist"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -800,7 +800,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"patched dc validation failed: one DC provider should be specified, got: []"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -809,7 +809,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"patched dc validation failed: one DC provider should be specified, got: [digitalocean aws]"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -818,7 +818,7 @@ func TestDatacenterPatchEndpoint(t *testing.T) {
 			dcPathName:       "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"patched dc validation failed: path seed name \"us-central1\" has to be equal to patch seed name \"different\""}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 	}
@@ -858,7 +858,7 @@ func TestDatacenterDeleteEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{}`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -866,7 +866,7 @@ func TestDatacenterDeleteEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
-			httpStatus:       403,
+			httpStatus:       http.StatusForbidden,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 		{
@@ -874,7 +874,7 @@ func TestDatacenterDeleteEndpoint(t *testing.T) {
 			dcName:           "idontexist",
 			seedName:         "us-central1",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: datacenter \"idontexist\" does not exists"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
@@ -882,7 +882,7 @@ func TestDatacenterDeleteEndpoint(t *testing.T) {
 			dcName:           "private-do1",
 			seedName:         "idontexist",
 			expectedResponse: `{"error":{"code":400,"message":"Bad request: seed \"idontexist\" does not exist"}}`,
-			httpStatus:       400,
+			httpStatus:       http.StatusBadRequest,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 	}

--- a/pkg/handler/v1/label/label_test.go
+++ b/pkg/handler/v1/label/label_test.go
@@ -59,7 +59,7 @@ func TestListSystemLabels(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v1/labels/system", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/labels/system", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, kubermaticObj, nil, hack.NewTestRouting)

--- a/pkg/handler/v1/node/node_test.go
+++ b/pkg/handler/v1/node/node_test.go
@@ -145,7 +145,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodes/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeIDToDelete), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodes/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeIDToDelete), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -317,7 +317,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments", tc.ProjectID, tc.ClusterID), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments", tc.ProjectID, tc.ClusterID), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -524,7 +524,7 @@ func TestListNodeDeployments(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments",
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments",
 				tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
@@ -705,7 +705,7 @@ func TestGetNodeDeployment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/venus",
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/venus",
 				tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
@@ -917,7 +917,7 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -1102,7 +1102,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID, tc.QueryParams), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID, tc.QueryParams), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -1396,7 +1396,7 @@ func TestDeleteNodeDeployment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s",
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s",
 				tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeIDToDelete), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
@@ -1560,7 +1560,7 @@ func TestNodeDeploymentMetrics(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes/metrics", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes/metrics", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}

--- a/pkg/handler/v1/presets/credentials_test.go
+++ b/pkg/handler/v1/presets/credentials_test.go
@@ -458,7 +458,7 @@ func TestCredentialEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/providers/%s/presets/credentials?datacenter=%s", tc.provider, tc.datacenter), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/providers/%s/presets/credentials?datacenter=%s", tc.provider, tc.datacenter), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			apiUser := test.GenDefaultAPIUser()

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -190,7 +190,7 @@ func TestRenameProjectEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s", tc.ProjectToRename), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s", tc.ProjectToRename), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -412,7 +412,7 @@ func TestListProjectEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// test data
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects?displayAll=%v", tc.DisplayAll), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects?displayAll=%v", tc.DisplayAll), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -672,7 +672,7 @@ func TestGetProjectEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// test data
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -808,7 +808,7 @@ func TestCreateProjectEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// test data
-			req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -893,7 +893,7 @@ func TestDeleteProjectEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// test data
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s", tc.ProjectToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s", tc.ProjectToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []ctrlruntimeclient.Object{}, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -1010,7 +1010,7 @@ func TestServiceAccountProjectAccess(t *testing.T) {
 				t.Fatalf("failed to create test endpoint: %v", err)
 			}
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s", tc.projectToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s", tc.projectToSync), strings.NewReader(""))
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 			res := httptest.NewRecorder()
 			getEp.ServeHTTP(res, req)
@@ -1022,7 +1022,7 @@ func TestServiceAccountProjectAccess(t *testing.T) {
 			test.CompareWithResult(t, res, tc.expectedGetProjectResponse)
 
 			// act 2 - create a new project using sa token
-			req = httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(tc.bodyCreate))
+			req = httptest.NewRequest(http.MethodPost, "/api/v1/projects", strings.NewReader(tc.bodyCreate))
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 			res = httptest.NewRecorder()
 			getEp.ServeHTTP(res, req)

--- a/pkg/handler/v1/provider/azure_test.go
+++ b/pkg/handler/v1/provider/azure_test.go
@@ -87,7 +87,7 @@ func TestAzureSizeEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v1/providers/azure/sizes", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/providers/azure/sizes", strings.NewReader(""))
 
 			req.Header.Add("SubscriptionID", testID)
 			req.Header.Add("ClientID", testID)

--- a/pkg/handler/v1/provider/openstack_test.go
+++ b/pkg/handler/v1/provider/openstack_test.go
@@ -130,7 +130,7 @@ func SetupOpenstackServer(t *testing.T) {
 			}
 
 			w.Header().Add("Content-Type", "application/json")
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				w.WriteHeader(201)
 			} else {
 				w.WriteHeader(200)
@@ -288,7 +288,7 @@ func TestOpenstackEndpoints(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tc.URL, strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, tc.URL, strings.NewReader(""))
 			if tc.QueryParams != nil {
 				q := req.URL.Query()
 				for k, v := range tc.QueryParams {

--- a/pkg/handler/v1/provider/openstack_test.go
+++ b/pkg/handler/v1/provider/openstack_test.go
@@ -131,9 +131,9 @@ func SetupOpenstackServer(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			if r.Method == http.MethodPost {
-				w.WriteHeader(201)
+				w.WriteHeader(http.StatusCreated)
 			} else {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}
 
 			_, err := w.Write(buf.Bytes())

--- a/pkg/handler/v1/provider/vsphere_test.go
+++ b/pkg/handler/v1/provider/vsphere_test.go
@@ -87,7 +87,7 @@ func TestVsphereEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tc.URL, nil)
+			req := httptest.NewRequest(http.MethodGet, tc.URL, nil)
 			req.Header.Add("DatacenterName", vSphereDatacenterName)
 			req.Header.Add("Username", "user")
 			req.Header.Add("Password", "pass")

--- a/pkg/handler/v1/seed/seed_test.go
+++ b/pkg/handler/v1/seed/seed_test.go
@@ -46,13 +46,13 @@ func TestSeedNamesListEndpoint(t *testing.T) {
 		{
 			name:             "admin should be able to list seed names",
 			expectedResponse: `["us-central1"]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAdminAPIUser(),
 		},
 		{
 			name:             "regular user should be able to list seed names",
 			expectedResponse: `["us-central1"]`,
-			httpStatus:       200,
+			httpStatus:       http.StatusOK,
 			existingAPIUser:  test.GenDefaultAPIUser(),
 		},
 	}

--- a/pkg/handler/v1/seed/seed_test.go
+++ b/pkg/handler/v1/seed/seed_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package seed_test
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestSeedNamesListEndpoint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v1/seed", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/seed", nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{},
 				[]ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.existingAPIUser), test.GenTestSeed()}, nil, hack.NewTestRouting)

--- a/pkg/handler/v1/serviceaccount/sa_test.go
+++ b/pkg/handler/v1/serviceaccount/sa_test.go
@@ -169,7 +169,7 @@ func TestCreateServiceAccountProject(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts", tc.projectToSync), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts", tc.projectToSync), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			ep, client, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, []ctrlruntimeclient.Object{}, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -342,7 +342,7 @@ func TestList(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts", tc.projectToSync), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts", tc.projectToSync), nil)
 			res := httptest.NewRecorder()
 
 			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, []ctrlruntimeclient.Object{}, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -460,7 +460,7 @@ func TestEdit(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s", tc.projectToSync, tc.saToUpdate), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s", tc.projectToSync, tc.saToUpdate), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			ep, client, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, []ctrlruntimeclient.Object{}, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -583,7 +583,7 @@ func TestDelete(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s", tc.projectToSync, tc.saToDelete), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s", tc.projectToSync, tc.saToDelete), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			ep, err := test.CreateTestEndpoint(*tc.existingAPIUser, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)

--- a/pkg/handler/v1/serviceaccount/token_test.go
+++ b/pkg/handler/v1/serviceaccount/token_test.go
@@ -127,7 +127,7 @@ func TestCreateTokenProject(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens", tc.projectToSync, tc.saToSync), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens", tc.projectToSync, tc.saToSync), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			ep, fakeClients, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -250,7 +250,7 @@ func TestListTokens(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens", tc.projectToSync, tc.saToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens", tc.projectToSync, tc.saToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -311,7 +311,7 @@ func TestServiceAccountCanGetProject(t *testing.T) {
 			var token string
 			var ep http.Handler
 			{
-				req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens", tc.projectToSync, "1"), strings.NewReader(`{"name":"ci-v","group":"viewers"}`))
+				req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens", tc.projectToSync, "1"), strings.NewReader(`{"name":"ci-v","group":"viewers"}`))
 				res := httptest.NewRecorder()
 
 				tc.existingKubermaticObjs = append(tc.existingKubermaticObjs, tc.existingSa)
@@ -338,7 +338,7 @@ func TestServiceAccountCanGetProject(t *testing.T) {
 			}
 
 			// act 2 - get the project using sa token
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s", tc.projectToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s", tc.projectToSync), strings.NewReader(""))
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 			res := httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
@@ -470,7 +470,7 @@ func TestPatchToken(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToSync), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToSync), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -648,7 +648,7 @@ func TestUpdateToken(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToSync), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToSync), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)
@@ -760,7 +760,7 @@ func TestDeleteToken(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToDelete), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToDelete), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			ep, clientset, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []ctrlruntimeclient.Object{}, tc.existingKubermaticObjs, nil, hack.NewTestRouting)

--- a/pkg/handler/v1/ssh/ssh_test.go
+++ b/pkg/handler/v1/ssh/ssh_test.go
@@ -117,7 +117,7 @@ func TestDeleteSSHKey(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			sshKeyID := tc.SSHKeyToDelete
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/sshkeys/%s", "my-first-project-ID", sshKeyID), nil)
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/sshkeys/%s", "my-first-project-ID", sshKeyID), nil)
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -228,7 +228,7 @@ func TestListSSHKeys(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/sshkeys", "my-first-project-ID"), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/sshkeys", "my-first-project-ID"), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -332,7 +332,7 @@ func TestCreateSSHKeysEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/sshkeys", "my-first-project-ID"), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/sshkeys", "my-first-project-ID"), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v1/user/user_test.go
+++ b/pkg/handler/v1/user/user_test.go
@@ -247,7 +247,7 @@ func TestGetUsersForProject(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/users", tc.ProjectToGet), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/users", tc.ProjectToGet), nil)
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -410,7 +410,7 @@ func TestDeleteUserFromProject(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/users/%s", tc.ProjectToSync, tc.UserIDToDelete), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/projects/%s/users/%s", tc.ProjectToSync, tc.UserIDToDelete), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -584,7 +584,7 @@ func TestEditUserInProject(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/users/%s", tc.ProjectToSync, tc.UserIDToUpdate), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/projects/%s/users/%s", tc.ProjectToSync, tc.UserIDToUpdate), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -816,7 +816,7 @@ func TestAddUserToProject(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/users", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/projects/%s/users", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -880,7 +880,7 @@ func TestGetCurrentUser(t *testing.T) {
 				t.Fatalf("failed to create test endpoint: %v", err)
 			}
 
-			req := httptest.NewRequest("GET", "/api/v1/me", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
 			res := httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
 
@@ -944,7 +944,7 @@ func TestNewUser(t *testing.T) {
 			}
 
 			// act
-			req := httptest.NewRequest("GET", "/api/v1/me", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
 			res := httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
 
@@ -1041,7 +1041,7 @@ func TestLogoutCurrentUser(t *testing.T) {
 				t.Fatalf("failed to create test endpoint: %v", err)
 			}
 
-			req := httptest.NewRequest("POST", "/api/v1/me/logout", nil)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/me/logout", nil)
 			res := httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
 

--- a/pkg/handler/v1/version_test.go
+++ b/pkg/handler/v1/version_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestKubermaticVersion(t *testing.T) {
-	req := httptest.NewRequest("GET", "/api/v1/version", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
 	res := httptest.NewRecorder()
 	ep, err := test.CreateTestEndpoint(*test.GenDefaultAPIUser(), []ctrlruntimeclient.Object{}, nil, nil, hack.NewTestRouting)
 	if err != nil {

--- a/pkg/handler/v2/addon/addon_test.go
+++ b/pkg/handler/v2/addon/addon_test.go
@@ -150,7 +150,7 @@ func TestGetAddon(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.AddonToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.AddonToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -313,7 +313,7 @@ func TestListAddons(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -470,7 +470,7 @@ func TestCreateAddon(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -648,7 +648,7 @@ func TestCreatePatchGetAddon(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.CreateBody))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.CreateBody))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -667,7 +667,7 @@ func TestCreatePatchGetAddon(t *testing.T) {
 				return
 			}
 
-			req = httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToPatch), strings.NewReader(tc.PatchBody))
+			req = httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToPatch), strings.NewReader(tc.PatchBody))
 			res = httptest.NewRecorder()
 
 			ep.ServeHTTP(res, req)
@@ -680,7 +680,7 @@ func TestCreatePatchGetAddon(t *testing.T) {
 				return
 			}
 
-			req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToGet), strings.NewReader(""))
+			req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToGet), strings.NewReader(""))
 			res = httptest.NewRecorder()
 
 			if res.Code != tc.ExpectedGetHTTPStatus {

--- a/pkg/handler/v2/allowed_registry/allowed_registry_test.go
+++ b/pkg/handler/v2/allowed_registry/allowed_registry_test.go
@@ -72,7 +72,7 @@ func TestCreateAllowedRegistry(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error marshalling body into json: %v", err)
 			}
-			req := httptest.NewRequest("POST", "/api/v2/allowedregistries", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/allowedregistries", bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, []ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.ExistingAPIUser)}, nil, hack.NewTestRouting)
 			if err != nil {
@@ -139,7 +139,7 @@ func TestGetAllowedRegistry(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/allowedregistries/%s", tc.WRName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/allowedregistries/%s", tc.WRName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -187,7 +187,7 @@ func TestListAllowedRegistries(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
 
-			req := httptest.NewRequest("GET", "/api/v2/allowedregistries", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/allowedregistries", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -250,7 +250,7 @@ func TestDeleteAllowedRegistry(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/allowedregistries/%s", tc.WRToDeleteName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/allowedregistries/%s", tc.WRToDeleteName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -321,7 +321,7 @@ func TestPatchAllowedRegistry(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
 
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v2/allowedregistries/%s", tc.WRName), strings.NewReader(tc.RawPatch))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v2/allowedregistries/%s", tc.WRName), strings.NewReader(tc.RawPatch))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {

--- a/pkg/handler/v2/application_definition/application_definition_test.go
+++ b/pkg/handler/v2/application_definition/application_definition_test.go
@@ -70,7 +70,7 @@ func TestListApplicationDefinitions(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v2/applicationdefinitions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/applicationdefinitions", nil)
 			res := httptest.NewRecorder()
 
 			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, nil, nil, tc.ExistingObjects, nil, hack.NewTestRouting)

--- a/pkg/handler/v2/cluster/binding_test.go
+++ b/pkg/handler/v2/cluster/binding_test.go
@@ -258,7 +258,7 @@ func TestBindUserToRole(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -374,7 +374,7 @@ func TestUnbindUserFromRoleBinding(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/roles/%s/%s/bindings", test.ProjectName, tc.clusterToGet, tc.namespace, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -613,7 +613,7 @@ func TestBindUserToClusterRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -730,7 +730,7 @@ func TestUnbindUserFromClusterRoleBinding(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterroles/%s/clusterbindings", test.ProjectName, tc.clusterToGet, tc.roleName), strings.NewReader(tc.body))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -834,7 +834,7 @@ func TestListRoleBinding(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/bindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/bindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -936,7 +936,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterbindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterbindings", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -305,7 +305,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			if tc.ExistingProject != nil {
@@ -626,7 +626,7 @@ func TestListClusters(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters", test.ProjectName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters", test.ProjectName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -757,7 +757,7 @@ func TestGetCluster(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -864,7 +864,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -881,7 +881,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 			test.CompareWithResult(t, res, tc.ExpectedResponse)
 
 			// validate if the cluster was deleted
-			req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/abcd/sshkeys", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/abcd/sshkeys", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res = httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
 			if res.Code != tc.ExpectedListClusterKeysStatus {
@@ -1205,7 +1205,7 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.QueryParams), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.QueryParams), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := make([]ctrlruntimeclient.Object, 0)
 			machineObj := make([]ctrlruntimeclient.Object, 0)
@@ -1470,7 +1470,7 @@ func TestGetClusterHealth(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/health", tc.ProjectToSync, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/health", tc.ProjectToSync, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -1656,7 +1656,7 @@ func TestGetClusterMetrics(t *testing.T) {
 			for _, node := range tc.ExistingNodes {
 				kubeObj = append(kubeObj, node)
 			}
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/metrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/metrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -1757,7 +1757,7 @@ func TestListNamespace(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/namespaces", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/namespaces", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -1916,7 +1916,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 			var ep http.Handler
 			{
 				var err error
-				req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.KeyToDelete), strings.NewReader(tc.Body))
+				req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.KeyToDelete), strings.NewReader(tc.Body))
 				res := httptest.NewRecorder()
 				var kubermaticObj []ctrlruntimeclient.Object
 				kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -2055,7 +2055,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.SSHKeyID), nil)
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/sshkeys/%s", tc.ProjectToSync, tc.ClusterToSync, tc.SSHKeyID), nil)
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -2154,7 +2154,7 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/sshkeys", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/sshkeys", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -2242,7 +2242,7 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 
 			// perform test
 			res := httptest.NewRecorder()
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/token", test.ProjectName, tc.clusterToGet.Name), nil)
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/token", test.ProjectName, tc.clusterToGet.Name), nil)
 			ep.ServeHTTP(res, req)
 
 			// check assertions

--- a/pkg/handler/v2/cluster/kubeconfig_test.go
+++ b/pkg/handler/v2/cluster/kubeconfig_test.go
@@ -171,7 +171,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/kubeconfig", tc.ProjectToGet, tc.ClusterToGet), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/kubeconfig", tc.ProjectToGet, tc.ClusterToGet), nil)
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v2/cluster/role_test.go
+++ b/pkg/handler/v2/cluster/role_test.go
@@ -67,7 +67,7 @@ func TestListRole(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/roles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/roles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -123,7 +123,7 @@ func TestListClusterRole(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterroles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterroles", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -191,7 +191,7 @@ func TestListRoleNames(t *testing.T) {
 			var kubeObj []ctrlruntimeclient.Object
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/rolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/rolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)
@@ -267,7 +267,7 @@ func TestListClusterRoleNames(t *testing.T) {
 			var kubernetesObj []ctrlruntimeclient.Object
 			var kubeObj []ctrlruntimeclient.Object
 			kubeObj = append(kubeObj, tc.existingKubernetesObjs...)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterrolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/clusterrolenames", test.ProjectName, tc.clusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.existingKubermaticObjs...)

--- a/pkg/handler/v2/cluster/upgrade_test.go
+++ b/pkg/handler/v2/cluster/upgrade_test.go
@@ -258,7 +258,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 			}
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/foo/upgrades", test.ProjectName), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/foo/upgrades", test.ProjectName), nil)
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{testStruct.cluster}
 			kubermaticObj = append(kubermaticObj, testStruct.existingKubermaticObjs...)
@@ -372,7 +372,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("entering")
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/nodes/upgrades",
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/nodes/upgrades",
 				tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object

--- a/pkg/handler/v2/cluster_template/cluster_template_test.go
+++ b/pkg/handler/v2/cluster_template/cluster_template_test.go
@@ -162,7 +162,7 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clustertemplates", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clustertemplates", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			if tc.ExistingProject != nil {
@@ -274,7 +274,7 @@ func TestListClusterTemplates(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clustertemplates", test.ProjectName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clustertemplates", test.ProjectName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -395,7 +395,7 @@ func TestGetClusterTemplates(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s", test.ProjectName, tc.TemplateID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s", test.ProjectName, tc.TemplateID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -510,7 +510,7 @@ func TestDeleteClusterTemplates(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s", test.ProjectName, tc.TemplateID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s", test.ProjectName, tc.TemplateID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -562,7 +562,7 @@ func TestCreateClusterTemplateInstance(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s/instances", test.ProjectName, tc.TemplateToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s/instances", test.ProjectName, tc.TemplateToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -684,7 +684,7 @@ func TestExportlusterTemplates(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s/export", test.ProjectName, tc.TemplateID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clustertemplates/%s/export", test.ProjectName, tc.TemplateID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -803,7 +803,7 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clustertemplates/import", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clustertemplates/import", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			if tc.ExistingProject != nil {

--- a/pkg/handler/v2/constraint/constraint_test.go
+++ b/pkg/handler/v2/constraint/constraint_test.go
@@ -136,7 +136,7 @@ func TestListConstraints(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints",
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints",
 				tc.ProjectID, tc.ClusterID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ctx := context.Background()
@@ -262,7 +262,7 @@ func TestGetConstraints(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints/%s",
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints/%s",
 				tc.ProjectID, tc.ClusterID, tc.ConstraintName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ctx := context.Background()
@@ -432,7 +432,7 @@ func TestDeleteConstraints(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints/%s",
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints/%s",
 				tc.ProjectID, tc.ClusterID, tc.ConstraintName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
@@ -592,7 +592,7 @@ func TestCreateConstraints(t *testing.T) {
 			t.Fatalf("error marshalling body into json: %v", err)
 		}
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints",
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints",
 				tc.ProjectID, tc.ClusterID), bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
@@ -725,7 +725,7 @@ func TestPatchConstraints(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints/%s",
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/constraints/%s",
 				tc.ProjectID, tc.ClusterID, tc.ConstraintName), strings.NewReader(tc.Patch))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
@@ -808,7 +808,7 @@ func TestCreateDefaultConstraints(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
 
-			req := httptest.NewRequest("POST", "/api/v2/constraints", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/constraints", bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
@@ -864,7 +864,7 @@ func TestListDefaultConstraints(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v2/constraints", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/constraints", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -922,7 +922,7 @@ func TestGetDefaultConstraint(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/constraints/%s", tc.CTName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/constraints/%s", tc.CTName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
@@ -979,7 +979,7 @@ func TestDeleteDefaultConstraints(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/constraints/%s", tc.CTToDeleteName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/constraints/%s", tc.CTToDeleteName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -1084,7 +1084,7 @@ func TestPatchDefaultConstraints(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
 
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v2/constraints/%s", tc.ConstraintName), strings.NewReader(tc.Patch))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v2/constraints/%s", tc.ConstraintName), strings.NewReader(tc.Patch))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {

--- a/pkg/handler/v2/constraint_template/constraint_template_test.go
+++ b/pkg/handler/v2/constraint_template/constraint_template_test.go
@@ -61,7 +61,7 @@ func TestListConstraintTemplates(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v2/constrainttemplates", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/constrainttemplates", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -121,7 +121,7 @@ func TestGetConstraintTemplates(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/constrainttemplates/%s", tc.CTName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/constrainttemplates/%s", tc.CTName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -217,7 +217,7 @@ func TestCreateConstraintTemplates(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error marshalling body into json: %v", err)
 			}
-			req := httptest.NewRequest("POST", "/api/v2/constrainttemplates", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/constrainttemplates", bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, []ctrlruntimeclient.Object{test.APIUserToKubermaticUser(*tc.ExistingAPIUser)}, nil, hack.NewTestRouting)
 			if err != nil {
@@ -306,7 +306,7 @@ func TestPatchConstraintTemplates(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
 
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v2/constrainttemplates/%s", tc.CTName), strings.NewReader(tc.RawPatch))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v2/constrainttemplates/%s", tc.CTName), strings.NewReader(tc.RawPatch))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -363,7 +363,7 @@ func TestDeleteConstraintTemplates(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.ExistingObjects = append(tc.ExistingObjects, test.APIUserToKubermaticUser(*tc.ExistingAPIUser))
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/constrainttemplates/%s", tc.CTToDeleteName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/constrainttemplates/%s", tc.CTToDeleteName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, nil, tc.ExistingObjects, nil, hack.NewTestRouting)
 			if err != nil {

--- a/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -182,7 +182,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters", tc.ProjectToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters", tc.ProjectToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			if tc.ExistingProject != nil {
@@ -268,7 +268,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
 			req.Header.Set("Action", externalcluster.DisconnectAction)
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
@@ -356,7 +356,7 @@ func TestListClusters(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters", test.ProjectName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters", test.ProjectName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -435,7 +435,7 @@ func TestGetClusterEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -509,7 +509,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -688,7 +688,7 @@ func TestGetClusterMetrics(t *testing.T) {
 			for _, node := range tc.ExistingNodes {
 				kubeObj = append(kubeObj, node)
 			}
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/metrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/metrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -811,7 +811,7 @@ func TestGetClusterEvents(t *testing.T) {
 			for _, node := range tc.ExistingNodes {
 				kubeObj = append(kubeObj, node)
 			}
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/events%s", test.ProjectName, tc.ClusterToGet, tc.QueryParams), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/events%s", test.ProjectName, tc.ClusterToGet, tc.QueryParams), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v2/external_cluster/node_test.go
+++ b/pkg/handler/v2/external_cluster/node_test.go
@@ -93,7 +93,7 @@ func TestListNodesEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/nodes", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/nodes", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -177,7 +177,7 @@ func TestGetNodeEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/nodes/%s", tc.ProjectToSync, tc.ClusterToSync, tc.NodeToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/nodes/%s", tc.ProjectToSync, tc.ClusterToSync, tc.NodeToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -307,7 +307,7 @@ func TestGetClusterNodesMetrics(t *testing.T) {
 			for _, node := range tc.ExistingNodes {
 				kubeObj = append(kubeObj, node)
 			}
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/nodesmetrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/kubernetes/clusters/%s/nodesmetrics", test.ProjectName, tc.ClusterToGet), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v2/gatekeeperconfig/gatekeeperconfig_test.go
+++ b/pkg/handler/v2/gatekeeperconfig/gatekeeperconfig_test.go
@@ -108,7 +108,7 @@ func TestGetConfigEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, nil, nil, tc.ExistingKubermaticObjs, nil, hack.NewTestRouting)
@@ -203,7 +203,7 @@ func TestDeleteConfigEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 
 			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, nil, nil, tc.ExistingKubermaticObjs, nil, hack.NewTestRouting)
@@ -305,7 +305,7 @@ func TestCreateConfigEndpoint(t *testing.T) {
 				t.Fatalf("error marshalling body into json: %v", err)
 			}
 
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), bytes.NewBuffer(body))
 			res := httptest.NewRecorder()
 
 			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, nil, nil, tc.ExistingKubermaticObjs, nil, hack.NewTestRouting)
@@ -405,7 +405,7 @@ func TestPatchConfigEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), strings.NewReader(tc.Patch))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/gatekeeper/config", tc.ProjectID, tc.ClusterID), strings.NewReader(tc.Patch))
 			res := httptest.NewRecorder()
 
 			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, nil, nil, tc.ExistingKubermaticObjs, nil, hack.NewTestRouting)

--- a/pkg/handler/v2/ipampool/ipampool_test.go
+++ b/pkg/handler/v2/ipampool/ipampool_test.go
@@ -148,7 +148,7 @@ func TestListIPAMPools(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.existingObjects = append(tc.existingObjects, test.APIUserToKubermaticUser(*tc.apiUser), test.GenTestSeed())
 
-			req := httptest.NewRequest("GET", "/api/v2/seeds/us-central1/ipampools", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/seeds/us-central1/ipampools", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.apiUser, nil, tc.existingObjects, nil, hack.NewTestRouting)
 			assert.NoError(t, err)
@@ -273,7 +273,7 @@ func TestGetIPAMPool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.existingObjects = append(tc.existingObjects, test.APIUserToKubermaticUser(*tc.apiUser), test.GenTestSeed())
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/seeds/us-central1/ipampools/%s", tc.ipamPoolName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/seeds/us-central1/ipampools/%s", tc.ipamPoolName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.apiUser, nil, tc.existingObjects, nil, hack.NewTestRouting)
 			assert.NoError(t, err)
@@ -483,7 +483,7 @@ func TestCreateIPAMPool(t *testing.T) {
 			reqBody, err := json.Marshal(tc.ipamPool)
 			assert.NoError(t, err)
 
-			req := httptest.NewRequest("POST", "/api/v2/seeds/us-central1/ipampools", bytes.NewReader(reqBody))
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/seeds/us-central1/ipampools", bytes.NewReader(reqBody))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.apiUser, nil, tc.existingObjects, nil, hack.NewTestRouting)
 			assert.NoError(t, err)
@@ -566,7 +566,7 @@ func TestDeleteIPAMPool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.existingObjects = append(tc.existingObjects, test.APIUserToKubermaticUser(*tc.apiUser), test.GenTestSeed())
 
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/seeds/us-central1/ipampools/%s", tc.ipamPoolName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/seeds/us-central1/ipampools/%s", tc.ipamPoolName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.apiUser, nil, tc.existingObjects, nil, hack.NewTestRouting)
 			assert.NoError(t, err)
@@ -770,7 +770,7 @@ func TestPatchIPAMPool(t *testing.T) {
 			reqBody, err := json.Marshal(tc.ipamPool)
 			assert.NoError(t, err)
 
-			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v2/seeds/us-central1/ipampools/%s", tc.ipamPool.Name), bytes.NewReader(reqBody))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v2/seeds/us-central1/ipampools/%s", tc.ipamPool.Name), bytes.NewReader(reqBody))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.apiUser, nil, tc.existingObjects, nil, hack.NewTestRouting)
 			assert.NoError(t, err)

--- a/pkg/handler/v2/machine/machine_test.go
+++ b/pkg/handler/v2/machine/machine_test.go
@@ -177,7 +177,7 @@ func TestCreateMachineDeployment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments", tc.ProjectID, tc.ClusterID), strings.NewReader(tc.Body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments", tc.ProjectID, tc.ClusterID), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
@@ -310,7 +310,7 @@ func TestDeleteMachineDeploymentNode(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/nodes/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeIDToDelete), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/nodes/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeIDToDelete), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -519,7 +519,7 @@ func TestListMachineDeployments(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments",
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments",
 				tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
@@ -700,7 +700,7 @@ func TestGetMachineDeployment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/venus",
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/venus",
 				tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
@@ -912,7 +912,7 @@ func TestListMachineDeploymentNodes(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s/nodes", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineDeploymentID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s/nodes", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineDeploymentID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -1213,7 +1213,7 @@ func TestListNodesForCluster(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/nodes", tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/nodes", tc.ProjectIDToSync, tc.ClusterIDToSync), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -1375,7 +1375,7 @@ func TestMachineDeploymentMetrics(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s/nodes/metrics", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineDeploymentID), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s/nodes/metrics", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineDeploymentID), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -1719,7 +1719,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s/nodes/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineDeploymentID, tc.QueryParams), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s/nodes/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineDeploymentID, tc.QueryParams), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}
 			machineObj := []ctrlruntimeclient.Object{}
@@ -1850,7 +1850,7 @@ func TestDeleteMachineDeployment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s",
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/machinedeployments/%s",
 				tc.ProjectIDToSync, tc.ClusterIDToSync, tc.MachineIDToDelete), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []ctrlruntimeclient.Object{}

--- a/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
+++ b/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
@@ -138,7 +138,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.existingObjects = append(tc.existingObjects, test.APIUserToKubermaticUser(*tc.apiUser), test.GenTestSeed())
 
-			req := httptest.NewRequest("GET", "/api/v2/seeds/us-central1/operatingsystemprofiles", strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/seeds/us-central1/operatingsystemprofiles", strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.apiUser, nil, tc.existingObjects, nil, hack.NewTestRouting)
 			assert.NoError(t, err)

--- a/pkg/handler/v2/preset/preset_test.go
+++ b/pkg/handler/v2/preset/preset_test.go
@@ -1529,7 +1529,7 @@ func TestPresetStats(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/presets/%s/stats", tc.PresetName), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/presets/%s/stats", tc.PresetName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			var kubermaticObj []ctrlruntimeclient.Object
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)

--- a/pkg/handler/v2/provider/kubevirt_test.go
+++ b/pkg/handler/v2/provider/kubevirt_test.go
@@ -189,7 +189,7 @@ func TestListPresetEndpoint(t *testing.T) {
 		// KUBEVIRT PRESET LIST
 		{
 			Name:               "scenario 1: preset list- kubevirt kubeconfig provided",
-			HTTPRequestMethod:  "GET",
+			HTTPRequestMethod:  http.MethodGet,
 			HTTPRequestURL:     "/api/v2/providers/kubevirt/vmflavors",
 			HTTPRequestHeaders: []KeyValue{{Key: "Kubeconfig", Value: fakeKvConfig}},
 			Body:               ``,
@@ -203,7 +203,7 @@ func TestListPresetEndpoint(t *testing.T) {
 		},
 		{
 			Name:               "scenario 2: preset list- kubevirt kubeconfig from kubermatic preset",
-			HTTPRequestMethod:  "GET",
+			HTTPRequestMethod:  http.MethodGet,
 			HTTPRequestURL:     "/api/v2/providers/kubevirt/vmflavors",
 			HTTPRequestHeaders: []KeyValue{{Key: "Credential", Value: "kubermatic-preset"}},
 			Body:               ``,
@@ -262,7 +262,7 @@ func TestListPresetNoCredentialsEndpoint(t *testing.T) {
 		// KUBEVIRT PRESET LIST No Credentials
 		{
 			Name:              "scenario 1: preset list- kubevirt kubeconfig from cluster",
-			HTTPRequestMethod: "GET",
+			HTTPRequestMethod: http.MethodGet,
 			HTTPRequestURL:    fmt.Sprintf("/api/v2/projects/%s/clusters/%s/providers/kubevirt/vmflavors", test.GenDefaultProject().Name, clusterId),
 			Body:              ``,
 			HTTPStatus:        http.StatusOK,
@@ -285,7 +285,7 @@ func TestListPresetNoCredentialsEndpoint(t *testing.T) {
 		},
 		{
 			Name:              "scenario 2: preset list- kubevirt kubeconfig from credential reference (secret)",
-			HTTPRequestMethod: "GET",
+			HTTPRequestMethod: http.MethodGet,
 			HTTPRequestURL:    fmt.Sprintf("/api/v2/projects/%s/clusters/%s/providers/kubevirt/vmflavors", test.GenDefaultProject().Name, clusterId),
 			Body:              ``,
 			HTTPStatus:        http.StatusOK,
@@ -372,7 +372,7 @@ func TestListStorageClassEndpoint(t *testing.T) {
 		// LIST Storage classes
 		{
 			Name:               "scenario 1: list storage classes- kubevirt kubeconfig provided",
-			HTTPRequestMethod:  "GET",
+			HTTPRequestMethod:  http.MethodGet,
 			HTTPRequestURL:     "/api/v2/providers/kubevirt/storageclasses",
 			HTTPRequestHeaders: []KeyValue{{Key: "Kubeconfig", Value: fakeKvConfig}},
 			Body:               ``,
@@ -386,7 +386,7 @@ func TestListStorageClassEndpoint(t *testing.T) {
 		},
 		{
 			Name:               "scenario 2: list storage classes- kubevirt from kubermatic preset",
-			HTTPRequestMethod:  "GET",
+			HTTPRequestMethod:  http.MethodGet,
 			HTTPRequestURL:     "/api/v2/providers/kubevirt/storageclasses",
 			HTTPRequestHeaders: []KeyValue{{Key: "Credential", Value: "kubermatic-preset"}},
 			Body:               ``,
@@ -445,7 +445,7 @@ func TestListStorageClassNoCredentialsEndpoint(t *testing.T) {
 		// LIST Storage classes No Credentials
 		{
 			Name:               "scenario 1: list storage classes- kubevirt kubeconfig from cluster",
-			HTTPRequestMethod:  "GET",
+			HTTPRequestMethod:  http.MethodGet,
 			HTTPRequestURL:     fmt.Sprintf("/api/v2/projects/%s/clusters/%s/providers/kubevirt/storageclasses", test.GenDefaultProject().Name, clusterId),
 			HTTPRequestHeaders: []KeyValue{{Key: "Credential", Value: "kubermatic-preset"}},
 			Body:               ``,
@@ -469,7 +469,7 @@ func TestListStorageClassNoCredentialsEndpoint(t *testing.T) {
 		},
 		{
 			Name:               "scenario 2: list storage classes- kubevirt kubeconfig from credential reference (secret)",
-			HTTPRequestMethod:  "GET",
+			HTTPRequestMethod:  http.MethodGet,
 			HTTPRequestURL:     fmt.Sprintf("/api/v2/projects/%s/clusters/%s/providers/kubevirt/storageclasses", test.GenDefaultProject().Name, clusterId),
 			HTTPRequestHeaders: []KeyValue{{Key: "Credential", Value: "kubermatic-preset"}},
 			Body:               ``,

--- a/pkg/handler/v2/provider/nutanix_test.go
+++ b/pkg/handler/v2/provider/nutanix_test.go
@@ -97,7 +97,7 @@ func TestNutanixClustersEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/providers/nutanix/%s/clusters", tc.dc), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/providers/nutanix/%s/clusters", tc.dc), strings.NewReader(""))
 
 			req.Header.Add("NutanixUsername", testNutanixUsername)
 			req.Header.Add("NutanixPassword", tc.password)
@@ -171,7 +171,7 @@ func TestNutanixProjectsEndpoint(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/providers/nutanix/%s/projects", tc.dc), strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/providers/nutanix/%s/projects", tc.dc), strings.NewReader(""))
 
 			req.Header.Add("NutanixUsername", testNutanixUsername)
 			req.Header.Add("NutanixPassword", tc.password)

--- a/pkg/handler/v2/provider/openstack_test.go
+++ b/pkg/handler/v2/provider/openstack_test.go
@@ -105,9 +105,9 @@ func setupOpenstackServer(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			if r.Method == http.MethodPost {
-				w.WriteHeader(201)
+				w.WriteHeader(http.StatusCreated)
 			} else {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}
 
 			_, err := w.Write(buf.Bytes())

--- a/pkg/handler/v2/provider/openstack_test.go
+++ b/pkg/handler/v2/provider/openstack_test.go
@@ -104,7 +104,7 @@ func setupOpenstackServer(t *testing.T) {
 			}
 
 			w.Header().Add("Content-Type", "application/json")
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				w.WriteHeader(201)
 			} else {
 				w.WriteHeader(200)
@@ -191,7 +191,7 @@ func TestOpenstackEndpoints(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tc.URL, strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, tc.URL, strings.NewReader(""))
 			if tc.QueryParams != nil {
 				q := req.URL.Query()
 				for k, v := range tc.QueryParams {

--- a/pkg/handler/v2/version/version_test.go
+++ b/pkg/handler/v2/version/version_test.go
@@ -160,7 +160,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 			}
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/providers/%s/versions", tc.provider), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/providers/%s/versions", tc.provider), nil)
 			res := httptest.NewRecorder()
 			var machineObj []ctrlruntimeclient.Object
 

--- a/pkg/handler/v2/webterminal/webterminal_test.go
+++ b/pkg/handler/v2/webterminal/webterminal_test.go
@@ -152,7 +152,7 @@ func TestCreateOIDCKubeconfig(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			reqURL := fmt.Sprintf("/api/v2/kubeconfig/secret?cluster_id=%s&project_id=%s&user_id=%s", tc.ClusterID, tc.ProjectID, tc.UserID)
-			req := httptest.NewRequest("GET", reqURL, strings.NewReader(""))
+			req := httptest.NewRequest(http.MethodGet, reqURL, strings.NewReader(""))
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, tc.ExistingObjects, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
 			if err != nil {
@@ -214,7 +214,7 @@ func TestCreateOIDCKubeconfig(t *testing.T) {
 
 				// call kubeconfig endpoint after authentication
 				// exchange code phase
-				req = httptest.NewRequest("GET", urlExchangeCodePhase, strings.NewReader(""))
+				req = httptest.NewRequest(http.MethodGet, urlExchangeCodePhase, strings.NewReader(""))
 				res = httptest.NewRecorder()
 
 				// create secure cookie

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -197,7 +198,7 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 		TTY:     true,
 	}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(cfg, http.MethodPost, req.URL())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/cloud/eks/authenticator/token.go
+++ b/pkg/provider/cloud/eks/authenticator/token.go
@@ -495,7 +495,7 @@ func (v tokenVerifier) Verify(token string) (*Identity, error) {
 		return nil, FormatError{fmt.Sprintf("X-Amz-Date parameter is expired (%.f minute expiration) %s", presignedURLExpiration.Minutes(), dateParam)}
 	}
 
-	req, err := http.NewRequest("GET", parsedURL.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), nil)
 	req.Header.Set(clusterIDHeader, v.clusterID)
 	req.Header.Set("accept", "application/json")
 

--- a/pkg/provider/cloud/eks/authenticator/token.go
+++ b/pkg/provider/cloud/eks/authenticator/token.go
@@ -514,8 +514,8 @@ func (v tokenVerifier) Verify(token string) (*Identity, error) {
 		return nil, NewSTSError(fmt.Sprintf("error reading HTTP result: %v", err))
 	}
 
-	if response.StatusCode != 200 {
-		return nil, NewSTSError(fmt.Sprintf("error from AWS (expected 200, got %d). Body: %s", response.StatusCode, string(responseBody[:])))
+	if response.StatusCode != http.StatusOK {
+		return nil, NewSTSError(fmt.Sprintf("error from AWS (expected %d, got %d). Body: %s", http.StatusOK, response.StatusCode, string(responseBody[:])))
 	}
 
 	var callerIdentity getCallerIdentityWrapper

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -78,7 +78,7 @@ type userclusterControllerData interface {
 }
 
 // DeploymentCreator returns the function to create and update the user cluster controller deployment
-// nolint:gocyclo
+//nolint:gocyclo
 func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -159,7 +159,7 @@ func (b *EndpointsBuilder) WithResourceVersion(rs string) *EndpointsBuilder {
 // WithEndpointsSubset starts the creation of an Endpoints Subset, the creation
 // must me terminated with a call to DoneWithEndpointSubset, after ports and
 // addresses are added.
-// nolint:golint
+//nolint:golint
 func (b *EndpointsBuilder) WithEndpointsSubset() *epsSubsetBuilder {
 	return &epsSubsetBuilder{eb: b}
 }

--- a/pkg/test/e2e/utils/dex/client.go
+++ b/pkg/test/e2e/utils/dex/client.go
@@ -126,7 +126,7 @@ func (c *Client) fetchLoginURL(ctx context.Context, connector ConnectorType) (*u
 
 	c.log.Debugw("Fetching OIDC login page", "url", loginURL.String())
 
-	req, err := http.NewRequest("GET", loginURL.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, loginURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for login page: %w", err)
 	}
@@ -174,7 +174,7 @@ func (c *Client) authenticate(ctx context.Context, loginURL *url.URL, login stri
 	c.log.Debugw("Sending login request", "url", loginURL.String(), "login", login)
 
 	// prepare request
-	req, err := http.NewRequest("POST", loginURL.String(), buf)
+	req, err := http.NewRequest(http.MethodPost, loginURL.String(), buf)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}

--- a/pkg/test/e2e/utils/http_test.go
+++ b/pkg/test/e2e/utils/http_test.go
@@ -40,70 +40,70 @@ func TestHttpClientWithRetries(t *testing.T) {
 			name: "success at first attempt",
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 					fmt.Fprintln(w, "success")
 				},
 			},
 
 			numRetries: 1,
-			expStatus:  200,
+			expStatus:  http.StatusOK,
 		},
 		{
 			name: "success after 2 allowed error codes",
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(404)
+					w.WriteHeader(http.StatusNotFound)
 					fmt.Fprintln(w, "failed")
 				},
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(404)
+					w.WriteHeader(http.StatusNotFound)
 					fmt.Fprintln(w, "failed")
 				},
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 					fmt.Fprintln(w, "success")
 				},
 			},
 			retryInterval:     1 * time.Millisecond,
 			numRetries:        3,
-			allowedErrorCodes: []int{404},
-			expStatus:         200,
+			allowedErrorCodes: []int{http.StatusNotFound},
+			expStatus:         http.StatusOK,
 		},
 		{
 			name: "success after 5xx",
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(500)
+					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, "temporary server error")
 				},
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 					fmt.Fprintln(w, "failed")
 				},
 			},
 			retryInterval: 1 * time.Millisecond,
 			numRetries:    2,
-			expStatus:     200,
+			expStatus:     http.StatusOK,
 		},
 		{
 			name: "do not retry after 501",
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(501)
+					w.WriteHeader(http.StatusNotImplemented)
 					fmt.Fprintln(w, "not implemented")
 				},
 			},
-			expStatus: 501,
+			expStatus: http.StatusNotImplemented,
 		},
 		{
 			name: "Error after retry timeout",
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(500)
+					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, "temporary server error")
 				},
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(503)
+					w.WriteHeader(http.StatusServiceUnavailable)
 					fmt.Fprintln(w, "temporary server error")
 				},
 			},
@@ -116,32 +116,32 @@ func TestHttpClientWithRetries(t *testing.T) {
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
 					time.AfterFunc(20*time.Millisecond, func() {
-						w.WriteHeader(200)
+						w.WriteHeader(http.StatusOK)
 						fmt.Fprintln(w, "success")
 					})
 				},
 				func(w http.ResponseWriter, r *http.Request) {
 					time.AfterFunc(20*time.Millisecond, func() {
-						w.WriteHeader(200)
+						w.WriteHeader(http.StatusOK)
 						fmt.Fprintln(w, "success")
 					})
 				},
 				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 					fmt.Fprintln(w, "success")
 				},
 			},
 			retryInterval:  1 * time.Millisecond,
 			numRetries:     3,
 			requestTimeout: 10 * time.Millisecond,
-			expStatus:      200,
+			expStatus:      http.StatusOK,
 		},
 		{
 			name: "Failed due to request timeout",
 			handlerFuncs: []http.HandlerFunc{
 				func(w http.ResponseWriter, r *http.Request) {
 					time.AfterFunc(20*time.Millisecond, func() {
-						w.WriteHeader(200)
+						w.WriteHeader(http.StatusOK)
 						fmt.Fprintln(w, "success")
 					})
 				},

--- a/pkg/test/e2e/utils/http_test.go
+++ b/pkg/test/e2e/utils/http_test.go
@@ -161,7 +161,7 @@ func TestHttpClientWithRetries(t *testing.T) {
 			ctx := context.Background()
 			rt := NewRoundTripperWithRetries(t, tt.requestTimeout, Backoff{Steps: tt.numRetries, Duration: tt.retryInterval, Factor: 1.0}, tt.allowedErrorCodes...)
 			cli := &http.Client{Transport: rt}
-			req, err := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 			if err != nil {
 				t.Fatalf("Error occurred while creating request: %v", err)
 			}

--- a/pkg/test/e2e/utils/kubernetes.go
+++ b/pkg/test/e2e/utils/kubernetes.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -122,7 +123,7 @@ func (t *TestPodConfig) Exec(container string, command ...string) (string, strin
 	}, scheme.ParameterCodec)
 
 	var stdout, stderr bytes.Buffer
-	err := execute("POST", req.URL(), t.Config, nil, &stdout, &stderr, tty)
+	err := execute(http.MethodPost, req.URL(), t.Config, nil, &stdout, &stderr, tty)
 
 	return stdout.String(), stderr.String(), err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
"Hm, let's log before actually doing the variable assignment, so that if it fails, the user has some context as to what was going on" -- those were my thoughts when I flipped those two lines in my giant refactoring PR a few days ago. Of course, since one line depends on the other, that was ..... :bomb:

As an extra bonus, I included some fixes for the upcoming `usestdlibvars` linter in golangci-lint 1.48.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
