### PR TITLE
allow to remove the unused UID in addon cluster references

### DIFF
--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -154,6 +154,14 @@ func (h *AdmissionHandler) ensureClusterReference(ctx context.Context, addon *ku
 }
 
 func (h *AdmissionHandler) validateUpdate(ctx context.Context, oldAddon *kubermaticv1.Addon, newAddon *kubermaticv1.Addon) error {
+	// We only care about the APIVersion, Kind and Name to stay the same, the rest can be changed
+	// as they are irrelevant.
+
+	oldAddon.Spec.Cluster.UID = newAddon.Spec.Cluster.UID
+	oldAddon.Spec.Cluster.Namespace = newAddon.Spec.Cluster.Namespace
+	oldAddon.Spec.Cluster.ResourceVersion = newAddon.Spec.Cluster.ResourceVersion
+	oldAddon.Spec.Cluster.FieldPath = newAddon.Spec.Cluster.FieldPath
+
 	if !equality.Semantic.DeepEqual(oldAddon.Spec.Cluster, newAddon.Spec.Cluster) {
 		return errors.New("Cluster reference cannot be changed")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Since #10703 we do not set the UID anymore, but the old webhook would reject such a change to an existing Addon object. This PR relaxes the immutability check a bit to make it possible.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
