### PR TITLE
Allow proxy mode change by CNI migration

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -241,7 +241,7 @@ func ValidateClusterUpdate(ctx context.Context, newCluster, oldCluster *kubermat
 		allErrs = append(allErrs, field.Invalid(path, newCluster.Spec.IsOperatingSystemManagerEnabled(), "OperatingSystemManager cannot be disabled once it's enabled"))
 	}
 
-	allErrs = append(allErrs, validateClusterNetworkingConfigUpdateImmutability(&newCluster.Spec.ClusterNetwork, &oldCluster.Spec.ClusterNetwork, specPath.Child("clusterNetwork"))...)
+	allErrs = append(allErrs, validateClusterNetworkingConfigUpdateImmutability(&newCluster.Spec.ClusterNetwork, &oldCluster.Spec.ClusterNetwork, newCluster.Labels, specPath.Child("clusterNetwork"))...)
 
 	// even though ErrorList later in ToAggregate() will filter out nil errors, it does so by
 	// stringifying them. A field.Error that is nil will panic when doing so, so one cannot simply
@@ -1023,7 +1023,7 @@ func ValidateNodePortRange(nodePortRange string, fldPath *field.Path) *field.Err
 	return nil
 }
 
-func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.ClusterNetworkingConfig, fldPath *field.Path) field.ErrorList {
+func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.ClusterNetworkingConfig, labels map[string]string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if oldC.IPFamily != "" {
@@ -1051,11 +1051,13 @@ func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.Clu
 	}
 
 	if oldC.ProxyMode != "" {
-		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
-			c.ProxyMode,
-			oldC.ProxyMode,
-			fldPath.Child("proxyMode"),
-		)...)
+		if _, ok := labels[UnsafeCNIMigrationLabel]; !ok { // allow proxy mode change by CNI migration
+			allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
+				c.ProxyMode,
+				oldC.ProxyMode,
+				fldPath.Child("proxyMode"),
+			)...)
+		}
 	}
 
 	if oldC.DNSDomain != "" {


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
As IPVS kube-proxy mode is not recommend to use with Cilium CNI, we need to allow changing proxy mode when doing manual CNI migration (see docs: https://github.com/kubermatic/docs/pull/1146).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow proxy mode change by CNI migration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1146
```
