### PR TITLE
Add user-cluster manager to user-cluster-webhook

### DIFF
--- a/cmd/kubermatic-webhook/options.go
+++ b/cmd/kubermatic-webhook/options.go
@@ -70,7 +70,7 @@ func initApplicationOptions() (appOptions, error) {
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all user clusters")
 	flag.StringVar(&configFile, "kubermatic-configuration-file", "", "(for development only) path to a KubermaticConfiguration YAML file")
 
-	c.webhook.AddFlags(flag.CommandLine)
+	c.webhook.AddFlags(flag.CommandLine, "webhook")
 	c.pprof.AddFlags(flag.CommandLine)
 	c.log.AddFlags(flag.CommandLine)
 

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -99,7 +99,7 @@ func main() {
 		log.Fatalw("Failed to create the user cluster manager", zap.Error(err))
 	}
 
-	// apply the CLI flags for configuring the webhook servers
+	// Apply the CLI flags for configuring the webhook servers.
 	if err := options.seedWebhook.Configure(seedMgr.GetWebhookServer()); err != nil {
 		log.Fatalw("Failed to configure webhook server", zap.Error(err))
 	}
@@ -124,10 +124,10 @@ func main() {
 	// /////////////////////////////////////////
 	// setup webhooks
 
-	// Setup the validation admission handler for ApplicationInstallation CRDs
+	// Setup the validation admission handler for ApplicationInstallation CRDs in seed manager.
 	applicationinstallationvalidation.NewAdmissionHandler(seedMgr.GetClient()).SetupWebhookWithManager(seedMgr)
 
-	// Setup Machine Webhook
+	// Setup Machine Webhook in user manager.
 	machineValidator, err := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle, options.projectID)
 	if err != nil {
 		log.Fatalw("Failed to setup Machine validator", zap.Error(err))
@@ -140,13 +140,13 @@ func main() {
 	// Start managers
 
 	go func() {
-		log.Info("Starting the user cluster webhook in the background...")
+		log.Info("Starting the user cluster manager in the background...")
 		if err := userMgr.Start(ctx); err != nil {
 			log.Fatalw("The user manager has failed", zap.Error(err))
 		}
 	}()
 
-	log.Info("Starting the seed webhook...")
+	log.Info("Starting the seed manager...")
 	if err := seedMgr.Start(ctx); err != nil {
 		log.Fatalw("The seed manager has failed", zap.Error(err))
 	}

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -77,7 +77,6 @@ func main() {
 		log.Fatalw("Failed to get user cluster kubeconfig")
 	}
 
-	// This case unusual in a sense that we need to configure and start managers for both user and seed clusters.
 	ctx := ctrlruntime.SetupSignalHandler()
 
 	seedMgr, err := manager.New(seedCfg, manager.Options{
@@ -116,9 +115,6 @@ func main() {
 
 	if err := seedMgr.Add(&options.pprof); err != nil {
 		log.Fatalw("Failed to add the pprof handler (seed manager)", zap.Error(err))
-	}
-	if err := userMgr.Add(&options.pprof); err != nil {
-		log.Fatalw("Failed to add the pprof handler (user-cluster manager)", zap.Error(err))
 	}
 
 	// /////////////////////////////////////////

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -29,11 +29,13 @@ import (
 )
 
 type appOptions struct {
-	webhook   webhook.Options
-	pprof     pprof.Opts
-	log       kubermaticlog.Options
-	caBundle  *certificates.CABundle
-	projectID string
+	seedWebhook                  webhook.Options
+	userWebhook                  webhook.Options
+	pprof                        pprof.Opts
+	log                          kubermaticlog.Options
+	caBundle                     *certificates.CABundle
+	projectID                    string
+	userClusterWebhookListenPort int
 }
 
 func initApplicationOptions() (appOptions, error) {
@@ -43,12 +45,15 @@ func initApplicationOptions() (appOptions, error) {
 
 	klog.InitFlags(nil)
 
-	c.webhook.AddFlags(flag.CommandLine)
+	c.seedWebhook.AddFlags(flag.CommandLine, "user-webhook")
+	c.userWebhook.AddFlags(flag.CommandLine, "seed-webhook")
+
 	c.pprof.AddFlags(flag.CommandLine)
 	c.log.AddFlags(flag.CommandLine)
 
 	var caBundleFile string
 	var projectID string
+
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all userclusters")
 	flag.StringVar(&projectID, "project-id", "", "Project ID in which cluster the webhook is running in")
 
@@ -61,8 +66,12 @@ func initApplicationOptions() (appOptions, error) {
 	c.caBundle = caBundle
 	c.projectID = projectID
 
-	if err := c.webhook.Validate(); err != nil {
-		return c, fmt.Errorf("invalid webhook configuration: %w", err)
+	if err := c.userWebhook.Validate(); err != nil {
+		return c, fmt.Errorf("invalid user cluster webhook configuration: %w", err)
+	}
+
+	if err := c.seedWebhook.Validate(); err != nil {
+		return c, fmt.Errorf("invalid seed webhook configuration: %w", err)
 	}
 
 	return c, nil

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -29,13 +29,12 @@ import (
 )
 
 type appOptions struct {
-	seedWebhook                  webhook.Options
-	userWebhook                  webhook.Options
-	pprof                        pprof.Opts
-	log                          kubermaticlog.Options
-	caBundle                     *certificates.CABundle
-	projectID                    string
-	userClusterWebhookListenPort int
+	seedWebhook webhook.Options
+	userWebhook webhook.Options
+	pprof       pprof.Opts
+	log         kubermaticlog.Options
+	caBundle    *certificates.CABundle
+	projectID   string
 }
 
 func initApplicationOptions() (appOptions, error) {

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -45,8 +45,8 @@ func initApplicationOptions() (appOptions, error) {
 
 	klog.InitFlags(nil)
 
-	c.seedWebhook.AddFlags(flag.CommandLine, "user-webhook")
-	c.userWebhook.AddFlags(flag.CommandLine, "seed-webhook")
+	c.seedWebhook.AddFlags(flag.CommandLine, "seed-webhook")
+	c.userWebhook.AddFlags(flag.CommandLine, "user-webhook")
 
 	c.pprof.AddFlags(flag.CommandLine)
 	c.log.AddFlags(flag.CommandLine)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -31,7 +31,9 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const machineValidatingWebhookConfigurationName = "kubermatic-machine-validation"
+const (
+	machineValidatingWebhookConfigurationName = "kubermatic-machine-validation"
+)
 
 // ValidatingWebhookConfigurationCreator returns the ValidatingWebhookConfiguration for the machine CRD.
 func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
@@ -43,7 +45,11 @@ func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace s
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.NamespacedScope
 
-			url := fmt.Sprintf("https://%s.%s.svc.cluster.local./validate-cluster-k8s-io-v1alpha1-machine", resources.UserClusterWebhookServiceName, namespace)
+			url := fmt.Sprintf("https://%s.%s.svc.cluster.local.:%d/validate-cluster-k8s-io-v1alpha1-machine",
+				resources.UserClusterWebhookServiceName,
+				namespace,
+				resources.UserClusterWebhookUserListenPort,
+			)
 
 			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -933,6 +933,8 @@ const (
 	UserClusterWebhookDeploymentName        = "usercluster-webhook"
 	UserClusterWebhookServiceName           = "usercluster-webhook"
 	UserClusterWebhookServingCertSecretName = "usercluster-webhook-serving-cert"
+	UserClusterWebhookSeedListenPort        = 443
+	UserClusterWebhookUserListenPort        = 6443
 )
 
 const (

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-webhook-cert-dir=/opt/webhook-serving-cert/","-webhook-cert-name=serving.crt","-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
@@ -31,7 +31,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed=webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
+        - '{"command":"user-cluster-webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-seed-webhook-listen-port=9443","-seed-webhook-cert-dir=/opt/webhook-serving-cert/","-seed-webhook-cert-name=serving.crt","-seed-webhook-key-name=serving.key","-user-webhook-listen-port=19443","-user-webhook-cert-dir=/opt/webhook-serving-cert/","-user-webhook-cert-name=serving.crt","-user-webhook-key-name=serving.key","-ca-bundle=/opt/ca-bundle/ca-bundle.pem","-project-id=my-project","-v=2"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   name: usercluster-webhook
 spec:
   ports:
-  - port: 443
+  - name: seed
+    port: 443
     protocol: TCP
     targetPort: 9443
+  - name: user
+    port: 6443
+    protocol: TCP
+    targetPort: 19443
   selector:
     app: usercluster-webhook
   type: ClusterIP

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -34,6 +34,11 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const (
+	seedWebhookListenPort = 9443
+	userWebhookListenPort = 19443
+)
+
 var (
 	defaultResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -89,9 +94,14 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 
 			args := []string{
 				"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-				"-webhook-cert-dir=/opt/webhook-serving-cert/",
-				fmt.Sprintf("-webhook-cert-name=%s", resources.ServingCertSecretKey),
-				fmt.Sprintf("-webhook-key-name=%s", resources.ServingCertKeySecretKey),
+				fmt.Sprintf("-seed-webhook-listen-port=%d", seedWebhookListenPort),
+				"-seed-webhook-cert-dir=/opt/webhook-serving-cert/",
+				fmt.Sprintf("-seed-webhook-cert-name=%s", resources.ServingCertSecretKey),
+				fmt.Sprintf("-seed=webhook-key-name=%s", resources.ServingCertKeySecretKey),
+				fmt.Sprintf("-user-webhook-listen-port=%d", userWebhookListenPort),
+				"-user-webhook-cert-dir=/opt/webhook-serving-cert/",
+				fmt.Sprintf("-user-webhook-cert-name=%s", resources.ServingCertSecretKey),
+				fmt.Sprintf("-user-webhook-key-name=%s", resources.ServingCertKeySecretKey),
 				fmt.Sprintf("-ca-bundle=/opt/ca-bundle/%s", resources.CABundleConfigMapKey),
 				fmt.Sprintf("-project-id=%s", projectID),
 			}

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -97,7 +97,7 @@ func DeploymentCreator(data webhookData) reconciling.NamedDeploymentCreatorGette
 				fmt.Sprintf("-seed-webhook-listen-port=%d", seedWebhookListenPort),
 				"-seed-webhook-cert-dir=/opt/webhook-serving-cert/",
 				fmt.Sprintf("-seed-webhook-cert-name=%s", resources.ServingCertSecretKey),
-				fmt.Sprintf("-seed=webhook-key-name=%s", resources.ServingCertKeySecretKey),
+				fmt.Sprintf("-seed-webhook-key-name=%s", resources.ServingCertKeySecretKey),
 				fmt.Sprintf("-user-webhook-listen-port=%d", userWebhookListenPort),
 				"-user-webhook-cert-dir=/opt/webhook-serving-cert/",
 				fmt.Sprintf("-user-webhook-cert-name=%s", resources.ServingCertSecretKey),

--- a/pkg/resources/usercluster-webhook/service.go
+++ b/pkg/resources/usercluster-webhook/service.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"fmt"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"

--- a/pkg/resources/usercluster-webhook/service.go
+++ b/pkg/resources/usercluster-webhook/service.go
@@ -18,7 +18,6 @@ package webhook
 
 import (
 	"fmt"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
@@ -42,10 +41,16 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 			}
 			se.Spec.Ports = []corev1.ServicePort{
 				{
-					Name:       "",
-					Port:       443,
+					Name:       "seed",
+					Port:       resources.UserClusterWebhookSeedListenPort,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(9443),
+					TargetPort: intstr.FromInt(seedWebhookListenPort),
+				},
+				{
+					Name:       "user",
+					Port:       resources.UserClusterWebhookUserListenPort,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(userWebhookListenPort),
 				},
 			}
 

--- a/pkg/webhook/flags.go
+++ b/pkg/webhook/flags.go
@@ -34,12 +34,12 @@ type Options struct {
 	keyName    string
 }
 
-func (opts *Options) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&opts.listenHost, "webhook-listen-host", "", "The listen host for the admission/mutation webhooks.")
-	fs.IntVar(&opts.listenPort, "webhook-listen-port", 9443, "The listen port for the admission/mutation webhooks.")
-	fs.StringVar(&opts.certDir, "webhook-cert-dir", "", "The directory containing the webhook serving certificate files.")
-	fs.StringVar(&opts.certName, "webhook-cert-name", "", "The certificate file name.")
-	fs.StringVar(&opts.keyName, "webhook-key-name", "", "The key file name.")
+func (opts *Options) AddFlags(fs *flag.FlagSet, prefix string) {
+	fs.StringVar(&opts.listenHost, fmt.Sprintf("%s-listen-host", prefix), "", "The listen host for the admission/mutation webhooks.")
+	fs.IntVar(&opts.listenPort, fmt.Sprintf("%s-listen-port", prefix), 9443, "The listen port for the admission/mutation webhooks.")
+	fs.StringVar(&opts.certDir, fmt.Sprintf("%s-cert-dir", prefix), "", "The directory containing the webhook serving certificate files.")
+	fs.StringVar(&opts.certName, fmt.Sprintf("%s-cert-name", prefix), "", "The certificate file name.")
+	fs.StringVar(&opts.keyName, fmt.Sprintf("%s-key-name", prefix), "", "The key file name.")
 }
 
 func checkValidFile(directory, filename string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to introduced architecture we are forced to start two managers (one for each cluster: seed, user) in a single process of `user-cluster-webhook`. Without that, webhook for validation resource quota in machines doesn't work, which makes seanse as webhook server in which we register validator never starts.

**Which issue(s) this PR fixes**:
Fixes #10716 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
Port for additional server has been chosen without a deep reflection. If anyone have better idea what ports we may use please feel free to chime in.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
