### PR TITLE
Upgrade gimps to 0.5.0

### DIFF
--- a/hack/verify-import-order.sh
+++ b/hack/verify-import-order.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/..
 source hack/lib.sh
 
 if ! [ -x "$(command -v gimps)" ]; then
-  version=0.4.1
+  version=0.5.0
 
   echodate "Downloading gimps v$version..."
 


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
With gimps 0.4.1, we have the following error:
`% ./hack/verify-import-order.sh
[2022-08-10T15:59:47+02:00] Sorting import statements...
2022/08/10 15:59:53 Cannot check if file "/Users/helenedurand/go/src/github.com/k8c.io/kubermatic/pkg/handler/v2/external_cluster/aks.go" is generated: failed to parse code: 671:264: expected type, found ',' (and 10 more errors)`
Working fine with latest 0.5.0

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
