### PR TITLE
KubeVirt Fix DataVolume usage at cluster creation time

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -28470,7 +28470,7 @@
           "x-go-name": "PodAntiAffinityPreset"
         },
         "primaryDiskOSImage": {
-          "description": "PrimaryDiskOSImage states the source from which the imported image will be downloaded.",
+          "description": "PrimaryDiskOSImage states the source from which the imported image will be downloaded.\nThis field contains:\na URL to download an Os Image from a HTTP source.\na DataVolume Name as source for DataVolume cloning.",
           "type": "string",
           "x-go-name": "PrimaryDiskOSImage"
         },

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1938,6 +1938,9 @@ type KubevirtNodeSpec struct {
 	Memory string `json:"memory"`
 
 	// PrimaryDiskOSImage states the source from which the imported image will be downloaded.
+	// This field contains:
+	// - a URL to download an Os Image from a HTTP source.
+	// - a DataVolume Name as source for DataVolume cloning.
 	// required: true
 	PrimaryDiskOSImage string `json:"primaryDiskOSImage"`
 	// PrimaryDiskStorageClassName states the storage class name for the provisioned PVCs.

--- a/pkg/resources/machine/common_test.go
+++ b/pkg/resources/machine/common_test.go
@@ -139,3 +139,54 @@ func TestGetVSphereProviderSpec(t *testing.T) {
 		})
 	}
 }
+
+var (
+	osImageURL              = "http://image-repo-http-server.kube-system.svc.cluster.local/images"
+	osImageDataVolumeName   = "dv-name"
+	osImageDataVolumeNsName = "namespace/dv-name"
+	ns                      = "namespace"
+)
+
+func TestExtractKubeVirtOsImageURLOrDataVolumeNsName(t *testing.T) {
+	type args struct {
+		namespace string
+		osImage   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "URL",
+			args: args{
+				osImage:   osImageURL,
+				namespace: ns,
+			},
+			want: osImageURL, // no change, URL kept
+		},
+		{
+			name: "DataVolumeName prefixed with namespace",
+			args: args{
+				osImage:   osImageDataVolumeNsName,
+				namespace: ns,
+			},
+			want: osImageDataVolumeNsName, // no change, already right format
+		},
+		{
+			name: "DataVolumeName",
+			args: args{
+				osImage:   osImageDataVolumeName,
+				namespace: ns,
+			},
+			want: osImageDataVolumeNsName, // add the namespace/ prefix
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractKubeVirtOsImageURLOrDataVolumeNsName(tt.args.namespace, tt.args.osImage); got != tt.want {
+				t.Errorf("extractKubeVirtOsImageURLOrDataVolumeNsName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -219,7 +219,7 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 		}
 	case nd.Spec.Template.Cloud.Kubevirt != nil && dc.Spec.Kubevirt != nil:
 		config.CloudProvider = providerconfig.CloudProviderKubeVirt
-		cloudExt, err = getKubevirtProviderSpec(nd.Spec.Template, dc)
+		cloudExt, err = getKubevirtProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/e2e/utils/apiclient/models/kubevirt_node_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/kubevirt_node_spec.go
@@ -41,6 +41,9 @@ type KubevirtNodeSpec struct {
 	PodAntiAffinityPreset string `json:"podAntiAffinityPreset,omitempty"`
 
 	// PrimaryDiskOSImage states the source from which the imported image will be downloaded.
+	// This field contains:
+	// a URL to download an Os Image from a HTTP source.
+	// a DataVolume Name as source for DataVolume cloning.
 	// Required: true
 	PrimaryDiskOSImage *string `json:"primaryDiskOSImage"`
 


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
This PR allows, at cluster creation time, to create a DataVolume _(Settings tab)_ and use it as source of DataVolume cloning _(Initial Nodes tab)_.
It was not possible as the DataVolume name expected in the  _(Settings tab)_  was expected to be formatted: <namespace>/<name> with <namespace>= the KubeVirt infra cluster dedicated name, which is the cluster.Status.NamespaceName generated after.

The change is to have only the DataVolume name in the _(Settings tab)_ , and prefix it with the dedicated namespace in KKP when creating the initialNodeDeployment. 
We keep the format namespace/DataVolumeName in the RawConfig so we can extract the namespace and the name in the machine-controller to be able to clone with a source in a different namespace (even though it's not possible right now due to policies, we might work on this on the next release). 

For this release:
- KKP prefixes the DataVolumeName with the dedicated namespace. If the name is already with the format namespace/name, we keep it (but cloning will fail due to policies).
- machine-controller extracts namespace and name from this name for the DataVolume to clone.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10699

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
The documentation will be done right after this PR, part of #10705.
```
