### PR TITLE
Add ClusterRole for listing namespaces in RBAC addon

### DIFF
--- a/addons/rbac/list-namespaces.yaml
+++ b/addons/rbac/list-namespaces.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: userClusterRole
+  name: list-namespaces
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "list"


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
In KKP, by default when a user cluster is created then the person who is creating it is assigned the `cluster-admin` role. This works fine as expected. 

Although we ran into a few issues when we removed the `cluster-admin` role and tried to restrict users on that cluster to specific namespaces. One of the issues was that the users were unable to see the namespaces that they had access to in the Kubernetes dashboard. This makes sense since the dashboard will trigger an API call to list all namespaces and fail because the user doesn't have that authority. For more info https://github.com/kubernetes/dashboard/issues/6785

```
"namespaces is forbidden: User \"alexilaiho@gmail.com\" cannot list resource \"namespaces\" in API group \"\" at the cluster scope"
```

For an example to demonstrate this issue, let's assign a user admin access to the `kube-system` namespace:
1. He is unable to list namespaces and will always be redirected to the `default` namespace. Which he doesn't have access to in this case
<img width="1791" alt="Screenshot 2022-08-02 at 9 40 16 PM" src="https://user-images.githubusercontent.com/18264334/184128787-4b4005fb-65fe-4960-b7ad-5ed0918c7f0f.png">

2. If he directly modifies the URL and sets the query parameter for `namespace` to `kube-system` then everything works fine for them.
<img width="1791" alt="Screenshot 2022-08-02 at 9 40 11 PM" src="https://user-images.githubusercontent.com/18264334/184128767-18c1b180-a5a6-48e1-987b-f435a3a573c0.png">

This can be super confusing for a basic user since they have no way to find this out. The same issue exists when someone is using `kubectl` as well.

As a workaround, for better user experience, we have decided to add a new cluster role for the RBAC addon which will give permissions to all the users to list namespaces.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
ClusterRole to list namespaces is shipped with the RBAC addon.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
