### PR TITLE
Allow admin user to list project's group bindings

### DIFF
--- a/pkg/ee/group-project-binding/provider/provider.go
+++ b/pkg/ee/group-project-binding/provider/provider.go
@@ -69,7 +69,7 @@ func (p *GroupProjectBindingProvider) List(ctx context.Context, userInfo *provid
 		return nil, err
 	}
 
-	if len(projectBindings.Items) > 0 {
+	if len(projectBindings.Items) > 0 && !userInfo.IsAdmin {
 		// TODO: once we merge group support, instead of kube api request, read permissions from userInfo.
 		// Fetch first binding with kube API to ensure user has permissions
 		_, err := p.Get(ctx, userInfo, projectBindings.Items[0].Name)

--- a/pkg/ee/group-project-binding/provider/provider.go
+++ b/pkg/ee/group-project-binding/provider/provider.go
@@ -69,7 +69,10 @@ func (p *GroupProjectBindingProvider) List(ctx context.Context, userInfo *provid
 		return nil, err
 	}
 
-	if len(projectBindings.Items) > 0 && !userInfo.IsAdmin {
+	if len(projectBindings.Items) > 0 {
+		if userInfo.IsAdmin {
+			return projectBindings.Items, nil
+		}
 		// TODO: once we merge group support, instead of kube api request, read permissions from userInfo.
 		// Fetch first binding with kube API to ensure user has permissions
 		_, err := p.Get(ctx, userInfo, projectBindings.Items[0].Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently admin users added to project as viewers, after switching project's tab to `Members` see following error:

<img width="365" alt="Screenshot 2022-08-11 at 14 32 55" src="https://user-images.githubusercontent.com/9121459/184134766-d49f1928-4c08-4f8d-9f48-748cec2954a0.png">

To avoid the error and stay consistent with the way we handle user bindings, we should allow listing group project bindings for users that are administrators.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
None
```
