### PR TITLE
fix external cluster metrics for clusters without CloudSpec

### DIFF
--- a/pkg/collectors/external_cluster.go
+++ b/pkg/collectors/external_cluster.go
@@ -127,6 +127,8 @@ func (cc *ExternalClusterCollector) clusterLabels(cluster *kubermaticv1.External
 	providerName := ""
 
 	switch {
+	case cluster.Spec.CloudSpec == nil:
+		providerName = ""
 	case cluster.Spec.CloudSpec.AKS != nil:
 		providerName = "aks"
 	case cluster.Spec.CloudSpec.EKS != nil:


### PR DESCRIPTION
**What this PR does / why we need it**:
I did not anticipate ExternalClusters having no CloudSpec at all. But for those where we have literally only a kubeconfig and no real provider, that's the case. IMHO a design mistake we might want to reconsider (à la the "bringyourown" provider for regular clusters).

For now this should fix the issue.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
