### PR TITLE
prevent accidental invalid config files in installer

### DIFF
--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -74,8 +74,8 @@ func loadKubermaticConfiguration(filename string) (*kubermaticv1.KubermaticConfi
 	}
 
 	config := &kubermaticv1.KubermaticConfiguration{}
-	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(content), 1024).Decode(config); err != nil {
-		return nil, raw, fmt.Errorf("failed to decode %s: %w", filename, err)
+	if err = yaml.UnmarshalStrict(content, config); err != nil {
+		return nil, nil, fmt.Errorf("%s is not a valid KubermaticConfiguration: %w", filename, err)
 	}
 
 	return config, raw, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
A lot of time could have been saved in #10589 if the installer simply rejected invalid config files. Sadly it was one of the few spots where we hadn't migrated to strict unmarshalling yet.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The `kubermatic-installer` now rejects `--config` files that are not actually valid `KubermaticConfiguration` objects.
```
