### PR TITLE
fix gimps download

### DIFF
--- a/hack/verify-import-order.sh
+++ b/hack/verify-import-order.sh
@@ -24,7 +24,8 @@ if ! [ -x "$(command -v gimps)" ]; then
 
   echodate "Downloading gimps v$version..."
 
-  curl -L https://github.com/xrstf/gimps/releases/download/v$version/gimps_${version}_linux_amd64.tar.gz | tar -xz gimps
+  curl -LO https://github.com/xrstf/gimps/releases/download/v$version/gimps_${version}_linux_amd64.zip
+  unzip gimps_${version}_linux_amd64.zip gimps
   mv gimps /usr/local/bin/
 
   echodate "Done!"


### PR DESCRIPTION
**What this PR does / why we need it**:
gimps 0.5 changed to zipfiles.

/kind bug

Fixes #10734

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
