### PR TITLE
fix NPE for external clusters

### DIFF
--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -88,7 +88,7 @@ func withKubeOnefilter(obj ctrlruntimeclient.Object) bool {
 	if !ok {
 		return false
 	}
-	return externalCluster.Spec.CloudSpec.KubeOne == nil
+	return externalCluster.Spec.CloudSpec == nil || externalCluster.Spec.CloudSpec.KubeOne == nil
 }
 
 // ExternalCluster controller doesn't process KubeOne clusters.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes

```
E0815 10:16:59.628512       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 625 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2782580?, 0x50a7160})
	k8s.io/apimachinery@v0.24.2/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xfffffffe?})
	k8s.io/apimachinery@v0.24.2/pkg/util/runtime/runtime.go:49 +0x75
panic({0x2782580, 0x50a7160})
	runtime/panic.go:838 +0x207
k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster.withKubeOnefilter(...)
	k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go:91
```

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
