### PR TITLE
Use rfc1035 for metering report name validation

### DIFF
--- a/pkg/ee/metering/report_config_handler.go
+++ b/pkg/ee/metering/report_config_handler.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -40,6 +41,7 @@ import (
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -72,8 +74,8 @@ type createReportConfigurationReq struct {
 }
 
 func (m createReportConfigurationReq) Validate() error {
-	if !validation.MeteringReportNameValidator.MatchString(m.Name) {
-		return utilerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
+	if errs := k8svalidation.IsDNS1035Label(m.Name); len(errs) != 0 {
+		return utilerrors.NewBadRequest("metering report configuration name must be valid rfc1035 label: %s", strings.Join(errs, ","))
 	}
 
 	cronExpressionParser := validation.GetCronExpressionParser()
@@ -109,8 +111,8 @@ type updateReportConfigurationReq struct {
 }
 
 func (m updateReportConfigurationReq) Validate() error {
-	if !validation.MeteringReportNameValidator.MatchString(m.Name) {
-		return utilerrors.NewBadRequest("metering report configuration name can contain only alphanumeric characters or '-'")
+	if errs := k8svalidation.IsDNS1035Label(m.Name); len(errs) != 0 {
+		return utilerrors.NewBadRequest("metering report configuration name must be valid rfc1035 label: %s", strings.Join(errs, ","))
 	}
 
 	if m.Body.Schedule != "" {

--- a/pkg/ee/metering/report_config_handler_test.go
+++ b/pkg/ee/metering/report_config_handler_test.go
@@ -238,7 +238,7 @@ func TestCreateMeteringReportConfigEndpoint(t *testing.T) {
 			existingKubermaticObjs: []ctrlruntimeclient.Object{testSeed},
 			existingAPIUser:        test.GenDefaultAdminAPIUser(),
 			httpStatus:             http.StatusBadRequest,
-			expectedResponse:       `{"error":{"code":400,"message":"metering report configuration name can contain only alphanumeric characters or '-'"}}`,
+			expectedResponse:       `{"error":{"code":400,"message":"metering report configuration name must be valid rfc1035 label: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"}}`,
 		},
 		// scenario 7
 		{
@@ -367,7 +367,7 @@ func TestUpdateMeteringReportConfigEndpoint(t *testing.T) {
 			existingKubermaticObjs: []ctrlruntimeclient.Object{testSeed},
 			existingAPIUser:        test.GenDefaultAdminAPIUser(),
 			httpStatus:             http.StatusBadRequest,
-			expectedResponse:       `{"error":{"code":400,"message":"metering report configuration name can contain only alphanumeric characters or '-'"}}`,
+			expectedResponse:       `{"error":{"code":400,"message":"metering report configuration name must be valid rfc1035 label: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"}}`,
 		},
 		// scenario 6
 		{

--- a/pkg/validation/metering.go
+++ b/pkg/validation/metering.go
@@ -18,14 +18,14 @@ package validation
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 
 	"github.com/robfig/cron/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-)
 
-var MeteringReportNameValidator = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+	"k8s.io/apimachinery/pkg/util/validation"
+)
 
 func GetCronExpressionParser() cron.Parser {
 	return cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
@@ -35,9 +35,11 @@ func ValidateMeteringConfiguration(configuration *kubermaticv1.MeteringConfigura
 	if configuration != nil && len(configuration.ReportConfigurations) > 0 {
 		parser := GetCronExpressionParser()
 		for reportName, reportConfig := range configuration.ReportConfigurations {
-			if !MeteringReportNameValidator.MatchString(reportName) {
-				return fmt.Errorf("metering report configuration name can contain only alphanumeric characters or '-', got: %s", reportName)
+
+			if errs := validation.IsDNS1035Label(reportName); len(errs) != 0 {
+				return fmt.Errorf("metering report configuration name must be valid rfc1035 label: %s", strings.Join(errs, ","))
 			}
+
 			if _, err := parser.Parse(reportConfig.Schedule); err != nil {
 				return fmt.Errorf("invalid cron expression format: %s", reportConfig.Schedule)
 			}

--- a/pkg/validation/metering.go
+++ b/pkg/validation/metering.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/robfig/cron/v3"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/util/validation"

--- a/pkg/validation/metering.go
+++ b/pkg/validation/metering.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/robfig/cron/v3"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -35,7 +33,6 @@ func ValidateMeteringConfiguration(configuration *kubermaticv1.MeteringConfigura
 	if configuration != nil && len(configuration.ReportConfigurations) > 0 {
 		parser := GetCronExpressionParser()
 		for reportName, reportConfig := range configuration.ReportConfigurations {
-
 			if errs := validation.IsDNS1035Label(reportName); len(errs) != 0 {
 				return fmt.Errorf("metering report configuration name must be valid rfc1035 label: %s", strings.Join(errs, ","))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where report names are invalid and cause the controller to throw errors during CronJob creation.

/kind bug

```release-note
NONE
```

**Documentation**:

```documentation
NONE
```
