### PR TITLE
update e2e test logic to handle secrets that are not pre-base64-encoded

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -18,6 +18,7 @@ package scenarios
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -56,7 +57,7 @@ func (s *googleScenario) APICluster(secrets types.Secrets) *apimodels.CreateClus
 				Cloud: &apimodels.CloudSpec{
 					DatacenterName: secrets.GCP.KKPDatacenter,
 					Gcp: &apimodels.GCPCloudSpec{
-						ServiceAccount: secrets.GCP.ServiceAccount,
+						ServiceAccount: base64.StdEncoding.EncodeToString([]byte(secrets.GCP.ServiceAccount)),
 						Network:        secrets.GCP.Network,
 						Subnetwork:     secrets.GCP.Subnetwork,
 					},
@@ -73,7 +74,7 @@ func (s *googleScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.GCP.KKPDatacenter,
 			GCP: &kubermaticv1.GCPCloudSpec{
-				ServiceAccount: secrets.GCP.ServiceAccount,
+				ServiceAccount: base64.StdEncoding.EncodeToString([]byte(secrets.GCP.ServiceAccount)),
 				Network:        secrets.GCP.Network,
 				Subnetwork:     secrets.GCP.Subnetwork,
 			},

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -18,6 +18,7 @@ package scenarios
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -51,7 +52,7 @@ func (s *kubevirtScenario) APICluster(secrets types.Secrets) *apimodels.CreateCl
 				Cloud: &apimodels.CloudSpec{
 					DatacenterName: secrets.Kubevirt.KKPDatacenter,
 					Kubevirt: &apimodels.KubevirtCloudSpec{
-						Kubeconfig: secrets.Kubevirt.Kubeconfig,
+						Kubeconfig: base64.StdEncoding.EncodeToString([]byte(secrets.Kubevirt.Kubeconfig)),
 					},
 				},
 				Version: apimodels.Semver(s.version.String()),
@@ -66,7 +67,7 @@ func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterS
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Kubevirt.KKPDatacenter,
 			Kubevirt: &kubermaticv1.KubevirtCloudSpec{
-				Kubeconfig: secrets.Kubevirt.Kubeconfig,
+				Kubeconfig: base64.StdEncoding.EncodeToString([]byte(secrets.Kubevirt.Kubeconfig)),
 			},
 		},
 		Version: s.version,

--- a/cmd/conformance-tester/pkg/types/secrets.go
+++ b/cmd/conformance-tester/pkg/types/secrets.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
+	"k8c.io/kubermatic/v2/pkg/test"
 )
 
 type Secrets struct {
@@ -68,14 +70,16 @@ type Secrets struct {
 		ProjectID     string
 	}
 	GCP struct {
-		KKPDatacenter  string
+		KKPDatacenter string
+		// ServiceAccount is the plaintext Service account (as JSON) without any (base64) encoding.
 		ServiceAccount string
 		Network        string
 		Subnetwork     string
 	}
 	Kubevirt struct {
 		KKPDatacenter string
-		Kubeconfig    string
+		// Kubeconfig is the plaintext kubeconfig without any (base64) encoding.
+		Kubeconfig string
 	}
 	Alibaba struct {
 		KKPDatacenter   string
@@ -172,7 +176,11 @@ func (s *Secrets) ParseFlags() error {
 			return fmt.Errorf("failed to read kubevirt kubeconfig file: %w", err)
 		}
 
-		s.Kubevirt.Kubeconfig = string(content)
+		s.Kubevirt.Kubeconfig = test.SafeBase64Decoding(string(content))
+	}
+
+	if s.GCP.ServiceAccount != "" {
+		s.GCP.ServiceAccount = test.SafeBase64Decoding(s.GCP.ServiceAccount)
 	}
 
 	return nil

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 
+	"k8c.io/kubermatic/v2/pkg/test"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client/project"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/models"
@@ -259,7 +260,7 @@ func (a gcp) CloudSpec() models.CloudSpec {
 		DatacenterName: "gcp-westeurope",
 		Gcp: &models.GCPCloudSpec{
 			Network:        "global/networks/dualstack",
-			ServiceAccount: os.Getenv("GOOGLE_SERVICE_ACCOUNT"),
+			ServiceAccount: test.SafeBase64Encoding(os.Getenv("GOOGLE_SERVICE_ACCOUNT")),
 			Subnetwork:     "projects/kubermatic-dev/regions/europe-west3/subnetworks/dualstack-europe-west3",
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes KKP's testing logic more flexible and allows to configure the kubevirt/GCP stuff both base64 encoded and as plaintext. In the future we want to consistently take the raw config values (i.e. not base64-encoded) from Vault, but now during the transitional time, we need to temporarily deal with both variants.

This does not change any non-test behaviour, this PR only adjusts our scripts and stuff to be more careful when encoding/decoding stuff. Once every release branch in KKP/dashboard/MC has been updated, we can cleanup Vault and then remove this helper code again.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
