### PR TITLE
[release/v2.19] update e2e test logic to handle secrets that are not pre-base64-encoded (#10758)

### DIFF
--- a/cmd/conformance-tests/scenarios_gcp.go
+++ b/cmd/conformance-tests/scenarios_gcp.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -65,7 +66,7 @@ func (s *gcpScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 				Cloud: &apimodels.CloudSpec{
 					DatacenterName: "gcp-westeurope",
 					Gcp: &apimodels.GCPCloudSpec{
-						ServiceAccount: secrets.GCP.ServiceAccount,
+						ServiceAccount: base64.StdEncoding.EncodeToString([]byte(secrets.GCP.ServiceAccount)),
 						Network:        secrets.GCP.Network,
 						Subnetwork:     secrets.GCP.Subnetwork,
 					},

--- a/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/cmd/conformance-tests/scenarios_kubevirt.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -70,7 +71,7 @@ func (s *kubevirtScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec
 			Spec: &apimodels.ClusterSpec{
 				Cloud: &apimodels.CloudSpec{
 					Kubevirt: &apimodels.KubevirtCloudSpec{
-						Kubeconfig: secrets.Kubevirt.Kubeconfig,
+						Kubeconfig: base64.StdEncoding.EncodeToString([]byte(secrets.Kubevirt.Kubeconfig)),
 					},
 					DatacenterName: "kubevirt-europe-west3-c",
 				},

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"encoding/base64"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -79,4 +80,28 @@ func NewSeedsGetter(seeds ...*kubermaticv1.Seed) provider.SeedsGetter {
 	return func() (map[string]*kubermaticv1.Seed, error) {
 		return result, nil
 	}
+}
+
+// SafeBase64Decoding takes a value and decodes it with base64, but only
+// if the given value can be decoded without errors. This primarily exists
+// because in older KKP releases, we sometimes had pre-base64-encoded secrets
+// in Vault, but during 2022 migrated to keeping plaintext in Vault.
+func SafeBase64Decoding(value string) string {
+	// If there was no error, the original value was already encoded.
+	if decoded, err := base64.StdEncoding.DecodeString(value); err == nil {
+		return string(decoded)
+	}
+
+	return value
+}
+
+// SafeBase64Encoding takes a value and encodes it with base64, but only
+// if the given value was not already base64-encoded.
+func SafeBase64Encoding(value string) string {
+	// If there was no error, the original value was already encoded.
+	if _, err := base64.StdEncoding.DecodeString(value); err == nil {
+		return value
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(value))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #10758.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
