### PR TITLE
Allow rendering dual-stack IPAddressPool in metallb addon

### DIFF
--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{- if not .Variables.disableAutoIPAMAllocation }}
+
 {{- if .Cluster.Network.IPAMAllocations.metallb }}
 {{- $allocation := .Cluster.Network.IPAMAllocations.metallb }}
 ---
@@ -32,12 +33,37 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- if and (index .Cluster.Network.IPAMAllocations "metallb-ipv4") (index .Cluster.Network.IPAMAllocations "metallb-ipv6") }}
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: kkp-managed-pool-dualstack
+  namespace: metallb-system
+spec:
+  addresses:
+{{- $allocNames := list "metallb-ipv4" "metallb-ipv6" }}
+{{- range $allocName := $allocNames }}
+{{- $allocation := index $.Cluster.Network.IPAMAllocations $allocName }}
+  {{- if eq $allocation.Type "prefix" }}
+    - {{ $allocation.CIDR }}
+  {{- end }}
+  {{- if eq $allocation.Type "range" }}
+    {{- range $allocation.Addresses }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- end }}
 
 {{- if .Variables.addressPoolYaml }}
 ---
 {{ .Variables.addressPoolYaml }}
 {{- end }}
+
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement

--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -43,8 +43,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-{{- $allocNames := list "metallb-ipv4" "metallb-ipv6" }}
-{{- range $allocName := $allocNames }}
+{{- range $allocName := list "metallb-ipv4" "metallb-ipv6" }}
 {{- $allocation := index $.Cluster.Network.IPAMAllocations $allocName }}
   {{- if eq $allocation.Type "prefix" }}
     - {{ $allocation.CIDR }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends the metallb addon & KKP IPAM integration to allow deploying dual-stack IP address pools. Docs drafted in https://github.com/kubermatic/docs/pull/1156

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**Special notes for your reviewer**:
In dual-stack case, the rendered IPAddressPool need to have both IPv4 and IPv6 addresses:

```
apiVersion: metallb.io/v1beta1
kind: IPAddressPool
metadata:
  name: kkp-managed-pool-dualstack
  namespace: metallb-system
spec:
  addresses:
  - 192.168.77.0/28
  - fdf7:74e3:21a::/64
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow rendering dual-stack IPAddressPool in metallb addon
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1156
```
