### PR TITLE
add retries to cleanup project/cluster in dualstack e2e test

### DIFF
--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -478,7 +478,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 	cleanup := func() {
 		n := len(teardowns)
 		for i := range teardowns {
-			wait.Poll(10*time.Second, 10*time.Minute, func() (bool, error) {
+			err := wait.Poll(10*time.Second, 10*time.Minute, func() (bool, error) {
 				err := teardowns[n-1-i]()
 				if err != nil {
 					t.Log(err)
@@ -486,6 +486,9 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 				}
 				return true, nil
 			})
+			if err != nil {
+				t.Errorf("cleanup failed: %s", err)
+			}
 		}
 	}
 
@@ -497,7 +500,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 	teardowns = append(teardowns, func() error {
 		err := apicli.DeleteProject(proj.ID)
 		if err != nil {
-			return fmt.Errorf("failed to delete project %s: %s", proj.ID, err)
+			return fmt.Errorf("failed to delete project %s: %w", proj.ID, err)
 		}
 		return nil
 	})
@@ -524,7 +527,7 @@ func createUsercluster(t *testing.T, apicli *utils.TestClient, projectName strin
 			HTTPClient:          http.DefaultClient,
 		}, apicli.GetBearerToken())
 		if err != nil {
-			return fmt.Errorf("failed to delete cluster %s/%s: %s", proj.ID, cluster.ID, err)
+			return fmt.Errorf("failed to delete cluster %s/%s: %w", proj.ID, cluster.ID, err)
 		}
 		return nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Dualstack smoketest that runs Azure tests almost always fails now to delete project/cluster. This adds retries during cleanup to help with those flakes. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
