### PR TITLE
fix kubevirt resource quota with vmipreset

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -26,6 +26,7 @@ package machine
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -81,6 +82,8 @@ const (
 	// Packet credential env.
 	envPacketToken     = "PACKET_API_KEY"
 	envPacketProjectID = "PACKET_PROJECT_ID"
+	// KubeVirt credential env.
+	envKubeVirtKubeConfig = "KUBEVIRT_KUBECONFIG"
 )
 
 func GetMachineResourceUsage(ctx context.Context,
@@ -303,11 +306,11 @@ func getKubeVirtResourceRequirements(ctx context.Context,
 	var cpuReq, memReq resource.Quantity
 	// if flavor is set, then take the resource details from the vmi preset, otherwise take it from the config
 	if len(flavor) != 0 {
-		kubeconfig, err := configVarResolver.GetConfigVarStringValue(rawConfig.Auth.Kubeconfig)
+		kubeconfig, err := configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Auth.Kubeconfig, envKubeVirtKubeConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get KubeVirt kubeconfig from machine config, error: %w", err)
 		}
-		preset, err := provider.KubeVirtVMIPreset(ctx, kubeconfig, flavor)
+		preset, err := provider.KubeVirtVMIPreset(ctx, base64.StdEncoding.EncodeToString([]byte(kubeconfig)), flavor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get KubeVirt VMI Preset, error: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the fetching of VMIPresets for kubevirt cluster which is required during resource quota validation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10768 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```


Signed-off-by: Sankalp Rangare <sankalprangare786@gmail.com>