### PR TITLE
change smoketest to use AWS+ubuntu

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -142,6 +142,8 @@ presubmits:
               value: cilium
             - name: PROVIDER
               value: all
+            - name: OS
+              value: all
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY
@@ -182,6 +184,8 @@ presubmits:
               value: canal
             - name: PROVIDER
               value: all
+            - name: OS
+              value: all
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY
@@ -220,7 +224,9 @@ presubmits:
             - name: CNI
               value: canal,cilium
             - name: PROVIDER
-              value: azure
+              value: aws
+            - name: OS
+              value: ubuntu
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -142,7 +142,7 @@ presubmits:
               value: cilium
             - name: PROVIDER
               value: all
-            - name: OS
+            - name: OSNAMES
               value: all
             - name: KUBERMATIC_EDITION
               value: ee
@@ -184,7 +184,7 @@ presubmits:
               value: canal
             - name: PROVIDER
               value: all
-            - name: OS
+            - name: OSNAMES
               value: all
             - name: KUBERMATIC_EDITION
               value: ee
@@ -225,7 +225,7 @@ presubmits:
               value: canal,cilium
             - name: PROVIDER
               value: aws
-            - name: OS
+            - name: OSNAMES
               value: ubuntu
             - name: KUBERMATIC_EDITION
               value: ee

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -74,6 +74,6 @@ export VSPHERE_PASSWORD="${VSPHERE_PASSWORD:-$(vault kv get -field=password dev/
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running dualstack tests..."
 
-go_test dualstack_e2e -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/... -args --cni $CNI --provider $PROVIDER
+go_test dualstack_e2e -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/... -args --cni $CNI --provider $PROVIDER --os $OS
 
 echodate "Dualstack tests done."

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -74,6 +74,6 @@ export VSPHERE_PASSWORD="${VSPHERE_PASSWORD:-$(vault kv get -field=password dev/
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running dualstack tests..."
 
-go_test dualstack_e2e -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/... -args --cni $CNI --provider $PROVIDER --os $OS
+go_test dualstack_e2e -race -timeout 1h -tags dualstack -v ./pkg/test/dualstack/... -args --cni $CNI --provider $PROVIDER --os $OSNAMES
 
 echodate "Dualstack tests done."

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -354,7 +354,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			}
 
 			t.Logf("waiting for nodes to come up")
-			err = checkNodeReadiness(t, userclusterClient, len(test.osNames))
+			err = checkNodeReadiness(t, userclusterClient, len(testOSNames))
 			if err != nil {
 				go func() {
 					mu.Lock()

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -267,6 +267,24 @@ func TestCloudClusterIPFamily(t *testing.T) {
 			continue
 		}
 
+		var testOSNames []string
+		if osNames == "all" {
+			testOSNames = test.osNames
+			t.Logf("testing all os in %q", testOSNames)
+		} else {
+			for _, osName := range test.osNames {
+				if strings.Contains(osNames, osName) {
+					testOSNames = append(testOSNames, osName)
+				} else {
+					t.Logf("skipping %q because it is not in %q", osName, osNames)
+				}
+			}
+		}
+		if len(testOSNames) == 0 {
+			t.Logf("skipping because no OS specified to test (available %q)", strings.Join(test.osNames, ","))
+			continue
+		}
+
 		cloud := cloudProviders[test.cloudName]
 		cloudSpec := cloud.CloudSpec()
 		cniSpec := cnis[test.cni]
@@ -311,7 +329,7 @@ func TestCloudClusterIPFamily(t *testing.T) {
 
 			nodeSpec := cloud.NodeSpec()
 
-			for _, osName := range test.osNames {
+			for _, osName := range testOSNames {
 				// TODO: why don't we need to do this for other clouds?
 				if test.cloudName == "openstack" {
 					img := openstack{}.getImage(osName)

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -44,7 +44,8 @@ const (
 var (
 	userconfig             string
 	ipFamily               string
-	cni                    string // comma separated list of cni
+	osNames                string // comma separated list of OS
+	cni                    string // comma separated list of CNI
 	provider               string // comma separated list of cloud providers
 	skipNodes              bool
 	skipHostNetworkPods    bool
@@ -54,6 +55,7 @@ var (
 func init() {
 	flag.StringVar(&userconfig, "userconfig", "", "path to kubeconfig of usercluster")
 	flag.StringVar(&ipFamily, "ipFamily", "IPv4", "IP family")
+	flag.StringVar(&osNames, "os", "", "Comma separated list of operating systems to test ubuntu,flatcar")
 	flag.StringVar(&cni, "cni", "", "CNI cilium|canal")
 	flag.StringVar(&provider, "provider", "", "Cloud providers like azure,aws,gcp")
 	flag.BoolVar(&skipNodes, "skipNodes", false, "If true, skips node IP address tests")

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -55,7 +55,7 @@ var (
 func init() {
 	flag.StringVar(&userconfig, "userconfig", "", "path to kubeconfig of usercluster")
 	flag.StringVar(&ipFamily, "ipFamily", "IPv4", "IP family")
-	flag.StringVar(&osNames, "os", "", "Comma separated list of operating systems to test ubuntu,flatcar")
+	flag.StringVar(&osNames, "os", "", "Comma separated list of operating systems to test e.g. ubuntu,flatcar")
 	flag.StringVar(&cni, "cni", "", "CNI cilium|canal")
 	flag.StringVar(&provider, "provider", "", "Cloud providers like azure,aws,gcp")
 	flag.BoolVar(&skipNodes, "skipNodes", false, "If true, skips node IP address tests")


### PR DESCRIPTION
**What this PR does / why we need it**:
Current dualstack smoketest tests all the OS on Azure. 
Testing all the OS is expensive. 
Azure cleanup is leaky. 
We switch to testing only Ubuntu on AWS for smoketest because it runs frequently.  

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
