### PR TITLE
Do not install gimps. Only tell the user to install it.

### DIFF
--- a/hack/verify-import-order.sh
+++ b/hack/verify-import-order.sh
@@ -29,25 +29,9 @@ i686) ARCH="386" ;;
 i386) ARCH="386" ;;
 esac
 
-version=0.5.0
-# Remove gimps if already installed but not with the right version
-if [ -x "$(command -v gimps)" ]; then
-  iversion="$(gimps --version | grep version)"
-  if [ ${iversion##version: } != $version ]; then
-    echodate "gimps version is not the expected one... removing it before re-install with the right version"
-    rm /usr/local/bin/gimps
-  fi
-fi
-
 if ! [ -x "$(command -v gimps)" ]; then
-
-  echodate "Downloading gimps v$version..."
-
-  curl -LO https://github.com/xrstf/gimps/releases/download/v$version/gimps_${version}_${OS}_${ARCH}.zip
-  unzip gimps_${version}_${OS}_${ARCH}.zip gimps
-  mv gimps /usr/local/bin/
-
-  echodate "Done!"
+  echodate "You need to have gimps installed before running this script. Please install it: https://github.com/xrstf/gimps"
+  exit 1
 fi
 
 echodate "Sorting import statements..."

--- a/hack/verify-import-order.sh
+++ b/hack/verify-import-order.sh
@@ -19,16 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-ARCH=$(uname -m)
-case $ARCH in
-armv6*) ARCH="armv6" ;;
-aarch64) ARCH="arm64" ;;
-x86) ARCH="386" ;;
-x86_64) ARCH="amd64" ;;
-i686) ARCH="386" ;;
-i386) ARCH="386" ;;
-esac
-
 if ! [ -x "$(command -v gimps)" ]; then
   echodate "You need to have gimps installed before running this script. Please install it: https://github.com/xrstf/gimps"
   exit 1

--- a/hack/verify-import-order.sh
+++ b/hack/verify-import-order.sh
@@ -19,13 +19,32 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
+ARCH=$(uname -m)
+case $ARCH in
+armv6*) ARCH="armv6" ;;
+aarch64) ARCH="arm64" ;;
+x86) ARCH="386" ;;
+x86_64) ARCH="amd64" ;;
+i686) ARCH="386" ;;
+i386) ARCH="386" ;;
+esac
+
+version=0.5.0
+# Remove gimps if already installed but not with the right version
+if [ -x "$(command -v gimps)" ]; then
+  iversion="$(gimps --version | grep version)"
+  if [ ${iversion##version: } != $version ]; then
+    echodate "gimps version is not the expected one... removing it before re-install with the right version"
+    rm /usr/local/bin/gimps
+  fi
+fi
+
 if ! [ -x "$(command -v gimps)" ]; then
-  version=0.5.0
 
   echodate "Downloading gimps v$version..."
 
-  curl -LO https://github.com/xrstf/gimps/releases/download/v$version/gimps_${version}_linux_amd64.zip
-  unzip gimps_${version}_linux_amd64.zip gimps
+  curl -LO https://github.com/xrstf/gimps/releases/download/v$version/gimps_${version}_${OS}_${ARCH}.zip
+  unzip gimps_${version}_${OS}_${ARCH}.zip gimps
   mv gimps /usr/local/bin/
 
   echodate "Done!"


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Update the `verify-import-order.sh` to:
- detect the OS and ARCH to download the right zip
- re-install gimps if already installed but with a version different from the expected one.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
