### PR TITLE
Rollback kubeconfig base64 encoding for KubeVirt functional tests

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -18,7 +18,6 @@ package scenarios
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -52,7 +51,7 @@ func (s *kubevirtScenario) APICluster(secrets types.Secrets) *apimodels.CreateCl
 				Cloud: &apimodels.CloudSpec{
 					DatacenterName: secrets.Kubevirt.KKPDatacenter,
 					Kubevirt: &apimodels.KubevirtCloudSpec{
-						Kubeconfig: base64.StdEncoding.EncodeToString([]byte(secrets.Kubevirt.Kubeconfig)),
+						Kubeconfig: secrets.Kubevirt.Kubeconfig,
 					},
 				},
 				Version: apimodels.Semver(s.version.String()),
@@ -67,7 +66,7 @@ func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterS
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Kubevirt.KKPDatacenter,
 			Kubevirt: &kubermaticv1.KubevirtCloudSpec{
-				Kubeconfig: base64.StdEncoding.EncodeToString([]byte(secrets.Kubevirt.Kubeconfig)),
+				Kubeconfig: secrets.Kubevirt.Kubeconfig,
 			},
 		},
 		Version: s.version,


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't have to encode kubeconfig for KubeVirt tests, since data is taken from a secret it's already base64 encoded.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
This PR fixes KubeVirt tests.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
