### PR TITLE
Fix metering reconcile

### DIFF
--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -232,6 +232,8 @@ fi
 retry 8 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing Seed"
 
+kubectl apply -f hack/ci/testdata/metering_s3_creds.yaml
+
 sleep 5
 echodate "Waiting for Kubermatic Operator to deploy Seed components..."
 retry 8 check_all_deployments_ready kubermatic

--- a/hack/ci/testdata/metering_s3_creds.yaml
+++ b/hack/ci/testdata/metering_s3_creds.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: kubermatic
 type: Opaque
 data:
-  accessKey: d2hhdGV2ZXJ5b3VsaWtlCg==
-  bucket: a2twLW1ldGVyaW5nLWUyZQo=
+  accessKey: d2hhdGV2ZXJ5b3VsaWtl
+  bucket: a2twLW1ldGVyaW5nLWUyZQ==
   endpoint: aHR0cHM6Ly9zMy5hbWF6b25hd3MuY29t
-  secretKey: ZHVtbXkK
+  secretKey: ZHVtbXk=

--- a/hack/ci/testdata/metering_s3_creds.yaml
+++ b/hack/ci/testdata/metering_s3_creds.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metering-s3
+  namespace: kubermatic
+type: Opaque
+data:
+  accessKey: d2hhdGV2ZXJ5b3VsaWtlCg==
+  bucket: a2twLW1ldGVyaW5nLWUyZQo=
+  endpoint: aHR0cHM6Ly9zMy5hbWF6b25hd3MuY29t
+  secretKey: ZHVtbXkK

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -36,7 +36,7 @@ spec:
   metering:
     enabled: true
     reports:
-      kubermatic-metering-report-weekly:
+      e2e-weekly:
         interval: 7
         schedule: 0 1 * * 6
     storageClassName: standard

--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -77,7 +77,7 @@ func prometheusStatefulSet(getRegistry registry.WithOverwriteFunc, seed *kuberma
 					Image:           getPrometheusImage(getRegistry),
 					ImagePullPolicy: "IfNotPresent",
 					Args:            []string{"--storage.tsdb.retention.time=90d", "--config.file=/etc/config/prometheus.yml", "--storage.tsdb.path=/data", "--web.console.libraries=/etc/prometheus/console_libraries", "--web.console.templates=/etc/prometheus/consoles", "--web.enable-lifecycle"},
-					Ports:           []corev1.ContainerPort{{ContainerPort: 9090}},
+					Ports:           []corev1.ContainerPort{{ContainerPort: 9090, Protocol: corev1.ProtocolTCP}},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("250m"),

--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -154,6 +154,8 @@ func prometheusStatefulSet(getRegistry registry.WithOverwriteFunc, seed *kuberma
 				return nil, fmt.Errorf("failed to parse value of prometheus pvc storage size %q: %w", seed.Spec.Metering.StorageSize, err)
 			}
 
+			volumeMode := corev1.PersistentVolumeFilesystem
+
 			sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -170,15 +172,13 @@ func prometheusStatefulSet(getRegistry registry.WithOverwriteFunc, seed *kuberma
 								corev1.ResourceStorage: pvcStorageSize,
 							},
 						},
+						VolumeMode:       &volumeMode,
+						StorageClassName: pointer.String(seed.Spec.Metering.StorageClassName),
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
 					},
 				},
-			}
-
-			if seed.Spec.Metering.StorageClassName != "" {
-				sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = pointer.String(seed.Spec.Metering.StorageClassName)
 			}
 
 			return sts, nil

--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -170,9 +170,15 @@ func prometheusStatefulSet(getRegistry registry.WithOverwriteFunc, seed *kuberma
 								corev1.ResourceStorage: pvcStorageSize,
 							},
 						},
-						StorageClassName: pointer.String(seed.Spec.Metering.StorageClassName),
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimPending,
 					},
 				},
+			}
+
+			if seed.Spec.Metering.StorageClassName != "" {
+				sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = pointer.String(seed.Spec.Metering.StorageClassName)
 			}
 
 			return sts, nil

--- a/pkg/ee/metering/prometheus/svc.go
+++ b/pkg/ee/metering/prometheus/svc.go
@@ -46,6 +46,7 @@ func prometheusService() reconciling.NamedServiceCreatorGetter {
 					Name:       Name,
 					Port:       80,
 					TargetPort: intstr.FromInt(9090),
+					Protocol:   corev1.ProtocolTCP,
 				},
 			}
 			svc.Spec.Selector = map[string]string{common.NameLabel: Name}

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -129,6 +129,10 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 		return fmt.Errorf("failed to reconcile reporting cronjob: %w", err)
 	}
 
+	if len(config.Rules) == 0 {
+		return nil
+	}
+
 	mc, bucket, err := getS3DataFromSeed(ctx, client)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix for reconcile metering prometheus sts.

- Fix for reconcile metering prometheus service. 

- As an addition the s3 buckets lifecycle configuration gets not updated if no retention is set. 
This prevents errors for s3 backends that do not support lifecycle configuration. 

- Adds dummy s3 metering secret to ci. 

/kind bug

**Special notes for your reviewer**:


```release-note
NONE
```


```documentation
NONE
```
