### PR TITLE
[release/v2.19] Disable vsphere improved-csi-idempotency

### DIFF
--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -21,6 +21,7 @@
 #   - template function to replace base registry
 #   - remove node selector for operator
 #   - set "improved-volume-topology": "false"
+#   - set "improved-csi-idempotency": "false"
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "vsphere" }}
@@ -178,7 +179,7 @@ data:
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
   "async-query-volume": "true"
-  "improved-csi-idempotency": "true"
+  "improved-csi-idempotency": "false"
   "improved-volume-topology": "false"
   "block-volume-snapshot": "false"
   "csi-windows-support": "false"


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables improved-csi-idempotency as it requires the csi driver to run in vmware-system-csi namespace.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10719

**What type of PR is this?**

/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fix an issue with vsphere csi driver using improved-csi-idempotency that's currently not supported by KKP.
```

**Documentation**:

```documentation
NONE
```
