### PR TITLE
temporarily make installer setup CRDs again

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -135,7 +135,7 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 	}
 
 	seedInSeed := &kubermaticv1.Seed{}
-	if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seed), seedInSeed); err != nil && !apierrors.IsNotFound(err) {
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(seed), seedInSeed); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get seed: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
#9748 changed our CRD management to be done entirely by the operator. However it turns out that this is entirely broken for _new_ seed clusters and for this KKP release (2.20) we do not have the time anymore to properly fix this.

Hence this PR brings back the CRD installation in the installer, so that effectively the setup experience for new seeds is identical to KKP 2.20 and earlier. #10795 will then do the correct things later after the code freeze.

This PR also includes a ciritical fix for the seed-sync controller, which used the wrong client (the master client) and so it would never reconcile a Seed onto a seed cluster.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
