### PR TITLE
Metering: use reconciling framework, use seedsGetter more consistently

### DIFF
--- a/pkg/ee/metering/handler.go
+++ b/pkg/ee/metering/handler.go
@@ -25,7 +25,6 @@
 package metering
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -34,14 +33,11 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -52,8 +48,6 @@ const (
 	Endpoint   = "endpoint"
 	SecretName = "metering-s3"
 )
-
-var secretNamespacedName = types.NamespacedName{Name: SecretName, Namespace: resources.KubermaticNamespace}
 
 type configurationReq struct {
 	Enabled          bool   `json:"enabled"`
@@ -85,7 +79,7 @@ func DecodeMeteringConfigurationsReq(r *http.Request) (interface{}, error) {
 }
 
 // CreateOrUpdateConfigurations creates or updates the metering tool configurations.
-func CreateOrUpdateConfigurations(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
+func CreateOrUpdateConfigurations(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(configurationReq)
 	if !ok {
 		return utilerrors.NewBadRequest("invalid request")
@@ -95,14 +89,14 @@ func CreateOrUpdateConfigurations(ctx context.Context, request interface{}, mast
 		return utilerrors.NewBadRequest(err.Error())
 	}
 
-	seedList := &kubermaticv1.SeedList{}
-	if err := masterClient.List(ctx, seedList, &ctrlruntimeclient.ListOptions{Namespace: resources.KubermaticNamespace}); err != nil {
-		return fmt.Errorf("failed listing seeds: %w", err)
+	seeds, err := seedsGetter()
+	if err != nil {
+		return fmt.Errorf("failed to get seed clients: %w", err)
 	}
 
-	for _, seed := range seedList.Items {
-		if err := updateSeedMeteringConfiguration(ctx, req, &seed, masterClient); err != nil {
-			return fmt.Errorf("failed to create or update metering tool credentials: %w", err)
+	for name, seed := range seeds {
+		if err := updateSeedMeteringConfiguration(ctx, req, seed, masterClient); err != nil {
+			return fmt.Errorf("failed to reconcile metering tool credentials on Seed %s: %w", name, err)
 		}
 	}
 
@@ -164,7 +158,7 @@ func CreateOrUpdateCredentials(ctx context.Context, request interface{}, seedsGe
 		return err
 	}
 
-	seeds, err := getSeeds(seedsGetter, seedClientGetter)
+	seeds, err := seedsGetter()
 	if err != nil {
 		return fmt.Errorf("failed to get seed clients: %w", err)
 	}
@@ -176,79 +170,31 @@ func CreateOrUpdateCredentials(ctx context.Context, request interface{}, seedsGe
 		Endpoint:  []byte(req.Endpoint),
 	}
 
-	for _, client := range seeds {
-		if err := createOrUpdateMeteringToolSecret(ctx, client, data); err != nil {
-			return fmt.Errorf("failed to create or update metering tool credentials: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func createOrUpdateMeteringToolSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, secretData map[string][]byte) error {
-	existingSecret := &corev1.Secret{}
-	if err := seedClient.Get(ctx, secretNamespacedName, existingSecret); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to probe for secret %q: %w", SecretName, err)
-	}
-
-	if existingSecret.Name == "" {
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      SecretName,
-				Namespace: resources.KubermaticNamespace,
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: secretData,
-		}
-
-		if err := seedClient.Create(ctx, secret); err != nil {
-			return fmt.Errorf("failed to create credential secret: %w", err)
-		}
-	} else {
-		if existingSecret.Data == nil {
-			existingSecret.Data = map[string][]byte{}
-		}
-
-		requiresUpdate := false
-
-		for k, v := range secretData {
-			if !bytes.Equal(v, existingSecret.Data[k]) {
-				requiresUpdate = true
-				break
-			}
-		}
-
-		if requiresUpdate {
-			existingSecret.Data = secretData
-			if err := seedClient.Update(ctx, existingSecret); err != nil {
-				return fmt.Errorf("failed to update credential secret: %w", err)
-			}
-		}
-	}
-
-	return nil
-}
-
-func getSeeds(seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) (map[*kubermaticv1.Seed]ctrlruntimeclient.Client, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get seeds: %w", err)
-	}
-
-	var seedClients = make(map[*kubermaticv1.Seed]ctrlruntimeclient.Client, len(seeds))
-
-	for _, seed := range seeds {
-		seedClient, err := seedClientGetter(seed)
+	for seedName, seed := range seeds {
+		client, err := seedClientGetter(seed)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get seed client for seed %q: %w", seed.Name, err)
+			return fmt.Errorf("failed to get client for seed %s: %w", seedName, err)
 		}
 
-		seedClients[seed] = seedClient
+		if err := ensureMeteringToolSecret(ctx, client, seed, data); err != nil {
+			return fmt.Errorf("failed to ensure metering tool credentials on seed %s: %w", seedName, err)
+		}
 	}
 
-	if len(seedClients) < 1 {
-		return nil, errors.New("no seeds found")
+	return nil
+}
+
+func ensureMeteringToolSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, seed *kubermaticv1.Seed, secretData map[string][]byte) error {
+	creator := func() (name string, create reconciling.SecretCreator) {
+		return SecretName, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			existing.Data = secretData
+			return existing, nil
+		}
 	}
 
-	return seedClients, nil
+	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretCreatorGetter{creator}, seed.Namespace, seedClient); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -51,7 +51,6 @@ import (
 )
 
 const (
-
 	// legacy naming.
 	meteringToolName = "kubermatic-metering"
 	meteringDataName = "metering-data"
@@ -68,7 +67,7 @@ func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Cl
 	overwriter := registry.GetOverwriteFunc(cfg.Spec.UserCluster.OverwriteRegistry)
 
 	// ensure legacy components are removed
-	err := cleanupLegacyMeteringResources(ctx, client)
+	err := cleanupLegacyMeteringResources(ctx, client, seed.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup legacy metering components: %w", err)
 	}
@@ -122,7 +121,7 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 	if err := reconciling.ReconcileCronJobs(
 		ctx,
 		cronJobs,
-		resources.KubermaticNamespace,
+		seed.Namespace,
 		client,
 		modifiers...,
 	); err != nil {
@@ -133,7 +132,7 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 		return nil
 	}
 
-	mc, bucket, err := getS3DataFromSeed(ctx, client)
+	mc, bucket, err := getS3DataFromSeed(ctx, seed, client)
 	if err != nil {
 		return err
 	}
@@ -242,8 +241,8 @@ func undeploy(ctx context.Context, client ctrlruntimeclient.Client, namespace st
 }
 
 // cleanupLegacyMeteringResources removes all active parts of the legacy metering installation.
-func cleanupLegacyMeteringResources(ctx context.Context, client ctrlruntimeclient.Client) error {
-	key := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: meteringToolName}
+func cleanupLegacyMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, namespace string) error {
+	key := types.NamespacedName{Namespace: namespace, Name: meteringToolName}
 	if err := cleanupResource(ctx, client, key, &appsv1.Deployment{}); err != nil {
 		return fmt.Errorf("failed to cleanup metering Deployment: %w", err)
 	}
@@ -258,7 +257,7 @@ func cleanupLegacyMeteringResources(ctx context.Context, client ctrlruntimeclien
 
 	legacyReportingCronJobs := &batchv1.CronJobList{}
 	listOpts := []ctrlruntimeclient.ListOption{
-		ctrlruntimeclient.InNamespace(resources.KubermaticNamespace),
+		ctrlruntimeclient.InNamespace(namespace),
 		ctrlruntimeclient.ListOption(ctrlruntimeclient.HasLabels{meteringToolName}),
 	}
 	if err := client.List(ctx, legacyReportingCronJobs, listOpts...); err != nil {
@@ -274,7 +273,7 @@ func cleanupLegacyMeteringResources(ctx context.Context, client ctrlruntimeclien
 		}
 	}
 
-	if err := cleanupResource(ctx, client, types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: meteringDataName}, &corev1.PersistentVolumeClaim{}); err != nil {
+	if err := cleanupResource(ctx, client, types.NamespacedName{Namespace: namespace, Name: meteringDataName}, &corev1.PersistentVolumeClaim{}); err != nil {
 		return fmt.Errorf("failed to cleanup metering PersistentVolumeClaim: %w", err)
 	}
 

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -66,8 +66,9 @@ func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
 func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, scheme *runtime.Scheme, cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) error {
 	overwriter := registry.GetOverwriteFunc(cfg.Spec.UserCluster.OverwriteRegistry)
 
-	// ensure legacy components are removed
-	err := cleanupLegacyMeteringResources(ctx, client, seed.Namespace)
+	// ensure legacy components are removed (as they were hardcoded to be in the KKP
+	// namespace, for the cleanup we must not use the Seed's namespace)
+	err := cleanupLegacyMeteringResources(ctx, client, resources.KubermaticNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup legacy metering components: %w", err)
 	}

--- a/pkg/ee/metering/report_config_handler.go
+++ b/pkg/ee/metering/report_config_handler.go
@@ -37,7 +37,6 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/resources"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 
@@ -263,7 +262,7 @@ func ListMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]apiv1
 }
 
 // CreateMeteringReportConfiguration adds new metering report configuration to the existing map.
-func CreateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
+func CreateMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(createReportConfigurationReq)
 	if !ok {
 		return utilerrors.NewBadRequest("invalid request")
@@ -273,13 +272,13 @@ func CreateMeteringReportConfiguration(ctx context.Context, request interface{},
 		return utilerrors.NewBadRequest(err.Error())
 	}
 
-	seedList := &kubermaticv1.SeedList{}
-	if err := masterClient.List(ctx, seedList, &ctrlruntimeclient.ListOptions{Namespace: resources.KubermaticNamespace}); err != nil {
+	seeds, err := seedsGetter()
+	if err != nil {
 		return fmt.Errorf("failed listing seeds: %w", err)
 	}
 
-	for _, seed := range seedList.Items {
-		if err := createMeteringReportConfiguration(ctx, req, &seed, masterClient); err != nil {
+	for _, seed := range seeds {
+		if err := createMeteringReportConfiguration(ctx, req, seed, masterClient); err != nil {
 			return err
 		}
 	}
@@ -288,7 +287,7 @@ func CreateMeteringReportConfiguration(ctx context.Context, request interface{},
 }
 
 // UpdateMeteringReportConfiguration adds new metering report configuration to the existing map.
-func UpdateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
+func UpdateMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(updateReportConfigurationReq)
 	if !ok {
 		return utilerrors.NewBadRequest("invalid request")
@@ -298,13 +297,13 @@ func UpdateMeteringReportConfiguration(ctx context.Context, request interface{},
 		return utilerrors.NewBadRequest(err.Error())
 	}
 
-	seedList := &kubermaticv1.SeedList{}
-	if err := masterClient.List(ctx, seedList, &ctrlruntimeclient.ListOptions{Namespace: resources.KubermaticNamespace}); err != nil {
+	seeds, err := seedsGetter()
+	if err != nil {
 		return fmt.Errorf("failed listing seeds: %w", err)
 	}
 
-	for _, seed := range seedList.Items {
-		if err := updateMeteringReportConfiguration(ctx, req, &seed, masterClient); err != nil {
+	for _, seed := range seeds {
+		if err := updateMeteringReportConfiguration(ctx, req, seed, masterClient); err != nil {
 			return err
 		}
 	}
@@ -313,19 +312,19 @@ func UpdateMeteringReportConfiguration(ctx context.Context, request interface{},
 }
 
 // DeleteMeteringReportConfiguration removes metering report configuration from the existing map.
-func DeleteMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
+func DeleteMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
 	req, ok := request.(deleteMeteringReportConfig)
 	if !ok {
 		return utilerrors.NewBadRequest("invalid request")
 	}
 
-	seedList := &kubermaticv1.SeedList{}
-	if err := masterClient.List(ctx, seedList, &ctrlruntimeclient.ListOptions{Namespace: resources.KubermaticNamespace}); err != nil {
+	seeds, err := seedsGetter()
+	if err != nil {
 		return fmt.Errorf("failed listing seeds: %w", err)
 	}
 
-	for _, seed := range seedList.Items {
-		if err := deleteMeteringReportConfiguration(ctx, req.Name, &seed, masterClient); err != nil {
+	for _, seed := range seeds {
+		if err := deleteMeteringReportConfiguration(ctx, req.Name, seed, masterClient); err != nil {
 			return err
 		}
 	}

--- a/pkg/handler/routes_v1_admin.go
+++ b/pkg/handler/routes_v1_admin.go
@@ -544,7 +544,7 @@ func (r Routing) createOrUpdateMeteringConfigurations() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.CreateOrUpdateMeteringConfigurations(r.userInfoGetter, r.masterClient)),
+		)(admin.CreateOrUpdateMeteringConfigurations(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeMeteringConfigurationsReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
@@ -619,7 +619,7 @@ func (r Routing) CreateMeteringReportConfiguration() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.CreateMeteringReportConfigurationEndpoint(r.userInfoGetter, r.masterClient)),
+		)(admin.CreateMeteringReportConfigurationEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeCreateMeteringReportConfigurationReq,
 		SetStatusCreatedHeader(EncodeJSON),
 		r.defaultServerOptions()...,
@@ -646,7 +646,7 @@ func (r Routing) UpdateMeteringReportConfiguration() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.UpdateMeteringReportConfigurationEndpoint(r.userInfoGetter, r.masterClient)),
+		)(admin.UpdateMeteringReportConfigurationEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeUpdateMeteringReportConfigurationReq,
 		SetStatusCreatedHeader(EncodeJSON),
 		r.defaultServerOptions()...,
@@ -670,7 +670,7 @@ func (r Routing) DeleteMeteringReportConfiguration() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
-		)(admin.DeleteMeteringReportConfigurationEndpoint(r.userInfoGetter, r.masterClient)),
+		)(admin.DeleteMeteringReportConfigurationEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeDeleteMeteringReportConfigurationReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -49,7 +49,7 @@ func CreateOrUpdateMeteringCredentials(userInfoGetter provider.UserInfoGetter, s
 }
 
 // CreateOrUpdateMeteringConfigurations configures kkp metering tool.
-func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
+func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -59,7 +59,7 @@ func CreateOrUpdateMeteringConfigurations(userInfoGetter provider.UserInfoGetter
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
-		if err := createOrUpdateMeteringConfigurations(ctx, req, masterClient); err != nil {
+		if err := createOrUpdateMeteringConfigurations(ctx, req, seedsGetter, masterClient); err != nil {
 			return nil, fmt.Errorf("failed to create/update metering SecretReq: %w", err)
 		}
 
@@ -108,7 +108,7 @@ func ListMeteringReportConfigurationsEndpoint(userInfoGetter provider.UserInfoGe
 }
 
 // CreateMeteringReportConfigurationEndpoint creates report configuration entry for kkp metering tool.
-func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
+func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -118,7 +118,7 @@ func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
-		if err := createMeteringReportConfiguration(ctx, req, masterClient); err != nil {
+		if err := createMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
 			return nil, fmt.Errorf("failed to create metering report configuration: %w", err)
 		}
 
@@ -127,7 +127,7 @@ func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 }
 
 // UpdateMeteringReportConfigurationEndpoint updates existing report configuration entry for kkp metering tool.
-func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
+func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -137,7 +137,7 @@ func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
-		if err := updateMeteringReportConfiguration(ctx, req, masterClient); err != nil {
+		if err := updateMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
 			return nil, fmt.Errorf("failed to update metering report configuration: %w", err)
 		}
 
@@ -146,7 +146,7 @@ func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 }
 
 // DeleteMeteringReportConfigurationEndpoint deletes report configuration entry for kkp metering tool.
-func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
+func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoGetter, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")
 		if err != nil {
@@ -156,7 +156,7 @@ func DeleteMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
-		if err := deleteMeteringReportConfiguration(ctx, req, masterClient); err != nil {
+		if err := deleteMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
 			return nil, fmt.Errorf("failed to delete metering report configuration: %w", err)
 		}
 

--- a/pkg/handler/v1/admin/wrappers_ce.go
+++ b/pkg/handler/v1/admin/wrappers_ce.go
@@ -33,7 +33,7 @@ func createOrUpdateMeteringCredentials(_ context.Context, _ interface{}, _ provi
 	return nil
 }
 
-func createOrUpdateMeteringConfigurations(_ context.Context, _ interface{}, masterClient ctrlruntimeclient.Client) error {
+func createOrUpdateMeteringConfigurations(_ context.Context, _ interface{}, _ provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
 	return nil
 }
 
@@ -45,15 +45,15 @@ func listMeteringReportConfigurations(_ provider.SeedsGetter) ([]apiv1.MeteringR
 	return nil, nil
 }
 
-func createMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlruntimeclient.Client) error {
+func createMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) error {
 	return nil
 }
 
-func updateMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlruntimeclient.Client) error {
+func updateMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) error {
 	return nil
 }
 
-func deleteMeteringReportConfiguration(_ context.Context, _ interface{}, _ ctrlruntimeclient.Client) error {
+func deleteMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) error {
 	return nil
 }
 

--- a/pkg/handler/v1/admin/wrappers_ee.go
+++ b/pkg/handler/v1/admin/wrappers_ee.go
@@ -33,8 +33,8 @@ func createOrUpdateMeteringCredentials(ctx context.Context, request interface{},
 	return metering.CreateOrUpdateCredentials(ctx, request, seedsGetter, seedClientGetter)
 }
 
-func createOrUpdateMeteringConfigurations(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
-	return metering.CreateOrUpdateConfigurations(ctx, request, masterClient)
+func createOrUpdateMeteringConfigurations(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
+	return metering.CreateOrUpdateConfigurations(ctx, request, seedsGetter, masterClient)
 }
 
 func getMeteringReportConfiguration(seedsGetter provider.SeedsGetter, request interface{}) (*apiv1.MeteringReportConfiguration, error) {
@@ -45,16 +45,16 @@ func listMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]apiv1
 	return metering.ListMeteringReportConfigurations(seedsGetter)
 }
 
-func createMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
-	return metering.CreateMeteringReportConfiguration(ctx, request, masterClient)
+func createMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
+	return metering.CreateMeteringReportConfiguration(ctx, request, seedsGetter, masterClient)
 }
 
-func updateMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
-	return metering.UpdateMeteringReportConfiguration(ctx, request, masterClient)
+func updateMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
+	return metering.UpdateMeteringReportConfiguration(ctx, request, seedsGetter, masterClient)
 }
 
-func deleteMeteringReportConfiguration(ctx context.Context, request interface{}, masterClient ctrlruntimeclient.Client) error {
-	return metering.DeleteMeteringReportConfiguration(ctx, request, masterClient)
+func deleteMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
+	return metering.DeleteMeteringReportConfiguration(ctx, request, seedsGetter, masterClient)
 }
 
 func listMeteringReports(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, seedClientGetter provider.SeedClientGetter) ([]apiv1.MeteringReport, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This does some quality of life changes to the new metering code.

* no more hardcoded "kubermatic" namespace
* use reconciling to manage secret
* use seedsGetter in more places

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
