### PR TITLE
Check that backup destination has credentials set

### DIFF
--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -180,6 +180,10 @@ func (c *clusterBackupCollector) setMetricsForCluster(ch chan<- prometheus.Metri
 }
 
 func (c *clusterBackupCollector) getS3Client(ctx context.Context, destination *kubermaticv1.BackupDestination) (*minio.Client, error) {
+	if destination.Credentials == nil {
+		return nil, fmt.Errorf("credentials not set for backup destination %q", destination)
+	}
+
 	key := types.NamespacedName{
 		Name:      destination.Credentials.Name,
 		Namespace: destination.Credentials.Namespace,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a nil pointer dereference that occurs when a backup destination has no credentials set. 

https://github.com/kubermatic/kubermatic/blob/master/pkg/apis/kubermatic/v1/datacenter.go#L312

Error message:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x290964a]

goroutine 1380 [running]:
k8c.io/kubermatic/v2/pkg/collectors.(*clusterBackupCollector).getS3Client(0xc000f5c410, {0x3db77b8, 0xc00013e3e8}, 0xc002abb080)
	k8c.io/kubermatic/v2/pkg/collectors/clusterbackup.go:184 +0x4a
k8c.io/kubermatic/v2/pkg/collectors.(*clusterBackupCollector).collectDestination(0x0?, {0x3db77b8, 0xc00013e3e8}, 0xc00060edff?, {0x60dc4b8, 0x0, 0xc001381cf8?}, {0xc002aea3c0, 0x6}, 0xc002abb080)
	k8c.io/kubermatic/v2/pkg/collectors/clusterbackup.go:141 +0xab
k8c.io/kubermatic/v2/pkg/collectors.(*clusterBackupCollector).collect(0xc000f5c410, {0x3db77b8, 0xc00013e3e8}, 0xc00030d7e0?)
	k8c.io/kubermatic/v2/pkg/collectors/clusterbackup.go:124 +0x32a
k8c.io/kubermatic/v2/pkg/collectors.(*clusterBackupCollector).Collect(0xc000f5c410, 0xc00129cf60?)
	k8c.io/kubermatic/v2/pkg/collectors/clusterbackup.go:93 +0x45
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	github.com/prometheus/client_golang@v1.12.2/prometheus/registry.go:446 +0xfb
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	github.com/prometheus/client_golang@v1.12.2/prometheus/registry.go:538 +0xb0b
```

/kind bug


```release-note
NONE
```

**Documentation**:

```documentation
NONE
```
