### PR TITLE
fix timing for OSM upgrade during KKP upgrade

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -312,13 +312,6 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *kubermaticv1.K
 		return err
 	}
 
-	// This is a migration that is required to ensure that with the release of KKP v2.21
-	// we don't enable OSM for existing clusters.
-	// TODO: Remove this with KKP 2.22 release.
-	if err := r.disableOperatingSystemManager(ctx, client, log); err != nil {
-		return err
-	}
-
 	if err := r.reconcileServiceAccounts(ctx, cfg, seed, client, log); err != nil {
 		return err
 	}
@@ -368,6 +361,13 @@ func (r *Reconciler) reconcileResources(ctx context.Context, cfg *kubermaticv1.K
 	common.CleanupWebhookServices(ctx, client, log, cfg.Namespace)
 
 	if err := metering.ReconcileMeteringResources(ctx, client, r.scheme, cfg, seed); err != nil {
+		return err
+	}
+
+	// This is a migration that is required to ensure that with the release of KKP v2.21
+	// we don't enable OSM for existing clusters.
+	// TODO: Remove this with KKP 2.22 release.
+	if err := r.disableOperatingSystemManager(ctx, client, log); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During a KKP upgrade from 2.20 to 2.21 (on a shared master/seed system)

1. the `master-operator` will begin to reconcile the master cluster and in doing so, it will remove the `cluster-webhook` Service. From this point on, the cluster validation webhook is effectively dead. The service gets removed because we migrate to the new standalone kubermatic-webhook.
1. then the `seed-operator` tries to reconcile, but since it tried to update Cluster objects before fixing the webhook, it would end up in an endless loop or reconciling errors.

This PR simply moves the OSM stuff to happen later, after the webhook was reconciled.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
