### PR TITLE
don't spam misleading errors during upgrade

### DIFF
--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -440,7 +440,9 @@ func getOldestAvailableVersion(log *zap.SugaredLogger, replicaSets []appsv1.Repl
 
 		versionLabel := rs.GetLabels()[resources.VersionLabel]
 		if versionLabel == "" {
-			log.Warnw("ReplicaSet has no version label, this should not happen", "replicaset", rs.Name)
+			// This is a normal condition during th KKP 2.20->2.21 upgrade, but for KKP 2.22 this
+			// log message should be increased to warning level.
+			log.Debugw("ReplicaSet has no version label, this should not happen", "replicaset", rs.Name)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During the KKP upgrade it's perfectly normal and expected for the ReplicaSets to have no version label yet. This PR therefore reduces the log verbosity for this release, as hundreds of log messages can be super scary (even to me, and I implemented the log warning in the first place).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
