### PR TITLE
Allow admin management to GroupProjectBindings

### DIFF
--- a/pkg/ee/group-project-binding/handler/handler.go
+++ b/pkg/ee/group-project-binding/handler/handler.go
@@ -75,7 +75,7 @@ func ListGroupProjectBindings(ctx context.Context, request interface{},
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	userInfo, err := getUserInfo(ctx, userInfoGetter, kubermaticProject.Name)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -153,7 +153,7 @@ func GetGroupProjectBinding(ctx context.Context, request interface{},
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	userInfo, err := getUserInfo(ctx, userInfoGetter, kubermaticProject.Name)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -228,7 +228,7 @@ func CreateGroupProjectBinding(ctx context.Context, request interface{},
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	userInfo, err := getUserInfo(ctx, userInfoGetter, kubermaticProject.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ func DeleteGroupProjectBinding(ctx context.Context, request interface{},
 		return common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	userInfo, err := getUserInfo(ctx, userInfoGetter, kubermaticProject.Name)
 	if err != nil {
 		return common.KubernetesErrorToHTTPError(err)
 	}
@@ -356,7 +356,7 @@ func PatchGroupProjectBinding(ctx context.Context, request interface{},
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	userInfo, err := getUserInfo(ctx, userInfoGetter, kubermaticProject.Name)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -395,4 +395,20 @@ func validateRole(role string) error {
 		return utilerrors.NewBadRequest("allowed roles are: %v", strings.Join(allowedRoles.List(), ", "))
 	}
 	return nil
+}
+
+func getUserInfo(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string) (*provider.UserInfo, error) {
+	userInfo, err := userInfoGetter(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if !userInfo.IsAdmin {
+		userInfo, err = userInfoGetter(ctx, projectID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return userInfo, err
 }

--- a/pkg/ee/group-project-binding/handler/handler_test.go
+++ b/pkg/ee/group-project-binding/handler/handler_test.go
@@ -44,6 +44,8 @@ import (
 func TestHandlerGroupProjectBindings(t *testing.T) {
 	t.Parallel()
 
+	testUser := test.GenAPIUser("bob", "bob@acme.com")
+
 	testcases := []struct {
 		name             string
 		method           string
@@ -59,13 +61,14 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 			name:            "scenario 1: list GroupProjectBindings in a project",
 			method:          http.MethodGet,
 			url:             "/api/v2/projects/foo-ID/groupbindings",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenProject("boo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "TestGroup", "owners"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -86,13 +89,14 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 			name:            "scenario 2: list GroupProjectBindings in an illicit project",
 			method:          http.MethodGet,
 			url:             "/api/v2/projects/foo-ID/groupbindings",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenProject("boo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "TestGroup", "owners"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusForbidden,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -103,11 +107,12 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 			name:            "scenario 3: get an existing GroupProjectBinding",
 			method:          http.MethodGet,
 			url:             "/api/v2/projects/boo-ID/groupbindings/boo-ID-xxxxxxxxxx",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("boo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -127,10 +132,11 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 			name:            "scenario 4: get a non-existing GroupProjectBinding",
 			method:          http.MethodGet,
 			url:             "/api/v2/projects/boo-ID/groupbindings/boo-ID-DoesNotExist",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("boo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -141,12 +147,13 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 			name:            "scenario 5: get an illicit GroupProjectBinding",
 			method:          http.MethodGet,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-xxxxxxxxxx",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenProject("boo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("boo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("boo-ID", "TestGroup", "owners"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusForbidden,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -161,10 +168,11 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				"role": "viewers",
 				"group": "viewers-test"
 			}`,
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusCreated,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -179,10 +187,11 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				"role": "invalid",
 				"group": "viewers-test"
 			}`,
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusBadRequest,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -193,11 +202,12 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 			name:            "scenario 8: delete an existing GroupProjectBinding",
 			method:          http.MethodDelete,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-xxxxxxxxxx",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -212,11 +222,12 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				"role": "owners"
 			}`,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-xxxxxxxxxx",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusOK,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -231,11 +242,12 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				"role": "owners"
 			}`,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-nonexisting",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusNotFound,
 			validateResp: func(resp *httptest.ResponseRecorder) error {
@@ -249,11 +261,12 @@ func TestHandlerGroupProjectBindings(t *testing.T) {
 				"role": "invalid"
 			}`,
 			url:             "/api/v2/projects/foo-ID/groupbindings/foo-ID-xxxxxxxxxx",
-			existingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
+			existingAPIUser: testUser,
 			existingObjects: []ctrlruntimeclient.Object{
 				test.GenProject("foo", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
 				test.GenBinding("foo-ID", "bob@acme.com", "editors"),
 				test.GenGroupBinding("foo-ID", "viewers-test", "viewers"),
+				test.APIUserToKubermaticUser(*testUser),
 			},
 			httpStatus: http.StatusBadRequest,
 			validateResp: func(resp *httptest.ResponseRecorder) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes KKP admins not being able to manage GroupProjectBindings.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10788

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
