### PR TITLE
add user-cluster rbac for applicationinstallations

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/rbac/resources.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/resources.go
@@ -23,6 +23,7 @@ import (
 	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/config/v1alpha1"
 
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/handler/v2/constraint"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -77,6 +78,11 @@ func CreateClusterRole(resourceName string, cr *rbacv1.ClusterRole) (*rbacv1.Clu
 		{
 			APIGroups: []string{clusterPolicyAPIGroup},
 			Resources: []string{"machinedeployments", "machinesets", "machines"},
+			Verbs:     verbs,
+		},
+		{
+			APIGroups: []string{appskubermaticv1.GroupName},
+			Resources: []string{appskubermaticv1.ApplicationInstallationResourceName},
 			Verbs:     verbs,
 		},
 		{

--- a/pkg/controller/user-cluster-controller-manager/rbac/resources_test.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/resources_test.go
@@ -32,13 +32,11 @@ func TestGeneratedResourcesForGroups(t *testing.T) {
 		resourceName      string
 		expectError       bool
 		expectedResources []string
-		expectedVerbs     []string
 	}{
 		{
 			name:              "scenario 1: check resources for owners",
 			resourceName:      genResourceName(rbac.OwnerGroupNamePrefix),
 			expectedResources: []string{"*"},
-			expectedVerbs:     []string{"*"},
 			expectError:       false,
 		},
 		{
@@ -82,7 +80,7 @@ func TestGeneratedResourcesForGroups(t *testing.T) {
 						break
 					}
 				}
-				if found == false {
+				if !found {
 					t.Errorf("Expected resource %q was not found in rulegroup %+v\n", resource, cr.Rules)
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Simon Bein <simontheleg@gmail.com>

**What this PR does / why we need it**:

This fixes a bug, where Project Viewers were not able to see AppInstalls in the panel (see #10728 for details)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10728 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

Note: This PR slightly changes how we validate the generated rules. Before we just took the first rule in the slice and checked if it exactly matches our expectations. However we cannot use this trick anymore, because now the expected resources are spread across two rules. In order to not overcomplicate the test, the new check simply makes sure that the requested resources are present in any of the rules of the slice, instead of checking if they exactly match. In the end, I think this tradeoff is acceptable, but let me know what you think.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```
