### PR TITLE
replace deprecated topology-zone label

### DIFF
--- a/pkg/resources/antiaffinity.go
+++ b/pkg/resources/antiaffinity.go
@@ -75,7 +75,7 @@ func FailureDomainZoneAntiAffinity(app string) corev1.WeightedPodAffinityTerm {
 					AppLabelKey: app,
 				},
 			},
-			TopologyKey: TopologyKeyFailureDomainZone,
+			TopologyKey: TopologyKeyZone,
 		},
 	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -417,8 +417,8 @@ const (
 
 	// TopologyKeyHostname defines the topology key for the node hostname.
 	TopologyKeyHostname = "kubernetes.io/hostname"
-	// TopologyKeyFailureDomainZone defines the topology key for the node's cloud provider zone.
-	TopologyKeyFailureDomainZone = "failure-domain.beta.kubernetes.io/zone"
+	// TopologyKeyZone defines the topology key for the node's cloud provider zone.
+	TopologyKeyZone = "topology.kubernetes.io/zone"
 
 	// MachineCRDName defines the CRD name for machine objects.
 	MachineCRDName = "machines.cluster.k8s.io"
@@ -1531,9 +1531,9 @@ func GetOverrides(componentSettings kubermaticv1.ComponentSettings) map[string]*
 }
 
 // SupportsFailureDomainZoneAntiAffinity checks if there are any nodes with the
-// TopologyKeyFailureDomainZone label.
+// TopologyKeyZone label.
 func SupportsFailureDomainZoneAntiAffinity(ctx context.Context, client ctrlruntimeclient.Client) (bool, error) {
-	selector, err := labels.Parse(TopologyKeyFailureDomainZone)
+	selector, err := labels.Parse(TopologyKeyZone)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse selector: %w", err)
 	}
@@ -1546,7 +1546,7 @@ func SupportsFailureDomainZoneAntiAffinity(ctx context.Context, client ctrlrunti
 
 	nodeList := &corev1.NodeList{}
 	if err := client.List(ctx, nodeList, opts); err != nil {
-		return false, fmt.Errorf("failed to list nodes having the %s label: %w", TopologyKeyFailureDomainZone, err)
+		return false, fmt.Errorf("failed to list nodes having the %s label: %w", TopologyKeyZone, err)
 	}
 
 	return len(nodeList.Items) != 0, nil


### PR DESCRIPTION
Signed-off-by: Simon Bein <simontheleg@gmail.com>

**What this PR does / why we need it**:

The `failure-domain.beta.kubernetes.io/zone` label has been deprecated in favor of `topology.kubernetes.io/zone` since [k8s 1.17](https://kubernetes.io/docs/reference/labels-annotations-taints/#failure-domainbetakubernetesiozone). This PR changes the templating for resources we deploy (e.g. etcd) to make use of the newer label.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind deprecation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use "topology.kubernetes.io/zone" instead of "failure-domain.beta.kubernetes.io/zone" for KKP components
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
