### PR TITLE
Skip IPv6 node addresses in DNAT controller

### DIFF
--- a/pkg/controller/kubeletdnat-controller/controller.go
+++ b/pkg/controller/kubeletdnat-controller/controller.go
@@ -174,6 +174,7 @@ func (r *Reconciler) syncDnatRules(ctx context.Context) error {
 }
 
 // getNodeAddresses returns all relevant addresses of a node.
+// Only IPv4 addresses are returned as OpenVPN connection to the worker nodes is IPv4-only.
 func getNodeAddresses(node corev1.Node) []string {
 	addressTypes := []corev1.NodeAddressType{corev1.NodeExternalIP, corev1.NodeInternalIP}
 	addresses := []string{}

--- a/pkg/controller/kubeletdnat-controller/controller.go
+++ b/pkg/controller/kubeletdnat-controller/controller.go
@@ -179,7 +179,7 @@ func getNodeAddresses(node corev1.Node) []string {
 	addresses := []string{}
 	for _, addressType := range addressTypes {
 		for _, address := range node.Status.Addresses {
-			if address.Type == addressType {
+			if address.Type == addressType && isIPv4(address.Address) {
 				addresses = append(addresses, address.Address)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Fixes apiserver-to-kubelet connection for dual-stack clusters using OpenVPN (not Konnectivity) if the nodes have both IPv4 and IPv6 addresses published in their node status.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
