### PR TITLE
fix externalcluster deletion bug

### DIFF
--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -207,11 +207,15 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 
 func (r *Reconciler) handleDeletion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
 	if kuberneteshelper.HasFinalizer(cluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer) {
-		return r.cleanUpKubeconfigSecret(ctx, cluster)
+		if err := r.cleanUpKubeconfigSecret(ctx, cluster); err != nil {
+			return err
+		}
 	}
 
 	if kuberneteshelper.HasFinalizer(cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer) {
-		return r.cleanUpCredentialsSecret(ctx, cluster)
+		if err := r.cleanUpCredentialsSecret(ctx, cluster); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**:
this pr fixes the bug of credential finalizer not removed as handledeletion method returns after processing the kubeconfig finalizer

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
