### PR TITLE
fix auto-update rule

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -524,7 +524,7 @@ spec:
         # To is the version to which an update is allowed.
         # Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
         # Can be a wildcard otherwise, e.g. "1.20.*".
-        to: 1.22.11
+        to: 1.22.12
       - from: 1.22.*
         to: 1.22.*
       - automatic: true

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -228,7 +228,7 @@ var (
 			{
 				// Auto-upgrade unsupported clusters.
 				From:      "1.21.*",
-				To:        "1.22.11",
+				To:        "1.22.12",
 				Automatic: pointer.BoolPtr(true),
 			},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The rule pointed to a version we don't actually support anymore.

/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
