### PR TITLE
Fix AWS node-termination-handler addon upgrade

### DIFF
--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -100,7 +100,7 @@ func IngressCreator(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Named
 			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassName
 
 			// If a Certificate is being issued, configure cert-manager by
-			// setting up the required annoations.
+			// setting up the required annotations.
 			issuer := cfg.Spec.Ingress.CertificateIssuer
 
 			if issuer.Name != "" {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -821,7 +821,7 @@ func (r *Reconciler) migrateAWSNodeTerminationAddon(ctx context.Context, client 
 func deleteAddon(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	addon := &kubermaticv1.Addon{}
 	key := types.NamespacedName{
-		Name:      "aws-node-termination-addon",
+		Name:      "aws-node-termination-handler",
 		Namespace: cluster.Status.NamespaceName,
 	}
 	if err := client.Get(ctx, key, addon); err != nil {

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -552,7 +552,7 @@ func (r *Reconciler) ensureResourcesCreatedConditionIsSet(ctx context.Context, a
 	}
 
 	oldAddon := addon.DeepCopy()
-	setAddonCodition(addon, kubermaticv1.AddonResourcesCreated, corev1.ConditionTrue)
+	setAddonCondition(addon, kubermaticv1.AddonResourcesCreated, corev1.ConditionTrue)
 	return r.Client.Status().Patch(ctx, addon, ctrlruntimeclient.MergeFrom(oldAddon))
 }
 
@@ -620,7 +620,7 @@ func formatGVK(gvk kubermaticv1.GroupVersionKind) string {
 	return fmt.Sprintf("%s/%s %s", gvk.Group, gvk.Version, gvk.Kind)
 }
 
-func setAddonCodition(a *kubermaticv1.Addon, condType kubermaticv1.AddonConditionType, status corev1.ConditionStatus) {
+func setAddonCondition(a *kubermaticv1.Addon, condType kubermaticv1.AddonConditionType, status corev1.ConditionStatus) {
 	now := metav1.Now()
 
 	condition, exists := a.Status.Conditions[condType]

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -110,6 +110,12 @@ const (
 	// NodePortProxyEnvoyContainerName is the name of the envoy container in the nodeport-proxy deployment.
 	NodePortProxyEnvoyContainerName = "envoy"
 
+	// AWSNodeTerminationHandlerMigrationAnnotation is set on Cluster objects that have completed
+	// the KKP 2.20->2.21 migration for the aws-node-termination-handler addon. This annoation should
+	// not be used by external controllers and will be removed once the need for the migration has gone.
+	// TODO: Remove this in KKP 2.22.
+	AWSNodeTerminationHandlerMigrationAnnotation = "kubermatic.k8c.io/migrated-aws-node-termination-handler-addon"
+
 	// ApiserverServiceName is the name for the apiserver service.
 	ApiserverServiceName = "apiserver-external"
 	// FrontLoadBalancerServiceName is the name of the LoadBalancer service that fronts everything

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -111,7 +111,7 @@ const (
 	NodePortProxyEnvoyContainerName = "envoy"
 
 	// AWSNodeTerminationHandlerMigrationAnnotation is set on Cluster objects that have completed
-	// the KKP 2.20->2.21 migration for the aws-node-termination-handler addon. This annoation should
+	// the KKP 2.20->2.21 migration for the aws-node-termination-handler addon. This annotation should
 	// not be used by external controllers and will be removed once the need for the migration has gone.
 	// TODO: Remove this in KKP 2.22.
 	AWSNodeTerminationHandlerMigrationAnnotation = "kubermatic.k8c.io/migrated-aws-node-termination-handler-addon"

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -160,7 +160,6 @@ func (h *AdmissionHandler) applyDefaults(ctx context.Context, c *kubermaticv1.Cl
 }
 
 // mutateCreate is an addition to regular defaulting for new clusters.
-// at the time of writing it handles features that should only be enabled for new clusters.
 func (h *AdmissionHandler) mutateCreate(newCluster *kubermaticv1.Cluster) error {
 	if newCluster.Spec.Features == nil {
 		newCluster.Spec.Features = map[string]bool{}

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -31,6 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -169,6 +170,15 @@ func (h *AdmissionHandler) mutateCreate(newCluster *kubermaticv1.Cluster) error 
 	if _, ok := newCluster.Spec.Features[kubermaticv1.ApiserverNetworkPolicy]; !ok {
 		newCluster.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] = true
 	}
+
+	// Set the annotation for the KKP 2.21 addon migration here; this prevents new
+	// clusters (created after a system has been updated from 2.20 to 2.21) from
+	// also being needlessly migrated (i.e. the addon is going to be installed twice).
+	// TODO: Remove this in KKP 2.22.
+	if newCluster.Annotations == nil {
+		newCluster.Annotations = map[string]string{}
+	}
+	newCluster.Annotations[resources.AWSNodeTerminationHandlerMigrationAnnotation] = "yes"
 
 	return nil
 }

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -279,6 +279,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/kubernetesDashboard", map[string]interface{}{"enabled": true}),
 				jsonpatch.NewOperation("replace", "/spec/exposeStrategy", string(defaults.DefaultExposeStrategy)),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			},
 		},
 		{
@@ -336,6 +337,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", true),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -381,7 +383,10 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			wantAllowed: true,
-			wantPatches: defaultPatches,
+			wantPatches: append(
+				defaultPatches,
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
+			),
 		},
 		{
 			name: "Default features",
@@ -424,6 +429,7 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				defaultPatches,
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -563,6 +569,7 @@ func TestHandle(t *testing.T) {
 					"type":    string(kubermaticv1.CNIPluginTypeCanal),
 					"version": cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 				}),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -817,6 +824,7 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				append(defaultPatches, defaultNetworkingPatches...),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -862,6 +870,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv4", float64(24)),
 				jsonpatch.NewOperation("replace", "/spec/features/externalCloudProvider", true),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.KubevirtCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -904,6 +913,7 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				append(defaultPatches, defaultNetworkingPatchesWithoutProxyMode...),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -943,6 +953,7 @@ func TestHandle(t *testing.T) {
 			wantPatches: append(
 				append(defaultPatches, defaultNetworkingPatchesWithoutProxyMode...),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{
@@ -990,6 +1001,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", resources.IPVSProxyMode),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipvs", map[string]interface{}{"strictArp": true}),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{resources.AWSNodeTerminationHandlerMigrationAnnotation: "yes"}),
 			),
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
The new manifest for the aws-node-termination-handler addon are not directly compatible with the old ones. Trying to apply the new manifests yields

> {"level":"error","time":"2022-08-22T11:59:33.885Z","logger":"kkp-addon-controller","caller":"addon/addon_controller.go:220","msg":"Reconciling failed","cluster":"lw8r98ngr4","addon":"aws-node-termination-handler","error":"failed to deploy the addon manifests into the cluster: failed to execute '/usr/local/bin/kubectl-1.22 --kubeconfig /tmp/cluster-lw8r98ngr4-addon-aws-node-termination-handler-kubeconfig apply --prune --filename /tmp/cluster-lw8r98ngr4-aws-node-termination-handler.yaml --selector kubermatic-addon=aws-node-termination-handler' for addon aws-node-termination-handler of cluster lw8r98ngr4: exit status 1\nWarning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+\npodsecuritypolicy.policy/aws-node-termination-handler configured\nserviceaccount/aws-node-termination-handler unchanged\nclusterrole.rbac.authorization.k8s.io/aws-node-termination-handler unchanged\nclusterrolebinding.rbac.authorization.k8s.io/aws-node-termination-handler unchanged\nrole.rbac.authorization.k8s.io/aws-node-termination-handler-psp unchanged\nError from server (Invalid): error when applying patch:\n{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"rbac.authorization.k8s.io/v1\\\",\\\"kind\\\":\\\"RoleBinding\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"labels\\\":{\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/managed-by\\\":\\\"Helm\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/part-of\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/version\\\":\\\"1.16.2\\\",\\\"helm.sh/chart\\\":\\\"aws-node-termination-handler-0.18.2\\\",\\\"kubermatic-addon\\\":\\\"aws-node-termination-handler\\\"},\\\"name\\\":\\\"aws-node-termination-handler-psp\\\",\\\"namespace\\\":\\\"kube-system\\\"},\\\"roleRef\\\":{\\\"apiGroup\\\":\\\"rbac.authorization.k8s.io\\\",\\\"kind\\\":\\\"Role\\\",\\\"name\\\":\\\"aws-node-termination-handler-psp\\\"},\\\"subjects\\\":[{\\\"kind\\\":\\\"ServiceAccount\\\",\\\"name\\\":\\\"aws-node-termination-handler\\\",\\\"namespace\\\":\\\"kube-system\\\"}]}\\n\"},\"labels\":{\"app.kubernetes.io/managed-by\":\"Helm\",\"app.kubernetes.io/part-of\":\"aws-node-termination-handler\",\"app.kubernetes.io/version\":\"1.16.2\",\"helm.sh/chart\":\"aws-node-termination-handler-0.18.2\",\"k8c.io/aws-spot\":null}},\"roleRef\":{\"kind\":\"Role\"}}\nto:\nResource: \"rbac.authorization.k8s.io/v1, Resource=rolebindings\", GroupVersionKind: \"rbac.authorization.k8s.io/v1, Kind=RoleBinding\"\nName: \"aws-node-termination-handler-psp\", Namespace: \"kube-system\"\nfor: \"/tmp/cluster-lw8r98ngr4-aws-node-termination-handler.yaml\": RoleBinding.rbac.authorization.k8s.io \"aws-node-termination-handler-psp\" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:\"rbac.authorization.k8s.io\", Kind:\"Role\", Name:\"aws-node-termination-handler-psp\"}: cannot change roleRef\nError from server (Invalid): error when applying patch:\n{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"apps/v1\\\",\\\"kind\\\":\\\"DaemonSet\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"labels\\\":{\\\"app.kubernetes.io/component\\\":\\\"daemonset\\\",\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/managed-by\\\":\\\"Helm\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/part-of\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/version\\\":\\\"1.16.2\\\",\\\"helm.sh/chart\\\":\\\"aws-node-termination-handler-0.18.2\\\",\\\"kubermatic-addon\\\":\\\"aws-node-termination-handler\\\"},\\\"name\\\":\\\"aws-node-termination-handler\\\",\\\"namespace\\\":\\\"kube-system\\\"},\\\"spec\\\":{\\\"selector\\\":{\\\"matchLabels\\\":{\\\"app.kubernetes.io/component\\\":\\\"daemonset\\\",\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"}},\\\"template\\\":{\\\"metadata\\\":{\\\"labels\\\":{\\\"app.kubernetes.io/component\\\":\\\"daemonset\\\",\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"k8s-app\\\":\\\"aws-node-termination-handler\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"}},\\\"spec\\\":{\\\"affinity\\\":{\\\"nodeAffinity\\\":{\\\"requiredDuringSchedulingIgnoredDuringExecution\\\":{\\\"nodeSelectorTerms\\\":[{\\\"matchExpressions\\\":[{\\\"key\\\":\\\"eks.amazonaws.com/compute-type\\\",\\\"operator\\\":\\\"NotIn\\\",\\\"values\\\":[\\\"fargate\\\"]}]}]}}},\\\"containers\\\":[{\\\"env\\\":[{\\\"name\\\":\\\"NODE_NAME\\\",\\\"valueFrom\\\":{\\\"fieldRef\\\":{\\\"fieldPath\\\":\\\"spec.nodeName\\\"}}},{\\\"name\\\":\\\"POD_NAME\\\",\\\"valueFrom\\\":{\\\"fieldRef\\\":{\\\"fieldPath\\\":\\\"metadata.name\\\"}}},{\\\"name\\\":\\\"NAMESPACE\\\",\\\"valueFrom\\\":{\\\"fieldRef\\\":{\\\"fieldPath\\\":\\\"metadata.namespace\\\"}}},{\\\"name\\\":\\\"ENABLE_PROBES_SERVER\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"PROBES_SERVER_PORT\\\",\\\"value\\\":\\\"8080\\\"},{\\\"name\\\":\\\"PROBES_SERVER_ENDPOINT\\\",\\\"value\\\":\\\"/healthz\\\"},{\\\"name\\\":\\\"LOG_LEVEL\\\",\\\"value\\\":\\\"info\\\"},{\\\"name\\\":\\\"JSON_LOGGING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_PROMETHEUS_SERVER\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"PROMETHEUS_SERVER_PORT\\\",\\\"value\\\":\\\"9092\\\"},{\\\"name\\\":\\\"METADATA_TRIES\\\",\\\"value\\\":\\\"3\\\"},{\\\"name\\\":\\\"DRY_RUN\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"CORDON_ONLY\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"TAINT_NODE\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"EXCLUDE_FROM_LOAD_BALANCERS\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"DELETE_LOCAL_DATA\\\",\\\"value\\\":\\\"true\\\"},{\\\"name\\\":\\\"IGNORE_DAEMON_SETS\\\",\\\"value\\\":\\\"true\\\"},{\\\"name\\\":\\\"POD_TERMINATION_GRACE_PERIOD\\\",\\\"value\\\":\\\"-1\\\"},{\\\"name\\\":\\\"NODE_TERMINATION_GRACE_PERIOD\\\",\\\"value\\\":\\\"120\\\"},{\\\"name\\\":\\\"EMIT_KUBERNETES_EVENTS\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_SPOT_INTERRUPTION_DRAINING\\\",\\\"value\\\":\\\"true\\\"},{\\\"name\\\":\\\"ENABLE_SCHEDULED_EVENT_DRAINING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_REBALANCE_MONITORING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_REBALANCE_DRAINING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_SQS_TERMINATION_DRAINING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"UPTIME_FROM_FILE\\\",\\\"value\\\":\\\"/proc/uptime\\\"}],\\\"image\\\":\\\"public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.16.2\\\",\\\"imagePullPolicy\\\":\\\"IfNotPresent\\\",\\\"name\\\":\\\"aws-node-termination-handler\\\",\\\"securityContext\\\":{\\\"allowPrivilegeEscalation\\\":false,\\\"readOnlyRootFilesystem\\\":true,\\\"runAsGroup\\\":1000,\\\"runAsNonRoot\\\":true,\\\"runAsUser\\\":1000},\\\"volumeMounts\\\":[{\\\"mountPath\\\":\\\"/proc/uptime\\\",\\\"name\\\":\\\"uptime\\\",\\\"readOnly\\\":true}]}],\\\"dnsPolicy\\\":\\\"ClusterFirstWithHostNet\\\",\\\"hostNetwork\\\":true,\\\"nodeSelector\\\":{\\\"k8c.io/aws-spot\\\":\\\"aws-node-termination-handler\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"},\\\"priorityClassName\\\":\\\"system-node-critical\\\",\\\"securityContext\\\":{\\\"fsGroup\\\":1000,\\\"seccompProfile\\\":{\\\"type\\\":\\\"RuntimeDefault\\\"}},\\\"serviceAccountName\\\":\\\"aws-node-termination-handler\\\",\\\"tolerations\\\":[{\\\"operator\\\":\\\"Exists\\\"}],\\\"volumes\\\":[{\\\"hostPath\\\":{\\\"path\\\":\\\"/proc/uptime\\\"},\\\"name\\\":\\\"uptime\\\"}]}},\\\"updateStrategy\\\":{\\\"rollingUpdate\\\":{\\\"maxUnavailable\\\":\\\"25%\\\"},\\\"type\\\":\\\"RollingUpdate\\\"}}}\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"daemonset\",\"app.kubernetes.io/managed-by\":\"Helm\",\"app.kubernetes.io/part-of\":\"aws-node-termination-handler\",\"app.kubernetes.io/version\":\"1.16.2\",\"helm.sh/chart\":\"aws-node-termination-handler-0.18.2\",\"k8c.io/aws-spot\":null}},\"spec\":{\"selector\":{\"matchLabels\":{\"app.kubernetes.io/component\":\"daemonset\"}},\"template\":{\"metadata\":{\"labels\":{\"app.kubernetes.io/component\":\"daemonset\",\"k8c.io/aws-spot\":null,\"k8s-app\":\"aws-node-termination-handler\"}},\"spec\":{\"$setElementOrder/containers\":[{\"name\":\"aws-node-termination-handler\"}],\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"matchExpressions\":[{\"key\":\"eks.amazonaws.com/compute-type\",\"operator\":\"NotIn\",\"values\":[\"fargate\"]}]}]}}},\"containers\":[{\"$setElementOrder/env\":[{\"name\":\"NODE_NAME\"},{\"name\":\"POD_NAME\"},{\"name\":\"NAMESPACE\"},{\"name\":\"ENABLE_PROBES_SERVER\"},{\"name\":\"PROBES_SERVER_PORT\"},{\"name\":\"PROBES_SERVER_ENDPOINT\"},{\"name\":\"LOG_LEVEL\"},{\"name\":\"JSON_LOGGING\"},{\"name\":\"ENABLE_PROMETHEUS_SERVER\"},{\"name\":\"PROMETHEUS_SERVER_PORT\"},{\"name\":\"METADATA_TRIES\"},{\"name\":\"DRY_RUN\"},{\"name\":\"CORDON_ONLY\"},{\"name\":\"TAINT_NODE\"},{\"name\":\"EXCLUDE_FROM_LOAD_BALANCERS\"},{\"name\":\"DELETE_LOCAL_DATA\"},{\"name\":\"IGNORE_DAEMON_SETS\"},{\"name\":\"POD_TERMINATION_GRACE_PERIOD\"},{\"name\":\"NODE_TERMINATION_GRACE_PERIOD\"},{\"name\":\"EMIT_KUBERNETES_EVENTS\"},{\"name\":\"ENABLE_SPOT_INTERRUPTION_DRAINING\"},{\"name\":\"ENABLE_SCHEDULED_EVENT_DRAINING\"},{\"name\":\"ENABLE_REBALANCE_MONITORING\"},{\"name\":\"ENABLE_REBALANCE_DRAINING\"},{\"name\":\"ENABLE_SQS_TERMINATION_DRAINING\"},{\"name\":\"UPTIME_FROM_FILE\"}],\"env\":[{\"name\":\"EXCLUDE_FROM_LOAD_BALANCERS\",\"value\":\"false\"},{\"name\":\"DELETE_LOCAL_DATA\",\"value\":\"true\"},{\"name\":\"IGNORE_DAEMON_SETS\",\"value\":\"true\"},{\"name\":\"POD_TERMINATION_GRACE_PERIOD\",\"value\":\"-1\"},{\"name\":\"NODE_TERMINATION_GRACE_PERIOD\",\"value\":\"120\"},{\"name\":\"EMIT_KUBERNETES_EVENTS\",\"value\":\"false\"},{\"name\":\"ENABLE_SPOT_INTERRUPTION_DRAINING\",\"value\":\"true\"},{\"name\":\"ENABLE_SCHEDULED_EVENT_DRAINING\",\"value\":\"false\"},{\"name\":\"ENABLE_SQS_TERMINATION_DRAINING\",\"value\":\"false\"},{\"name\":\"UPTIME_FROM_FILE\",\"value\":\"/proc/uptime\"},{\"$patch\":\"delete\",\"name\":\"CHECK_ASG_TAG_BEFORE_DRAINING\"},{\"$patch\":\"delete\",\"name\":\"GRACE_PERIOD\"},{\"$patch\":\"delete\",\"name\":\"INSTANCE_METADATA_URL\"},{\"$patch\":\"delete\",\"name\":\"MANAGED_ASG_TAG\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_HEADERS\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_PROXY\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_TEMPLATE\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_URL\"}],\"image\":\"public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.16.2\",\"name\":\"aws-node-termination-handler\",\"resources\":null}],\"securityContext\":{\"fsGroup\":1000}}},\"updateStrategy\":{\"rollingUpdate\":{\"maxUnavailable\":\"25%\"}}}}\nto:\nResource: \"apps/v1, Resource=daemonsets\", GroupVersionKind: \"apps/v1, Kind=DaemonSet\"\nName: \"aws-node-termination-handler\", Namespace: \"kube-system\"\nfor: \"/tmp/cluster-lw8r98ngr4-aws-node-termination-handler.yaml\": DaemonSet.apps \"aws-node-termination-handler\" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{\"app.kubernetes.io/component\":\"daemonset\", \"app.kubernetes.io/instance\":\"aws-node-termination-handler\", \"app.kubernetes.io/name\":\"aws-node-termination-handler\", \"kubernetes.io/os\":\"linux\"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable\n","errorCauses":[{"error":"failed to deploy the addon manifests into the cluster: failed to execute '/usr/local/bin/kubectl-1.22 --kubeconfig /tmp/cluster-lw8r98ngr4-addon-aws-node-termination-handler-kubeconfig apply --prune --filename /tmp/cluster-lw8r98ngr4-aws-node-termination-handler.yaml --selector kubermatic-addon=aws-node-termination-handler' for addon aws-node-termination-handler of cluster lw8r98ngr4: exit status 1\nWarning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+\npodsecuritypolicy.policy/aws-node-termination-handler configured\nserviceaccount/aws-node-termination-handler unchanged\nclusterrole.rbac.authorization.k8s.io/aws-node-termination-handler unchanged\nclusterrolebinding.rbac.authorization.k8s.io/aws-node-termination-handler unchanged\nrole.rbac.authorization.k8s.io/aws-node-termination-handler-psp unchanged\nError from server (Invalid): error when applying patch:\n{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"rbac.authorization.k8s.io/v1\\\",\\\"kind\\\":\\\"RoleBinding\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"labels\\\":{\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/managed-by\\\":\\\"Helm\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/part-of\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/version\\\":\\\"1.16.2\\\",\\\"helm.sh/chart\\\":\\\"aws-node-termination-handler-0.18.2\\\",\\\"kubermatic-addon\\\":\\\"aws-node-termination-handler\\\"},\\\"name\\\":\\\"aws-node-termination-handler-psp\\\",\\\"namespace\\\":\\\"kube-system\\\"},\\\"roleRef\\\":{\\\"apiGroup\\\":\\\"rbac.authorization.k8s.io\\\",\\\"kind\\\":\\\"Role\\\",\\\"name\\\":\\\"aws-node-termination-handler-psp\\\"},\\\"subjects\\\":[{\\\"kind\\\":\\\"ServiceAccount\\\",\\\"name\\\":\\\"aws-node-termination-handler\\\",\\\"namespace\\\":\\\"kube-system\\\"}]}\\n\"},\"labels\":{\"app.kubernetes.io/managed-by\":\"Helm\",\"app.kubernetes.io/part-of\":\"aws-node-termination-handler\",\"app.kubernetes.io/version\":\"1.16.2\",\"helm.sh/chart\":\"aws-node-termination-handler-0.18.2\",\"k8c.io/aws-spot\":null}},\"roleRef\":{\"kind\":\"Role\"}}\nto:\nResource: \"rbac.authorization.k8s.io/v1, Resource=rolebindings\", GroupVersionKind: \"rbac.authorization.k8s.io/v1, Kind=RoleBinding\"\nName: \"aws-node-termination-handler-psp\", Namespace: \"kube-system\"\nfor: \"/tmp/cluster-lw8r98ngr4-aws-node-termination-handler.yaml\": RoleBinding.rbac.authorization.k8s.io \"aws-node-termination-handler-psp\" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:\"rbac.authorization.k8s.io\", Kind:\"Role\", Name:\"aws-node-termination-handler-psp\"}: cannot change roleRef\nError from server (Invalid): error when applying patch:\n{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"apps/v1\\\",\\\"kind\\\":\\\"DaemonSet\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"labels\\\":{\\\"app.kubernetes.io/component\\\":\\\"daemonset\\\",\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/managed-by\\\":\\\"Helm\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/part-of\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/version\\\":\\\"1.16.2\\\",\\\"helm.sh/chart\\\":\\\"aws-node-termination-handler-0.18.2\\\",\\\"kubermatic-addon\\\":\\\"aws-node-termination-handler\\\"},\\\"name\\\":\\\"aws-node-termination-handler\\\",\\\"namespace\\\":\\\"kube-system\\\"},\\\"spec\\\":{\\\"selector\\\":{\\\"matchLabels\\\":{\\\"app.kubernetes.io/component\\\":\\\"daemonset\\\",\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"}},\\\"template\\\":{\\\"metadata\\\":{\\\"labels\\\":{\\\"app.kubernetes.io/component\\\":\\\"daemonset\\\",\\\"app.kubernetes.io/instance\\\":\\\"aws-node-termination-handler\\\",\\\"app.kubernetes.io/name\\\":\\\"aws-node-termination-handler\\\",\\\"k8s-app\\\":\\\"aws-node-termination-handler\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"}},\\\"spec\\\":{\\\"affinity\\\":{\\\"nodeAffinity\\\":{\\\"requiredDuringSchedulingIgnoredDuringExecution\\\":{\\\"nodeSelectorTerms\\\":[{\\\"matchExpressions\\\":[{\\\"key\\\":\\\"eks.amazonaws.com/compute-type\\\",\\\"operator\\\":\\\"NotIn\\\",\\\"values\\\":[\\\"fargate\\\"]}]}]}}},\\\"containers\\\":[{\\\"env\\\":[{\\\"name\\\":\\\"NODE_NAME\\\",\\\"valueFrom\\\":{\\\"fieldRef\\\":{\\\"fieldPath\\\":\\\"spec.nodeName\\\"}}},{\\\"name\\\":\\\"POD_NAME\\\",\\\"valueFrom\\\":{\\\"fieldRef\\\":{\\\"fieldPath\\\":\\\"metadata.name\\\"}}},{\\\"name\\\":\\\"NAMESPACE\\\",\\\"valueFrom\\\":{\\\"fieldRef\\\":{\\\"fieldPath\\\":\\\"metadata.namespace\\\"}}},{\\\"name\\\":\\\"ENABLE_PROBES_SERVER\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"PROBES_SERVER_PORT\\\",\\\"value\\\":\\\"8080\\\"},{\\\"name\\\":\\\"PROBES_SERVER_ENDPOINT\\\",\\\"value\\\":\\\"/healthz\\\"},{\\\"name\\\":\\\"LOG_LEVEL\\\",\\\"value\\\":\\\"info\\\"},{\\\"name\\\":\\\"JSON_LOGGING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_PROMETHEUS_SERVER\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"PROMETHEUS_SERVER_PORT\\\",\\\"value\\\":\\\"9092\\\"},{\\\"name\\\":\\\"METADATA_TRIES\\\",\\\"value\\\":\\\"3\\\"},{\\\"name\\\":\\\"DRY_RUN\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"CORDON_ONLY\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"TAINT_NODE\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"EXCLUDE_FROM_LOAD_BALANCERS\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"DELETE_LOCAL_DATA\\\",\\\"value\\\":\\\"true\\\"},{\\\"name\\\":\\\"IGNORE_DAEMON_SETS\\\",\\\"value\\\":\\\"true\\\"},{\\\"name\\\":\\\"POD_TERMINATION_GRACE_PERIOD\\\",\\\"value\\\":\\\"-1\\\"},{\\\"name\\\":\\\"NODE_TERMINATION_GRACE_PERIOD\\\",\\\"value\\\":\\\"120\\\"},{\\\"name\\\":\\\"EMIT_KUBERNETES_EVENTS\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_SPOT_INTERRUPTION_DRAINING\\\",\\\"value\\\":\\\"true\\\"},{\\\"name\\\":\\\"ENABLE_SCHEDULED_EVENT_DRAINING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_REBALANCE_MONITORING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_REBALANCE_DRAINING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"ENABLE_SQS_TERMINATION_DRAINING\\\",\\\"value\\\":\\\"false\\\"},{\\\"name\\\":\\\"UPTIME_FROM_FILE\\\",\\\"value\\\":\\\"/proc/uptime\\\"}],\\\"image\\\":\\\"public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.16.2\\\",\\\"imagePullPolicy\\\":\\\"IfNotPresent\\\",\\\"name\\\":\\\"aws-node-termination-handler\\\",\\\"securityContext\\\":{\\\"allowPrivilegeEscalation\\\":false,\\\"readOnlyRootFilesystem\\\":true,\\\"runAsGroup\\\":1000,\\\"runAsNonRoot\\\":true,\\\"runAsUser\\\":1000},\\\"volumeMounts\\\":[{\\\"mountPath\\\":\\\"/proc/uptime\\\",\\\"name\\\":\\\"uptime\\\",\\\"readOnly\\\":true}]}],\\\"dnsPolicy\\\":\\\"ClusterFirstWithHostNet\\\",\\\"hostNetwork\\\":true,\\\"nodeSelector\\\":{\\\"k8c.io/aws-spot\\\":\\\"aws-node-termination-handler\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"},\\\"priorityClassName\\\":\\\"system-node-critical\\\",\\\"securityContext\\\":{\\\"fsGroup\\\":1000,\\\"seccompProfile\\\":{\\\"type\\\":\\\"RuntimeDefault\\\"}},\\\"serviceAccountName\\\":\\\"aws-node-termination-handler\\\",\\\"tolerations\\\":[{\\\"operator\\\":\\\"Exists\\\"}],\\\"volumes\\\":[{\\\"hostPath\\\":{\\\"path\\\":\\\"/proc/uptime\\\"},\\\"name\\\":\\\"uptime\\\"}]}},\\\"updateStrategy\\\":{\\\"rollingUpdate\\\":{\\\"maxUnavailable\\\":\\\"25%\\\"},\\\"type\\\":\\\"RollingUpdate\\\"}}}\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"daemonset\",\"app.kubernetes.io/managed-by\":\"Helm\",\"app.kubernetes.io/part-of\":\"aws-node-termination-handler\",\"app.kubernetes.io/version\":\"1.16.2\",\"helm.sh/chart\":\"aws-node-termination-handler-0.18.2\",\"k8c.io/aws-spot\":null}},\"spec\":{\"selector\":{\"matchLabels\":{\"app.kubernetes.io/component\":\"daemonset\"}},\"template\":{\"metadata\":{\"labels\":{\"app.kubernetes.io/component\":\"daemonset\",\"k8c.io/aws-spot\":null,\"k8s-app\":\"aws-node-termination-handler\"}},\"spec\":{\"$setElementOrder/containers\":[{\"name\":\"aws-node-termination-handler\"}],\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"matchExpressions\":[{\"key\":\"eks.amazonaws.com/compute-type\",\"operator\":\"NotIn\",\"values\":[\"fargate\"]}]}]}}},\"containers\":[{\"$setElementOrder/env\":[{\"name\":\"NODE_NAME\"},{\"name\":\"POD_NAME\"},{\"name\":\"NAMESPACE\"},{\"name\":\"ENABLE_PROBES_SERVER\"},{\"name\":\"PROBES_SERVER_PORT\"},{\"name\":\"PROBES_SERVER_ENDPOINT\"},{\"name\":\"LOG_LEVEL\"},{\"name\":\"JSON_LOGGING\"},{\"name\":\"ENABLE_PROMETHEUS_SERVER\"},{\"name\":\"PROMETHEUS_SERVER_PORT\"},{\"name\":\"METADATA_TRIES\"},{\"name\":\"DRY_RUN\"},{\"name\":\"CORDON_ONLY\"},{\"name\":\"TAINT_NODE\"},{\"name\":\"EXCLUDE_FROM_LOAD_BALANCERS\"},{\"name\":\"DELETE_LOCAL_DATA\"},{\"name\":\"IGNORE_DAEMON_SETS\"},{\"name\":\"POD_TERMINATION_GRACE_PERIOD\"},{\"name\":\"NODE_TERMINATION_GRACE_PERIOD\"},{\"name\":\"EMIT_KUBERNETES_EVENTS\"},{\"name\":\"ENABLE_SPOT_INTERRUPTION_DRAINING\"},{\"name\":\"ENABLE_SCHEDULED_EVENT_DRAINING\"},{\"name\":\"ENABLE_REBALANCE_MONITORING\"},{\"name\":\"ENABLE_REBALANCE_DRAINING\"},{\"name\":\"ENABLE_SQS_TERMINATION_DRAINING\"},{\"name\":\"UPTIME_FROM_FILE\"}],\"env\":[{\"name\":\"EXCLUDE_FROM_LOAD_BALANCERS\",\"value\":\"false\"},{\"name\":\"DELETE_LOCAL_DATA\",\"value\":\"true\"},{\"name\":\"IGNORE_DAEMON_SETS\",\"value\":\"true\"},{\"name\":\"POD_TERMINATION_GRACE_PERIOD\",\"value\":\"-1\"},{\"name\":\"NODE_TERMINATION_GRACE_PERIOD\",\"value\":\"120\"},{\"name\":\"EMIT_KUBERNETES_EVENTS\",\"value\":\"false\"},{\"name\":\"ENABLE_SPOT_INTERRUPTION_DRAINING\",\"value\":\"true\"},{\"name\":\"ENABLE_SCHEDULED_EVENT_DRAINING\",\"value\":\"false\"},{\"name\":\"ENABLE_SQS_TERMINATION_DRAINING\",\"value\":\"false\"},{\"name\":\"UPTIME_FROM_FILE\",\"value\":\"/proc/uptime\"},{\"$patch\":\"delete\",\"name\":\"CHECK_ASG_TAG_BEFORE_DRAINING\"},{\"$patch\":\"delete\",\"name\":\"GRACE_PERIOD\"},{\"$patch\":\"delete\",\"name\":\"INSTANCE_METADATA_URL\"},{\"$patch\":\"delete\",\"name\":\"MANAGED_ASG_TAG\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_HEADERS\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_PROXY\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_TEMPLATE\"},{\"$patch\":\"delete\",\"name\":\"WEBHOOK_URL\"}],\"image\":\"public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.16.2\",\"name\":\"aws-node-termination-handler\",\"resources\":null}],\"securityContext\":{\"fsGroup\":1000}}},\"updateStrategy\":{\"rollingUpdate\":{\"maxUnavailable\":\"25%\"}}}}\nto:\nResource: \"apps/v1, Resource=daemonsets\", GroupVersionKind: \"apps/v1, Kind=DaemonSet\"\nName: \"aws-node-termination-handler\", Namespace: \"kube-system\"\nfor: \"/tmp/cluster-lw8r98ngr4-aws-node-termination-handler.yaml\": DaemonSet.apps \"aws-node-termination-handler\" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{\"app.kubernetes.io/component\":\"daemonset\", \"app.kubernetes.io/instance\":\"aws-node-termination-handler\", \"app.kubernetes.io/name\":\"aws-node-termination-handler\", \"kubernetes.io/os\":\"linux\"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable\n"}]}

To fix this, this PR adds a bit of migration code to the operator. This new code will delete the old addon and then the addoninstaller will bring it back. A temporary annotation on the Cluster object is used to remind ourselves that the addon was migrated already.

This hack has the unfortunate downside that new clusters, created after the KKP 2.21 update, would also be migrated. This is somewhat harmless but annoying and ugly and so this PR also modifies our webhook to inject the correct annotation right during
cluster creations. This whole hack is ugly enough already that this one extension doesn't make it worse. It's also all just temporary code that will be removed in KKP 2.22.

/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
