### PR TITLE
Add NetworkPolicy from UserCluster apiserver to the webhook

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -591,6 +591,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			apiserver.DNSAllowCreator(c, data),
 			apiserver.EctdAllowCreator(c),
 			apiserver.MachineControllerWebhookCreator(c),
+			apiserver.UserClusterWebhookCreator(c),
 		}
 
 		// one shared limited context for all hostname resolutions

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -210,7 +210,7 @@ func UserClusterWebhookCreator(c *kubermaticv1.Cluster) reconciling.NamedNetwork
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										resources.AppLabelKey: "usercluster-webhook",
+										resources.AppLabelKey: resources.UserClusterWebhookDeploymentName,
 									},
 								},
 							},

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -192,6 +192,38 @@ func MachineControllerWebhookCreator(c *kubermaticv1.Cluster) reconciling.NamedN
 	}
 }
 
+func UserClusterWebhookCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
+	return func() (string, reconciling.NetworkPolicyCreator) {
+		return resources.NetworkPolicyMachineControllerWebhookAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: "usercluster-webhook",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}
+
 func MetricsServerAllowCreator(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyCreatorGetter {
 	return func() (string, reconciling.NetworkPolicyCreator) {
 		return resources.NetworkPolicyMetricsServerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
during the testing of #10710 there was a networking problem identified - usercluster's apiserver is not able to connect to the usercluster's webhook, which is required for the applications to work.

**Which issue(s) this PR fixes**:


**What type of PR is this?**
Add one of the following kinds:
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
