### PR TITLE
Correctly match Rocky Linux image for node OS label

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/node-labeler/api/api.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/api/api.go
@@ -44,12 +44,12 @@ const (
 
 // OSLabelMatchValues is a mapping between OS labels and the strings to match on in OSImage.
 // Note that these are all lower case.
-var OSLabelMatchValues = map[string]string{
-	CentOSLabelValue:      "centos",
-	UbuntuLabelValue:      "ubuntu",
-	SLESLabelValue:        "sles",
-	RHELLabelValue:        "rhel",
-	FlatcarLabelValue:     "flatcar container linux",
-	RockyLinuxLabelValue:  "rockylinux",
-	AmazonLinuxLabelValue: "amzn2",
+var OSLabelMatchValues = map[string][]string{
+	CentOSLabelValue:      {"centos"},
+	UbuntuLabelValue:      {"ubuntu"},
+	SLESLabelValue:        {"sles"},
+	RHELLabelValue:        {"rhel"},
+	FlatcarLabelValue:     {"flatcar container linux"},
+	RockyLinuxLabelValue:  {"rockylinux", "rocky linux"},
+	AmazonLinuxLabelValue: {"amzn2"},
 }

--- a/pkg/controller/user-cluster-controller-manager/node-labeler/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/controller.go
@@ -164,9 +164,11 @@ func findDistributionLabel(osImage string) string {
 	matchedLabel := ""
 	matchedValue := ""
 	for k, v := range api.OSLabelMatchValues {
-		if strings.Contains(osImage, v) && len(v) > len(matchedValue) {
-			matchedLabel = k
-			matchedValue = v
+		for _, substring := range v {
+			if strings.Contains(osImage, substring) && len(substring) > len(matchedValue) {
+				matchedLabel = k
+				matchedValue = substring
+			}
 		}
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/node-labeler/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/controller_test.go
@@ -132,6 +132,20 @@ func TestReconcile(t *testing.T) {
 			expectedLabels: map[string]string{"x-kubernetes.io/distribution": "rhel"},
 		},
 		{
+			name: "rocky linux label gets added",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: requestName,
+				},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Rocky Linux 8.5 (Green Obsidian)",
+					},
+				},
+			},
+			expectedLabels: map[string]string{"x-kubernetes.io/distribution": "rockylinux"},
+		},
+		{
 			name: "unknown os, error",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
I discovered while testing Azure that our current logic to match node images to Rocky Linux is insufficient, so this PR adds an additional substring to match for. Added a unit test using a "real" image I got on Azure.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10817

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
