### PR TITLE
Lowered default node count setting

### DIFF
--- a/pkg/handler/v1/admin/settings_test.go
+++ b/pkg/handler/v1/admin/settings_test.go
@@ -43,7 +43,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 1
 		{
 			name:                   "scenario 1: user gets settings first time",
-			expectedResponse:       `{"customLinks":[],"defaultNodeCount":10,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
+			expectedResponse:       `{"customLinks":[],"defaultNodeCount":2,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),

--- a/pkg/provider/kubernetes/settings.go
+++ b/pkg/provider/kubernetes/settings.go
@@ -76,7 +76,7 @@ func (s *SettingsProvider) createDefaultGlobalSettings(ctx context.Context) (*ku
 				Enabled:  false,
 				Enforced: false,
 			},
-			DefaultNodeCount:            10,
+			DefaultNodeCount:            2,
 			DisplayDemoInfo:             false,
 			DisplayAPIDocs:              false,
 			DisplayTermsOfService:       false,

--- a/pkg/test/e2e/api/settings_test.go
+++ b/pkg/test/e2e/api/settings_test.go
@@ -49,7 +49,7 @@ func TestGetDefaultGlobalSettings(t *testing.T) {
 					Enabled:  false,
 					Enforced: false,
 				},
-				DefaultNodeCount:            10,
+				DefaultNodeCount:            2,
 				DisplayDemoInfo:             false,
 				DisplayAPIDocs:              false,
 				DisplayTermsOfService:       false,


### PR DESCRIPTION
**What this PR does / why we need it**:
Lowers the `defaultNodeCount` setting which is set upon KKP installation from 10 to 2. 10 seems like too much.

/kind cleanup
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Lowered the default `defaultNodeSize` which is set in KubermaticSetting during KKP installation from 10 to 2. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
