### PR TITLE
Fix for Equinix Metal cloud provider resource usage memory calculation

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -794,7 +794,7 @@ func getPacketResourceRequirements(ctx context.Context,
 	}
 
 	if plan.Specs.Memory.Total != "" {
-		memReq, err = resource.ParseQuantity(plan.Specs.Memory.Total)
+		memReq, err = resource.ParseQuantity(strings.TrimSuffix(plan.Specs.Memory.Total, "B"))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing machine memory request to quantity: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix for equinox provider resource usage memory calculation

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
