### PR TITLE
KubeVirt: do not reconcile the namespace if the name is empty

### DIFF
--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -98,6 +98,12 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		return cluster, err
 	}
 
+	// If the cluster NamespaceName is not filled yet, return a conflict error:
+	// will requeue but not send an error event
+	if cluster.Status.NamespaceName == "" {
+		return cluster, apierrors.NewConflict(kubermaticv1.Resource("cluster"), cluster.Name, fmt.Errorf("cluster.Status.NamespaceName for cluster %s", cluster.Name))
+	}
+
 	cluster, err = reconcileNamespace(ctx, cluster.Status.NamespaceName, cluster, update, client)
 	if err != nil {
 		return cluster, err


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10843 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:
When initialising the Cloud Provider and ensuring the creation of the namespace <cluster-xyz> in the infrastructure KubeVirt cluster, the reconcile was called several times until `cluster.Status.NamespaceName` is filled.
This was raising a bunch of times an error until this name is filled.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: fix to ensure that we do not raise an error when reconciling the namespace in the infrastructure KubeVirt cluster, until we get the value of the namespace to create, avoiding transient errors.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
No documentation to updated, a bug fix.