### PR TITLE
include rarecase for gke ReleaseChannel

### DIFF
--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -212,7 +212,7 @@ func ListUpgrades(ctx context.Context, sa, zone, name string) ([]*apiv1.MasterVe
 	}
 	upgradesMap := map[string]bool{}
 
-	if cluster.ReleaseChannel != nil {
+	if cluster.ReleaseChannel != nil && len(cluster.ReleaseChannel.Channel) > 0 && cluster.ReleaseChannel.Channel != resources.GKEUnspecifiedReleaseChannel {
 		releaseChannel = cluster.ReleaseChannel.Channel
 		for _, channel := range resp.Channels {
 			// select versions from the current channel

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -724,6 +724,7 @@ const (
 	ExternalEKSClusterAccessKeyID     = "accessKeyId"
 	ExternalEKSClusterSecretAccessKey = "secretAccessKey"
 	ExternalGKEClusterSeriveAccount   = "serviceAccount"
+	GKEUnspecifiedReleaseChannel      = "UNSPECIFIED"
 	GKERapidReleaseChannel            = "RAPID"
 	GKERegularReleaseChannel          = "REGULAR"
 	GKEStableReleaseChannel           = "STABLE"


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**:
- Include the rarecase of GKE where cluster.ReleaseChannel == &{ [] []} (!=nil) but empty
- or the channel is UNSPECIFIED

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
