### PR TITLE
application: gitSource, avoid confusing message if git remote is using file protocol

### DIFF
--- a/pkg/applications/providers/source/git.go
+++ b/pkg/applications/providers/source/git.go
@@ -18,7 +18,9 @@ package source
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 	"path"
 
 	"github.com/go-git/go-git/v5"
@@ -56,6 +58,9 @@ func (g GitSource) DownloadSource(destination string) (string, error) {
 
 	checkout := g.getCheckoutStrategy()
 	if err := checkout(g.Ctx, destination, g.Source, auth); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", errors.New("failed to clone repository: file protocol not supported, please check git remote url")
+		}
 		return "", fmt.Errorf("failed to clone repository: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

we use go-git libray which is described as `a highly extensible git implementation library written in pure Go`  but if you read carefully [COMPATIBILITY.md](https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md) you can see library fallback to the git binary for file protocol.

if the user makes a mistake in the git remote URL. It can be interpreted as remote with file protocol and raise the confusing error: `'git' executable not found in $PATH`.   To avoid that we catch the error and say the file protocol is not supported.


**For example:** 
 Using this git remote URL `git@gitlab.com/vgramer1/helm-charts` instead of `git@gitlab.com:vgramer1/helm-charts` (slash instead of colon after the host) will raise the error 
```
failed to download application source: failed to clone repository: exec: "git": executable file not found in $PATH
```

**Error message before the PR:**
```
$k get ev
8m10s         Warning   ApplicationInstallationReconcileFailed   applicationinstallation/my-broken-app   handling installation of application installation: failed to download application source: failed to clone repository: exec: "git": executable file not found in $PATH
```

**Error message after the PR:**
```
$ k get ev
6m32s       Warning   ApplicationInstallationReconcileFailed   applicationinstallation/my-broken-app   handling installation of application installation: failed to download application source: failed to clone repository: file protocol not supported, please check git remote url
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
