### PR TITLE
Remove placeholder message from encryptionConfiguration

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -259,7 +259,6 @@ type ClusterSpec struct {
 	ApplicationSettings *ApplicationSettings `json:"applicationSettings,omitempty"`
 
 	// Optional: Configures encryption-at-rest for Kubernetes API data. This needs the `encryptionAtRest` feature gate.
-	// THIS IS A PLACEHOLDER AND NOT FUNCTIONAL YET.
 	EncryptionConfiguration *EncryptionConfiguration `json:"encryptionConfiguration,omitempty"`
 
 	// If this is set to true, the cluster will not be reconciled by KKP.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1900,8 +1900,7 @@ spec:
                 type: boolean
               encryptionConfiguration:
                 description: 'Optional: Configures encryption-at-rest for Kubernetes
-                  API data. This needs the `encryptionAtRest` feature gate. THIS IS
-                  A PLACEHOLDER AND NOT FUNCTIONAL YET.'
+                  API data. This needs the `encryptionAtRest` feature gate.'
                 properties:
                   enabled:
                     description: Enables encryption-at-rest on this cluster.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1868,8 +1868,7 @@ spec:
                 type: boolean
               encryptionConfiguration:
                 description: 'Optional: Configures encryption-at-rest for Kubernetes
-                  API data. This needs the `encryptionAtRest` feature gate. THIS IS
-                  A PLACEHOLDER AND NOT FUNCTIONAL YET.'
+                  API data. This needs the `encryptionAtRest` feature gate.'
                 properties:
                   enabled:
                     description: Enables encryption-at-rest on this cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:

`ClusterSpec.EncryptionConfiguration` had a comment saying this was only a placeholder and non-functional. That is no longer true, but I forgot to remove the comment when implementing the encryption-at-rest feature.

This PR removes that comment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**

/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```