### PR TITLE
validate length of EAR encryption key

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
@@ -47,7 +48,9 @@ var (
 	// ErrCloudChangeNotAllowed describes that it is not allowed to change the cloud provider.
 	ErrCloudChangeNotAllowed  = errors.New("not allowed to change the cloud provider")
 	azureLoadBalancerSKUTypes = sets.NewString("", string(kubermaticv1.AzureStandardLBSKU), string(kubermaticv1.AzureBasicLBSKU))
+)
 
+const (
 	// UnsafeCNIUpgradeLabel allows unsafe CNI version upgrade (difference in versions more than one minor version).
 	UnsafeCNIUpgradeLabel = "unsafe-cni-upgrade"
 	// UnsafeCNIMigrationLabel allows unsafe CNI type migration.
@@ -61,6 +64,9 @@ var (
 	// "-control-plane" being added by KKP. This leaves 39 usable characters
 	// and to give some wiggle room, we define the max length to be 36.
 	MaxClusterNameLength = 36
+
+	// EARKeyLength is required key length for encryption at rest.
+	EARKeyLength = 32
 )
 
 // ValidateClusterSpec validates the given cluster spec. If this is not called from within another validation
@@ -399,6 +405,12 @@ func validateEncryptionConfiguration(spec *kubermaticv1.ClusterSpec, fieldPath *
 					allErrs = append(allErrs, field.Invalid(childPath, key.Name,
 						"'value' and 'secretRef' cannot be set at the same time"))
 				}
+
+				if key.Value != "" {
+					if err := validateKeyLength(key.Value); err != nil {
+						allErrs = append(allErrs, field.Invalid(childPath, key.Name, fmt.Sprint(err)))
+					}
+				}
 			}
 		}
 
@@ -406,6 +418,20 @@ func validateEncryptionConfiguration(spec *kubermaticv1.ClusterSpec, fieldPath *
 	}
 
 	return allErrs
+}
+
+// validateKeyLength base64 decodes key and checks length.
+func validateKeyLength(key string) error {
+	data, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return err
+	}
+
+	if len(data) != EARKeyLength {
+		return fmt.Errorf("key length should be 32 it is %d", len(data))
+	}
+
+	return nil
 }
 
 func validateEncryptionUpdate(oldCluster *kubermaticv1.Cluster, newCluster *kubermaticv1.Cluster) field.ErrorList {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -886,3 +886,63 @@ func TestValidateGCPCloudSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateEncryptionConfiguration(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterSpec *kubermaticv1.ClusterSpec
+		expectErr   bool
+	}{
+		{
+			name: "small key",
+			clusterSpec: &kubermaticv1.ClusterSpec{
+				Features: map[string]bool{
+					kubermaticv1.ClusterFeatureEncryptionAtRest: true,
+				},
+				EncryptionConfiguration: &kubermaticv1.EncryptionConfiguration{
+					Enabled: true,
+					Secretbox: &kubermaticv1.SecretboxEncryptionConfiguration{
+						Keys: []kubermaticv1.SecretboxKey{
+							{
+								Name:  "small-key",
+								Value: "cmLcMbw6gdxPHQ==",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "good key",
+			clusterSpec: &kubermaticv1.ClusterSpec{
+				Features: map[string]bool{
+					kubermaticv1.ClusterFeatureEncryptionAtRest: true,
+				},
+				EncryptionConfiguration: &kubermaticv1.EncryptionConfiguration{
+					Enabled: true,
+					Secretbox: &kubermaticv1.SecretboxEncryptionConfiguration{
+						Keys: []kubermaticv1.SecretboxKey{
+							{
+								Name:  "good-key",
+								Value: "RGolflgAc+eBbm1lys87pTNQZVf0i67rlpPZGtTkVjQ=",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log(test.name)
+			err := validateEncryptionConfiguration(test.clusterSpec, field.NewPath("spec", "encryptionConfiguration"))
+			t.Logf("%+v", err)
+			if (err != nil) != test.expectErr {
+				t.Logf("expected error: %t, got: %+v", test.expectErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates length of the encryption key used for EAR. Currently the length is not validated. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10829 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
