### PR TITLE
Remove Region from EKS Preset

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13936,6 +13936,13 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13947,13 +13954,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
           }
         ],
         "responses": {
@@ -25762,10 +25762,6 @@
           "description": "Only enabled presets will be available in the KKP dashboard.",
           "type": "boolean",
           "x-go-name": "Enabled"
-        },
-        "region": {
-          "type": "string",
-          "x-go-name": "Region"
         },
         "secretAccessKey": {
           "type": "string",

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -379,13 +379,11 @@ type EKS struct {
 
 	AccessKeyID     string `json:"accessKeyID"`
 	SecretAccessKey string `json:"secretAccessKey"`
-	Region          string `json:"region"`
 }
 
 func (s EKS) IsValid() bool {
 	return len(s.AccessKeyID) > 0 &&
-		len(s.SecretAccessKey) > 0 &&
-		len(s.Region) > 0
+		len(s.SecretAccessKey) > 0
 }
 
 type AKS struct {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -188,13 +188,10 @@ spec:
                     enabled:
                       description: Only enabled presets will be available in the KKP dashboard.
                       type: boolean
-                    region:
-                      type: string
                     secretAccessKey:
                       type: string
                   required:
                     - accessKeyID
-                    - region
                     - secretAccessKey
                   type: object
                 enabled:

--- a/pkg/handler/v2/external_cluster/eks.go
+++ b/pkg/handler/v2/external_cluster/eks.go
@@ -103,11 +103,14 @@ type EKSClusterListReq struct {
 }
 
 func (req EKSTypesReq) Validate() error {
+	if len(req.Region) == 0 {
+		return fmt.Errorf("Region cannot be empty")
+	}
 	if len(req.Credential) != 0 {
 		return nil
 	}
-	if len(req.AccessKeyID) == 0 || len(req.SecretAccessKey) == 0 || len(req.Region) == 0 {
-		return fmt.Errorf("EKS Credentials or Region cannot be empty")
+	if len(req.AccessKeyID) == 0 || len(req.SecretAccessKey) == 0 {
+		return fmt.Errorf("EKS Credentials cannot be empty")
 	}
 	return nil
 }
@@ -116,14 +119,8 @@ func (req EKSReq) Validate() error {
 	if len(req.VpcId) == 0 {
 		return fmt.Errorf("EKS VPC ID cannot be empty")
 	}
-	if len(req.Credential) != 0 {
-		return nil
-	}
-	if len(req.AccessKeyID) == 0 || len(req.SecretAccessKey) == 0 {
-		return fmt.Errorf("EKS Credentials cannot be empty")
-	}
-	if len(req.Region) == 0 {
-		return fmt.Errorf("Region cannot be empty")
+	if err := req.EKSTypesReq.Validate(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -341,7 +338,6 @@ func getEKSCredentialsFromReq(ctx context.Context, req EKSTypesReq, userInfoGett
 		if credentials := preset.Spec.EKS; credentials != nil {
 			accessKeyID = credentials.AccessKeyID
 			secretAccessKey = credentials.SecretAccessKey
-			region = credentials.Region
 		}
 	}
 

--- a/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/pkg/handler/v2/external_cluster/external_cluster.go
@@ -227,7 +227,6 @@ func CreateEndpoint(
 				if credentials := preset.Spec.EKS; credentials != nil {
 					cloud.EKS.AccessKeyID = credentials.AccessKeyID
 					cloud.EKS.SecretAccessKey = credentials.SecretAccessKey
-					cloud.EKS.Region = credentials.Region
 				}
 			}
 

--- a/pkg/test/e2e/utils/apiclient/models/e_k_s.go
+++ b/pkg/test/e2e/utils/apiclient/models/e_k_s.go
@@ -27,9 +27,6 @@ type EKS struct {
 	// Only enabled presets will be available in the KKP dashboard.
 	Enabled bool `json:"enabled,omitempty"`
 
-	// region
-	Region string `json:"region,omitempty"`
-
 	// secret access key
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if a preset is selected (instead of setting the AWS credentials) for EKS external cluster (creation or import), region is set from the EKS preset attribute. In that case, the user cannot choose a different region. So, the idea of this PR is to make the region always come from the user selection, not from the preset.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10876

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/kind api-change

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
