### PR TITLE
Add report types to metering schedule configuration

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -550,14 +550,24 @@
                 "schedule": {
                   "type": "string",
                   "x-go-name": "Schedule"
+                },
+                "types": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-go-name": "Types"
                 }
               }
             }
           }
         ],
         "responses": {
-          "201": {
-            "$ref": "#/responses/empty"
+          "200": {
+            "description": "MeteringReportConfiguration",
+            "schema": {
+              "$ref": "#/definitions/MeteringReportConfiguration"
+            }
           },
           "401": {
             "$ref": "#/responses/empty"
@@ -612,6 +622,13 @@
                 "schedule": {
                   "type": "string",
                   "x-go-name": "Schedule"
+                },
+                "types": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-go-name": "Types"
                 }
               }
             }
@@ -619,7 +636,10 @@
         ],
         "responses": {
           "201": {
-            "$ref": "#/responses/empty"
+            "description": "MeteringReportConfiguration",
+            "schema": {
+              "$ref": "#/definitions/MeteringReportConfiguration"
+            }
           },
           "401": {
             "$ref": "#/responses/empty"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2711,10 +2711,11 @@ type MeteringReport struct {
 // MeteringReportConfiguration holds report configuration
 // swagger:model MeteringReportConfiguration
 type MeteringReportConfiguration struct {
-	Name      string  `json:"name"`
-	Schedule  string  `json:"schedule"`
-	Interval  uint32  `json:"interval"`
-	Retention *uint32 `json:"retention,omitempty"`
+	Name      string   `json:"name"`
+	Schedule  string   `json:"schedule"`
+	Interval  uint32   `json:"interval"`
+	Retention *uint32  `json:"retention,omitempty"`
+	Types     []string `json:"types"`
 }
 
 // ReportURL represent an S3 pre signed URL to download a report

--- a/pkg/handler/routes_v1_admin.go
+++ b/pkg/handler/routes_v1_admin.go
@@ -611,7 +611,7 @@ func (r Routing) ListMeteringReportConfigurations() http.Handler {
 //
 //     Responses:
 //       default: errorResponse
-//       201: empty
+//       201: MeteringReportConfiguration
 //       401: empty
 //       403: empty
 func (r Routing) CreateMeteringReportConfiguration() http.Handler {
@@ -638,7 +638,7 @@ func (r Routing) CreateMeteringReportConfiguration() http.Handler {
 //
 //     Responses:
 //       default: errorResponse
-//       201: empty
+//       200: MeteringReportConfiguration
 //       401: empty
 //       403: empty
 func (r Routing) UpdateMeteringReportConfiguration() http.Handler {
@@ -648,7 +648,7 @@ func (r Routing) UpdateMeteringReportConfiguration() http.Handler {
 			middleware.UserSaver(r.userProvider),
 		)(admin.UpdateMeteringReportConfigurationEndpoint(r.userInfoGetter, r.seedsGetter, r.masterClient)),
 		admin.DecodeUpdateMeteringReportConfigurationReq,
-		SetStatusCreatedHeader(EncodeJSON),
+		EncodeJSON,
 		r.defaultServerOptions()...,
 	)
 }

--- a/pkg/handler/v1/admin/metering.go
+++ b/pkg/handler/v1/admin/metering.go
@@ -118,11 +118,11 @@ func CreateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
-		if err := createMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
-			return nil, fmt.Errorf("failed to create metering report configuration: %w", err)
+		if config, err := createMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
+			return config, err
+		} else {
+			return config, nil
 		}
-
-		return nil, nil
 	}
 }
 
@@ -137,11 +137,11 @@ func UpdateMeteringReportConfigurationEndpoint(userInfoGetter provider.UserInfoG
 			return nil, apierrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
 		}
 
-		if err := updateMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
-			return nil, fmt.Errorf("failed to update metering report configuration: %w", err)
+		if config, err := updateMeteringReportConfiguration(ctx, req, seedsGetter, masterClient); err != nil {
+			return config, err
+		} else {
+			return config, nil
 		}
-
-		return nil, nil
 	}
 }
 

--- a/pkg/handler/v1/admin/wrappers_ce.go
+++ b/pkg/handler/v1/admin/wrappers_ce.go
@@ -45,12 +45,12 @@ func listMeteringReportConfigurations(_ provider.SeedsGetter) ([]apiv1.MeteringR
 	return nil, nil
 }
 
-func createMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) error {
-	return nil
+func createMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) (*apiv1.MeteringReportConfiguration, error) {
+	return nil, nil
 }
 
-func updateMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) error {
-	return nil
+func updateMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) (*apiv1.MeteringReportConfiguration, error) {
+	return nil, nil
 }
 
 func deleteMeteringReportConfiguration(_ context.Context, _ interface{}, _ provider.SeedsGetter, _ ctrlruntimeclient.Client) error {

--- a/pkg/handler/v1/admin/wrappers_ee.go
+++ b/pkg/handler/v1/admin/wrappers_ee.go
@@ -45,11 +45,11 @@ func listMeteringReportConfigurations(seedsGetter provider.SeedsGetter) ([]apiv1
 	return metering.ListMeteringReportConfigurations(seedsGetter)
 }
 
-func createMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
+func createMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) (*apiv1.MeteringReportConfiguration, error) {
 	return metering.CreateMeteringReportConfiguration(ctx, request, seedsGetter, masterClient)
 }
 
-func updateMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) error {
+func updateMeteringReportConfiguration(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, masterClient ctrlruntimeclient.Client) (*apiv1.MeteringReportConfiguration, error) {
 	return metering.UpdateMeteringReportConfiguration(ctx, request, seedsGetter, masterClient)
 }
 

--- a/pkg/test/e2e/utils/apiclient/client/admin/admin_client.go
+++ b/pkg/test/e2e/utils/apiclient/client/admin/admin_client.go
@@ -68,7 +68,7 @@ type ClientService interface {
 
 	UpdateAdmissionPlugin(params *UpdateAdmissionPluginParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateAdmissionPluginOK, error)
 
-	UpdateMeteringReportConfiguration(params *UpdateMeteringReportConfigurationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateMeteringReportConfigurationCreated, error)
+	UpdateMeteringReportConfiguration(params *UpdateMeteringReportConfigurationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateMeteringReportConfigurationOK, error)
 
 	UpdateSeed(params *UpdateSeedParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateSeedOK, error)
 
@@ -838,7 +838,7 @@ func (a *Client) UpdateAdmissionPlugin(params *UpdateAdmissionPluginParams, auth
 /*
   UpdateMeteringReportConfiguration Updates existing report configuration for KKP metering tool. Only available in Kubermatic Enterprise Edition
 */
-func (a *Client) UpdateMeteringReportConfiguration(params *UpdateMeteringReportConfigurationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateMeteringReportConfigurationCreated, error) {
+func (a *Client) UpdateMeteringReportConfiguration(params *UpdateMeteringReportConfigurationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateMeteringReportConfigurationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateMeteringReportConfigurationParams()
@@ -864,7 +864,7 @@ func (a *Client) UpdateMeteringReportConfiguration(params *UpdateMeteringReportC
 	if err != nil {
 		return nil, err
 	}
-	success, ok := result.(*UpdateMeteringReportConfigurationCreated)
+	success, ok := result.(*UpdateMeteringReportConfigurationOK)
 	if ok {
 		return success, nil
 	}

--- a/pkg/test/e2e/utils/apiclient/client/admin/create_metering_report_configuration_responses.go
+++ b/pkg/test/e2e/utils/apiclient/client/admin/create_metering_report_configuration_responses.go
@@ -62,16 +62,27 @@ func NewCreateMeteringReportConfigurationCreated() *CreateMeteringReportConfigur
 
 /* CreateMeteringReportConfigurationCreated describes a response with status code 201, with default header values.
 
-EmptyResponse is a empty response
+MeteringReportConfiguration
 */
 type CreateMeteringReportConfigurationCreated struct {
+	Payload *models.MeteringReportConfiguration
 }
 
 func (o *CreateMeteringReportConfigurationCreated) Error() string {
-	return fmt.Sprintf("[POST /api/v1/admin/metering/configurations/reports/{name}][%d] createMeteringReportConfigurationCreated ", 201)
+	return fmt.Sprintf("[POST /api/v1/admin/metering/configurations/reports/{name}][%d] createMeteringReportConfigurationCreated  %+v", 201, o.Payload)
+}
+func (o *CreateMeteringReportConfigurationCreated) GetPayload() *models.MeteringReportConfiguration {
+	return o.Payload
 }
 
 func (o *CreateMeteringReportConfigurationCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.MeteringReportConfiguration)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }
@@ -172,6 +183,9 @@ type CreateMeteringReportConfigurationBody struct {
 
 	// schedule
 	Schedule string `json:"schedule,omitempty"`
+
+	// types
+	Types []string `json:"types"`
 }
 
 // Validate validates this create metering report configuration body

--- a/pkg/test/e2e/utils/apiclient/client/admin/update_metering_report_configuration_responses.go
+++ b/pkg/test/e2e/utils/apiclient/client/admin/update_metering_report_configuration_responses.go
@@ -25,8 +25,8 @@ type UpdateMeteringReportConfigurationReader struct {
 // ReadResponse reads a server response into the received o.
 func (o *UpdateMeteringReportConfigurationReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
-	case 201:
-		result := NewUpdateMeteringReportConfigurationCreated()
+	case 200:
+		result := NewUpdateMeteringReportConfigurationOK()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -55,23 +55,34 @@ func (o *UpdateMeteringReportConfigurationReader) ReadResponse(response runtime.
 	}
 }
 
-// NewUpdateMeteringReportConfigurationCreated creates a UpdateMeteringReportConfigurationCreated with default headers values
-func NewUpdateMeteringReportConfigurationCreated() *UpdateMeteringReportConfigurationCreated {
-	return &UpdateMeteringReportConfigurationCreated{}
+// NewUpdateMeteringReportConfigurationOK creates a UpdateMeteringReportConfigurationOK with default headers values
+func NewUpdateMeteringReportConfigurationOK() *UpdateMeteringReportConfigurationOK {
+	return &UpdateMeteringReportConfigurationOK{}
 }
 
-/* UpdateMeteringReportConfigurationCreated describes a response with status code 201, with default header values.
+/* UpdateMeteringReportConfigurationOK describes a response with status code 200, with default header values.
 
-EmptyResponse is a empty response
+MeteringReportConfiguration
 */
-type UpdateMeteringReportConfigurationCreated struct {
+type UpdateMeteringReportConfigurationOK struct {
+	Payload *models.MeteringReportConfiguration
 }
 
-func (o *UpdateMeteringReportConfigurationCreated) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/admin/metering/configurations/reports/{name}][%d] updateMeteringReportConfigurationCreated ", 201)
+func (o *UpdateMeteringReportConfigurationOK) Error() string {
+	return fmt.Sprintf("[PUT /api/v1/admin/metering/configurations/reports/{name}][%d] updateMeteringReportConfigurationOK  %+v", 200, o.Payload)
+}
+func (o *UpdateMeteringReportConfigurationOK) GetPayload() *models.MeteringReportConfiguration {
+	return o.Payload
 }
 
-func (o *UpdateMeteringReportConfigurationCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *UpdateMeteringReportConfigurationOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.MeteringReportConfiguration)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }
@@ -172,6 +183,9 @@ type UpdateMeteringReportConfigurationBody struct {
 
 	// schedule
 	Schedule string `json:"schedule,omitempty"`
+
+	// types
+	Types []string `json:"types"`
 }
 
 // Validate validates this update metering report configuration body


### PR DESCRIPTION
**What this PR does / why we need it**:
As seed CRD has been extended with additional report types we need to introduce this change to the API.

**Which issue(s) this PR fixes**:
Fixes #10815 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `types` parameter, defining report types, to the `/api/v1/admin/metering/configurations/reports` POST and PUT.
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/blob/master/content/kubermatic/master/tutorials-howtos/metering/_index.en.md
```
