### PR TITLE
Split semver package

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/base.go
+++ b/cmd/conformance-tester/pkg/scenarios/base.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	apimodels "k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/models"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ type Scenario interface {
 	OperatingSystem() providerconfig.OperatingSystem
 	ContainerRuntime() string
 	DualstackEnabled() bool
-	Version() semver.Semver
+	Version() k8csemverv1.Semver
 	Datacenter() *kubermaticv1.Datacenter
 	Name() string
 	Log(log *zap.SugaredLogger) *zap.SugaredLogger
@@ -68,7 +68,7 @@ type Scenario interface {
 type baseScenario struct {
 	cloudProvider    providerconfig.CloudProvider
 	operatingSystem  providerconfig.OperatingSystem
-	version          semver.Semver
+	version          k8csemverv1.Semver
 	containerRuntime string
 	dualstackEnabled bool
 	datacenter       *kubermaticv1.Datacenter
@@ -82,7 +82,7 @@ func (s *baseScenario) OperatingSystem() providerconfig.OperatingSystem {
 	return s.operatingSystem
 }
 
-func (s *baseScenario) Version() semver.Semver {
+func (s *baseScenario) Version() k8csemverv1.Semver {
 	return s.version
 }
 
@@ -219,7 +219,7 @@ func (s *baseScenario) SetDualstackEnabled(enabled bool) {
 	s.dualstackEnabled = enabled
 }
 
-func createMachineDeployment(replicas int, version *semver.Semver, os providerconfig.OperatingSystem, osSpec interface{}, provider providerconfig.CloudProvider, providerSpec interface{}, dualstack bool) (clusterv1alpha1.MachineDeployment, error) {
+func createMachineDeployment(replicas int, version *k8csemverv1.Semver, os providerconfig.OperatingSystem, osSpec interface{}, provider providerconfig.CloudProvider, providerSpec interface{}, dualstack bool) (clusterv1alpha1.MachineDeployment, error) {
 	replicas32 := int32(replicas)
 
 	var encodedOSSpec json.RawMessage

--- a/cmd/conformance-tester/pkg/scenarios/generator.go
+++ b/cmd/conformance-tester/pkg/scenarios/generator.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,7 +66,7 @@ func (g *Generator) WithOperatingSystems(operatingSystems ...string) *Generator 
 	return g
 }
 
-func (g *Generator) WithVersions(versions ...*semver.Semver) *Generator {
+func (g *Generator) WithVersions(versions ...*k8csemverv1.Semver) *Generator {
 	for _, version := range versions {
 		g.versions.Insert(version.String())
 	}
@@ -94,7 +94,7 @@ func (g *Generator) Scenarios(ctx context.Context, opts *types.Options, log *zap
 	scenarios := []Scenario{}
 
 	for _, version := range g.versions.List() {
-		s, err := semver.NewSemver(version)
+		s, err := k8csemverv1.NewSemver(version)
 		if err != nil {
 			return nil, fmt.Errorf("invalid version %q: %w", version, err)
 		}
@@ -166,7 +166,7 @@ func providerScenario(
 	opts *types.Options,
 	provider providerconfig.CloudProvider,
 	os providerconfig.OperatingSystem,
-	version semver.Semver,
+	version k8csemverv1.Semver,
 	containerRuntime string,
 	datacenter *kubermaticv1.Datacenter,
 ) (Scenario, error) {
@@ -233,7 +233,7 @@ func isValidNewScenario(opts *types.Options, log *zap.SugaredLogger, scenario Sc
 
 	// apply static filters
 	clusterVersion := scenario.Version()
-	dockerSupported := clusterVersion.LessThan(semver.NewSemverOrDie("1.24"))
+	dockerSupported := clusterVersion.LessThan(k8csemverv1.NewSemverOrDie("1.24"))
 	if !dockerSupported && scenario.ContainerRuntime() == resources.ContainerRuntimeDocker {
 		scenario.Log(log).Infow("Skipping because CRI is not supported in this Kubernetes version.")
 		return false

--- a/cmd/conformance-tester/pkg/tests/metrics.go
+++ b/cmd/conformance-tester/pkg/tests/metrics.go
@@ -28,7 +28,7 @@ import (
 	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,7 +101,7 @@ func TestUserClusterMetrics(ctx context.Context, log *zap.SugaredLogger, opts *c
 		"machine_cpu_cores",
 	)
 
-	if cluster.Spec.Version.LessThan(semver.NewSemverOrDie("v1.23.0")) {
+	if cluster.Spec.Version.LessThan(k8csemverv1.NewSemverOrDie("v1.23.0")) {
 		expected.Insert("scheduler_e2e_scheduling_duration_seconds_count")
 	} else {
 		// this metric is only available in 1.23 and replaces scheduler_e2e_scheduling_duration_seconds_counts

--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -34,7 +34,7 @@ import (
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	kubermativsemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test"
 	apiclient "k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client"
 	"k8c.io/kubermatic/v2/pkg/util/flagopts"
@@ -56,7 +56,7 @@ type Options struct {
 
 	Providers            sets.String
 	Releases             sets.String
-	Versions             []*kubermativsemver.Semver
+	Versions             []*k8csemverv1.Semver
 	EnableDistributions  sets.String
 	ExcludeDistributions sets.String
 	Distributions        sets.String
@@ -304,7 +304,7 @@ func combineSets(include, exclude, all sets.String, flagname string) (sets.Strin
 	return chosen, nil
 }
 
-func getLatestMinorVersions(versions []kubermativsemver.Semver) []string {
+func getLatestMinorVersions(versions []k8csemverv1.Semver) []string {
 	minorMap := map[uint64]*semverlib.Version{}
 
 	for _, version := range versions {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -32194,7 +32194,7 @@
     "Semver": {
       "type": "string",
       "title": "Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version struct so it can be used in our API.",
-      "x-go-package": "k8c.io/kubermatic/v2/pkg/semver"
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/semver/v1"
     },
     "ServiceAccount": {
       "description": "ServiceAccount represent an API service account",

--- a/codegen/addon-resources/main.go
+++ b/codegen/addon-resources/main.go
@@ -30,7 +30,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -167,7 +167,7 @@ func createTemplateData() (*addon.TemplateData, error) {
 		},
 		Status: kubermaticv1.ClusterStatus{
 			Versions: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane: *semver.NewSemverOrDie("2.20.0"),
+				ControlPlane: *k8csemverv1.NewSemverOrDie("2.20.0"),
 			},
 		},
 	}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -914,7 +914,7 @@ type ClusterSpec struct {
 	MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
 
 	// Version desired version of the kubernetes master components
-	Version ksemver.Semver `json:"version"`
+	Version k8csemverv1.Semver `json:"version"`
 
 	// OIDC settings
 	OIDC kubermaticv1.OIDCSettings `json:"oidc,omitempty"`
@@ -992,7 +992,7 @@ func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
 		Cloud                                PublicCloudSpec                        `json:"cloud"`
 		MachineNetworks                      []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
-		Version                              ksemver.Semver                         `json:"version"`
+		Version                              k8csemverv1.Semver                     `json:"version"`
 		OIDC                                 kubermaticv1.OIDCSettings              `json:"oidc"`
 		UpdateWindow                         *kubermaticv1.UpdateWindow             `json:"updateWindow,omitempty"`
 		UsePodSecurityPolicyAdmissionPlugin  bool                                   `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
@@ -1270,7 +1270,7 @@ func newPublicVMwareCloudDirectorCloudSpec(internal *kubermaticv1.VMwareCloudDir
 // ClusterStatus defines the cluster status.
 type ClusterStatus struct {
 	// Version actual version of the kubernetes master components
-	Version ksemver.Semver `json:"version"`
+	Version k8csemverv1.Semver `json:"version"`
 	// URL specifies the address at which the cluster is available
 	URL string `json:"url"`
 	// ExternalCCMMigration represents the migration status to the external CCM
@@ -2633,7 +2633,7 @@ type AdmissionPlugin struct {
 	Name   string `json:"name"`
 	Plugin string `json:"plugin"`
 	// FromVersion flag can be empty. It means the plugin fit to all k8s versions
-	FromVersion *ksemver.Semver `json:"fromVersion,omitempty"`
+	FromVersion *k8csemverv1.Semver `json:"fromVersion,omitempty"`
 }
 
 // Seed represents a seed object

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -23,7 +23,7 @@ import (
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 )
 
 func TestNewClusterSpec_MarshalJSON(t *testing.T) {
@@ -38,7 +38,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		{
 			"case 1: filter username and password from OpenStack",
 			apiv1.ClusterSpec{
-				Version: *semver.NewSemverOrDie("1.2.3"),
+				Version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 				Cloud: kubermaticv1.CloudSpec{
 					DatacenterName: "OpenstackDatacenter",
 					Openstack: &kubermaticv1.OpenstackCloudSpec{
@@ -58,7 +58,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		{
 			"case 2: client ID and client secret from Azure",
 			apiv1.ClusterSpec{
-				Version: *semver.NewSemverOrDie("1.2.3"),
+				Version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 				Cloud: kubermaticv1.CloudSpec{
 					Azure: &kubermaticv1.AzureCloudSpec{
 						ClientID:        valueToBeFiltered,
@@ -78,7 +78,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		{
 			"case 3: filter token from Hetzner",
 			apiv1.ClusterSpec{
-				Version: *semver.NewSemverOrDie("1.2.3"),
+				Version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 				Cloud: kubermaticv1.CloudSpec{
 					Hetzner: &kubermaticv1.HetznerCloudSpec{
 						Token: valueToBeFiltered,
@@ -89,7 +89,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		{
 			"case 4: filter token from DigitalOcean",
 			apiv1.ClusterSpec{
-				Version: *semver.NewSemverOrDie("1.2.3"),
+				Version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 				Cloud: kubermaticv1.CloudSpec{
 					Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
 						Token: valueToBeFiltered,
@@ -100,7 +100,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		{
 			"case 5: filter usernames and passwords from VSphere",
 			apiv1.ClusterSpec{
-				Version: *semver.NewSemverOrDie("1.2.3"),
+				Version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 				Cloud: kubermaticv1.CloudSpec{
 					VSphere: &kubermaticv1.VSphereCloudSpec{
 						Password: valueToBeFiltered,
@@ -118,7 +118,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		{
 			"case 6: filter access key ID and secret access key from AWS",
 			apiv1.ClusterSpec{
-				Version: *semver.NewSemverOrDie("1.2.3"),
+				Version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 				Cloud: kubermaticv1.CloudSpec{
 					AWS: &kubermaticv1.AWSCloudSpec{
 						AccessKeyID:         valueToBeFiltered,

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -24,7 +24,7 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -468,7 +468,7 @@ type ExternalClusterStatus struct {
 // ExternalClusterSpec defines the external cluster specification.
 type ExternalClusterSpec struct {
 	// Version desired version of the kubernetes master components
-	Version ksemver.Semver `json:"version,omitempty"`
+	Version k8csemverv1.Semver `json:"version,omitempty"`
 
 	GKEClusterSpec *GKEClusterSpec `json:"gkeclusterSpec,omitempty"`
 	EKSClusterSpec *EKSClusterSpec `json:"eksclusterSpec,omitempty"`

--- a/pkg/apis/kubermatic/v1/admission_plugin.go
+++ b/pkg/apis/kubermatic/v1/admission_plugin.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -52,5 +52,5 @@ type AdmissionPluginSpec struct {
 	PluginName string `json:"pluginName"`
 
 	// FromVersion flag can be empty. It means the plugin fit to all k8s versions
-	FromVersion *semver.Semver `json:"fromVersion,omitempty"`
+	FromVersion *k8csemverv1.Semver `json:"fromVersion,omitempty"`
 }

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -176,7 +176,7 @@ type ClusterSpec struct {
 	HumanReadableName string `json:"humanReadableName"`
 
 	// Version defines the wanted version of the control plane.
-	Version semver.Semver `json:"version"`
+	Version k8csemverv1.Semver `json:"version"`
 
 	// Cloud contains information regarding the cloud provider that
 	// is responsible for hosting the cluster's workload.
@@ -578,23 +578,23 @@ type ClusterStatus struct {
 type ClusterVersionsStatus struct {
 	// ControlPlane is the currently active cluster version. This can lag behind the apiserver
 	// version if an update is currently rolling out.
-	ControlPlane semver.Semver `json:"controlPlane"`
+	ControlPlane k8csemverv1.Semver `json:"controlPlane"`
 	// Apiserver is the currently desired version of the kube-apiserver. During
 	// upgrades across multiple minor versions (e.g. from 1.20 to 1.23), this will gradually
 	// be increased by the update-controller until the desired cluster version (spec.version)
 	// is reached.
-	Apiserver semver.Semver `json:"apiserver"`
+	Apiserver k8csemverv1.Semver `json:"apiserver"`
 	// ControllerManager is the currently desired version of the kube-controller-manager. This
 	// field behaves the same as the apiserver field.
-	ControllerManager semver.Semver `json:"controllerManager"`
+	ControllerManager k8csemverv1.Semver `json:"controllerManager"`
 	// Scheduler is the currently desired version of the kube-scheduler. This field behaves the
 	// same as the apiserver field.
-	Scheduler semver.Semver `json:"scheduler"`
+	Scheduler k8csemverv1.Semver `json:"scheduler"`
 	// OldestNodeVersion is the oldest node version currently in use inside the cluster. This can be
 	// nil if there are no nodes. This field is primarily for speeding up reconciling, so that
 	// the controller doesn't have to re-fetch to the usercluster and query its node on every
 	// reconciliation.
-	OldestNodeVersion *semver.Semver `json:"oldestNodeVersion,omitempty"`
+	OldestNodeVersion *k8csemverv1.Semver `json:"oldestNodeVersion,omitempty"`
 }
 
 // HasConditionValue returns true if the cluster status has the given condition with the given status.

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -350,9 +350,9 @@ type KubermaticProjectsMigratorConfiguration struct {
 // KubermaticVersioningConfiguration configures the available and default Kubernetes versions.
 type KubermaticVersioningConfiguration struct {
 	// Versions lists the available versions.
-	Versions []semver.Semver `json:"versions,omitempty"`
+	Versions []k8csemverv1.Semver `json:"versions,omitempty"`
 	// Default is the default version to offer users.
-	Default *semver.Semver `json:"default,omitempty"`
+	Default *k8csemverv1.Semver `json:"default,omitempty"`
 
 	// Updates is a list of available and automatic upgrades.
 	// All 'to' versions must be configured in the version list for this orchestrator.
@@ -384,11 +384,11 @@ const (
 // ExternalClusterProviderVersioningConfiguration configures the available and default Kubernetes versions for ExternalCluster Providers.
 type ExternalClusterProviderVersioningConfiguration struct {
 	// Versions lists the available versions.
-	Versions []semver.Semver `json:"versions,omitempty"`
+	Versions []k8csemverv1.Semver `json:"versions,omitempty"`
 	// Default is the default version to offer users.
-	Default *semver.Semver `json:"default,omitempty"`
+	Default *k8csemverv1.Semver `json:"default,omitempty"`
 	// Updates is a list of available upgrades.
-	Updates []semver.Semver `json:"updates,omitempty"`
+	Updates []k8csemverv1.Semver `json:"updates,omitempty"`
 }
 
 // Update represents an update option for a user cluster.

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	semverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3051,7 +3051,7 @@ func (in *ExternalClusterProviderVersioningConfiguration) DeepCopyInto(out *Exte
 	*out = *in
 	if in.Versions != nil {
 		in, out := &in.Versions, &out.Versions
-		*out = make([]semver.Semver, len(*in))
+		*out = make([]semverv1.Semver, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -3063,7 +3063,7 @@ func (in *ExternalClusterProviderVersioningConfiguration) DeepCopyInto(out *Exte
 	}
 	if in.Updates != nil {
 		in, out := &in.Updates, &out.Updates
-		*out = make([]semver.Semver, len(*in))
+		*out = make([]semverv1.Semver, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -4033,7 +4033,7 @@ func (in *KubermaticVersioningConfiguration) DeepCopyInto(out *KubermaticVersion
 	*out = *in
 	if in.Versions != nil {
 		in, out := &in.Versions, &out.Versions
-		*out = make([]semver.Semver, len(*in))
+		*out = make([]semverv1.Semver, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -35,7 +35,7 @@ import (
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/util/kubectl"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -488,7 +488,7 @@ func (r *Reconciler) setupManifestInteraction(ctx context.Context, log *zap.Suga
 	return kubeconfigFilename, manifestFilename, done, nil
 }
 
-func (r *Reconciler) getApplyCommand(ctx context.Context, kubeconfigFilename, manifestFilename string, selector fmt.Stringer, clusterVersion semver.Semver) (*exec.Cmd, error) {
+func (r *Reconciler) getApplyCommand(ctx context.Context, kubeconfigFilename, manifestFilename string, selector fmt.Stringer, clusterVersion k8csemverv1.Semver) (*exec.Cmd, error) {
 	binary, err := kubectl.BinaryForClusterVersion(&clusterVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine kubectl binary to use: %w", err)

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/util/kubectl"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
@@ -150,7 +150,7 @@ func TestController_combineManifests(t *testing.T) {
 }
 
 func setupTestCluster(cidrBlock string) *kubermaticv1.Cluster {
-	version := *semver.NewSemverOrDie("v1.11.1")
+	version := *k8csemverv1.NewSemverOrDie("v1.11.1")
 
 	return &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -212,7 +212,7 @@ func (r *Reconciler) controlPlaneUpgrade(ctx context.Context, log *zap.SugaredLo
 	}
 	oldCluster := cluster.DeepCopy()
 
-	sver, err := semver.NewSemver(update.Version.String())
+	sver, err := k8csemverv1.NewSemver(update.Version.String())
 	if err != nil {
 		return fmt.Errorf("failed to parse version %q: %w", update.Version.String(), err)
 	}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -33,7 +33,7 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/util/yaml"
 
@@ -60,7 +60,7 @@ func encodeContainerAsYAML(t *testing.T, c *corev1.Container) string {
 }
 
 func genTestCluster() *kubermaticv1.Cluster {
-	version := *semver.NewSemverOrDie("1.16.3")
+	version := *k8csemverv1.NewSemverOrDie("1.16.3")
 
 	return &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/seed-controller-manager/monitoring/resources_test.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources_test.go
@@ -22,7 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +48,7 @@ func TestCreateConfigMap(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						DatacenterName: TestDC,
 					},
-					Version: *semver.NewSemverOrDie("v1.11.3"),
+					Version: *k8csemverv1.NewSemverOrDie("v1.11.3"),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "cluster-nico1",
@@ -66,7 +66,7 @@ func TestCreateConfigMap(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						DatacenterName: TestDC,
 					},
-					Version: *semver.NewSemverOrDie("v1.11.3"),
+					Version: *k8csemverv1.NewSemverOrDie("v1.11.3"),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "cluster-nico1",

--- a/pkg/controller/seed-controller-manager/update-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller_test.go
@@ -26,7 +26,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,7 +54,7 @@ func TestGetOldestAvailableVersion(t *testing.T) {
 
 	testcases := []struct {
 		sets     []appsv1.ReplicaSet
-		expected *semver.Semver
+		expected *k8csemverv1.Semver
 	}{
 		{
 			sets: []appsv1.ReplicaSet{
@@ -84,28 +84,28 @@ func TestGetOldestAvailableVersion(t *testing.T) {
 			sets: []appsv1.ReplicaSet{
 				makeSet(1, "1.2.3"),
 			},
-			expected: semver.NewSemverOrDie("1.2.3"),
+			expected: k8csemverv1.NewSemverOrDie("1.2.3"),
 		},
 		{
 			sets: []appsv1.ReplicaSet{
 				makeSet(1, "1.2.3"),
 				makeSet(1, "1.2.4"),
 			},
-			expected: semver.NewSemverOrDie("1.2.3"),
+			expected: k8csemverv1.NewSemverOrDie("1.2.3"),
 		},
 		{
 			sets: []appsv1.ReplicaSet{
 				makeSet(0, "1.2.3"),
 				makeSet(1, "1.2.4"),
 			},
-			expected: semver.NewSemverOrDie("1.2.4"),
+			expected: k8csemverv1.NewSemverOrDie("1.2.4"),
 		},
 		{
 			sets: []appsv1.ReplicaSet{
 				makeSet(1, "1.2.4"),
 				makeSet(0, "1.2.3"),
 			},
-			expected: semver.NewSemverOrDie("1.2.4"),
+			expected: k8csemverv1.NewSemverOrDie("1.2.4"),
 		},
 	}
 
@@ -189,15 +189,15 @@ func TestGetNextApiserverVersion(t *testing.T) {
 	// This test (and this controller, really) is not about unit testing
 	// all the possible incompatibility options, so we skip them here.
 	versions := kubermaticv1.KubermaticVersioningConfiguration{
-		Versions: []semver.Semver{
-			*semver.NewSemverOrDie("1.20.0"),
-			*semver.NewSemverOrDie("1.20.1"),
-			*semver.NewSemverOrDie("1.20.2"),
-			*semver.NewSemverOrDie("1.21.0"),
-			*semver.NewSemverOrDie("1.21.3"),
-			*semver.NewSemverOrDie("1.22.5"),
-			*semver.NewSemverOrDie("1.23.0"),
-			*semver.NewSemverOrDie("1.24.0"),
+		Versions: []k8csemverv1.Semver{
+			*k8csemverv1.NewSemverOrDie("1.20.0"),
+			*k8csemverv1.NewSemverOrDie("1.20.1"),
+			*k8csemverv1.NewSemverOrDie("1.20.2"),
+			*k8csemverv1.NewSemverOrDie("1.21.0"),
+			*k8csemverv1.NewSemverOrDie("1.21.3"),
+			*k8csemverv1.NewSemverOrDie("1.22.5"),
+			*k8csemverv1.NewSemverOrDie("1.23.0"),
+			*k8csemverv1.NewSemverOrDie("1.24.0"),
 		},
 		Updates: []kubermaticv1.Update{
 			{
@@ -238,57 +238,57 @@ func TestGetNextApiserverVersion(t *testing.T) {
 
 	testcases := []struct {
 		name             string
-		specVersion      semver.Semver
-		apiserverVersion semver.Semver
-		expected         *semver.Semver
+		specVersion      k8csemverv1.Semver
+		apiserverVersion k8csemverv1.Semver
+		expected         *k8csemverv1.Semver
 		expectedErr      bool
 	}{
 		{
 			name:             "allow simple patch release update",
-			apiserverVersion: *semver.NewSemverOrDie("1.20.0"),
-			specVersion:      *semver.NewSemverOrDie("1.20.1"),
-			expected:         semver.NewSemverOrDie("1.20.1"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.20.0"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+			expected:         k8csemverv1.NewSemverOrDie("1.20.1"),
 		},
 		{
 			name:             "allow updating to the next minor",
-			apiserverVersion: *semver.NewSemverOrDie("1.20.2"),
-			specVersion:      *semver.NewSemverOrDie("1.21.0"),
-			expected:         semver.NewSemverOrDie("1.21.0"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.20.2"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+			expected:         k8csemverv1.NewSemverOrDie("1.21.0"),
 		},
 		{
 			name:             "allow updating to the max next minor",
-			apiserverVersion: *semver.NewSemverOrDie("1.20.2"),
-			specVersion:      *semver.NewSemverOrDie("1.21.3"),
-			expected:         semver.NewSemverOrDie("1.21.3"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.20.2"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.21.3"),
+			expected:         k8csemverv1.NewSemverOrDie("1.21.3"),
 		},
 		{
 			name:             "take the highest patch release of the next minor when upgrading across multiple minors",
-			apiserverVersion: *semver.NewSemverOrDie("1.20.2"),
-			specVersion:      *semver.NewSemverOrDie("1.23.0"),
-			expected:         semver.NewSemverOrDie("1.21.3"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.20.2"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.23.0"),
+			expected:         k8csemverv1.NewSemverOrDie("1.21.3"),
 		},
 		{
 			name:             "currently active version is not configured anymore",
-			apiserverVersion: *semver.NewSemverOrDie("1.20.7"),
-			specVersion:      *semver.NewSemverOrDie("1.21.0"),
-			expected:         semver.NewSemverOrDie("1.21.0"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.20.7"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+			expected:         k8csemverv1.NewSemverOrDie("1.21.0"),
 		},
 		{
 			name:             "no path configured",
-			apiserverVersion: *semver.NewSemverOrDie("1.23.0"),
-			specVersion:      *semver.NewSemverOrDie("1.24.0"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.23.0"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.24.0"),
 			expectedErr:      true,
 		},
 		{
 			name:             "unsupported target version",
-			apiserverVersion: *semver.NewSemverOrDie("1.20.0"),
-			specVersion:      *semver.NewSemverOrDie("1.20.9"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.20.0"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.20.9"),
 			expectedErr:      true,
 		},
 		{
 			name:             "unsupported target version across a minor release",
-			apiserverVersion: *semver.NewSemverOrDie("1.21.3"),
-			specVersion:      *semver.NewSemverOrDie("1.22.0"),
+			apiserverVersion: *k8csemverv1.NewSemverOrDie("1.21.3"),
+			specVersion:      *k8csemverv1.NewSemverOrDie("1.22.0"),
 			expectedErr:      true,
 		},
 	}
@@ -335,15 +335,15 @@ func TestGetNextApiserverVersion(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	versions := kubermaticv1.KubermaticVersioningConfiguration{
-		Versions: []semver.Semver{
-			*semver.NewSemverOrDie("1.20.0"),
-			*semver.NewSemverOrDie("1.20.1"),
-			*semver.NewSemverOrDie("1.20.2"),
-			*semver.NewSemverOrDie("1.21.0"),
-			*semver.NewSemverOrDie("1.21.3"),
-			*semver.NewSemverOrDie("1.22.5"),
-			*semver.NewSemverOrDie("1.23.0"),
-			*semver.NewSemverOrDie("1.24.0"),
+		Versions: []k8csemverv1.Semver{
+			*k8csemverv1.NewSemverOrDie("1.20.0"),
+			*k8csemverv1.NewSemverOrDie("1.20.1"),
+			*k8csemverv1.NewSemverOrDie("1.20.2"),
+			*k8csemverv1.NewSemverOrDie("1.21.0"),
+			*k8csemverv1.NewSemverOrDie("1.21.3"),
+			*k8csemverv1.NewSemverOrDie("1.22.5"),
+			*k8csemverv1.NewSemverOrDie("1.23.0"),
+			*k8csemverv1.NewSemverOrDie("1.24.0"),
 		},
 		Updates: []kubermaticv1.Update{
 			{
@@ -384,7 +384,7 @@ func TestReconcile(t *testing.T) {
 
 	testcases := []struct {
 		name           string
-		specVersion    semver.Semver
+		specVersion    k8csemverv1.Semver
 		clusterStatus  kubermaticv1.ClusterVersionsStatus
 		currentStatus  controlPlaneStatus
 		healthy        bool
@@ -398,212 +398,212 @@ func TestReconcile(t *testing.T) {
 
 		{
 			name:          "new cluster created, set the initial status",
-			specVersion:   *semver.NewSemverOrDie("1.23.0"),
+			specVersion:   *k8csemverv1.NewSemverOrDie("1.23.0"),
 			healthy:       false,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.23.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.23.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.23.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.23.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.23.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.23.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.23.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.23.0"),
 			},
 		},
 		{
 			name:        "cluster is healthy and up-to-date, nothing to do",
-			specVersion: *semver.NewSemverOrDie("1.20.1"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.20.1"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.20.1"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.20.1"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.20.1"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.20.1"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.20.1"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.20.1"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 		},
 		{
 			name:        "cluster up-to-date, but not yet healthy, do nothing and wait for it to be come healthy",
-			specVersion: *semver.NewSemverOrDie("1.20.1"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.20.1"),
 			healthy:     false,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.20.1"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.20.1"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.20.1"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.20.1"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.20.1"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.20.1"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 		},
 		{
 			name:        "vanilla cluster that was just told to be updated by changing its spec",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.20.1"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.20.1"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.20.1"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.20.1"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"), // this should be updated to the spec
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"), // this should be updated to the spec
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 		},
 		{
 			name:        "waiting for the new apiserver to become healthy before updating the controlplanne version, i.e. do nothing yet",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     false,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.20.1"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.20.1"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 		},
 		{
 			name:        "apiserver is updated, but control plane is still rolling out (e.g. etcd is still updating), do nothing and wait for healthy",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     false,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 		},
 		{
 			name:        "apiserver became healthy, mark control plane as updated and mark cm/scheduler to be updated",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.20.1"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.20.1"),
-				Scheduler:         *semver.NewSemverOrDie("1.20.1"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.20.1"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 		},
 		{
 			name:        "wait for control plane to come up, do nothing",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     false,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.20.1"),
-				scheduler:         semver.NewSemverOrDie("1.20.1"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.20.1"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.20.1"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 		},
 		{
 			name:        "update completed, back to a vanilla cluster",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.21.0"),
-				scheduler:         semver.NewSemverOrDie("1.21.0"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.21.0"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 		},
 		{
 			name:        "update to 1.23 and ensure we jump to 1.22",
-			specVersion: *semver.NewSemverOrDie("1.23.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.23.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.21.0"),
-				scheduler:         semver.NewSemverOrDie("1.21.0"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.21.0"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.22.5"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.22.5"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 		},
 
@@ -613,76 +613,76 @@ func TestReconcile(t *testing.T) {
 
 		{
 			name:        "cluster still has ancient nodes, cannot progress with updates",
-			specVersion: *semver.NewSemverOrDie("1.23.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.23.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.22.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.22.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.22.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.22.0"),
-				OldestNodeVersion: semver.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.22.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.22.0"),
+				OldestNodeVersion: k8csemverv1.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.22.0"),
-				controllerManager: semver.NewSemverOrDie("1.22.0"),
-				scheduler:         semver.NewSemverOrDie("1.22.0"),
-				nodes:             semver.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
+				apiserver:         k8csemverv1.NewSemverOrDie("1.22.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.22.0"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.22.0"),
+				nodes:             k8csemverv1.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.22.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.22.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.22.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.22.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.22.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.22.0"),
 			},
 		},
 
 		{
 			name:        "cluster still has ancient nodes, but is (erroneously) on its way to update and so we should allow this to complete",
-			specVersion: *semver.NewSemverOrDie("1.23.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.23.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.22.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.23.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.22.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.22.0"),
-				OldestNodeVersion: semver.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.23.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.22.0"),
+				OldestNodeVersion: k8csemverv1.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.23.0"),
-				controllerManager: semver.NewSemverOrDie("1.22.0"),
-				scheduler:         semver.NewSemverOrDie("1.22.0"),
-				nodes:             semver.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
+				apiserver:         k8csemverv1.NewSemverOrDie("1.23.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.22.0"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.22.0"),
+				nodes:             k8csemverv1.NewSemverOrDie("1.20.0"), // allows max 1.22.* control plane
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.23.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.23.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.23.0"), // allow them to follow the apiserver's version
-				Scheduler:         *semver.NewSemverOrDie("1.23.0"), // allow them to follow the apiserver's version
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.23.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.23.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.23.0"), // allow them to follow the apiserver's version
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.23.0"), // allow them to follow the apiserver's version
 			},
 		},
 
 		{
 			name:        "cluster still has old nodes, but young enough to permit an update",
-			specVersion: *semver.NewSemverOrDie("1.23.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.23.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.22.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.22.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.22.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.22.0"),
-				OldestNodeVersion: semver.NewSemverOrDie("1.21.0"), // allows max 1.23.* control plane
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.22.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.22.0"),
+				OldestNodeVersion: k8csemverv1.NewSemverOrDie("1.21.0"), // allows max 1.23.* control plane
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.22.0"),
-				controllerManager: semver.NewSemverOrDie("1.22.0"),
-				scheduler:         semver.NewSemverOrDie("1.22.0"),
-				nodes:             semver.NewSemverOrDie("1.21.0"), // allows max 1.23.* control plane
+				apiserver:         k8csemverv1.NewSemverOrDie("1.22.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.22.0"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.22.0"),
+				nodes:             k8csemverv1.NewSemverOrDie("1.21.0"), // allows max 1.23.* control plane
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.22.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.23.0"), // updated!
-				ControllerManager: *semver.NewSemverOrDie("1.22.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.22.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.23.0"), // updated!
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.22.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.22.0"),
 			},
 		},
 
@@ -691,68 +691,68 @@ func TestReconcile(t *testing.T) {
 
 		{
 			name:        "vanilla cluster that was just told to be downgraded by changing its spec",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.3"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.3"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.3"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.3"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.3"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.3"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.3"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.3"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.3"),
-				controllerManager: semver.NewSemverOrDie("1.21.3"),
-				scheduler:         semver.NewSemverOrDie("1.21.3"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.3"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.21.3"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.21.3"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.3"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"), // this should be updated to the spec
-				ControllerManager: *semver.NewSemverOrDie("1.21.3"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.3"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.3"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"), // this should be updated to the spec
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.3"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.3"),
 			},
 		},
 		{
 			name:        "downgraded apiserver came alive, rest of control plane should downgrade as well",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.3"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.3"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.3"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.3"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.3"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.3"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.21.3"),
-				scheduler:         semver.NewSemverOrDie("1.21.3"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.21.3"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.21.3"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 		},
 		{
 			name:        "downgrade completes",
-			specVersion: *semver.NewSemverOrDie("1.21.0"),
+			specVersion: *k8csemverv1.NewSemverOrDie("1.21.0"),
 			healthy:     true,
 			clusterStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			currentStatus: controlPlaneStatus{
-				apiserver:         semver.NewSemverOrDie("1.21.0"),
-				controllerManager: semver.NewSemverOrDie("1.21.0"),
-				scheduler:         semver.NewSemverOrDie("1.21.0"),
+				apiserver:         k8csemverv1.NewSemverOrDie("1.21.0"),
+				controllerManager: k8csemverv1.NewSemverOrDie("1.21.0"),
+				scheduler:         k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 			expectedStatus: kubermaticv1.ClusterVersionsStatus{
-				ControlPlane:      *semver.NewSemverOrDie("1.21.0"),
-				Apiserver:         *semver.NewSemverOrDie("1.21.0"),
-				ControllerManager: *semver.NewSemverOrDie("1.21.0"),
-				Scheduler:         *semver.NewSemverOrDie("1.21.0"),
+				ControlPlane:      *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Apiserver:         *k8csemverv1.NewSemverOrDie("1.21.0"),
+				ControllerManager: *k8csemverv1.NewSemverOrDie("1.21.0"),
+				Scheduler:         *k8csemverv1.NewSemverOrDie("1.21.0"),
 			},
 		},
 	}

--- a/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
@@ -25,7 +25,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -88,9 +88,9 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return fmt.Errorf("failed to get nodes: %w", err)
 	}
 
-	var oldestVersion *semver.Semver
+	var oldestVersion *k8csemverv1.Semver
 	for _, node := range nodes.Items {
-		parsed, err := semver.NewSemver(node.Status.NodeInfo.KubeletVersion)
+		parsed, err := k8csemverv1.NewSemver(node.Status.NodeInfo.KubeletVersion)
 		if err != nil {
 			return fmt.Errorf("failed to get nodes: %w", err)
 		}
@@ -103,7 +103,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	// parse the version again to reliably get rid of the "v" prefix, otherwise
 	// this could lead to reconcile loops; our semver types are weird when marshalled.
 	if oldestVersion != nil {
-		parsed, err := semver.NewSemver(oldestVersion.String())
+		parsed, err := k8csemverv1.NewSemver(oldestVersion.String())
 		if err != nil {
 			return fmt.Errorf("failed to parse version %v: %w", oldestVersion, err)
 		}

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -28,7 +28,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -71,8 +71,8 @@ const (
 	DefaultNoProxy = "127.0.0.1/8,localhost,.local,.local.,kubernetes,.default,.svc"
 )
 
-func newSemver(s string) semver.Semver {
-	sv := semver.NewSemverOrDie(s)
+func newSemver(s string) k8csemverv1.Semver {
+	sv := k8csemverv1.NewSemverOrDie(s)
 	return *sv
 }
 
@@ -216,8 +216,8 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.23.9"),
-		Versions: []semver.Semver{
+		Default: k8csemverv1.NewSemverOrDie("v1.23.9"),
+		Versions: []k8csemverv1.Semver{
 			// Kubernetes 1.22
 			newSemver("v1.22.5"),
 			newSemver("v1.22.9"),
@@ -298,8 +298,8 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.22"),
-		Versions: []semver.Semver{
+		Default: k8csemverv1.NewSemverOrDie("v1.22"),
+		Versions: []k8csemverv1.Semver{
 			newSemver("v1.23"),
 			newSemver("v1.22"),
 			newSemver("v1.21"),
@@ -310,8 +310,8 @@ var (
 	aksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
-		Default: semver.NewSemverOrDie("v1.22"),
-		Versions: []semver.Semver{
+		Default: k8csemverv1.NewSemverOrDie("v1.22"),
+		Versions: []k8csemverv1.Semver{
 			newSemver("v1.24"),
 			newSemver("v1.23"),
 			newSemver("v1.22"),

--- a/pkg/defaulting/configuration_test.go
+++ b/pkg/defaulting/configuration_test.go
@@ -19,7 +19,7 @@ package defaulting
 import (
 	"testing"
 
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 )
 
 func TestAutomaticUpdateRulesMatchVersions(t *testing.T) {
@@ -29,7 +29,7 @@ func TestAutomaticUpdateRulesMatchVersions(t *testing.T) {
 			continue
 		}
 
-		toVersion, err := semver.NewSemver(update.To)
+		toVersion, err := k8csemverv1.NewSemver(update.To)
 		if err != nil {
 			t.Errorf("Version %q in update rule %d is not a valid version: %v", update.To, i, err)
 			continue

--- a/pkg/handler/common/cluster_test.go
+++ b/pkg/handler/common/cluster_test.go
@@ -22,7 +22,7 @@ import (
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,11 +53,11 @@ func TestExternalCCMMigration(t *testing.T) {
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
 					},
-					Version: *semver.NewSemverOrDie(kubernetesVersionToTest),
+					Version: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie(kubernetesVersionToTest),
+						ControlPlane: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 					},
 				},
 			},
@@ -82,11 +82,11 @@ func TestExternalCCMMigration(t *testing.T) {
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
 					},
-					Version: *semver.NewSemverOrDie(kubernetesVersionToTest),
+					Version: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie(kubernetesVersionToTest),
+						ControlPlane: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 					},
 					Conditions: map[kubermaticv1.ClusterConditionType]kubermaticv1.ClusterCondition{
 						kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted: {
@@ -107,11 +107,11 @@ func TestExternalCCMMigration(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{},
 					},
-					Version: *semver.NewSemverOrDie(kubernetesVersionToTest),
+					Version: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie(kubernetesVersionToTest),
+						ControlPlane: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 					},
 				},
 			},
@@ -127,11 +127,11 @@ func TestExternalCCMMigration(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						Fake: &kubermaticv1.FakeCloudSpec{},
 					},
-					Version: *semver.NewSemverOrDie(kubernetesVersionToTest),
+					Version: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie(kubernetesVersionToTest),
+						ControlPlane: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 					},
 				},
 			},
@@ -156,11 +156,11 @@ func TestExternalCCMMigration(t *testing.T) {
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
 					},
-					Version: *semver.NewSemverOrDie(kubernetesVersionToTest),
+					Version: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie(kubernetesVersionToTest),
+						ControlPlane: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 					},
 					Conditions: map[kubermaticv1.ClusterConditionType]kubermaticv1.ClusterCondition{
 						kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted: {
@@ -190,11 +190,11 @@ func TestExternalCCMMigration(t *testing.T) {
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
 					},
-					Version: *semver.NewSemverOrDie(kubernetesVersionToTest),
+					Version: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie(kubernetesVersionToTest),
+						ControlPlane: *k8csemverv1.NewSemverOrDie(kubernetesVersionToTest),
 					},
 				},
 			},

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	ksemver "k8c.io/kubermatic/v2/pkg/semver/v1"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	"k8c.io/kubermatic/v2/pkg/version"

--- a/pkg/handler/test/fake_provider.go
+++ b/pkg/handler/test/fake_provider.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -141,6 +141,10 @@ type FakeExternalClusterProvider struct {
 
 var _ provider.ExternalClusterProvider = &FakeExternalClusterProvider{}
 
+func (p *FakeExternalClusterProvider) VersionsEndpoint(ctx context.Context, configGetter provider.KubermaticConfigurationGetter, providerType kubermaticv1.ExternalClusterProviderType) ([]apiv1.MasterVersion, error) {
+	return p.Provider.VersionsEndpoint(ctx, configGetter, providerType)
+}
+
 func (p *FakeExternalClusterProvider) CreateOrUpdateCredentialSecretForCluster(ctx context.Context, cloud *apiv2.ExternalClusterCloudSpec, projectID, clusterID string) (*providerconfig.GlobalSecretKeySelector, error) {
 	return p.Provider.CreateOrUpdateCredentialSecretForCluster(ctx, cloud, projectID, clusterID)
 }
@@ -171,12 +175,8 @@ func (p *FakeExternalClusterProvider) Update(ctx context.Context, userInfo *prov
 	return p.Provider.Update(ctx, userInfo, cluster)
 }
 
-func (p *FakeExternalClusterProvider) GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*semver.Semver, error) {
+func (p *FakeExternalClusterProvider) GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*k8csemverv1.Semver, error) {
 	return defaulting.DefaultKubernetesVersioning.Default, nil
-}
-
-func (p *FakeExternalClusterProvider) VersionsEndpoint(ctx context.Context, configGetter provider.KubermaticConfigurationGetter, providerType kubermaticv1.ExternalClusterProviderType) ([]apiv1.MasterVersion, error) {
-	return p.Provider.VersionsEndpoint(ctx, configGetter, providerType)
 }
 
 func (p *FakeExternalClusterProvider) GetClient(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (ctrlruntimeclient.Client, error) {

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -54,7 +54,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -258,11 +258,11 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 					AccessibleAddons: []string{"addon1", "addon2"},
 				},
 				Versions: kubermaticv1.KubermaticVersioningConfiguration{
-					Versions: []semver.Semver{
-						*semver.NewSemverOrDie("8.8.8"),
-						*semver.NewSemverOrDie("9.9.9"),
-						*semver.NewSemverOrDie("9.9.10"),
-						*semver.NewSemverOrDie("9.11.3"),
+					Versions: []k8csemverv1.Semver{
+						*k8csemverv1.NewSemverOrDie("8.8.8"),
+						*k8csemverv1.NewSemverOrDie("9.9.9"),
+						*k8csemverv1.NewSemverOrDie("9.9.10"),
+						*k8csemverv1.NewSemverOrDie("9.11.3"),
 					},
 				},
 			},
@@ -1034,7 +1034,7 @@ func GenDefaultKubermaticObjects(objs ...ctrlruntimeclient.Object) []ctrlruntime
 }
 
 func GenCluster(id string, name string, projectID string, creationTime time.Time, modifiers ...func(*kubermaticv1.Cluster)) *kubermaticv1.Cluster {
-	version := *semver.NewSemverOrDie("9.9.9") // initTestEndpoint() configures KKP to know 8.8.8 and 9.9.9
+	version := *k8csemverv1.NewSemverOrDie("9.9.9") // initTestEndpoint() configures KKP to know 8.8.8 and 9.9.9
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   id,
@@ -1323,10 +1323,10 @@ func GenDefaultSettings() *kubermaticv1.KubermaticSetting {
 	}
 }
 
-func GenDefaultVersions() []semver.Semver {
-	return []semver.Semver{
-		*semver.NewSemverOrDie("1.22.12"),
-		*semver.NewSemverOrDie("1.23.9"),
+func GenDefaultVersions() []k8csemverv1.Semver {
+	return []k8csemverv1.Semver{
+		*k8csemverv1.NewSemverOrDie("1.22.12"),
+		*k8csemverv1.NewSemverOrDie("1.23.9"),
 	}
 }
 

--- a/pkg/handler/v1/admin/admission_plugin_test.go
+++ b/pkg/handler/v1/admin/admission_plugin_test.go
@@ -27,7 +27,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +35,7 @@ import (
 
 func TestListAdmissionPluginEndpoint(t *testing.T) {
 	t.Parallel()
-	version113, err := semver.NewSemver("v1.13")
+	version113, err := k8csemverv1.NewSemver("v1.13")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestListAdmissionPluginEndpoint(t *testing.T) {
 
 func TestGetAdmissionPluginEndpoint(t *testing.T) {
 	t.Parallel()
-	version113, err := semver.NewSemver("v1.13")
+	version113, err := k8csemverv1.NewSemver("v1.13")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestGetAdmissionPluginEndpoint(t *testing.T) {
 
 func TestDeleteAdmissionPluginEndpoint(t *testing.T) {
 	t.Parallel()
-	version113, err := semver.NewSemver("v1.13")
+	version113, err := k8csemverv1.NewSemver("v1.13")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func TestDeleteAdmissionPluginEndpoint(t *testing.T) {
 
 func TestUpdateAdmissionPluginEndpoint(t *testing.T) {
 	t.Parallel()
-	version113, err := semver.NewSemver("v1.13")
+	version113, err := k8csemverv1.NewSemver("v1.13")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/handler/v1/admission-plugin/admission_plugin_test.go
+++ b/pkg/handler/v1/admission-plugin/admission_plugin_test.go
@@ -30,7 +30,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +46,7 @@ func init() {
 func TestCredentialEndpoint(t *testing.T) {
 	t.Parallel()
 
-	v114, err := semver.NewSemver("1.14")
+	v114, err := k8csemverv1.NewSemver("1.14")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/handler/v1/cluster/cluster_test.go
+++ b/pkg/handler/v1/cluster/cluster_test.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1443,7 +1443,7 @@ func TestListClusters(t *testing.T) {
 							DatacenterName: "private-do1",
 							Fake:           &kubermaticv1.FakeCloudSpec{},
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 						ClusterNetwork: &kubermaticv1.ClusterNetworkingConfig{
 							IPFamily:             kubermaticv1.IPFamilyIPv4,
@@ -1462,7 +1462,7 @@ func TestListClusters(t *testing.T) {
 						},
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -1479,7 +1479,7 @@ func TestListClusters(t *testing.T) {
 							DatacenterName: "private-do1",
 							Fake:           &kubermaticv1.FakeCloudSpec{},
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 						ClusterNetwork: &kubermaticv1.ClusterNetworkingConfig{
 							IPFamily:             kubermaticv1.IPFamilyIPv4,
@@ -1498,7 +1498,7 @@ func TestListClusters(t *testing.T) {
 						},
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -1523,7 +1523,7 @@ func TestListClusters(t *testing.T) {
 								Project:        "project",
 							},
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 						ClusterNetwork: &kubermaticv1.ClusterNetworkingConfig{
 							IPFamily:             kubermaticv1.IPFamilyIPv4,
@@ -1542,7 +1542,7 @@ func TestListClusters(t *testing.T) {
 						},
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationSupported,
 					},
@@ -1579,7 +1579,7 @@ func TestListClusters(t *testing.T) {
 							DatacenterName: "private-do1",
 							Fake:           &kubermaticv1.FakeCloudSpec{},
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 						ClusterNetwork: &kubermaticv1.ClusterNetworkingConfig{
 							IPFamily:             kubermaticv1.IPFamilyIPv4,
@@ -1598,7 +1598,7 @@ func TestListClusters(t *testing.T) {
 						},
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -1615,7 +1615,7 @@ func TestListClusters(t *testing.T) {
 							DatacenterName: "private-do1",
 							Fake:           &kubermaticv1.FakeCloudSpec{},
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 						ClusterNetwork: &kubermaticv1.ClusterNetworkingConfig{
 							IPFamily:             kubermaticv1.IPFamilyIPv4,
@@ -1634,7 +1634,7 @@ func TestListClusters(t *testing.T) {
 						},
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -1659,7 +1659,7 @@ func TestListClusters(t *testing.T) {
 								Project:        "project",
 							},
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 						ClusterNetwork: &kubermaticv1.ClusterNetworkingConfig{
 							IPFamily:             kubermaticv1.IPFamilyIPv4,
@@ -1678,7 +1678,7 @@ func TestListClusters(t *testing.T) {
 						},
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationSupported,
 					},
@@ -1770,11 +1770,11 @@ func TestListClustersForProject(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -1814,11 +1814,11 @@ func TestListClustersForProject(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationSupported,
 					},
@@ -1867,11 +1867,11 @@ func TestListClustersForProject(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -1912,10 +1912,10 @@ func TestListClustersForProject(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version: *semver.NewSemverOrDie("9.9.9"),
+						Version: *k8csemverv1.NewSemverOrDie("9.9.9"),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationSupported,
 					},

--- a/pkg/handler/v1/cluster/upgrade_test.go
+++ b/pkg/handler/v1/cluster/upgrade_test.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	k8csemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -50,7 +50,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 		existingKubermaticObjs     []ctrlruntimeclient.Object
 		existingMachineDeployments []*clusterv1alpha1.MachineDeployment
 		apiUser                    apiv1.User
-		versions                   []k8csemver.Semver
+		versions                   []k8csemverv1.Semver
 		updates                    []kubermaticv1.Update
 		incompatibilities          []kubermaticv1.Incompatibility
 		wantUpdates                []*apiv1.MasterVersion
@@ -60,7 +60,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			cluster: func() *kubermaticv1.Cluster {
 				c := test.GenCluster("foo", "foo", "project", time.Now())
 				c.Labels = map[string]string{"user": test.UserName}
-				c.Spec.Version = *k8csemver.NewSemverOrDie("1.6.0")
+				c.Spec.Version = *k8csemverv1.NewSemverOrDie("1.6.0")
 				return c
 			}(),
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -76,10 +76,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 					Version: semverlib.MustParse("1.7.0"),
 				},
 			},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.6.0"),
-				*k8csemver.NewSemverOrDie("1.6.1"),
-				*k8csemver.NewSemverOrDie("1.7.0"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.6.0"),
+				*k8csemverv1.NewSemverOrDie("1.6.1"),
+				*k8csemverv1.NewSemverOrDie("1.7.0"),
 			},
 			updates: []kubermaticv1.Update{
 				{
@@ -99,7 +99,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			cluster: func() *kubermaticv1.Cluster {
 				c := test.GenCluster("foo", "foo", "project", time.Now())
 				c.Labels = map[string]string{"user": test.UserName}
-				c.Spec.Version = *k8csemver.NewSemverOrDie("1.6.0")
+				c.Spec.Version = *k8csemverv1.NewSemverOrDie("1.6.0")
 				return c
 			}(),
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -122,10 +122,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 					RestrictedByKubeletVersion: true,
 				},
 			},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.6.0"),
-				*k8csemver.NewSemverOrDie("1.6.1"),
-				*k8csemver.NewSemverOrDie("1.7.0"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.6.0"),
+				*k8csemverv1.NewSemverOrDie("1.6.1"),
+				*k8csemverv1.NewSemverOrDie("1.7.0"),
 			},
 			updates: []kubermaticv1.Update{
 				{
@@ -148,7 +148,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 					cluster.Spec.Cloud.Fake = nil
 				})
 				c.Labels = map[string]string{"user": test.UserName}
-				c.Spec.Version = *k8csemver.NewSemverOrDie("1.21.0")
+				c.Spec.Version = *k8csemverv1.NewSemverOrDie("1.21.0")
 				return c
 			}(),
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -160,11 +160,11 @@ func TestGetClusterUpgrades(t *testing.T) {
 					Version: semverlib.MustParse("1.21.1"),
 				},
 			},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.21.0"),
-				*k8csemver.NewSemverOrDie("1.21.1"),
-				*k8csemver.NewSemverOrDie("1.22.0"),
-				*k8csemver.NewSemverOrDie("1.22.1"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.21.0"),
+				*k8csemverv1.NewSemverOrDie("1.21.1"),
+				*k8csemverv1.NewSemverOrDie("1.22.0"),
+				*k8csemverv1.NewSemverOrDie("1.22.1"),
 			},
 			updates: []kubermaticv1.Update{
 				{
@@ -197,7 +197,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			cluster: func() *kubermaticv1.Cluster {
 				c := test.GenCluster("foo", "foo", "project", time.Now())
 				c.Labels = map[string]string{"user": test.UserName}
-				c.Spec.Version = *k8csemver.NewSemverOrDie("1.6.0")
+				c.Spec.Version = *k8csemverv1.NewSemverOrDie("1.6.0")
 				return c
 			}(),
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -206,8 +206,8 @@ func TestGetClusterUpgrades(t *testing.T) {
 			existingMachineDeployments: []*clusterv1alpha1.MachineDeployment{},
 			apiUser:                    *test.GenDefaultAPIUser(),
 			wantUpdates:                []*apiv1.MasterVersion{},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.6.0"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.6.0"),
 			},
 			updates: []kubermaticv1.Update{},
 		},
@@ -216,7 +216,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			cluster: func() *kubermaticv1.Cluster {
 				c := test.GenCluster("foo", "foo", "project", time.Now())
 				c.Labels = map[string]string{"user": test.UserName, kubermaticv1.ProjectIDLabelKey: "my-first-project-ID"}
-				c.Spec.Version = *k8csemver.NewSemverOrDie("1.6.0")
+				c.Spec.Version = *k8csemverv1.NewSemverOrDie("1.6.0")
 				return c
 			}(),
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -233,10 +233,10 @@ func TestGetClusterUpgrades(t *testing.T) {
 					Version: semverlib.MustParse("1.7.0"),
 				},
 			},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.6.0"),
-				*k8csemver.NewSemverOrDie("1.6.1"),
-				*k8csemver.NewSemverOrDie("1.7.0"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.6.0"),
+				*k8csemverv1.NewSemverOrDie("1.6.1"),
+				*k8csemverv1.NewSemverOrDie("1.7.0"),
 			},
 			updates: []kubermaticv1.Update{
 				{
@@ -325,7 +325,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 				test.GenTestSeed(),
 				func() *kubermaticv1.Cluster {
 					cluster := test.GenDefaultCluster()
-					cluster.Spec.Version = *k8csemver.NewSemverOrDie("1.12.1")
+					cluster.Spec.Version = *k8csemverv1.NewSemverOrDie("1.12.1")
 					return cluster
 				}(),
 			),
@@ -346,7 +346,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 				test.GenTestSeed(),
 				func() *kubermaticv1.Cluster {
 					cluster := test.GenDefaultCluster()
-					cluster.Spec.Version = *k8csemver.NewSemverOrDie("1.1.1")
+					cluster.Spec.Version = *k8csemverv1.NewSemverOrDie("1.1.1")
 					return cluster
 				}(),
 			),
@@ -367,7 +367,7 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 				test.GenTestSeed(),
 				func() *kubermaticv1.Cluster {
 					cluster := test.GenDefaultCluster()
-					cluster.Spec.Version = *k8csemver.NewSemverOrDie("1.12.1")
+					cluster.Spec.Version = *k8csemverv1.NewSemverOrDie("1.12.1")
 					return cluster
 				}(),
 				genUser("John", "john@acme.com", true),
@@ -423,7 +423,7 @@ func TestGetNodeUpgrades(t *testing.T) {
 		controlPlaneVersion    string
 		apiUser                apiv1.User
 		existingUpdates        []kubermaticv1.Update
-		existingVersions       []k8csemver.Semver
+		existingVersions       []k8csemverv1.Semver
 		expectedOutput         []*apiv1.MasterVersion
 		existingKubermaticObjs []ctrlruntimeclient.Object
 	}{
@@ -447,19 +447,19 @@ func TestGetNodeUpgrades(t *testing.T) {
 					Automatic: pointer.BoolPtr(false),
 				},
 			},
-			existingVersions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("0.0.1"),
-				*k8csemver.NewSemverOrDie("0.1.0"),
-				*k8csemver.NewSemverOrDie("1.0.0"),
-				*k8csemver.NewSemverOrDie("1.4.0"),
-				*k8csemver.NewSemverOrDie("1.4.1"),
-				*k8csemver.NewSemverOrDie("1.5.0"),
-				*k8csemver.NewSemverOrDie("1.5.1"),
-				*k8csemver.NewSemverOrDie("1.6.0"),
-				*k8csemver.NewSemverOrDie("1.6.1"),
-				*k8csemver.NewSemverOrDie("1.7.0"),
-				*k8csemver.NewSemverOrDie("1.7.1"),
-				*k8csemver.NewSemverOrDie("2.0.0"),
+			existingVersions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("0.0.1"),
+				*k8csemverv1.NewSemverOrDie("0.1.0"),
+				*k8csemverv1.NewSemverOrDie("1.0.0"),
+				*k8csemverv1.NewSemverOrDie("1.4.0"),
+				*k8csemverv1.NewSemverOrDie("1.4.1"),
+				*k8csemverv1.NewSemverOrDie("1.5.0"),
+				*k8csemverv1.NewSemverOrDie("1.5.1"),
+				*k8csemverv1.NewSemverOrDie("1.6.0"),
+				*k8csemverv1.NewSemverOrDie("1.6.1"),
+				*k8csemverv1.NewSemverOrDie("1.7.0"),
+				*k8csemverv1.NewSemverOrDie("1.7.1"),
+				*k8csemverv1.NewSemverOrDie("2.0.0"),
 			},
 			expectedOutput: []*apiv1.MasterVersion{
 				{
@@ -527,7 +527,7 @@ func TestGetMasterVersionsEndpoint(t *testing.T) {
 		clusterType            string
 		apiUser                apiv1.User
 		existingUpdates        []kubermaticv1.Update
-		existingVersions       []k8csemver.Semver
+		existingVersions       []k8csemverv1.Semver
 		expectedOutput         []*apiv1.MasterVersion
 		existingKubermaticObjs []ctrlruntimeclient.Object
 	}{
@@ -537,9 +537,9 @@ func TestGetMasterVersionsEndpoint(t *testing.T) {
 			apiUser:                *test.GenDefaultAPIUser(),
 			existingKubermaticObjs: []ctrlruntimeclient.Object{test.GenDefaultUser()},
 			existingUpdates:        []kubermaticv1.Update{},
-			existingVersions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.13.5"),
-				*k8csemver.NewSemverOrDie("3.11.5"),
+			existingVersions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.13.5"),
+				*k8csemverv1.NewSemverOrDie("3.11.5"),
 			},
 			expectedOutput: []*apiv1.MasterVersion{
 				{

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
 	corev1 "k8s.io/api/core/v1"
@@ -379,11 +379,11 @@ func TestListClusters(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -415,11 +415,11 @@ func TestListClusters(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -459,11 +459,11 @@ func TestListClusters(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationSupported,
 					},
@@ -515,11 +515,11 @@ func TestListClusters(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -551,11 +551,11 @@ func TestListClusters(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationUnsupported,
 					},
@@ -595,11 +595,11 @@ func TestListClusters(t *testing.T) {
 							Type:    kubermaticv1.CNIPluginTypeCanal,
 							Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 						},
-						Version:               *semver.NewSemverOrDie("9.9.9"),
+						Version:               *k8csemverv1.NewSemverOrDie("9.9.9"),
 						EnableUserSSHKeyAgent: pointer.BoolPtr(false),
 					},
 					Status: apiv1.ClusterStatus{
-						Version:              *semver.NewSemverOrDie("9.9.9"),
+						Version:              *k8csemverv1.NewSemverOrDie("9.9.9"),
 						URL:                  "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 						ExternalCCMMigration: apiv1.ExternalCCMMigrationSupported,
 					},

--- a/pkg/handler/v2/cluster/upgrade_test.go
+++ b/pkg/handler/v2/cluster/upgrade_test.go
@@ -34,7 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	k8csemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemver "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/handler/v2/version/version_test.go
+++ b/pkg/handler/v2/version/version_test.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	k8csemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +44,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 		existingKubermaticObjs []ctrlruntimeclient.Object
 		apiUser                apiv1.User
 		provider               kubermaticv1.ProviderType
-		versions               []k8csemver.Semver
+		versions               []k8csemverv1.Semver
 		updates                []kubermaticv1.Update
 		incompatibilities      []kubermaticv1.Incompatibility
 		wantVersions           []*apiv1.MasterVersion
@@ -70,11 +70,11 @@ func TestGetClusterUpgrades(t *testing.T) {
 					Version: semverlib.MustParse("1.22.1"),
 				},
 			},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.21.0"),
-				*k8csemver.NewSemverOrDie("1.21.1"),
-				*k8csemver.NewSemverOrDie("1.22.0"),
-				*k8csemver.NewSemverOrDie("1.22.1"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.21.0"),
+				*k8csemverv1.NewSemverOrDie("1.21.1"),
+				*k8csemverv1.NewSemverOrDie("1.22.0"),
+				*k8csemverv1.NewSemverOrDie("1.22.1"),
 			},
 			updates: []kubermaticv1.Update{
 				{
@@ -114,11 +114,11 @@ func TestGetClusterUpgrades(t *testing.T) {
 					Version: semverlib.MustParse("1.21.1"),
 				},
 			},
-			versions: []k8csemver.Semver{
-				*k8csemver.NewSemverOrDie("1.21.0"),
-				*k8csemver.NewSemverOrDie("1.21.1"),
-				*k8csemver.NewSemverOrDie("1.22.0"),
-				*k8csemver.NewSemverOrDie("1.22.1"),
+			versions: []k8csemverv1.Semver{
+				*k8csemverv1.NewSemverOrDie("1.21.0"),
+				*k8csemverv1.NewSemverOrDie("1.21.1"),
+				*k8csemverv1.NewSemverOrDie("1.22.0"),
+				*k8csemverv1.NewSemverOrDie("1.22.1"),
 			},
 			updates: []kubermaticv1.Update{
 				{

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -43,7 +43,7 @@ import (
 	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -348,7 +348,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	}
 	objects := []runtime.Object{configMapList, secretList, serviceList}
 
-	clusterSemver, err := ksemver.NewSemver(clusterVersion.Version.String())
+	clusterSemver, err := k8csemverv1.NewSemver(clusterVersion.Version.String())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -32,7 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
-	k8csemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
@@ -125,7 +125,7 @@ func getAutoUpdateConstraints(defaultedConfig *kubermaticv1.KubermaticConfigurat
 	return upgradeConstraints, errs
 }
 
-func clusterVersionIsConfigured(version k8csemver.Semver, defaultedConfig *kubermaticv1.KubermaticConfiguration, constraints []*semverlib.Constraints) bool {
+func clusterVersionIsConfigured(version k8csemverv1.Semver, defaultedConfig *kubermaticv1.KubermaticConfiguration, constraints []*semverlib.Constraints) bool {
 	// is this version still straight up supported?
 	for _, configured := range defaultedConfig.Spec.Versions.Versions {
 		if configured.Equal(&version) {

--- a/pkg/install/stack/kubermatic-master/validation_test.go
+++ b/pkg/install/stack/kubermatic-master/validation_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	"k8s.io/utils/pointer"
 )
@@ -28,33 +28,33 @@ import (
 func TestClusterVersionIsConfigured(t *testing.T) {
 	testcases := []struct {
 		name       string
-		version    semver.Semver
+		version    k8csemverv1.Semver
 		versions   kubermaticv1.KubermaticVersioningConfiguration
 		configured bool
 	}{
 		{
 			name:    "version is directly supported",
-			version: *semver.NewSemverOrDie("1.0.0"),
+			version: *k8csemverv1.NewSemverOrDie("1.0.0"),
 			versions: kubermaticv1.KubermaticVersioningConfiguration{
-				Versions: []semver.Semver{
-					*semver.NewSemverOrDie("1.0.0"),
+				Versions: []k8csemverv1.Semver{
+					*k8csemverv1.NewSemverOrDie("1.0.0"),
 				},
 			},
 			configured: true,
 		},
 		{
 			name:    "version is not configured",
-			version: *semver.NewSemverOrDie("1.0.0"),
+			version: *k8csemverv1.NewSemverOrDie("1.0.0"),
 			versions: kubermaticv1.KubermaticVersioningConfiguration{
-				Versions: []semver.Semver{
-					*semver.NewSemverOrDie("2.0.0"),
+				Versions: []k8csemverv1.Semver{
+					*k8csemverv1.NewSemverOrDie("2.0.0"),
 				},
 			},
 			configured: false,
 		},
 		{
 			name:    "update constraint matches because it's auto update",
-			version: *semver.NewSemverOrDie("1.0.0"),
+			version: *k8csemverv1.NewSemverOrDie("1.0.0"),
 			versions: kubermaticv1.KubermaticVersioningConfiguration{
 				Updates: []kubermaticv1.Update{
 					{
@@ -68,7 +68,7 @@ func TestClusterVersionIsConfigured(t *testing.T) {
 		},
 		{
 			name:    "constraint expression matches",
-			version: *semver.NewSemverOrDie("1.2.3"),
+			version: *k8csemverv1.NewSemverOrDie("1.2.3"),
 			versions: kubermaticv1.KubermaticVersioningConfiguration{
 				Updates: []kubermaticv1.Update{
 					{
@@ -82,7 +82,7 @@ func TestClusterVersionIsConfigured(t *testing.T) {
 		},
 		{
 			name:    "update constraint does not match because it's no auto update",
-			version: *semver.NewSemverOrDie("1.0.0"),
+			version: *k8csemverv1.NewSemverOrDie("1.0.0"),
 			versions: kubermaticv1.KubermaticVersioningConfiguration{
 				Updates: []kubermaticv1.Update{
 					{

--- a/pkg/provider/cloud/aks/provider.go
+++ b/pkg/provider/cloud/aks/provider.go
@@ -35,7 +35,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -314,7 +314,7 @@ func ListUpgrades(ctx context.Context, cred resources.AKSCredentials, resourceGr
 	}
 
 	for _, upgradesItem := range upgradeProperties.ControlPlaneProfile.Upgrades {
-		v, err := ksemver.NewSemver(*upgradesItem.KubernetesVersion)
+		v, err := k8csemverv1.NewSemver(*upgradesItem.KubernetesVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -242,7 +242,7 @@ func ListUpgrades(ctx context.Context, sa, zone, name string) ([]*apiv1.MasterVe
 	}
 
 	for version, isDefault := range upgradesMap {
-		v, err := ksemver.NewSemver(version)
+		v, err := k8csemverv1.NewSemver(version)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/kubernetes/admission_plugin_test.go
+++ b/pkg/provider/kubernetes/admission_plugin_test.go
@@ -22,7 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,11 +35,11 @@ import (
 func TestListAdmissionPluginsFromVersion(t *testing.T) {
 	t.Parallel()
 
-	version113, err := semver.NewSemver("v1.13")
+	version113, err := k8csemverv1.NewSemver("v1.13")
 	if err != nil {
 		t.Fatal(err)
 	}
-	version116, err := semver.NewSemver("v1.16")
+	version116, err := k8csemverv1.NewSemver("v1.16")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/provider/kubernetes/external_cluster.go
+++ b/pkg/provider/kubernetes/external_cluster.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
 
 	corev1 "k8s.io/api/core/v1"
@@ -223,7 +223,7 @@ func (p *ExternalClusterProvider) GetClient(ctx context.Context, cluster *kuberm
 	return p.GenerateClient(cfg)
 }
 
-func (p *ExternalClusterProvider) GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*ksemver.Semver, error) {
+func (p *ExternalClusterProvider) GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*k8csemverv1.Semver, error) {
 	secretKeyGetter := provider.SecretKeySelectorValueFuncFactory(ctx, p.clientPrivileged)
 	rawKubeconfig, err := secretKeyGetter(cluster.Spec.KubeconfigReference, resources.KubeconfigSecretKey)
 	if err != nil {
@@ -246,7 +246,7 @@ func (p *ExternalClusterProvider) GetVersion(ctx context.Context, cluster *kuber
 	if err != nil {
 		return nil, err
 	}
-	v, err := ksemver.NewSemver(version.GitVersion)
+	v, err := k8csemverv1.NewSemver(version.GitVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -27,7 +27,7 @@ import (
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -746,7 +746,7 @@ type ExternalClusterProvider interface {
 
 	CreateOrUpdateKubeOneCredentialSecret(ctx context.Context, cloud apiv2.KubeOneCloudSpec, externalCluster *kubermaticv1.ExternalCluster) error
 
-	GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*ksemver.Semver, error)
+	GetVersion(ctx context.Context, cluster *kubermaticv1.ExternalCluster) (*k8csemverv1.Semver, error)
 
 	VersionsEndpoint(ctx context.Context, configGetter KubermaticConfigurationGetter, providerType kubermaticv1.ExternalClusterProviderType) ([]apiv1.MasterVersion, error)
 

--- a/pkg/resources/cloudconfig/configmap_test.go
+++ b/pkg/resources/cloudconfig/configmap_test.go
@@ -25,7 +25,7 @@ import (
 	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -244,7 +244,7 @@ func TestOpenStackCloudConfig(t *testing.T) {
 			name: "use-octavia enabled at cluster level",
 			cluster: &kubermaticv1.Cluster{
 				Spec: kubermaticv1.ClusterSpec{
-					Version: *semver.NewSemverOrDie("v1.1.1"),
+					Version: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							UseOctavia: pointer.BoolPtr(true),
@@ -253,7 +253,7 @@ func TestOpenStackCloudConfig(t *testing.T) {
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("v1.1.1"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					},
 				},
 			},
@@ -277,14 +277,14 @@ func TestOpenStackCloudConfig(t *testing.T) {
 			name: "use-octavia enabled at seed level",
 			cluster: &kubermaticv1.Cluster{
 				Spec: kubermaticv1.ClusterSpec{
-					Version: *semver.NewSemverOrDie("v1.1.1"),
+					Version: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{},
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("v1.1.1"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					},
 				},
 			},
@@ -310,7 +310,7 @@ func TestOpenStackCloudConfig(t *testing.T) {
 			name: "use-octavia not set",
 			cluster: &kubermaticv1.Cluster{
 				Spec: kubermaticv1.ClusterSpec{
-					Version: *semver.NewSemverOrDie("v1.1.1"),
+					Version: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{
 							UseOctavia: pointer.BoolPtr(false),
@@ -319,7 +319,7 @@ func TestOpenStackCloudConfig(t *testing.T) {
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("v1.1.1"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					},
 				},
 			},
@@ -345,14 +345,14 @@ func TestOpenStackCloudConfig(t *testing.T) {
 			name: "use-octavia not set",
 			cluster: &kubermaticv1.Cluster{
 				Spec: kubermaticv1.ClusterSpec{
-					Version: *semver.NewSemverOrDie("v1.1.1"),
+					Version: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{},
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("v1.1.1"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					},
 				},
 			},

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -23,7 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -147,7 +147,7 @@ func azureDeploymentCreator(data *resources.TemplateData) reconciling.NamedDeplo
 	}
 }
 
-func getAzureVersion(version semver.Semver) (string, error) {
+func getAzureVersion(version k8csemverv1.Semver) (string, error) {
 	// reminder: do not forget to update addons/azure-cloud-node-manager as well!
 	switch version.MajorMinor() {
 	case v121:
@@ -186,7 +186,7 @@ func getAzureFlags(data *resources.TemplateData) []string {
 
 // AzureCloudControllerSupported checks if this version of Kubernetes is supported
 // by our implementation of the external cloud controller.
-func AzureCloudControllerSupported(version semver.Semver) bool {
+func AzureCloudControllerSupported(version k8csemverv1.Semver) bool {
 	if _, err := getAzureVersion(version); err != nil {
 		return false
 	}

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -23,7 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -172,7 +172,7 @@ func getOSFlags(data *resources.TemplateData) []string {
 	return flags
 }
 
-func getOSVersion(version semver.Semver) (string, error) {
+func getOSVersion(version k8csemverv1.Semver) (string, error) {
 	switch version.MajorMinor() {
 	case v121:
 		return "1.21.0", nil
@@ -189,7 +189,7 @@ func getOSVersion(version semver.Semver) (string, error) {
 
 // OpenStackCloudControllerSupported checks if this version of Kubernetes is supported
 // by our implementation of the external cloud controller.
-func OpenStackCloudControllerSupported(version semver.Semver) bool {
+func OpenStackCloudControllerSupported(version k8csemverv1.Semver) bool {
 	if _, err := getOSVersion(version); err != nil {
 		return false
 	}

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -23,7 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -170,7 +170,7 @@ func getCPIContainer(version string, data *resources.TemplateData) corev1.Contai
 	return c
 }
 
-func getVsphereCPIVersion(version semver.Semver) string {
+func getVsphereCPIVersion(version k8csemverv1.Semver) string {
 	switch version.MajorMinor() {
 	case v121:
 		return "1.21.3"

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +51,7 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "test",
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("v1.1.1"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					},
 				},
 			},
@@ -77,7 +77,7 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "test",
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("v1.1.1"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("v1.1.1"),
 					},
 				},
 			},
@@ -99,12 +99,12 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						Openstack: &kubermaticv1.OpenstackCloudSpec{},
 					},
-					Version: *semver.NewSemverOrDie("1.23.5"),
+					Version: *k8csemverv1.NewSemverOrDie("1.23.5"),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "test",
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("1.23.5"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("1.23.5"),
 					},
 					Conditions: map[kubermaticv1.ClusterConditionType]kubermaticv1.ClusterCondition{
 						kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted: {
@@ -125,12 +125,12 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						AWS: &kubermaticv1.AWSCloudSpec{},
 					},
-					Version: *semver.NewSemverOrDie("1.23.5"),
+					Version: *k8csemverv1.NewSemverOrDie("1.23.5"),
 				},
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "test",
 					Versions: kubermaticv1.ClusterVersionsStatus{
-						ControlPlane: *semver.NewSemverOrDie("1.23.5"),
+						ControlPlane: *k8csemverv1.NewSemverOrDie("1.23.5"),
 					},
 				},
 			},

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -29,7 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -389,7 +389,7 @@ func ImageTag(c *kubermaticv1.Cluster) string {
 	// also external components like the kubernetes dashboard or external ccms wait for
 	// the new apiserver to be ready; etcd however is different and gets updated together
 	// with the apiserver
-	if c.Status.Versions.Apiserver.LessThan(semver.NewSemverOrDie("1.22.0")) {
+	if c.Status.Versions.Apiserver.LessThan(k8csemverv1.NewSemverOrDie("1.22.0")) {
 		return "v3.4.3"
 	}
 

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -23,7 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	"k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -178,7 +178,7 @@ func getVolumes() []corev1.Volume {
 	}
 }
 
-func getDashboardVersion(clusterVersion semver.Semver) (string, error) {
+func getDashboardVersion(clusterVersion v1.Semver) (string, error) {
 	// check the GitHub releases for find compat info on the dashboard:
 	// https://github.com/kubernetes/dashboard/releases
 

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -40,7 +40,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	ksemver "k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
@@ -290,7 +290,7 @@ func TestLoadFiles(t *testing.T) {
 							Features:       features,
 							ExposeStrategy: kubermaticv1.ExposeStrategyLoadBalancer,
 							Cloud:          cloudspec,
-							Version:        *ksemver.NewSemverOrDie(ver.Version.String()),
+							Version:        *k8csemverv1.NewSemverOrDie(ver.Version.String()),
 							ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 								Services: kubermaticv1.NetworkRanges{
 									CIDRBlocks: []string{"10.240.16.0/20"},
@@ -326,10 +326,10 @@ func TestLoadFiles(t *testing.T) {
 						Status: kubermaticv1.ClusterStatus{
 							NamespaceName: "cluster-de-test-01",
 							Versions: kubermaticv1.ClusterVersionsStatus{
-								ControlPlane:      *ksemver.NewSemverOrDie(ver.Version.String()),
-								Apiserver:         *ksemver.NewSemverOrDie(ver.Version.String()),
-								ControllerManager: *ksemver.NewSemverOrDie(ver.Version.String()),
-								Scheduler:         *ksemver.NewSemverOrDie(ver.Version.String()),
+								ControlPlane:      *k8csemverv1.NewSemverOrDie(ver.Version.String()),
+								Apiserver:         *k8csemverv1.NewSemverOrDie(ver.Version.String()),
+								ControllerManager: *k8csemverv1.NewSemverOrDie(ver.Version.String()),
+								Scheduler:         *k8csemverv1.NewSemverOrDie(ver.Version.String()),
 							},
 							Address: kubermaticv1.ClusterAddress{
 								ExternalName: "jh8j81chn.europe-west3-c.dev.kubermatic.io",

--- a/pkg/semver/v1/semver.go
+++ b/pkg/semver/v1/semver.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"flag"
+	"fmt"
+
+	semverlib "github.com/Masterminds/semver/v3"
+)
+
+var (
+	_ flag.Value = new(Semver)
+)
+
+// Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version struct so it can be used in our API.
+type Semver string
+
+// NewSemver creates new Semver version struct and returns pointer to it.
+func NewSemver(ver string) (*Semver, error) {
+	v := new(Semver)
+	if err := v.Set(ver); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// NewSemverOrDie behaves similar to NewVersion, i.e. it creates new Semver version struct, but panics if an error happens.
+func NewSemverOrDie(ver string) *Semver {
+	sv, err := NewSemver(ver)
+	if err != nil {
+		panic(err)
+	}
+
+	return sv
+}
+
+// Set initializes semver struct and sets version.
+func (s *Semver) Set(ver string) error {
+	if _, err := semverlib.NewVersion(ver); err != nil {
+		return err
+	}
+	*s = Semver(ver)
+
+	return nil
+}
+
+// Semver returns github.com/Masterminds/semver/v3 struct.
+// In case when Semver is nil, nil will be returned.
+// In case of parsing error, nil will be returned.
+func (s *Semver) Semver() *semverlib.Version {
+	if s == nil {
+		return nil
+	}
+
+	sver, err := semverlib.NewVersion(string(*s))
+	if err != nil {
+		return nil
+	}
+
+	return sver
+}
+
+// Equal compares two version structs by comparing Semver values.
+func (s *Semver) Equal(b *Semver) bool {
+	if s == nil || b == nil {
+		return false
+	}
+
+	sver, bver := s.Semver(), b.Semver()
+	if sver == nil || bver == nil {
+		return false
+	}
+
+	return sver.Equal(bver)
+}
+
+func (s *Semver) LessThan(b *Semver) bool {
+	if s == nil || b == nil {
+		return false
+	}
+
+	sver, bver := s.Semver(), b.Semver()
+	if sver == nil || bver == nil {
+		return false
+	}
+
+	return sver.LessThan(bver)
+}
+
+func (s *Semver) GreaterThan(b *Semver) bool {
+	if s == nil || b == nil {
+		return false
+	}
+
+	sver, bver := s.Semver(), b.Semver()
+	if sver == nil || bver == nil {
+		return false
+	}
+
+	return sver.GreaterThan(bver)
+}
+
+// String returns string representation of Semver version.
+// Note that the following transformations are being made to the original version:
+//  - any leading 'v' is trimmed off -> e.g. 'v1.0.0' -> '1.0.0'
+//  - expansion to major.minor.patch format -> e.g. '1' -> '1.0.0'
+func (s *Semver) String() string {
+	sver := s.Semver()
+	if sver == nil {
+		return ""
+	}
+
+	return sver.String()
+}
+
+// MajorMinor returns a string like "Major.Minor".
+func (s *Semver) MajorMinor() string {
+	sver := s.Semver()
+	if sver == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%d.%d", sver.Major(), sver.Minor())
+}
+
+func (s Semver) DeepCopy() Semver {
+	if s.Semver() == nil {
+		return ""
+	}
+
+	return *NewSemverOrDie(s.String())
+}
+
+func (in *Semver) DeepCopyInto(out *Semver) {
+	*out = in.DeepCopy()
+}

--- a/pkg/semver/v1/semver_test.go
+++ b/pkg/semver/v1/semver_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "testing"
+
+func TestDeepCopy(t *testing.T) {
+	tt := []struct {
+		name string
+		in   *Semver
+		exp  string
+	}{
+		{
+			name: "full version prefixed by v",
+			in:   NewSemverOrDie("v1.0.0"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "partial version prefixed by v",
+			in:   NewSemverOrDie("v1"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "full version no prefix",
+			in:   NewSemverOrDie("1.0.0"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "partial version no prefix",
+			in:   NewSemverOrDie("1"),
+			exp:  "1.0.0",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := tc.in.DeepCopy()
+
+			// we need to test for string equality here, as both semver.String() as well as
+			// NewSemverOrDie take a biased stance on transforming the version
+			if string(cp) != tc.exp {
+				t.Errorf("Expected copy to be %q, got %q", string(*tc.in), string(cp))
+			}
+		})
+	}
+}

--- a/pkg/semver/v2/semver.go
+++ b/pkg/semver/v2/semver.go
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package semver
+package v2
 
 import (
 	"flag"
-	"fmt"
 
 	semverlib "github.com/Masterminds/semver/v3"
 )
@@ -28,6 +27,9 @@ var (
 )
 
 // Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version struct so it can be used in our API.
+//
+// v2 differs from  v1 in the following manner:
+//  - Running DeepCopy(), String() will preserve the original manner the version was provided in as opposed to normalizing the string. Instead a Normalize() func is introduced
 type Semver string
 
 // NewSemver creates new Semver version struct and returns pointer to it.
@@ -116,8 +118,12 @@ func (s *Semver) GreaterThan(b *Semver) bool {
 	return sver.GreaterThan(bver)
 }
 
-// String returns string representation of Semver version.
-func (s *Semver) String() string {
+// Normalize returns a normalized string representation of Semver version.
+// Note that the following transformations are being made to the original version:
+//  - any leading 'v' is trimmed off -> e.g. 'v1.0.0' -> '1.0.0'
+//  - expansion to major.minor.patch format -> e.g. '1' -> '1.0.0'
+// To retrieve the original value, see Original() func.
+func (s *Semver) Normalize() string {
 	sver := s.Semver()
 	if sver == nil {
 		return ""
@@ -126,14 +132,11 @@ func (s *Semver) String() string {
 	return sver.String()
 }
 
-// MajorMinor returns a string like "Major.Minor".
-func (s *Semver) MajorMinor() string {
-	sver := s.Semver()
-	if sver == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("%d.%d", sver.Major(), sver.Minor())
+// String returns string representation of Semver version.
+// Unlike semver/v1, no normalization is being done. See Normalize() for normalization.
+// By overriding String() in semver/v2, we ensure compatibility with consumers like fmt.
+func (s Semver) String() string {
+	return string(s)
 }
 
 func (s Semver) DeepCopy() Semver {

--- a/pkg/semver/v2/semver_test.go
+++ b/pkg/semver/v2/semver_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"testing"
+)
+
+func TestDeepCopy(t *testing.T) {
+	tt := []struct {
+		name string
+		in   *Semver
+		exp  string
+	}{
+		{
+			name: "full version prefixed by v",
+			in:   NewSemverOrDie("v1.0.0"),
+			exp:  "v1.0.0",
+		},
+		{
+			name: "partial version prefixed by v",
+			in:   NewSemverOrDie("v1"),
+			exp:  "v1",
+		},
+		{
+			name: "full version no prefix",
+			in:   NewSemverOrDie("1.0.0"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "partial version no prefix",
+			in:   NewSemverOrDie("1"),
+			exp:  "1",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := tc.in.DeepCopy()
+
+			// we need to test for string equality here, as both semver.String() as well as
+			// NewSemverOrDie take a biased stance on transforming the version
+			if string(cp) != tc.exp {
+				t.Errorf("Expected copy to be %q, got %q", string(*tc.in), string(cp))
+			}
+		})
+	}
+}
+
+func TestNewSemver(t *testing.T) {
+	tt := []struct {
+		name string
+		in   string
+		exp  string
+	}{
+		{
+			name: "full version prefixed by v",
+			in:   "v1.0.0",
+			exp:  "v1.0.0",
+		},
+		{
+			name: "partial version prefixed by v",
+			in:   "v1",
+			exp:  "v1",
+		},
+		{
+			name: "full version no prefix",
+			in:   "1.0.0",
+			exp:  "1.0.0",
+		},
+		{
+			name: "partial version no prefix",
+			in:   "1",
+			exp:  "1",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			sv := NewSemverOrDie(tc.in)
+
+			// we need to test for string equality here, as both semver.String() as well as
+			// NewSemverOrDie take a biased stance on transforming the version
+			if string(*sv) != tc.exp {
+				t.Errorf("Expected copy to be %q, got %q", tc.in, sv)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tt := []struct {
+		name string
+		in   *Semver
+		exp  string
+	}{
+		{
+			name: "full version prefixed by v",
+			in:   NewSemverOrDie("v1.0.0"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "partial version prefixed by v",
+			in:   NewSemverOrDie("v1"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "full version no prefix",
+			in:   NewSemverOrDie("1.0.0"),
+			exp:  "1.0.0",
+		},
+		{
+			name: "partial version no prefix",
+			in:   NewSemverOrDie("1"),
+			exp:  "1.0.0",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			norm := tc.in.Normalize()
+
+			if norm != tc.exp {
+				t.Errorf("Expected copy to be %q, got %q", string(*tc.in), norm)
+			}
+		})
+	}
+}

--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -36,7 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/ccm-migration/providers"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/ccm-migration/utils"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
@@ -51,7 +51,7 @@ import (
 type testOptions struct {
 	skipCleanup       bool
 	logOptions        log.Options
-	kubernetesVersion semver.Semver
+	kubernetesVersion k8csemverv1.Semver
 
 	provider string
 

--- a/pkg/test/e2e/ccm-migration/cluster.go
+++ b/pkg/test/e2e/ccm-migration/cluster.go
@@ -29,7 +29,7 @@ import (
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,7 +54,7 @@ type ClusterJig struct {
 	Log            *zap.SugaredLogger
 	Name           string
 	DatacenterName string
-	Version        semver.Semver
+	Version        k8csemverv1.Semver
 	SeedClient     ctrlruntimeclient.Client
 	Cluster        *kubermaticv1.Cluster
 }

--- a/pkg/test/e2e/ccm-migration/providers/azure.go
+++ b/pkg/test/e2e/ccm-migration/providers/azure.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	"k8c.io/operating-system-manager/pkg/providerconfig/ubuntu"
 
@@ -45,7 +45,7 @@ const (
 	azureCCMDeploymentName = "azure-cloud-controller-manager"
 )
 
-func NewClusterJigAzure(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger, version semver.Semver, seedDatacenter string, credentials AzureCredentialsType) *AzureClusterJig {
+func NewClusterJigAzure(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger, version k8csemverv1.Semver, seedDatacenter string, credentials AzureCredentialsType) *AzureClusterJig {
 	return &AzureClusterJig{
 		CommonClusterJig: CommonClusterJig{
 			name:           utilcluster.MakeClusterName(),

--- a/pkg/test/e2e/ccm-migration/providers/cluster.go
+++ b/pkg/test/e2e/ccm-migration/providers/cluster.go
@@ -27,7 +27,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/ccm-migration/utils"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -54,7 +54,7 @@ type ClusterJigInterface interface {
 type CommonClusterJig struct {
 	name           string
 	DatacenterName string
-	Version        semver.Semver
+	Version        k8csemverv1.Semver
 	log            *zap.SugaredLogger
 
 	SeedClient ctrlruntimeclient.Client

--- a/pkg/test/e2e/ccm-migration/providers/openstack.go
+++ b/pkg/test/e2e/ccm-migration/providers/openstack.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	"k8c.io/operating-system-manager/pkg/providerconfig/ubuntu"
 
@@ -49,7 +49,7 @@ type OpenstackClusterJig struct {
 	Credentials OpenstackCredentialsType
 }
 
-func NewClusterJigOpenstack(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger, version semver.Semver, seedDatacenter string, credentials OpenstackCredentialsType) *OpenstackClusterJig {
+func NewClusterJigOpenstack(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger, version k8csemverv1.Semver, seedDatacenter string, credentials OpenstackCredentialsType) *OpenstackClusterJig {
 	return &OpenstackClusterJig{
 		CommonClusterJig: CommonClusterJig{
 			name:           utilcluster.MakeClusterName(),

--- a/pkg/test/e2e/ccm-migration/providers/vsphere.go
+++ b/pkg/test/e2e/ccm-migration/providers/vsphere.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	"k8c.io/operating-system-manager/pkg/providerconfig/ubuntu"
 
@@ -50,7 +50,7 @@ type VsphereClusterJig struct {
 	Credentials VsphereCredentialsType
 }
 
-func NewClusterJigVsphere(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger, version semver.Semver, seedDatacenter string, credentials VsphereCredentialsType) *VsphereClusterJig {
+func NewClusterJigVsphere(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger, version k8csemverv1.Semver, seedDatacenter string, credentials VsphereCredentialsType) *VsphereClusterJig {
 	return &VsphereClusterJig{
 		CommonClusterJig: CommonClusterJig{
 			name:           utilcluster.MakeClusterName(),

--- a/pkg/test/e2e/ccm-migration/utils/helpers.go
+++ b/pkg/test/e2e/ccm-migration/utils/helpers.go
@@ -20,7 +20,7 @@ import (
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,7 +86,7 @@ func DefaultProject(projectName string) *kubermaticv1.Project {
 	}
 }
 
-func DefaultCluster(clusterName string, version semver.Semver, cloudSpec kubermaticv1.CloudSpec, projectID string) *kubermaticv1.Cluster {
+func DefaultCluster(clusterName string, version k8csemverv1.Semver, cloudSpec kubermaticv1.CloudSpec, projectID string) *kubermaticv1.Cluster {
 	return &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName,

--- a/pkg/test/e2e/expose-strategy/client.go
+++ b/pkg/test/e2e/expose-strategy/client.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +69,7 @@ type clientJig struct {
 	e2eutils.TestPodConfig
 }
 
-func (cj *clientJig) QueryApiserverVersion(kasHostPort string, insecure bool, expectServerVersion semver.Semver, retries, minSuccess int) bool {
+func (cj *clientJig) QueryApiserverVersion(kasHostPort string, insecure bool, expectServerVersion k8csemverv1.Semver, retries, minSuccess int) bool {
 	c := []string{
 		"kubectl",
 		"version",

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -28,7 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -131,7 +131,7 @@ func (j *ClusterJig) WithAddons(addons ...Addon) *ClusterJig {
 }
 
 func (j *ClusterJig) WithVersion(version string) *ClusterJig {
-	j.spec.Version = *semver.NewSemverOrDie(version)
+	j.spec.Version = *k8csemverv1.NewSemverOrDie(version)
 	return j
 }
 

--- a/pkg/test/e2e/jig/flags.go
+++ b/pkg/test/e2e/jig/flags.go
@@ -30,7 +30,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,8 +106,8 @@ func ClusterVersion(log *zap.SugaredLogger) string {
 	return v
 }
 
-func ClusterSemver(log *zap.SugaredLogger) semver.Semver {
-	return *semver.NewSemverOrDie(ClusterVersion(log))
+func ClusterSemver(log *zap.SugaredLogger) k8csemverv1.Semver {
+	return *k8csemverv1.NewSemverOrDie(ClusterVersion(log))
 }
 
 func DatacenterName() string {

--- a/pkg/test/e2e/utils/util.go
+++ b/pkg/test/e2e/utils/util.go
@@ -26,7 +26,7 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 
 	"k8c.io/kubermatic/v2/pkg/defaulting"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils/apiclient/client"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -62,7 +62,7 @@ func KubernetesVersion() string {
 	version := defaulting.DefaultKubernetesVersioning.Default
 
 	if v := os.Getenv("VERSION_TO_TEST"); v != "" {
-		version = semver.NewSemverOrDie(v)
+		version = k8csemverv1.NewSemverOrDie(v)
 	}
 
 	return "v" + version.String()

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -30,7 +30,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 )
 
@@ -93,7 +93,7 @@ func ObjectYAMLDiff(t *testing.T, expectedObj, actualObj interface{}) error {
 	return nil
 }
 
-func kubernetesVersions(cfg *kubermaticv1.KubermaticConfiguration) []semver.Semver {
+func kubernetesVersions(cfg *kubermaticv1.KubermaticConfiguration) []k8csemverv1.Semver {
 	if cfg == nil {
 		return defaulting.DefaultKubernetesVersioning.Versions
 	}
@@ -104,10 +104,10 @@ func kubernetesVersions(cfg *kubermaticv1.KubermaticConfiguration) []semver.Semv
 // LatestKubernetesVersion returns the most recent supported patch release. Passing nil
 // for the KubermaticConfiguration is fine and in this case the compiled-in defaults will
 // be used.
-func LatestKubernetesVersion(cfg *kubermaticv1.KubermaticConfiguration) *semver.Semver {
+func LatestKubernetesVersion(cfg *kubermaticv1.KubermaticConfiguration) *k8csemverv1.Semver {
 	versions := kubernetesVersions(cfg)
 
-	var latest *semver.Semver
+	var latest *k8csemverv1.Semver
 	for i, version := range versions {
 		if latest == nil || version.GreaterThan(latest) {
 			latest = &versions[i]
@@ -121,7 +121,7 @@ func LatestKubernetesVersion(cfg *kubermaticv1.KubermaticConfiguration) *semver.
 // which are latest-1 (i.e. if KKP is configured to support up to 1.29.7, then the stable
 // releases would be all in the  1.28.x line). Passing nil for the KubermaticConfiguration
 // is fine and in this case the compiled-in defaults will be used.
-func LatestStableKubernetesVersion(cfg *kubermaticv1.KubermaticConfiguration) *semver.Semver {
+func LatestStableKubernetesVersion(cfg *kubermaticv1.KubermaticConfiguration) *k8csemverv1.Semver {
 	latest := LatestKubernetesVersion(cfg)
 	if latest == nil {
 		return nil
@@ -136,8 +136,8 @@ func LatestStableKubernetesVersion(cfg *kubermaticv1.KubermaticConfiguration) *s
 // LatestKubernetesVersionForRelease returns the most recent supported patch release
 // for a given release branch (i.e. release="1.24" might return "1.24.7"). Passing nil for the
 // KubermaticConfiguration is fine and in this case the compiled-in defaults will be used.
-func LatestKubernetesVersionForRelease(release string, cfg *kubermaticv1.KubermaticConfiguration) *semver.Semver {
-	parsed, err := semver.NewSemver(release)
+func LatestKubernetesVersionForRelease(release string, cfg *kubermaticv1.KubermaticConfiguration) *k8csemverv1.Semver {
+	parsed, err := k8csemverv1.NewSemver(release)
 	if err != nil {
 		return nil
 	}
@@ -145,7 +145,7 @@ func LatestKubernetesVersionForRelease(release string, cfg *kubermaticv1.Kuberma
 	versions := kubernetesVersions(cfg)
 	minor := parsed.Semver().Minor()
 
-	var stable *semver.Semver
+	var stable *k8csemverv1.Semver
 	for i, version := range versions {
 		if version.Semver().Minor() != minor {
 			continue

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 // support v1.2.x and v1.0.x, to ship only mandatory variants for kubectl.
 // See https://kubernetes.io/releases/version-skew-policy/#kubectl for
 // more information.
-func BinaryForClusterVersion(version *semver.Semver) (string, error) {
+func BinaryForClusterVersion(version *k8csemverv1.Semver) (string, error) {
 	var binary string
 
 	switch version.MajorMinor() {
@@ -55,7 +55,7 @@ func BinaryForClusterVersion(version *semver.Semver) (string, error) {
 	return filepath.Join("/usr/local/bin/", binary), nil
 }
 
-func VerifyVersionSkew(clusterVersion, kubectlVersion semver.Semver) error {
+func VerifyVersionSkew(clusterVersion, kubectlVersion k8csemverv1.Semver) error {
 	clusterMajor := clusterVersion.Semver().Major()
 	kubectlMajor := kubectlVersion.Semver().Major()
 

--- a/pkg/util/kubectl/kubectl_integration_test.go
+++ b/pkg/util/kubectl/kubectl_integration_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"k8c.io/kubermatic/v2/pkg/defaulting"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 )
 
 type kubectlVersionOutput struct {
@@ -51,7 +51,7 @@ func TestVersionSkewIsRespected(t *testing.T) {
 	}
 }
 
-func testVersionSkew(clusterVersison semver.Semver, dockerImage string) error {
+func testVersionSkew(clusterVersison k8csemverv1.Semver, dockerImage string) error {
 	binary, err := BinaryForClusterVersion(&clusterVersison)
 	if err != nil {
 		return fmt.Errorf("no kubectl binary found: %w", err)
@@ -80,7 +80,7 @@ func testVersionSkew(clusterVersison semver.Semver, dockerImage string) error {
 		return fmt.Errorf("failed to decode kubectl output: %w", err)
 	}
 
-	kubectlVersion, err := semver.NewSemver(data.ClientVersion.GitVersion)
+	kubectlVersion, err := k8csemverv1.NewSemver(data.ClientVersion.GitVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse %q as a semver: %w", data.ClientVersion.GitVersion, err)
 	}

--- a/pkg/util/kubectl/kubectl_test.go
+++ b/pkg/util/kubectl/kubectl_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"k8c.io/kubermatic/v2/pkg/defaulting"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 )
 
 func TestKubectlForAllSupportedVersions(t *testing.T) {
@@ -57,7 +57,7 @@ func TestVerifyVersionSkew(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(fmt.Sprintf("%s vs. %s", testcase.cluster, testcase.kubectl), func(t *testing.T) {
-			err := VerifyVersionSkew(*semver.NewSemverOrDie(testcase.cluster), *semver.NewSemverOrDie(testcase.kubectl))
+			err := VerifyVersionSkew(*k8csemverv1.NewSemverOrDie(testcase.cluster), *k8csemverv1.NewSemverOrDie(testcase.kubectl))
 
 			if testcase.valid && err != nil {
 				t.Fatalf("kubectl %s should have been compatible to cluster %s, but got error: %v", testcase.kubectl, testcase.cluster, err)

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
@@ -1102,7 +1102,7 @@ func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.Clu
 	return allErrs
 }
 
-func validateCNIUpdate(newCni *kubermaticv1.CNIPluginSettings, oldCni *kubermaticv1.CNIPluginSettings, labels map[string]string, k8sVersion semver.Semver) *field.Error {
+func validateCNIUpdate(newCni *kubermaticv1.CNIPluginSettings, oldCni *kubermaticv1.CNIPluginSettings, labels map[string]string, k8sVersion k8csemverv1.Semver) *field.Error {
 	basePath := field.NewPath("spec", "cniPlugin")
 
 	// if there was no CNI setting, we allow the mutation to happen

--- a/pkg/validation/kubermaticconfiguration_test.go
+++ b/pkg/validation/kubermaticconfiguration_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 )
 
 func TestValidateKubermaticConfigurationVersions(t *testing.T) {
@@ -84,11 +84,11 @@ func TestValidateKubermaticConfigurationVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := kubermaticv1.KubermaticVersioningConfiguration{}
 			if tt.defaultVersion != "" {
-				config.Default = semver.NewSemverOrDie(tt.defaultVersion)
+				config.Default = k8csemverv1.NewSemverOrDie(tt.defaultVersion)
 			}
 
 			for _, v := range tt.versions {
-				version := semver.NewSemverOrDie(v)
+				version := k8csemverv1.NewSemverOrDie(v)
 				config.Versions = append(config.Versions, *version)
 			}
 

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -30,7 +30,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
@@ -647,7 +647,7 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{
 							Name:    "foo",
-							Version: *semver.NewSemverOrDie("1.24"),
+							Version: *k8csemverv1.NewSemverOrDie("1.24"),
 							CloudSpec: kubermaticv1.CloudSpec{
 								ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 								DatacenterName: "openstack-dc",
@@ -676,7 +676,7 @@ func TestHandle(t *testing.T) {
 					OldObject: runtime.RawExtension{
 						Raw: rawClusterGen{
 							Name:    "foo",
-							Version: *semver.NewSemverOrDie("1.23"),
+							Version: *k8csemverv1.NewSemverOrDie("1.23"),
 							CloudSpec: kubermaticv1.CloudSpec{
 								ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 								DatacenterName: "openstack-dc",
@@ -722,7 +722,7 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{
 							Name:    "foo",
-							Version: *semver.NewSemverOrDie("1.23"),
+							Version: *k8csemverv1.NewSemverOrDie("1.23"),
 							CloudSpec: kubermaticv1.CloudSpec{
 								ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 								DatacenterName: "openstack-dc",
@@ -751,7 +751,7 @@ func TestHandle(t *testing.T) {
 					OldObject: runtime.RawExtension{
 						Raw: rawClusterGen{
 							Name:    "foo",
-							Version: *semver.NewSemverOrDie("1.22"),
+							Version: *k8csemverv1.NewSemverOrDie("1.22"),
 							CloudSpec: kubermaticv1.CloudSpec{
 								ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 								DatacenterName: "openstack-dc",
@@ -1268,7 +1268,7 @@ func TestHandle(t *testing.T) {
 
 type rawClusterGen struct {
 	Name                  string
-	Version               semver.Semver
+	Version               k8csemverv1.Semver
 	CloudSpec             kubermaticv1.CloudSpec
 	CNIPluginSpec         *kubermaticv1.CNIPluginSettings
 	ExternalCloudProvider bool

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -25,7 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test"
 	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
@@ -1419,7 +1419,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.23.9"),
+				Version: k8csemverv1.NewSemverOrDie("1.23.9"),
 			}.Build(),
 			oldCluster: rawClusterGen{
 				Name:      "foo",
@@ -1444,7 +1444,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.22.12"),
+				Version: k8csemverv1.NewSemverOrDie("1.22.12"),
 			}.BuildPtr(),
 			wantAllowed: true,
 		},
@@ -1647,7 +1647,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.0.0"),
+				Version: k8csemverv1.NewSemverOrDie("1.0.0"),
 			}.Build(),
 			wantAllowed: false,
 		},
@@ -1673,7 +1673,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.0.0"),
+				Version: k8csemverv1.NewSemverOrDie("1.0.0"),
 			}.Build(),
 			wantAllowed: false,
 		},
@@ -1699,7 +1699,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.99.99"),
+				Version: k8csemverv1.NewSemverOrDie("1.99.99"),
 			}.Build(),
 			oldCluster: rawClusterGen{
 				Name:      "foo",
@@ -1780,7 +1780,7 @@ type rawClusterGen struct {
 	NetworkConfig         kubermaticv1.ClusterNetworkingConfig
 	ComponentSettings     kubermaticv1.ComponentSettings
 	CNIPlugin             *kubermaticv1.CNIPluginSettings
-	Version               *semver.Semver
+	Version               *k8csemverv1.Semver
 }
 
 func (r rawClusterGen) BuildPtr() *kubermaticv1.Cluster {

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -25,7 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/semver"
+	k8csemverv1 "k8c.io/kubermatic/v2/pkg/semver/v1"
 	"k8c.io/kubermatic/v2/pkg/test"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -675,7 +675,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.0.0"),
+				Version: k8csemverv1.NewSemverOrDie("1.0.0"),
 			}.Build(),
 			wantAllowed: false,
 		},
@@ -731,7 +731,7 @@ type rawTemplateGen struct {
 	NetworkConfig         kubermaticv1.ClusterNetworkingConfig
 	ComponentSettings     kubermaticv1.ComponentSettings
 	CNIPlugin             *kubermaticv1.CNIPluginSettings
-	Version               *semver.Semver
+	Version               *k8csemverv1.Semver
 }
 
 func (r rawTemplateGen) BuildPtr() *kubermaticv1.ClusterTemplate {


### PR DESCRIPTION
Signed-off-by: Simon Bein <simontheleg@gmail.com>

**What this PR does / why we need it**:

Creates a v1 and v2 version of the semver package. v2 differs from v1 in the following manner: Running DeepCopy(), String() will preserve the original manner the version was provided in as opposed to normalizing the string. Instead a Normalize() func is introduced. This behaviour is required for Applications where we interact with third party components (e.g. git, helm), which would break with the normalization. Since we use the normalization in some parts, the v1 version of the package was introduced and will be used in these places.

Applications will be the first component to make use of the v2 package. In order to keep this PR as small as possible, the changes to Apps will be rolled out in a separate commit. 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```
